### PR TITLE
 	Change definition to Content

### DIFF
--- a/src/Jackett/Jackett.csproj
+++ b/src/Jackett/Jackett.csproj
@@ -370,9 +370,9 @@
     <None Include="CurlSharp.dll.config">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
-    <None Include="Definitions\hdme.yml">
+    <Content Include="Definitions\hdme.yml">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
-    </None>
+    </Content>
     <None Include="packages.config">
       <SubType>Designer</SubType>
     </None>


### PR DESCRIPTION
This might fix the System.IO.DirectoryNotFoundException: Directory '.../Definitions' not found issues.