### PR TITLE
[Horriblesubs] prepend horriblesubs tag to title for better filtering in sonarr

### DIFF
--- a/src/Jackett/Definitions/horriblesubs.yml
+++ b/src/Jackett/Definitions/horriblesubs.yml
@@ -13,7 +13,10 @@
       search: [q]
       tv-search: [q, season, ep]
   
-  settings: []
+  settings:
+    - name: prepend-horriblesubs
+      type: checkbox
+      label: Prepend [Horriblesubs] to torrent title
 
   search:
     path: "lib/{{if .Query.Keywords }}search.php{{else}}latest.php{{end}}"
@@ -40,7 +43,7 @@
         selector: table.release-table > tbody > tr > td.dl-label
         filters:
           - name: prepend
-            args: "[Horriblesubs] "
+            args: "{{if .Config.prepend-horriblesubs}}[Horriblesubs] {{else}}{{end}}"
       details:
         attribute: class
         filters:

--- a/src/Jackett/Definitions/horriblesubs.yml
+++ b/src/Jackett/Definitions/horriblesubs.yml
@@ -38,6 +38,9 @@
         text: "1"
       title:
         selector: table.release-table > tbody > tr > td.dl-label
+        filters:
+          - name: prepend
+            args: "[Horriblesubs] "
       details:
         attribute: class
         filters:


### PR DESCRIPTION
This will fix my personal use case in sonarr.
Instead of 
`Natsume Yuujinchou Roku -​ 05 [480p]`
 I need 
`[Horriblesubs] Natsume Yuujinchou Roku -​ 05 [480p]`

I like to keep my subtitles in sonarr consistent, so I made a tag filter in sonarr that requires horriblesubs to be in the torrent title for some series. This is also how the torrent title looks like when horriblesubs publishes to other trackers.