### PR TITLE
Replace T411 (closed) with YggTorrent (new replacement)

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Developer note: The software implements the [Torznab](https://github.com/Sonarr/
  * Tokyo Toshokan
  * TorrentProject
  * Torrentz2
- 
+
 ### Supported Private Trackers
  * 2 Fast 4 You
  * 3D Torrents
@@ -142,7 +142,7 @@ Developer note: The software implements the [Torznab](https://github.com/Sonarr/
  * LosslessClub
  * M-Team - TP
  * Magico
- * Majomparádé 
+ * Majomparádé
  * Mononoké-BT
  * MoreThanTV
  * MyAnonamouse
@@ -200,7 +200,6 @@ Developer note: The software implements the [Torznab](https://github.com/Sonarr/
  * TenYardTracker
  * Torrent Network
  * Torrent Sector Crew
- * Torrent411
  * Torrent9
  * TorrentBD
  * TorrentBytes
@@ -227,13 +226,14 @@ Developer note: The software implements the [Torznab](https://github.com/Sonarr/
  * x264
  * XSpeeds
  * Xthor
- * Xtreme Zone 
+ * Xtreme Zone
+ * YggTorrent
  * Zamunda.net
  * Zelka.org
  * Ztracker
 
 Trackers marked with  [![(invite needed)][inviteneeded]](#) have no active maintainer and are missing features or are broken. If you have an invite for them please send it to kaso1717 -at- gmail.com to get them fixed/improved.
- 
+
 ## Installation on Windows
 
 We recommend you install Jackett as a Windows service using the supplied installer. You may also download the zipped version if you would like to configure everything manually.
@@ -249,7 +249,7 @@ To get started with using the installer for Jackett, follow the steps below:
 
 When installed as a service the tray icon acts as a way to open/start/stop Jackett. If you opted to not install it as a service then Jackett will run its web server from the tray tool.
 
-Jackett can also be run from the command line if you would like to see log messages (Ensure the server isn't already running from the tray/service). This can be done by using "JackettConsole.exe" (for Command Prompt), found in the Jackett data folder: "%ProgramData%\Jackett". 
+Jackett can also be run from the command line if you would like to see log messages (Ensure the server isn't already running from the tray/service). This can be done by using "JackettConsole.exe" (for Command Prompt), found in the Jackett data folder: "%ProgramData%\Jackett".
 
 ## Installation on Linux
  1. Install [Mono 4](http://www.mono-project.com/download/#download-lin) or better (version 4.8 is recommended)

--- a/src/Jackett/Definitions/yggtorrent.yml
+++ b/src/Jackett/Definitions/yggtorrent.yml
@@ -1,0 +1,105 @@
+﻿---
+  site: yggtorrent
+  name: YGGtorrent
+  language: fr-fr
+  type: private
+  encoding: UTF-8
+  links:
+    - http://yggtorrent.com
+
+  caps:
+    categorymappings:
+      - {id: films, cat: Movies, desc: "Movies"}
+      #- {id: series, cat: TV, desc: "TV"}
+
+    modes:
+      search: [q]
+      #tv-search: [q, season, ep]
+
+  login:
+    path: /alpha/user/login
+    method: post
+    inputs:
+      id: "{{ .Config.username }}"
+      pass: "{{ .Config.password }}"
+      submit: ""
+    error:
+      - selector: "body > div.page-content > div > div.col-md-10 > div > div > div > div > div.content-box-large.box-with-header > form > center > table > tbody > tr:nth-child(3) > td:nth-child(2) > button.text:contains('Se connecter')"
+    test:
+      path: "/alpha/"
+
+  search:
+    path: "/alpha/engine/search?q={{ .Query.Keywords }}"
+    rows:
+      selector: "table.table.table-striped > tbody > tr"
+    fields:
+      site_date:
+        selector: "td:nth-child(2)"
+        filters:
+          - name: replace
+            args: ["il y a ", ""]
+          - name: replace
+            args: [ " jours", " days"]
+          - name: replace
+            args: [ " jour", " day"]
+          - name: replace
+            args: [ " heures", " hours"]
+          - name: replace
+            args: [ " heure", " hour"]
+          - name: replace
+            args: [ " semaines", " weeks"]
+          - name: replace
+            args: [ " semaine", " week"]
+          - name: replace
+            args: [ " mois", " month"]
+          - name: replace
+            args: [ " ans", " years"]
+          - name: replace
+            args: [ " an", " year"]
+          - name: append
+            args: " ago"
+      title:
+        selector: "a.torrent-name"
+      details:
+        selector: "a.torrent-name"
+        attribute: href
+      download:
+        selector: "td:nth-child(1) > a:not(.torrent-name)"
+        attribute: href
+      size:
+        selector: "td:nth-child(3)"
+        filters:
+          - name: re_replace
+            args: [ "\\.(\\d) KB", "$1X00"]
+          - name: re_replace
+            args: [ " KB", "000"]
+          - name: re_replace
+            args: [ "\\.(\\d) MB", "$1X00000"]
+          - name: re_replace
+            args: [ " MB", "000000"]
+          - name: re_replace
+            args: [ "\\.(\\d) GB", "$1X00000000"]
+          - name: re_replace
+            args: [ " GB", "000000000"]
+          - name: re_replace
+            args: [ "\\.(\\d) TB", "$1X00000000000"]
+          - name: re_replace
+            args: [ " TB", "000000000000"]
+          - name: replace
+            args: [ "X", "" ]
+      seeders:
+        text: 0
+      seeders:
+        selector: "td[style^='color:#058c05;']"
+        optional: true
+      leechers:
+        text: 0
+      leechers:
+        selector: "td[style^='color:#ff5252;']"
+        optional: true
+      date:
+        text: "{{ .Result.site_date }}"
+      downloadvolumefactor:
+        text: "1"
+      uploadvolumefactor:
+        text: "0.75"

--- a/src/Jackett/Definitions/yggtorrent.yml
+++ b/src/Jackett/Definitions/yggtorrent.yml
@@ -15,9 +15,23 @@
     modes:
       search: [q]
       #tv-search: [q, season, ep]
-
+  settings:
+    - name: username
+      type: text
+      label: Username (email or username)
+    - name: password
+      type: password
+      label: Password
+    - name: special_path
+      type: checkbox
+      label: Use an alternative path
+      default: true
+    - name: path
+      type: text
+      label: Alternative path (as seen in url)
+      default: "alpha"
   login:
-    path: /alpha/user/login
+    path: "{{if .Config.special_path }}/{{ .Config.path }}{{else}}{{end}}/user/login"
     method: post
     inputs:
       id: "{{ .Config.username }}"
@@ -26,10 +40,9 @@
     error:
       - selector: "body > div.page-content > div > div.col-md-10 > div > div > div > div > div.content-box-large.box-with-header > form > center > table > tbody > tr:nth-child(3) > td:nth-child(2) > button.text:contains('Se connecter')"
     test:
-      path: "/alpha/"
-
+      path: "{{if .Config.special_path }}/{{ .Config.path }}{{else}}{{end}}/"
   search:
-    path: "/alpha/engine/search?q={{ .Query.Keywords }}"
+    path: "{{if .Config.special_path }}/{{ .Config.path }}{{else}}{{end}}{{if .Keywords}}/engine/search?q={{ .Keywords}}/{{else}}/torrents/2145-filmvideo{{end}}"
     rows:
       selector: "table.table.table-striped > tbody > tr"
     fields:
@@ -102,4 +115,4 @@
       downloadvolumefactor:
         text: "1"
       uploadvolumefactor:
-        text: "0.75"
+        text: "1"


### PR DESCRIPTION
Hi,

I've seen @ploufs PR on the same subject.
Think this version is more functional :

- Using /alpha/ instead of /dev/
- Working login system. As Ygg is now private
- Working date translation/compatibility
- Disabled TV-show search (I'll reactivate it soon, when YggTorrent will introduce filters in search options)

Thank you