### PR TITLE
Add advanced search to TokyoTosho indexer.

### DIFF
--- a/src/Jackett/Definitions/tokyotosho.yml
+++ b/src/Jackett/Definitions/tokyotosho.yml
@@ -38,6 +38,7 @@
     inputs:
       terms: "{{ .Query.Keywords }}"
       type: "{{ .Config.type-id }}"
+      cat: "{{ .Config.type-id }}"
     rows:
       selector: "table.listing tr.category_0"
       after: 1

--- a/src/Jackett/Definitions/tokyotosho.yml
+++ b/src/Jackett/Definitions/tokyotosho.yml
@@ -8,6 +8,11 @@
   links:
     - https://www.tokyotosho.info/
 
+  settings:
+    - name: type-id
+      type: text
+      label: Type Id
+
   caps:
     categories:
       1:  TV/Anime # Anime
@@ -32,6 +37,7 @@
     path: "{{if .Query.Keywords }}search.php{{else}}index.php{{end}}"
     inputs:
       terms: "{{ .Query.Keywords }}"
+      type: "{{ .Config.type-id }}"
     rows:
       selector: "table.listing tr.category_0"
       after: 1


### PR DESCRIPTION
Adds support for advanced search on tokyotosho. If you leave both settings empty it will behave like it did before.

If you want to find a specific id, go to https://www.tokyotosho.info/ and create the filter you want to use and press search. In the url, `type` is the type id.