### PR TITLE
Update BJShare.cs

### DIFF
--- a/src/Jackett/Indexers/BJShare.cs
+++ b/src/Jackett/Indexers/BJShare.cs
@@ -282,7 +282,7 @@ namespace Jackett.Indexers
                             release.Description = release.Description.Replace(" / Free", ""); // Remove Free Tag
                             
                             release.Description = release.Description.Replace("Full HD", "1080p");
-                            release.Description = release.Description.Replace("/ HD / ", "/ 720p /");
+                            release.Description = release.Description.Replace("HD", "720p");
                             release.Description = release.Description.Replace("4K", "2160p");
 
                             int nBarra = release.Title.IndexOf("[");


### PR DESCRIPTION
Updated so it properly replaces "HD" to "720p" since this is the tracker's default naming pattern for every 720p release.