### PR TITLE
Update the BTN API url

### DIFF
--- a/src/Jackett/Indexers/BroadcastTheNet.cs
+++ b/src/Jackett/Indexers/BroadcastTheNet.cs
@@ -22,7 +22,7 @@ namespace Jackett.Indexers
 {
     public class BroadcastTheNet : BaseIndexer, IIndexer
     {
-        string APIBASE = "http://api.btnapps.net/";
+        string APIBASE = "https://api.broadcasthe.net";
 
         new ConfigurationDataAPIKey configData
         {


### PR DESCRIPTION
Fixes Jackett/Jackett#1096

In short, BTN's old API url is no longer working. The new url is https://api.broadcasthe.net