### PR TITLE
Nyaa.si: Fix date field so it correctly parses as UTC time.

### DIFF
--- a/src/Jackett/Definitions/nyaasi.yml
+++ b/src/Jackett/Definitions/nyaasi.yml
@@ -62,8 +62,10 @@
       date:
         selector: td:nth-child(5)
         filters:
+          - name: append
+            args: " -00"
           - name: dateparse
-            args: "2006-01-02 15:04 UTC"
+            args: "2006-01-02 15:04 -07"
       seeders:
         selector: td:nth-child(6)
       leechers:


### PR DESCRIPTION
The previous parsing logic was failing due to the `UTC` in the supplied format which wasn't present in the string.