### PR TITLE
Fixed Disabled SSL on tracker side with BlueTigers Provider

### DIFF
--- a/src/Jackett/Indexers/BlueTigers.cs
+++ b/src/Jackett/Indexers/BlueTigers.cs
@@ -31,7 +31,7 @@ namespace Jackett.Indexers
         public BlueTigers(IIndexerManagerService i, IWebClient wc, Logger l, IProtectionService ps)
             : base(name: "BlueTigers",
                 description: "BlueTigers - No Ratio - Private",
-                link: "https://www.bluetigers.ca/",
+                link: "http://www.bluetigers.ca/",
                 caps: new TorznabCapabilities(),
                 manager: i,
                 client: wc,


### PR DESCRIPTION
### Fixed Disabled SSL on tracker side with BlueTigers Provider

> BlueTigers has a new infrastructure now.

SSL is disabled (redirected to non-ssl domain)
Provider crash if you keep using SSL (with 2 options for SSL activated too)

*Updated with love,*
JigSaw