### PR TITLE
Add advanced search to Anidex indexer

### DIFF
--- a/src/Jackett/Definitions/anidex.yml
+++ b/src/Jackett/Definitions/anidex.yml
@@ -16,7 +16,10 @@
       tv-search: [q, season, ep]
 
   settings:
-    - name: language-id
+    - name: cat-id
+      type: text
+      label: Category Id
+    - name: lang-id
       type: text
       label: Language Id
       
@@ -27,8 +30,8 @@
     inputs:
       page: "torrents"
       filename: "{{ .Query.Keywords }}"
-      category: "0"
-      lang_id: "{{ .Config.language-id }}"
+      category: "{{ .Config.cat-id }}"
+      lang_id: "{{ .Config.lang-id }}"
     rows:
       selector: div.table-responsive > table > tbody > tr
     fields:

--- a/src/Jackett/Definitions/anidex.yml
+++ b/src/Jackett/Definitions/anidex.yml
@@ -15,7 +15,10 @@
       search: [q]
       tv-search: [q, season, ep]
 
-  settings: []
+  settings:
+    - name: language-id
+      type: text
+      label: Language Id
       
   search:
     path: "ajax/page.ajax.php"
@@ -25,6 +28,7 @@
       page: "torrents"
       filename: "{{ .Query.Keywords }}"
       category: "0"
+      lang_id: "{{ .Config.language-id }}"
     rows:
       selector: div.table-responsive > table > tbody > tr
     fields:


### PR DESCRIPTION
Adds support for advanced search on Anidex. If you leave both settings empty it will behave like it did before.

If you want to find a category or language id, go to https://anidex.info/?id=1&adv=1&lang_id=1&q= and create the filter you want to use and press search. In the url, `id` is the category id and `lang_id` is the language id.