### PR TITLE
[Fix] Redirection errors

### DIFF
--- a/src/Jackett/Definitions/thegeeks.yml
+++ b/src/Jackett/Definitions/thegeeks.yml
@@ -6,7 +6,7 @@
   type: private
   encoding: UTF-8
   links:
-    - http://thegeeks.click/
+    - https://thegeeks.click/
 
   caps:
     categorymappings:


### PR DESCRIPTION
- The Geeks uses SSL

Currently, if a user tries to add thegeeks.click, he will face a redirection error.