### PR TITLE
Torrent9: Domain change .top -> .cc

### DIFF
--- a/src/Jackett/Definitions/torrent9.yml
+++ b/src/Jackett/Definitions/torrent9.yml
@@ -5,7 +5,7 @@
   type: public
   encoding: UTF-8
   links:
-    - http://www.torrent9.top/
+    - http://www.torrent9.cc/
 
   caps:
     categorymappings:


### PR DESCRIPTION
The site has changed domain name.