### PR TITLE
BitHDTV - Stop trying to keep up with changing width

### DIFF
--- a/src/Jackett/Indexers/BitHdtv.cs
+++ b/src/Jackett/Indexers/BitHdtv.cs
@@ -102,7 +102,7 @@ namespace Jackett.Indexers
             {
                 CQ dom = results.Content;
                 dom["#needseed"].Remove();
-                foreach (var table in dom["table[width='785'] > tbody"])
+                foreach (var table in dom["table[align=center] + br + table > tbody"])
                 {
                     var rows = table.Cq().Children();
                     foreach (var row in rows.Skip(1))


### PR DESCRIPTION
Width on the table element changed again (back to 750.)  This should stop us
from caring about the width and just find the right table.  Basically looks for
the table after the paging bar.