### PR TITLE
AnimeTorrents: Skip releases which newbie user's can't download yet

### DIFF
--- a/src/Jackett/Indexers/AnimeTorrents.cs
+++ b/src/Jackett/Indexers/AnimeTorrents.cs
@@ -147,6 +147,10 @@ namespace Jackett.Indexers
                     {
                         release.Link = new Uri(qLink.Attr("href"));
                     }
+                    else
+                    {
+                        continue;
+                    }
 
                     var sizeStr = qRow.Find("td:eq(5)").Text();
                     release.Size = ReleaseInfo.GetBytes(sizeStr);


### PR DESCRIPTION
Fix #644