### PR TITLE
Switch anidex to use to torrent link vs magnet link

### DIFF
--- a/src/Jackett/Definitions/anidex.yml
+++ b/src/Jackett/Definitions/anidex.yml
@@ -36,7 +36,7 @@
         selector: td:nth-child(3) > a.torrent
         attribute: href
       download:
-        selector: td:nth-child(6) > a
+        selector: td:nth-child(5) > a
         attribute: href
       size:
         selector: td:nth-child(7)


### PR DESCRIPTION
@kaso17 FYI I found out today that anidex does not always have a magnet link corresponding to returned search results. As a result it is more reliable to use the torrent link instead of the magnet link that my definition currently uses. To do this one just needs to change the download selector from `td:nth-child(6) > a` to `td:nth-child(5) > a`.