### PR TITLE
HorribleSubs: Fix date parsing for RSS feed.

### DIFF
--- a/src/Jackett/Definitions/horriblesubs.yml
+++ b/src/Jackett/Definitions/horriblesubs.yml
@@ -39,6 +39,8 @@
             args: ["/", "-"]
           - name: dateparse 
             args: "01-02-06"
+          - name: dateparse 
+            args: "01-02"
     fields:
       category:
         text: "1"


### PR DESCRIPTION
Update indexer definition to support dates in the format of `mm/dd` as well as `mm/dd/yy` since [`/lib/search.php`](http://horriblesubs.info/lib/search.php?value=naruto) returns `mm/dd/yy` while [`/latest/php`](http://horriblesubs.info/lib/latest.php) only returns `mm/dd`.

Fixes #1402.