### PR TITLE
Fixed sonarr not finding episode numbers with animebytes

### DIFF
--- a/src/Jackett/Indexers/AnimeBytes.cs
+++ b/src/Jackett/Indexers/AnimeBytes.cs
@@ -302,9 +302,9 @@ namespace Jackett.Indexers
                                 releaseInfo = releaseInfo.Replace("Season ", "S");
                                 releaseInfo = releaseInfo.Trim();
                                 int test = 0;
-                                if (InsertSeason && int.TryParse(releaseInfo, out test) && releaseInfo.Length==1)
+                                if (InsertSeason && int.TryParse(releaseInfo, out test) && releaseInfo.Length<=3)
                                 {
-                                    releaseInfo = "S01E0" + releaseInfo;
+                                    releaseInfo = "E0" + releaseInfo;
                                 }
 
                             }

--- a/src/Jackett/Models/IndexerConfig/Bespoke/ConfigurationDataAnimeBytes.cs
+++ b/src/Jackett/Models/IndexerConfig/Bespoke/ConfigurationDataAnimeBytes.cs
@@ -18,7 +18,7 @@ namespace Jackett.Models.IndexerConfig.Bespoke
         {
             IncludeRaw = new BoolItem() { Name = "IncludeRaw", Value = false };
             DateWarning = new DisplayItem("This tracker does not supply upload dates so they are based off year of release.") { Name = "DateWarning" };
-            InsertSeason = new BoolItem() { Name = "Prefix episode number with S01 for Sonarr Compatability", Value = false };
+            InsertSeason = new BoolItem() { Name = "Prefix episode number with E0 for Sonarr Compatability", Value = false };
         }
     }
 }


### PR DESCRIPTION
Sonarr gets confused if you add a S01 on anime seasons. Since animbytes includes the season name in the title, the episode number is enough for a full match.