### PR TITLE
PTN: do AND search instead of OR search

### DIFF
--- a/src/Jackett/Indexers/PirateTheNet.cs
+++ b/src/Jackett/Indexers/PirateTheNet.cs
@@ -104,12 +104,12 @@ namespace Jackett.Indexers
             queryCollection.Add("bookmarks", "showall");
             queryCollection.Add("subscriptions", "showall");
             queryCollection.Add("skw", "showall");
-            queryCollection.Add("advancedsearchparameters", "");
+            //queryCollection.Add("advancedsearchparameters", "");
 
             if (!string.IsNullOrWhiteSpace(searchString))
             {
-                // search keywords use OR by default and it seems like there's no way to change it, expect unwanted results
-                queryCollection.Add("searchstring", searchString);
+                // perform AND search on movie name using 'advancedsearchparameters' instead of 'searchstring'
+                queryCollection.Add("advancedsearchparameters", "[name=" + searchString + "]");
             }
 
             var cats = MapTorznabCapsToTrackers(query);


### PR DESCRIPTION
The PTN indexer returned a lot of irrelevant results.
If you searched for 'the guard' it returned results for 'the' and for 'guard', not only for both terms.
I think this fixes it, I tested it locally using manual search for 'the guard' and 'the lobster'.
Please correct me if I'm wrong.