### PR TITLE
Adding an aggregate torznab feed for all configured trackers

### DIFF
--- a/src/Jackett.Test/TestIIndexerManagerServiceHelper.cs
+++ b/src/Jackett.Test/TestIIndexerManagerServiceHelper.cs
@@ -52,5 +52,10 @@ namespace JackettTest
         {
             throw new NotImplementedException();
         }
+
+        public void InitAggregateIndexer()
+        {
+            throw new NotImplementedException();
+        }
     }
 }

--- a/src/Jackett/Indexers/AggregateIndexer.cs
+++ b/src/Jackett/Indexers/AggregateIndexer.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Jackett.Models;
+using Newtonsoft.Json.Linq;
+using Jackett.Services;
+using Jackett.Utils.Clients;
+using NLog;
+
+namespace Jackett.Indexers
+{
+    class AggregateIndexer : BaseIndexer, IIndexer
+    {
+        private IEnumerable<IIndexer> Indexers;
+        public AggregateIndexer(IIndexerManagerService i, IWebClient wc, Logger l, IProtectionService ps)
+            : base("AggregateSearch", "http://127.0.0.1/", "This feed includes all configured trackers", i, wc, l, new Models.IndexerConfig.ConfigurationData(), ps)
+        {
+        }
+
+        public void SetIndexers(IEnumerable<IIndexer> indexers)
+        {
+            Indexers = indexers;
+            base.IsConfigured = true;
+        }
+
+        public async Task<IndexerConfigurationStatus> ApplyConfiguration(JToken configJson)
+        {
+            return IndexerConfigurationStatus.Completed;
+        }
+
+        public async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
+        {
+            var tasks = new List<Task<IEnumerable<ReleaseInfo>>>();
+            foreach (var indexer in Indexers.Where(i => i.IsConfigured))
+                tasks.Add(indexer.PerformQuery(query));
+
+            var t = Task.WhenAll<IEnumerable<ReleaseInfo>>(tasks);
+            t.Wait();
+
+            IEnumerable<ReleaseInfo> result = t.Result.SelectMany(x => x).OrderByDescending(r => r.PublishDate);
+            // Limiting the response size might be interesting for use-cases where there are
+            // tons of trackers configured in Jackett. For now just use the limit param if
+            // someone wants to do that.
+            if (query.Limit > 0)
+                result = result.Take(query.Limit);
+            return result;
+        }
+    }
+}

--- a/src/Jackett/Jackett.csproj
+++ b/src/Jackett/Jackett.csproj
@@ -178,6 +178,7 @@
     <Compile Include="Controllers\TorznabController.cs" />
     <Compile Include="Controllers\DownloadController.cs" />
     <Compile Include="Engine.cs" />
+    <Compile Include="Indexers\AggregateIndexer.cs" />
     <Compile Include="Indexers\HDOnly.cs" />
     <Compile Include="Indexers\cgpeers.cs" />
     <Compile Include="Indexers\PiXELHD.cs" />

--- a/src/Jackett/Services/ServerService.cs
+++ b/src/Jackett/Services/ServerService.cs
@@ -287,6 +287,7 @@ namespace Jackett.Services
             {
                 indexerService.InitCardigannIndexers(dir);
             }
+            indexerService.InitAggregateIndexer();
             indexerService.SortIndexers();
             client.Init();
             updater.CleanupTempDir();


### PR DESCRIPTION
This adds just a basic first implementation of a special
torznab feed that will make all configured trackers available
with all the supported query params.
- This should close Jackett/Jackett#1247
- This also contributes to Jackett/Jackett#921