### PR TITLE
Update the SearchUrl

### DIFF
--- a/src/Jackett/Indexers/DanishBits.cs
+++ b/src/Jackett/Indexers/DanishBits.cs
@@ -21,7 +21,7 @@ namespace Jackett.Indexers
     public class DanishBits : BaseIndexer, IIndexer
     {
         private string LoginUrl { get { return SiteLink + "login.php"; } }
-        private string SearchUrl { get { return SiteLink + "torrents.php"; } }
+        private string SearchUrl { get { return SiteLink + "couchpotato.php"; } }
 
         new NxtGnConfigurationData configData
         {


### PR DESCRIPTION
Rules have changed on the site.
I have not tested this, but the other searchurl bans your profile.