### PR TITLE
add tracker Deildu

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,7 @@ Developer note: The software implements the [Torznab](https://github.com/Sonarr/
  * CZTeam
  * DanishBits
  * DataScene
+ * Deildu
  * Demonoid
  * Diablo Torrent
  * DigitalHive

--- a/src/Jackett/Definitions/deildu.yml
+++ b/src/Jackett/Definitions/deildu.yml
@@ -1,0 +1,92 @@
+---
+  site: deildu
+  name: Deildu
+  language: is-is
+  type: semi-private
+  encoding: iso-8859-1
+  links:
+    - https://deildu.net/
+
+  caps:
+    categorymappings:
+      - {id: 11, cat: Audio, desc: "Music"}
+      - {id: 6, cat: Movies, desc: "Movies"}
+      - {id: 5, cat: Movies/DVD, desc: "Movies DVDR"}
+      - {id: 8, cat: TV, desc: "TV shows"}
+      - {id: 12, cat: Movies/HD, desc: "HD Movies"}
+      - {id: 12, cat: TV/HD, desc: "HD TV"}
+      - {id: 9, cat: TV/Documentary, desc: "TV - Documentaries"}
+      - {id: 9, cat: Movies/Other, desc: "Movie - Documentaries"}
+      - {id: 2, cat: TV/Sport, desc: "Sports"}
+      - {id: 7, cat: Movies/Other, desc: "Cartoons"}
+      - {id: 14, cat: PC, desc: "Windows"}
+      - {id: 3, cat: PC/Mac, desc: "Mac"}
+      - {id: 10, cat: PC/Games, desc: "Games"}
+      - {id: 4, cat: XXX, desc: "XXX"}
+      - {id: 1, cat: Other, desc: "Other"}
+
+    modes:
+      search: [q]
+      tv-search: [q, season, ep]
+
+  login:
+    path: takelogin.php
+    method: post
+    inputs:
+      username: "{{ .Config.username }}"
+      password: "{{ .Config.password }}"
+      keeplogged: 1
+
+  test:
+      path: my.php
+
+  search:
+    path: browse.php
+    inputs:
+      $raw: "{{range .Categories}}c{{.}}=1&{{end}}"
+      search: "{{ .Query.Keywords }}"
+      incldead: "1"
+    rows:
+      selector: table[class="torrentlist"] > tbody > tr:has(a[href*="details.php?id="])
+      filters:
+        - name: andmatch
+          args: 55
+    fields:
+      download:
+        selector: a[href^="download.php"]
+        attribute: href
+      title:
+        selector: td:nth-child(2)
+#      category:
+#        selector: a[href^="browse.php?cat="]
+#        attribute: href
+#        filters:
+#          - name: querystring
+#            args: cat
+      details:
+        selector: a[href^="details.php?id="]
+        attribute: href
+      size:
+        selector: td:nth-child(7)
+      files:
+        selector: td:nth-child(4)
+      grabs:
+        selector: td:nth-child(8)
+        filters:
+          - name: regexp
+            args: ([\d,]+)
+      seeders:
+        selector: td:nth-child(9)
+      leechers:
+        selector: td:nth-child(10)
+      date:
+        selector: td:nth-child(6)
+        filters:
+          - name: dateparse
+            args: "2006-01-0215:04:05"
+      downloadvolumefactor:
+        case:
+          "*": "1"
+      uploadvolumefactor:
+        case:
+          "*": "1"


### PR DESCRIPTION
I had a few problems with category. Because of poor categorizing on the tracker I had to disable Jackett from reading the categories. All HD content on the tracker is in one category so category mapping had issues with using the same id.
It still searches with categories though and everything else works.