### PR TITLE
Fixing a bunch of issues with the newly added AggregateIndexer

### DIFF
--- a/src/Jackett/Indexers/BaseIndexer.cs
+++ b/src/Jackett/Indexers/BaseIndexer.cs
@@ -105,7 +105,7 @@ namespace Jackett.Indexers
             return releases;
         }
 
-        public Uri UncleanLink(Uri link)
+        public virtual Uri UncleanLink(Uri link)
         {
             if (string.IsNullOrWhiteSpace(downloadUrlBase))
             {

--- a/src/Jackett/Services/IndexerManagerService.cs
+++ b/src/Jackett/Services/IndexerManagerService.cs
@@ -132,7 +132,7 @@ namespace Jackett.Services
         {
             logger.Info("Adding aggregate indexer");
             AggregateIndexer aggregateIndexer = new AggregateIndexer(this, container.Resolve<IWebClient>(), logger, container.Resolve<IProtectionService>());
-            aggregateIndexer.SetIndexers(indexers.Values);
+            aggregateIndexer.SetIndexers(indexers.Where(p => p.Value.IsConfigured).Select(p => p.Value));
 
             this.aggregateIndexer = aggregateIndexer;
         }


### PR DESCRIPTION
This patch improves the general stability of the aggregate.
- Result is generated even if some trackers failed to answer
  or some other issue were encountered
- Fixes Jackett/Jackett#1316