### PR TITLE
Add KAT passkey login

### DIFF
--- a/src/Jackett/Definitions/kickasstorrent.yml
+++ b/src/Jackett/Definitions/kickasstorrent.yml
@@ -85,7 +85,22 @@
       search: [q]
       tv-search: [q, season, ep]
 
-  settings: []
+  settings:
+    - name: username
+      type: text
+      label: Username
+    - name: passkey
+      type: text
+      label: Passkey
+
+  login:
+    method: post
+    path: "new/account-login.php"
+    inputs:
+      username: "{{ .Config.username }}"
+      passkey: "{{ .Config.passkey }}"
+    test:
+      path: index.php
 
   search:
     path: "/new/torrents-search.php"


### PR DESCRIPTION
Hi! This is referring to issue #1379 and should fix it (at least it does for me)! What it does is add username and passkey (input by the user) and uses them to log in through a simple POST request. I haven't tested it much (and I'm not sure the `test` part does anything) but I've been able to successfully search, effectively circumventing the CAPTCHAs (yay!).
Should KAT be changed to "semi-private" or not? Because technically it's a public tracker, but for Jackett's purposes, it seems it can't be used without an account.

Cheers and good night,

Joe