### PR TITLE
Fixed T411 TV Series episode category offset

### DIFF
--- a/src/Jackett/Indexers/T411.cs
+++ b/src/Jackett/Indexers/T411.cs
@@ -178,17 +178,15 @@ namespace Jackett.Indexers
                 if (query.Episode != null)
                 {
                     int episodeInt;
+                    int episodeCategoryOffset = 936;
                     ParseUtil.TryCoerceInt(query.Episode, out episodeInt);
-                    if (episodeInt >= 1 && episodeInt <= 30)
-                    {
-                        var episodeTermValue = 937 + episodeInt;
-                        searchUrl += "&term[46][]=" + episodeTermValue;
-                    }
-                    else if (episodeInt >= 31 && episodeInt <= 60)
-                    {
-                        var episodeTermValue = 1087 + episodeInt - 30;
-                        searchUrl += "&term[46][]=" + episodeTermValue;
-                    }
+                    if (episodeInt >= 1 && episodeInt <= 8)
+                        episodeCategoryOffset = 936;
+                    else if (episodeInt >= 9 && episodeInt <= 30)
+                        episodeCategoryOffset = 937;
+                    else if (episodeInt >= 31)
+                        episodeCategoryOffset = 1057;
+                    searchUrl += "&term[46][]=" + (episodeCategoryOffset + episodeInt);
                     queryStringOverride += " " + query.Episode;
                 }
             }


### PR DESCRIPTION
T411 weirdly changed their internal ID mapping to episode number.
Eg. Jackett would return S03E05 instead of S03E04.
I also cleaned the code.