### PR TITLE
Limetorrents: remove season tag without episode from keywords

### DIFF
--- a/src/Jackett/Definitions/limetorrents.yml
+++ b/src/Jackett/Definitions/limetorrents.yml
@@ -27,7 +27,10 @@
     selector: a.csprite_dltorrent
 
   search:
-    path: "{{if .Query.Keywords}}search/all/{{ .Query.Keywords}}/{{else}}/index.php?page=latest100{{end}}"
+    path: "{{if .Keywords}}search/all/{{ .Keywords}}/{{else}}/index.php?page=latest100{{end}}"
+    keywordsfilters:
+      - name: re_replace
+        args: ["S[0-9]{2}([^E]|$)", ""] #remove season tag without episode
     rows:
       selector: ".table2 > tbody > tr[bgcolor]"
     fields:


### PR DESCRIPTION
Remove season tag without episode (search doesn't support it)