### PR TITLE
Fix tokyotosho failing test and add type

### DIFF
--- a/src/Jackett/Definitions/tokyotosho.yml
+++ b/src/Jackett/Definitions/tokyotosho.yml
@@ -65,7 +65,7 @@
           - name: regexp
             args: "Date: (.+?) ?$"
           - name: dateparse
-            args: "2006-01-02 15:04 MST"
+            args: "2006-01-02 15:04 UTC"
       seeders:
         selector: td:nth-child(5) > span:nth-child(1)
       leechers:

--- a/src/Jackett/Definitions/tokyotosho.yml
+++ b/src/Jackett/Definitions/tokyotosho.yml
@@ -2,7 +2,8 @@
   site: tokyotosho
   name: Tokyo Toshokan
   description: "A BitTorrent Library for Japanese Media"
-  language: en-us
+  language: UTF-8
+  type: public
   links:
     - https://www.tokyotosho.info/
 
@@ -27,7 +28,7 @@
       tv-search: [q, season, ep]
 
   search:
-    path: "{{if .Query.Keywords }}search.php{{end}}"
+    path: "{{if .Query.Keywords }}search.php{{else}}index.php{{end}}"
     inputs:
       terms: "{{ .Query.Keywords }}"
     rows:

--- a/src/Jackett/Definitions/tokyotosho.yml
+++ b/src/Jackett/Definitions/tokyotosho.yml
@@ -2,7 +2,7 @@
   site: tokyotosho
   name: Tokyo Toshokan
   description: "A BitTorrent Library for Japanese Media"
-  language: UTF-8
+  language: en-us
   type: public
   links:
     - https://www.tokyotosho.info/

--- a/src/Jackett/Definitions/tokyotosho.yml
+++ b/src/Jackett/Definitions/tokyotosho.yml
@@ -4,6 +4,7 @@
   description: "A BitTorrent Library for Japanese Media"
   language: en-us
   type: public
+  encoding: UTF-8
   links:
     - https://www.tokyotosho.info/
 


### PR DESCRIPTION
- Fixed definition failing test, https://www.tokyotosho.info/ redirects to https://www.tokyotosho.info/index.php
- Changed language to UTF-8.
- Added "public" type