### PR TITLE
Torrent Sector Crew: Fix rows selector for people with "Empfohlene Torrents in der Liste anzeigen" disabled.

### DIFF
--- a/src/Jackett/Definitions/torrentsectorcrew.yml
+++ b/src/Jackett/Definitions/torrentsectorcrew.yml
@@ -118,7 +118,7 @@
       orderby: "added"
       sort: desc
     rows:
-      selector: "h2 +p + br + table.tablebrowse > tbody > tr[style=\"height: 45px;\"], tr:contains(\"Alle Torrents\") + tr > td > table.tablebrowse > tbody > tr[style=\"height: 45px;\"]"
+      selector: "h2 +p + br + table.tablebrowse > tbody > tr[style=\"height: 45px;\"], tr:contains(\"Weiter\") > td > table.tablebrowse > tbody > tr[style=\"height: 45px;\"]"
     fields:
       title:
         selector: a[title][href^="details.php"]


### PR DESCRIPTION
Fix #717