### PR TITLE
SSL Fix by default, Now use TLS (1.2, 1.1, 1) by default

### DIFF
--- a/src/CurlSharp/SSLFix.cs
+++ b/src/CurlSharp/SSLFix.cs
@@ -1,13 +1,28 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Collections.ObjectModel;
 
 namespace CurlSharp
 {
+    /// <summary>
+    /// Our SSL FIX for CURL contain authorized Ciphers for SSL Communications
+    /// </summary>
     public class SSLFix
     {
-        public const string CipherList = "rsa_aes_128_sha,ecdhe_rsa_aes_256_sha,ecdhe_ecdsa_aes_128_sha";
+        // Our CiphersList
+        private static readonly ReadOnlyCollection<string> Ciphers = new ReadOnlyCollection<string>( new[] {
+            // Default supported ciphers by Jackett
+            "rsa_aes_128_sha",
+            "ecdhe_rsa_aes_256_sha",
+            "ecdhe_ecdsa_aes_128_sha"
+        });
+
+        /// <summary>
+        /// List of ciphers supported by Jackett
+        /// </summary>
+        /// <returns>Formatted string of ciphers</returns>
+        public static string CiphersList()
+        {
+            // Comma-Separated list of ciphers
+            return string.Join(",", Ciphers);
+        }
     }
 }

--- a/src/Jackett/CurlHelper.cs
+++ b/src/Jackett/CurlHelper.cs
@@ -127,11 +127,11 @@ namespace Jackett
                         }
                     }
 
-                    if (Startup.DoSSLFix == true)
+                    if (Startup.DoSSLFix.GetValueOrDefault(true))
                     {
                         // http://stackoverflow.com/questions/31107851/how-to-fix-curl-35-cannot-communicate-securely-with-peer-no-common-encryptio
                         // https://git.fedorahosted.org/cgit/mod_nss.git/plain/docs/mod_nss.html
-                        easy.SslCipherList = SSLFix.CipherList;
+                        easy.SslCipherList = SSLFix.CiphersList();
                         easy.FreshConnect = true;
                         easy.ForbidReuse = true;
                     }

--- a/src/Jackett/Utils/Clients/HttpWebClient.cs
+++ b/src/Jackett/Utils/Clients/HttpWebClient.cs
@@ -70,8 +70,11 @@ namespace Jackett.Utils.Clients
                 useProxy = true;
             }
 
+            // SecurityProtocolType values below not available in Mono < 4.3 
+            const int SecurityProtocolTypeTls11 = 768;
+            const int SecurityProtocolTypeTls12 = 3072;
             // Specify to use TLS 1.2 as default connection
-            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+            ServicePointManager.SecurityProtocol |= (SecurityProtocolType)(SecurityProtocolTypeTls12 | SecurityProtocolTypeTls11);
 
             var client = new HttpClient(new HttpClientHandler
             {

--- a/src/Jackett/Utils/Clients/HttpWebClient.cs
+++ b/src/Jackett/Utils/Clients/HttpWebClient.cs
@@ -69,6 +69,10 @@ namespace Jackett.Utils.Clients
                 proxyServer = new WebProxy(Startup.ProxyConnection, false);
                 useProxy = true;
             }
+
+            // Specify to use TLS 1.2 as default connection
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12 | SecurityProtocolType.Tls11 | SecurityProtocolType.Tls;
+
             var client = new HttpClient(new HttpClientHandler
             {
                 CookieContainer = cookies,

--- a/src/Jackett/Utils/Clients/UnixSafeCurlWebClient.cs
+++ b/src/Jackett/Utils/Clients/UnixSafeCurlWebClient.cs
@@ -85,11 +85,11 @@ namespace Jackett.Utils.Clients
             var tempFile = Path.GetTempFileName();
             args.AppendFormat("--output \"{0}\" ", tempFile);
 
-            if (Startup.DoSSLFix == true)
+            if (Startup.DoSSLFix.GetValueOrDefault(true))
             {
                 // http://stackoverflow.com/questions/31107851/how-to-fix-curl-35-cannot-communicate-securely-with-peer-no-common-encryptio
                 // https://git.fedorahosted.org/cgit/mod_nss.git/plain/docs/mod_nss.html
-                args.Append("--cipher " + SSLFix.CipherList);
+                args.Append("--cipher " + SSLFix.CiphersList());
             }
             if (Startup.IgnoreSslErrors == true)
             {


### PR DESCRIPTION
### Optimized & Fixed Jackett SSL Mecanism

> SSL Fix is enabled by default, recoded ciphers list
> Jackett HTTP Web Client is now using TLS by default (1.2, 1.1, 1)

Fixed ISS. #311 and so many others.

*Updated with love,*
JigSaw