### PR TITLE
Update KAT definition for real login test, error handling and indexer testing logic

### DIFF
--- a/src/Jackett/Definitions/kickasstorrent.yml
+++ b/src/Jackett/Definitions/kickasstorrent.yml
@@ -106,7 +106,7 @@
       selector: a[href="account-logout.php"]
 
   search:
-    path: "/new/torrents-search.php"
+    path: "/new/{{if .Query.Keywords}}torrents-search.php{{else}}torrents.php{{end}}"
     inputs:
       $raw: "{{range .Categories}}c{{.}}=1&{{end}}"
       search: "\"{{ .Query.Keywords }}\""

--- a/src/Jackett/Definitions/kickasstorrent.yml
+++ b/src/Jackett/Definitions/kickasstorrent.yml
@@ -99,6 +99,8 @@
     inputs:
       username: "{{ .Config.username }}"
       passkey: "{{ .Config.passkey }}"
+    error:
+      - selector: div#main:has(font.error:contains("Access Denied"))
     test:
       path: "/new/index.php"
       selector: a[href="account-logout.php"]

--- a/src/Jackett/Definitions/kickasstorrent.yml
+++ b/src/Jackett/Definitions/kickasstorrent.yml
@@ -100,7 +100,7 @@
       username: "{{ .Config.username }}"
       passkey: "{{ .Config.passkey }}"
     error:
-      - selector: div#main:has(font.error:contains("Access Denied"))
+      - selector: font.error:contains("Access Denied")
     test:
       path: "/new/index.php"
       selector: a[href="account-logout.php"]

--- a/src/Jackett/Definitions/kickasstorrent.yml
+++ b/src/Jackett/Definitions/kickasstorrent.yml
@@ -95,12 +95,13 @@
 
   login:
     method: post
-    path: "new/account-login.php"
+    path: "/new/account-login.php"
     inputs:
       username: "{{ .Config.username }}"
       passkey: "{{ .Config.passkey }}"
     test:
-      path: index.php
+      path: "/new/index.php"
+      selector: a[href="account-logout.php"]
 
   search:
     path: "/new/torrents-search.php"


### PR DESCRIPTION
I had issues with KAT requesting a relogin and I thought it was time I made a real login test (the one I wrote was a scam) and added error handling. Succeeds with correct credentials, gracefully fails otherwise.
On a sidenote : testing KAT as a provider currently fails because searching with an empty string returns no results (hence Jackett sees it as a failure). This should be addressed but as long as the user is logged in, searching works.

EDIT: As you can see, the sidenote has been addressed by me!