### PR TITLE
Fix #1383 nyaa-pantsu date selector incorrect

### DIFF
--- a/src/Jackett/Definitions/nyaa-pantsu.yml
+++ b/src/Jackett/Definitions/nyaa-pantsu.yml
@@ -72,7 +72,7 @@
         selector: td:nth-child(5)
         optional: true
       date:
-        selector: td.date
+        selector: td.date-short
         filters:
           - name: dateparse
             args: "2006-01-02T15:04:05Z"


### PR DESCRIPTION
Looking at the html of nyaa-pantsu search page, the date field is using a class of .date-short not .date.

this corrects the above.