### PR TITLE
Modified to use new download URL format

### DIFF
--- a/src/Jackett/Indexers/BitHdtv.cs
+++ b/src/Jackett/Indexers/BitHdtv.cs
@@ -23,7 +23,7 @@ namespace Jackett.Indexers
     {
         private string LoginUrl { get { return SiteLink + "takelogin.php"; } }
         private string SearchUrl { get { return SiteLink + "torrents.php?"; } }
-        private string DownloadUrl { get { return SiteLink + "download.php?/{0}/dl.torrent"; } }
+        private string DownloadUrl { get { return SiteLink + "download.php?id={0}"; } }
 
         new ConfigurationDataBasicLogin configData
         {


### PR DESCRIPTION
Addressing this issue https://github.com/Jackett/Jackett/issues/359

> Bit-HDTV announced on their forum they changed things, in particular the format of the url to download the .torrent files which prevents Jackett to retrieve them.
> 
> Old format : /download.php?/123456/dl.torrent
> New format : /download.php?id=123456