### PR TITLE
Update BJShare.cs

### DIFF
--- a/src/Jackett/Indexers/BJShare.cs
+++ b/src/Jackett/Indexers/BJShare.cs
@@ -280,6 +280,18 @@ namespace Jackett.Indexers
                             }
 
                             release.Description = release.Description.Replace(" / Free", ""); // Remove Free Tag
+                            
+                            release.Description = release.Description.Replace("Full HD", "1080p");
+                            release.Description = release.Description.Replace("/ HD / ", "/ 720p /");
+                            release.Description = release.Description.Replace("4K", "2160p");
+
+                            int nBarra = release.Title.IndexOf("[");
+                            if (nBarra != -1)
+                            {
+                                release.Title = release.Title.Substring(nBarra + 1); 
+                                release.Title = release.Title.Replace("]" , "");
+                            } 
+                            
                             release.Title += " " + release.Description; // add year and Description to the release Title to add some meaning to it
 
                             // check for previously stripped search terms


### PR DESCRIPTION
Improvements for indexer. 
With these fixes, now the indexer can parse the quality correctly , with the right name of serie/movie.
