### PR TITLE
Rewrote MoreThanTV indexer

### DIFF
--- a/src/Jackett/Indexers/MoreThanTV.cs
+++ b/src/Jackett/Indexers/MoreThanTV.cs
@@ -1,5 +1,4 @@
-﻿using CsQuery;
-using Jackett.Models;
+﻿using Jackett.Models;
 using Jackett.Services;
 using Jackett.Utils;
 using Jackett.Utils.Clients;
@@ -7,15 +6,16 @@ using Newtonsoft.Json.Linq;
 using NLog;
 using System;
 using System.Collections.Generic;
-using System.IO;
+using System.Globalization;
 using System.Linq;
 using System.Net;
-using System.Net.Http;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
+using AngleSharp.Parser.Html;
+using CsQuery;
 using Jackett.Models.IndexerConfig;
+using Newtonsoft.Json;
 
 namespace Jackett.Indexers
 {
@@ -23,6 +23,7 @@ namespace Jackett.Indexers
     {
         private string LoginUrl { get { return SiteLink + "login.php"; } }
         private string SearchUrl { get { return SiteLink + "ajax.php?action=browse&searchstr="; } }
+        private string SearchUrlTorrents { get { return SiteLink + "torrents.php?tags_type=1&order_by=time&order_way=desc&group_results=1&action=basic&searchsubmit=1&searchstr="; } }
         private string DownloadUrl { get { return SiteLink + "torrents.php?action=download&id="; } }
         private string GuidUrl { get { return SiteLink + "torrents.php?torrentid="; } }
 
@@ -70,80 +71,127 @@ namespace Jackett.Indexers
             return IndexerConfigurationStatus.RequiresTesting;
         }
 
-        private void FillReleaseInfoFromJson(ReleaseInfo release, JObject r)
-        {
-            var id = r["torrentId"];
-            release.Size = (long)r["size"];
-            release.Seeders = (int)r["seeders"];
-            release.Peers = (int)r["leechers"] + release.Seeders;
-            release.Guid = new Uri(GuidUrl + id);
-            release.Comments = release.Guid;
-
-            if ((string)r["category"] == "TV")
-            {
-                release.Category = TorznabCatType.TV.ID;
-            }
-            else if ((string)r["category"] == "Movies")
-            {
-                release.Category = TorznabCatType.Movies.ID;
-            }
-
-            release.Link = new Uri(DownloadUrl + id);
-        }
-
         public async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {
+            logger.Warn("=========================================================================================");
+
+            var isTv = Array.IndexOf(query.Categories, TorznabCatType.TV.ID) > -1;
             var releases = new List<ReleaseInfo>();
-            string qryString = query.GetQueryString();
+            var searchQuery = query.GetQueryString();
 
-            Match matchQry = new Regex(@".*\s[Ss]{1}\d{2}$").Match(qryString);
-            if (matchQry.Success)
-            {
-                //If search string ends in S## eg. S03 (season search) add an asterix to search term
-                qryString += "*";
-            }
+            await GetReleases(releases, searchQuery);
 
-            var episodeSearchUrl = SearchUrl + HttpUtility.UrlEncode(qryString);
-            WebClientStringResult response = await RequestStringWithCookiesAndRetry(episodeSearchUrl);
+            // Search for torrent groups
+//            if (isTv)
+//            {
+//                var seasonMatch = new Regex(@".*\s[Ss]{1}\d{2}").Match(searchQuery);
+//                if (seasonMatch.Success)
+//                {
+//                    var newSearchQuery = Regex.Replace(searchQuery, @"[Ss]{1}\d{2}", $"Season {query.Season}");
+//
+//                    await GetReleases(releases, newSearchQuery);
+//                }
+//            }
+
+            logger.Warn("=========================================================================================");
+
+            return releases;
+        }
+
+        private async Task GetReleases(List<ReleaseInfo> releases, string query)
+        {
+            var searchUrl = SearchUrlTorrents + HttpUtility.UrlEncode(query);
+            var response = await RequestStringWithCookiesAndRetry(searchUrl);
 
             try
             {
-                string decodedResponse = WebUtility.HtmlDecode(response.Content);
-                var json = JObject.Parse(decodedResponse);
-                foreach (JObject r in json["response"]["results"])
+                var parser = new HtmlParser();
+                var document = parser.Parse(response.Content);
+                var groups = document.QuerySelectorAll(".torrent_table > tbody > tr.group");
+                var torrents = document.QuerySelectorAll(".torrent_table > tbody > tr.torrent"); // TODO: Handle individual torrents
+
+                // Loop through all torrent (season) groups
+                foreach (var group in groups)
                 {
-                    DateTime pubDate = DateTime.MinValue;
-                    double dateNum;
-                    if (double.TryParse((string)r["groupTime"], out dateNum))
+                    var showName = group.QuerySelector(".tp-showname a").InnerHtml.Replace("(", "").Replace(")", "").Replace(' ', '.');
+                    var season = group.QuerySelector(".big_info a").InnerHtml;
+                    var tags = group.QuerySelectorAll(".tags a").Select(x => x.InnerHtml).ToArray();
+
+                    logger.Warn($"Showname: {showName} - {season}");
+
+                    // Loop through all group items
+                    var previousElement = group;
+                    var qualityEdition = string.Empty;
+                    while (true)
                     {
-                        pubDate = DateTimeUtil.UnixTimestampToDateTime(dateNum);
-                        pubDate = DateTime.SpecifyKind(pubDate, DateTimeKind.Utc).ToLocalTime();
-                    }
+                        var groupItem = previousElement.NextElementSibling;
 
-                    string groupName = (string)r["groupName"];
+                        if (groupItem == null) break;
 
-                    if (r["torrents"] is JArray)
-                    {
-                        string showName = (string) r["artist"];
+                        if (!groupItem.ClassList[0].Equals("group_torrent") ||
+                            !groupItem.ClassList[1].StartsWith("groupid_")) break;
 
-                        foreach (JObject t in r["torrents"])
+                        // Found a new edition
+                        if (groupItem.ClassList[2].Equals("edition"))
                         {
-                            var release = new ReleaseInfo();
-                            release.PublishDate = pubDate;
-                            release.Title = $"{showName} {groupName}";
-                            release.Description = $"{showName} {groupName}";
-                            FillReleaseInfoFromJson(release, t);
-                            releases.Add(release);
+                            qualityEdition = groupItem.QuerySelector(".edition_info strong").TextContent.Split('/')[1].Trim();
                         }
-                    }
-                    else
-                    {
-                        var release = new ReleaseInfo();
-                        release.PublishDate = pubDate;
-                        release.Title = groupName;
-                        release.Description = groupName;
-                        FillReleaseInfoFromJson(release, r);
-                        releases.Add(release);
+                        else if (groupItem.ClassList[2].StartsWith("edition_"))
+                        {
+                            if (qualityEdition.Equals(string.Empty)) break;
+
+                            // Parse required data
+                            var downloadAnchor = groupItem.QuerySelectorAll("td a").Last();
+                            var downloadAnchorHref = downloadAnchor.Attributes["href"].Value;
+
+                            var torrentId = downloadAnchorHref.Substring(downloadAnchorHref.LastIndexOf('=') + 1);
+                            var qualityData = downloadAnchor.InnerHtml.Split('/');
+                            var publishDate = DateTime.ParseExact(groupItem.QuerySelector(".time.tooltip").Attributes["title"].Value, "MMM dd yyyy, HH:mm", CultureInfo.InvariantCulture, DateTimeStyles.AssumeLocal);
+                            var torrentData = groupItem.QuerySelectorAll(".number_column"); // Size (xx.xx GB[ (Max)]) Snatches (xx) Seeders (xx) Leechers (xx)
+
+                            if (qualityData.Length < 2)
+                                throw new Exception($"We expected 2 or more quality datas, instead we have {qualityData.Length}.");
+
+                            if (torrentData.Length != 4)
+                                throw new Exception($"We expected 4 torrent datas, instead we have {torrentData.Length}.");
+
+                            var size = ParseSizeToBytes(torrentData[0].TextContent);
+                            var seeders = int.Parse(torrentData[2].TextContent);
+                            var guid = new Uri(GuidUrl + torrentId);
+
+                            // Build title
+                            var title = string.Join(".", new List<string>
+                            {
+                                showName,
+                                SeasonToShortSeason(season),
+                                qualityData[1].Trim(),
+                                qualityEdition, // Audio quality should be after this one. Unobtainable at the moment.
+                                $"{qualityData[0].Trim()}-MTV"
+                            });
+
+                            // Build releaseinfo
+                            var releaseInfo = new ReleaseInfo
+                            {
+                                Title = title,
+                                Description = title,
+                                Category = TorznabCatType.TV.ID, // Who seasons movies right
+                                Link = new Uri(DownloadUrl + torrentId),
+                                PublishDate = publishDate,
+                                Seeders = seeders,
+                                Peers = seeders,
+                                Size = size,
+                                Guid = guid,
+                                Comments = guid
+                            };
+
+                            releases.Add(releaseInfo);
+                        }
+                        else
+                        {
+                            break;
+                        }
+
+                        previousElement = groupItem;
                     }
                 }
             }
@@ -151,8 +199,43 @@ namespace Jackett.Indexers
             {
                 OnParseError(response.Content, ex);
             }
-
-            return releases;
         }
+
+        // Changes "Season 1" to "S01"
+        private static string SeasonToShortSeason(string season)
+        {
+            var seasonMatch = new Regex(@"Season (?<seasonNumber>\d{1,2})").Match(season);
+            if (seasonMatch.Success)
+            {
+                season = $"S{int.Parse(seasonMatch.Groups["seasonNumber"].Value):00}";
+            }
+
+            return season;
+        }
+
+        // Changes "xx.xx GB/MB" to bytes
+        private static long ParseSizeToBytes(string strSize)
+        {
+            var sizeParts = strSize.Split(' ');
+            if (sizeParts.Length != 2)
+                throw new Exception($"We expected 2 size parts, instead we have {sizeParts.Length}.");
+
+            var size = double.Parse(sizeParts[0]);
+
+            switch (sizeParts[1].Trim())
+            {
+                case "GB":
+                    size = size*1000*1000*1000;
+                    break;
+                case "MB":
+                    size = size*1000*1000;
+                    break;
+                default:
+                    throw new Exception($"Unknown size type {sizeParts[1].Trim()}.");
+            }
+
+            return (long) Math.Ceiling(size);
+        }
+
     }
 }

--- a/src/Jackett/Indexers/MoreThanTV.cs
+++ b/src/Jackett/Indexers/MoreThanTV.cs
@@ -110,7 +110,7 @@ namespace Jackett.Indexers
                 var parser = new HtmlParser();
                 var document = parser.Parse(response.Content);
                 var groups = document.QuerySelectorAll(".torrent_table > tbody > tr.group");
-                var torrents = document.QuerySelectorAll(".torrent_table > tbody > tr.torrent"); // TODO: Handle individual torrents
+                var torrents = document.QuerySelectorAll(".torrent_table > tbody > tr.torrent");
 
                 // Loop through all torrent (season) groups
                 foreach (var group in groups)


### PR DESCRIPTION
I wanted to fix searching for seasons but I accidentally ended up rewriting almost the entire indexer.

The issue was that MoreThanTV has "torrent groups" named "Season 1/2/3" etc.. and the torznab response literally said "<title>Season 1</title>", of course sonarr won't accept that. It can now grab all torrent group items and rewrites the title so sonarr can parse it.

Another issue was that the previous indexer searched for "Arrow S01" while you can only find the groups if you search for "Arrow Season 1".

Let me know if changes are required or something is not clear.