### PR TITLE
Fix TV search for MoreThanTV

### DIFF
--- a/src/Jackett/Indexers/MoreThanTV.cs
+++ b/src/Jackett/Indexers/MoreThanTV.cs
@@ -70,7 +70,7 @@ namespace Jackett.Indexers
 
         public async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {
-            var isTv = Array.IndexOf(query.Categories, TorznabCatType.TV.ID) > -1;
+            var isTv = TorznabCatType.QueryContainsParentCategory(query.Categories, TorznabCatType.TV.ID);
             var releases = new List<ReleaseInfo>();
             var searchQuery = query.GetQueryString();
 


### PR DESCRIPTION
The logic to check if the query is for TV is not working correctly because the query can contain sub categories.
This will fix it.