### PR TITLE
Updated T411 domain references to the new domain used.

### DIFF
--- a/src/Jackett/Indexers/T411.cs
+++ b/src/Jackett/Indexers/T411.cs
@@ -17,7 +17,7 @@ namespace Jackett.Indexers
 {
     public class T411 : BaseIndexer, IIndexer
     {
-        const string ApiUrl = "https://api.t411.ai";
+        const string ApiUrl = "https://api.t411.al";
         const string AuthUrl = ApiUrl + "/auth";
         const string SearchUrl = ApiUrl + "/torrents/search/";
         const string TermsUrl = ApiUrl + "/terms/tree";
@@ -35,7 +35,7 @@ namespace Jackett.Indexers
         public T411(IIndexerManagerService i, Logger l, IWebClient wc, IProtectionService ps)
             : base(name: "T411",
                 description: "French Torrent Tracker",
-                link: "https://t411.ai/",
+                link: "https://t411.al/",
                 caps: TorznabUtil.CreateDefaultTorznabTVCaps(),
                 manager: i,
                 client: wc,


### PR DESCRIPTION
Updated T411 domain references to the new domain used.