### PR TITLE
Add missing torznab attributes files, grabs, downloadvolumefactor, uploadvolumefactor

### DIFF
--- a/src/Jackett/Content/custom.js
+++ b/src/Jackett/Content/custom.js
@@ -345,6 +345,32 @@ function clearNotifications() {
     $('[data-notify="container"]').remove();
 }
 
+function updateReleasesRow(row)
+{    
+    var labels = $(row).find("span.release-labels");
+    var DownloadVolumeFactor = parseFloat($(row).find("td.DownloadVolumeFactor").html());
+    var UploadVolumeFactor = parseFloat($(row).find("td.UploadVolumeFactor").html());
+
+    labels.empty();
+
+    if (!isNaN(DownloadVolumeFactor)) {
+        if (DownloadVolumeFactor == 0) {
+            labels.append('\n<span class="label label-success">FREELEECH</span>');
+        } else if (DownloadVolumeFactor < 1) {
+            labels.append('\n<span class="label label-primary">' + DownloadVolumeFactor * 100 + '%DL</span>');
+        } else if (DownloadVolumeFactor > 1) {
+            labels.append('\n<span class="label label-danger">' + DownloadVolumeFactor * 100 + '%DL</span>');
+        }
+    }
+
+    if (!isNaN(UploadVolumeFactor)) {
+        if (UploadVolumeFactor == 0) {
+            labels.append('\n<span class="label label-warning">NO UPLOAD</span>');
+        } else if (UploadVolumeFactor != 1) {
+            labels.append('\n<span class="label label-info">' + UploadVolumeFactor * 100 + '%UL</span>');
+        }
+    }
+}
 
 function bindUIButtons() {
     $('body').on('click', '.downloadlink', function (e, b) {
@@ -372,6 +398,7 @@ function bindUIButtons() {
             var releaseTemplate = Handlebars.compile($("#jackett-releases").html());
             var item = { releases: data, Title: 'Releases' };
             var releaseDialog = $(releaseTemplate(item));
+            releaseDialog.find('tr.jackett-releases-row').each(function () { updateReleasesRow(this); });
             releaseDialog.find('table').DataTable(
                  {
                      "pageLength": 20,
@@ -419,7 +446,7 @@ function bindUIButtons() {
                          var count = 0;
                          this.api().columns().every(function () {
                              count++;
-                             if (count === 5 || count === 9) {
+                             if (count === 5 || count === 10) {
                                  var column = this;
                                  var select = $('<select><option value=""></option></select>')
                                      .appendTo($(column.footer()).empty())
@@ -518,6 +545,7 @@ function bindUIButtons() {
                     var resultsTemplate = Handlebars.compile($("#jackett-search-results").html());
                     var results = $('#searchResults');
                     results.html($(resultsTemplate(data)));
+                    results.find('tr.jackett-search-results-row').each(function () { updateReleasesRow(this); });
 
                     results.find('table').DataTable(
                     {
@@ -554,7 +582,7 @@ function bindUIButtons() {
                             var count = 0;
                             this.api().columns().every(function () {
                                 count++;
-                                if (count === 3 || count === 7) {
+                                if (count === 3 || count === 8) {
                                     var column = this;
                                     var select = $('<select><option value=""></option></select>')
                                         .appendTo($(column.footer()).empty())

--- a/src/Jackett/Content/index.html
+++ b/src/Jackett/Content/index.html
@@ -236,26 +236,34 @@
                                     <th>Name</th>
                                     <th>Size</th>
                                     <th>Size</th>
+                                    <th>Files</th>
                                     <th>Category</th>
+                                    <th>Grabs</th>
                                     <th>Seeds</th>
                                     <th>Leechers</th>
+                                    <th>DL Factor</th>
+                                    <th>UL Factor</th>
                                     <th>Download</th>
                                 </tr>
                             </thead>
                             <tbody>
                                 {{#each releases}}
-                                <tr>
+                                <tr class="jackett-releases-row">
                                     <td>{{PublishDate}}</td>
                                     <td>{{FirstSeen}}</td>
                                     <td>{{jacketTimespan PublishDate}}</td>
                                     <td>{{jacketTimespan FirstSeen}}</td>
                                     <td>{{Tracker}}</td>
-                                    <td><a href="{{Comments}}">{{Title}}</a></td>
+                                    <td><a href="{{Comments}}">{{Title}}</a> <span class="release-labels"></span></td>
                                     <td>{{Size}}</td>
                                     <td>{{jacketSize Size}}</td>
+                                    <td>{{Files}}</td>
                                     <td>{{CategoryDesc}}</td>
+                                    <td>{{Grabs}}</td>
                                     <td>{{Seeders}}</td>
                                     <td>{{Peers}}</td>
+                                    <td class="DownloadVolumeFactor">{{DownloadVolumeFactor}}</td>
+                                    <td class="UploadVolumeFactor">{{UploadVolumeFactor}}</td>
                                     <td class="downloadcolumn">
                                         <a class="downloadlink" title="Download locally" href="{{Link}}"><i class="fa fa-download"></i></a>
                                         {{#if BlackholeLink}}
@@ -267,6 +275,12 @@
                             </tbody>
                             <tfoot>
                                 <tr>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
+                                    <td></td>
                                     <td></td>
                                     <td></td>
                                     <td></td>
@@ -334,24 +348,32 @@
                     <th>Name</th>
                     <th>Size</th>
                     <th>Size</th>
+                    <th>Files</th>
                     <th>Category</th>
+                    <th>Grabs</th>
                     <th>Seeds</th>
                     <th>Leechers</th>
+                    <th>DL Factor</th>
+                    <th>UL Factor</th>
                     <th>Download</th>
                 </tr>
             </thead>
             <tbody>
                 {{#each Results}}
-                <tr>
+                <tr class="jackett-search-results-row">
                     <td>{{PublishDate}}</td>
                     <td>{{jacketTimespan PublishDate}}</td>
                     <td>{{Tracker}}</td>
-                    <td><a href="{{Comments}}">{{Title}}</a></td>
+                    <td><a href="{{Comments}}">{{Title}}</a> <span class="release-labels"></span></td>
                     <td>{{Size}}</td>
                     <td>{{jacketSize Size}}</td>
+                    <td>{{Files}}</td>
                     <td>{{CategoryDesc}}</td>
+                    <td>{{Grabs}}</td>
                     <td>{{Seeders}}</td>
                     <td>{{Peers}}</td>
+                    <td class="DownloadVolumeFactor">{{DownloadVolumeFactor}}</td>
+                    <td class="UploadVolumeFactor">{{UploadVolumeFactor}}</td>
                     <td class="downloadcolumn">
                         <a class="downloadlink" title="Download locally" href="{{Link}}"><i class="fa fa-download"></i></a>
                         {{#if BlackholeLink}}
@@ -363,6 +385,12 @@
             </tbody>
             <tfoot>
                 <tr>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                    <td></td>
+                    <td></td>
                     <td></td>
                     <td></td>
                     <td></td>

--- a/src/Jackett/Jackett.csproj
+++ b/src/Jackett/Jackett.csproj
@@ -184,6 +184,7 @@
     <Compile Include="Indexers\BitHdtv.cs" />
     <Compile Include="Indexers\BitMeTV.cs" />
     <Compile Include="Indexers\Demonoid.cs" />
+    <Compile Include="Indexers\DigitalHive.cs" />
     <Compile Include="Indexers\BroadcastTheNet.cs" />
     <Compile Include="Indexers\DanishBits.cs" />
     <Compile Include="Indexers\Abnormal.cs" />
@@ -501,6 +502,9 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Content\logos\demonoid.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\logos\digitalhive.png">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
     <Content Include="Content\logos\cinemaz.png">

--- a/src/Jackett/Models/ReleaseInfo.cs
+++ b/src/Jackett/Models/ReleaseInfo.cs
@@ -19,6 +19,8 @@ namespace Jackett.Models
         public DateTime PublishDate { get; set; }
         public int Category { get; set; }
         public long? Size { get; set; }
+        public long? Files { get; set; }
+        public long? Grabs { get; set; }
         public string Description { get; set; }
         public long? RageID { get; set; }
         public long? TVDBId { get; set; }
@@ -30,6 +32,8 @@ namespace Jackett.Models
         public Uri MagnetUri { get; set; }
         public double? MinimumRatio { get; set; }
         public long? MinimumSeedTime { get; set; }
+        public double? DownloadVolumeFactor { get; set; }
+        public double? UploadVolumeFactor { get; set; }
 
         public object Clone()
         {
@@ -42,6 +46,8 @@ namespace Jackett.Models
                 PublishDate = PublishDate,
                 Category = Category,
                 Size = Size,
+                Files = Files,
+                Grabs = Grabs,
                 Description = Description,
                 RageID = RageID,
                 Imdb = Imdb,
@@ -51,7 +57,9 @@ namespace Jackett.Models
                 InfoHash = InfoHash,
                 MagnetUri = MagnetUri,
                 MinimumRatio = MinimumRatio,
-                MinimumSeedTime = MinimumSeedTime
+                MinimumSeedTime = MinimumSeedTime,
+                DownloadVolumeFactor = DownloadVolumeFactor,
+                UploadVolumeFactor = UploadVolumeFactor
             };
         }
 

--- a/src/Jackett/Models/ResultPage.cs
+++ b/src/Jackett/Models/ResultPage.cs
@@ -70,7 +70,7 @@ namespace Jackett.Models
                             r.Comments == null ? null : new XElement("comments", r.Comments.ToString()),
                             r.PublishDate == DateTime.MinValue ? null : new XElement("pubDate", xmlDateFormat(r.PublishDate)),
                             r.Size == null ? null : new XElement("size", r.Size),
-                            r.Files == null ? null : new XElement("fiels", r.Files),
+                            r.Files == null ? null : new XElement("files", r.Files),
                             r.Grabs == null ? null : new XElement("grabs", r.Grabs),
                             new XElement("description", r.Description),
                             new XElement("link", r.Link ?? r.MagnetUri),

--- a/src/Jackett/Models/ResultPage.cs
+++ b/src/Jackett/Models/ResultPage.cs
@@ -70,6 +70,8 @@ namespace Jackett.Models
                             r.Comments == null ? null : new XElement("comments", r.Comments.ToString()),
                             r.PublishDate == DateTime.MinValue ? null : new XElement("pubDate", xmlDateFormat(r.PublishDate)),
                             r.Size == null ? null : new XElement("size", r.Size),
+                            r.Files == null ? null : new XElement("fiels", r.Files),
+                            r.Grabs == null ? null : new XElement("grabs", r.Grabs),
                             new XElement("description", r.Description),
                             new XElement("link", r.Link ?? r.MagnetUri),
                             r.Category == 0 ? null : new XElement("category", r.Category),
@@ -87,7 +89,9 @@ namespace Jackett.Models
                             getTorznabElement("peers", r.Peers),
                             getTorznabElement("infohash", r.InfoHash),
                             getTorznabElement("minimumratio", r.MinimumRatio),
-                            getTorznabElement("minimumseedtime", r.MinimumSeedTime)
+                            getTorznabElement("minimumseedtime", r.MinimumSeedTime),
+							getTorznabElement("downloadvolumefactor", r.DownloadVolumeFactor),
+							getTorznabElement("uploadvolumefactor", r.UploadVolumeFactor)
                         )
                     )
                 )


### PR DESCRIPTION
files: Number of files
grabs: Number of times item downloaded
downloadvolumefactor: factor for the download volume, in most cases it should be set to 1, if a torrent is set to freeleech set it to 0, if only 50% is counted set it to 0.5
uploadvolumefactor: factor for the upload volume, in most cases it should be set to 1, if a torrent is set to neutral leech (upload is not counted) set it to 0, if it's set to double upload set it to 2