### PR TITLE
Fix IMDB Matching

### DIFF
--- a/src/Jackett/Utils/TorznabCapsUtil.cs
+++ b/src/Jackett/Utils/TorznabCapsUtil.cs
@@ -74,7 +74,7 @@ namespace Jackett.Utils
             // Filter out releases that do have a valid imdb ID, that is not equal to the one we're searching for.
             return
                 results.Where(
-                    result => !result.Imdb.HasValue || result.Imdb.Value == 0 || ("tt" + result.Imdb.Value).Equals(imdb));
+                    result => !result.Imdb.HasValue || result.Imdb.Value == 0 || ("tt" + result.Imdb.Value.ToString("D7")).Equals(imdb));
         } 
 
         private static string CleanTitle(string title)


### PR DESCRIPTION
Comparing number to string was failing when imdb id had a leading zero