### PR TITLE
Fix parsing for IceTorrent

### DIFF
--- a/src/Jackett/Definitions/icetorrent.yml
+++ b/src/Jackett/Definitions/icetorrent.yml
@@ -78,7 +78,7 @@
       incldead: 1
       search_by: "{{ if .Query.IMDBID }}imdb{{else}}name{{end}}"
     rows:
-      selector: .torrenttable table[class!="ice"] > tbody > tr:has(a[title][href^="details.php?id="])
+      selector: table[class!="ice"] > tbody > tr:has(a[title][href^="details.php?id="])
     fields:
       title:
         selector: a[title][href^="details.php?id="]


### PR DESCRIPTION
Correct the HTML parsing so rows are returned.  They probably changed the HTML of the page recently.