### PR TITLE
Add advanced search to Nyaa.si indexer.

### DIFF
--- a/src/Jackett/Definitions/nyaasi.yml
+++ b/src/Jackett/Definitions/nyaasi.yml
@@ -7,7 +7,13 @@
   links:
     - https://nyaa.si
     
-  settings: []
+  settings:
+    - name: filter-id
+      type: text
+      label: Filter Id
+    - name: cat-id
+      type: text
+      label: Category Id
 
   caps:
     categorymappings:
@@ -35,11 +41,12 @@
       search: [q]
       tv-search: [q]
 
-
   search:
     path: /
     inputs:
-      q: "{{ .Query.Keywords}}"
+      q: "{{ .Query.Keywords }}"
+      f: "{{ .Config.filter-id }}"
+      c: "{{ .Config.cat-id }}"
     rows:
       selector: tr.default,tr.danger,tr.success
     fields:


### PR DESCRIPTION
Adds support for advanced search on nyaa.si. If you leave both settings empty it will behave like it did before.

If you want to find a specific id, go to https://nyaa.si/ and create the filter you want to use and press search. In the url, `f` is the filter id and `c` is the category id.