### PR TITLE
Added yts.ag as an indexer.

### DIFF
--- a/src/Jackett/Indexers/yts.cs
+++ b/src/Jackett/Indexers/yts.cs
@@ -1,0 +1,220 @@
+﻿using Jackett.Models;
+using Jackett.Models.IndexerConfig;
+using Jackett.Services;
+using Jackett.Utils;
+using Jackett.Utils.Clients;
+using Newtonsoft.Json.Linq;
+using NLog;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Globalization;
+using System.Linq;
+using System.Threading.Tasks;
+using System.Text;
+using System.Web;
+
+namespace Jackett.Indexers
+{
+    public class Yts : BaseWebIndexer
+    {
+        readonly static string defaultSiteLink = "https://yts.ag/";
+
+        private Uri BaseUri
+        {
+            get { return new Uri(configData.Url.Value); }
+            set { configData.Url.Value = value.ToString(); }
+        }
+
+        private string ApiEndpoint { get { return BaseUri + "api/v2/list_movies.json"; } }
+
+        new ConfigurationDataUrl configData
+        {
+            get { return (ConfigurationDataUrl)base.configData; }
+            set { base.configData = value; }
+        }
+
+        public Yts(IIndexerConfigurationService configService, IWebClient wc, Logger l, IProtectionService ps)
+            : base(name: "YTS",
+                description: null,
+                link: "https://yts.ag/",
+                caps: new TorznabCapabilities(),
+                configService: configService,
+                client: wc,
+                logger: l,
+                p: ps,
+                configData: new ConfigurationDataUrl(defaultSiteLink))
+        {
+            Encoding = Encoding.GetEncoding("windows-1252");
+            Language = "en-us";
+            Type = "public";
+
+            TorznabCaps.SupportsImdbSearch = true;
+
+            webclient.requestDelay = 2.5; // 0.5 requests per second (2 causes problems)
+
+            AddCategoryMapping(45, TorznabCatType.MoviesHD, "Movies/x264/720");
+            AddCategoryMapping(44, TorznabCatType.MoviesHD, "Movies/x264/1080");
+            AddCategoryMapping(47, TorznabCatType.Movies3D, "Movies/x264/3D");
+        }
+
+        public override async Task<IndexerConfigurationStatus> ApplyConfiguration(JToken configJson)
+        {
+            configData.LoadValuesFromJson(configJson);
+            var releases = await PerformQuery(new TorznabQuery());
+
+            await ConfigureIfOK(string.Empty, releases.Count() > 0, () =>
+            {
+                throw new Exception("Could not find releases from this URL");
+            });
+
+            return IndexerConfigurationStatus.Completed;
+        }
+
+        protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
+        {
+            return await PerformQuery(query, 0);
+        }
+
+        public async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query, int attempts)
+        {
+            var releases = new List<ReleaseInfo>();
+            var searchString = query.GetQueryString();
+            
+            var queryCollection = new NameValueCollection();
+
+            if (query.ImdbID != null)
+            {
+                queryCollection.Add("query_term", query.ImdbID);
+            }
+            else if (!string.IsNullOrWhiteSpace(searchString))
+            {
+                searchString = searchString.Replace("'", ""); // ignore ' (e.g. search for america's Next Top Model)
+                queryCollection.Add("query_term", searchString);
+            }
+
+            // This API does not seem to be working for quality=720p or quality=1080p
+            // Only quality=3D seems to return a proper result?
+            //var cats = string.Join(";", MapTorznabCapsToTrackers(query));
+            //if (!string.IsNullOrEmpty(cats))
+            //{
+            //    if (cats == "45")
+            //    {
+            //        queryCollection.Add("quality", "720p");
+            //    }
+            //    if (cats == "44")
+            //    {
+            //        queryCollection.Add("quality", "1080p");
+            //    }
+            //    if (cats == "2050")
+            //    {
+            //        queryCollection.Add("quality", "3D");
+            //    }
+            //}
+
+            var searchUrl = ApiEndpoint + "?" + queryCollection.GetQueryString();
+            var response = await RequestStringWithCookiesAndRetry(searchUrl, string.Empty);
+
+            try
+            {
+                var jsonContent = JObject.Parse(response.Content);
+
+                string result = jsonContent.Value<string>("status");
+                if (result != "ok") // query was not successful
+                {
+                    return releases.ToArray();
+                }
+
+                var data_items = jsonContent.Value<JToken>("data");
+                int movie_count = data_items.Value<int>("movie_count");
+                if (movie_count < 1) // no results found in query
+                {
+                    return releases.ToArray();
+                }
+
+                foreach (var movie_item in data_items.Value<JToken>("movies"))
+                {
+                    foreach (var torrent_info in movie_item.Value<JArray>("torrents"))
+                    {
+                        var release = new ReleaseInfo();
+
+                        // Append the quality to the title because thats how radarr seems to be determining the quality?
+                        release.Title = movie_item.Value<string>("title_long") + " " + torrent_info.Value<string>("quality");
+                        var imdb = movie_item.Value<string>("imdb_code");
+                        release.Imdb = ParseUtil.GetImdbID(imdb);
+
+                        // API does not provide magnet link, so, construct it
+                        string magnet_uri = "magnet:?xt=urn:btih:" + torrent_info.Value<string>("hash") +
+                        "&dn=" + movie_item.Value<string>("slug") +
+                        "&tr=udp://open.demonii.com:1337/announce" +
+                        "&tr=udp://tracker.openbittorrent.com:80" +
+                        "&tr=udp://tracker.coppersurfer.tk:6969" +
+                        "&tr=udp://glotorrents.pw:6969/announce" +
+                        "&tr=udp://tracker.opentrackr.org:1337/announce" +
+                        "&tr=udp://torrent.gresille.org:80/announce" +
+                        "&tr=udp://p4p.arenabg.com:1337&tr=udp://tracker.leechers-paradise.org:6969";
+
+                        release.MagnetUri = new Uri(magnet_uri);
+                        release.InfoHash = torrent_info.Value<string>("hash");
+
+                        // ex: 2015-08-16 21:25:08 +0000
+                        var dateStr = torrent_info.Value<string>("date_uploaded");
+                        var dateTime = DateTime.ParseExact(dateStr, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+                        release.PublishDate = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc).ToLocalTime();
+                        release.Link = new Uri(torrent_info.Value<string>("url"));
+                        release.Seeders = torrent_info.Value<int>("seeds");
+                        release.Peers = torrent_info.Value<int>("peers") + release.Seeders;
+                        release.Size = torrent_info.Value<long>("size_bytes");
+                        release.DownloadVolumeFactor = 0;
+                        release.UploadVolumeFactor = 1;
+
+                        release.Comments = release.Link;
+                        release.Guid = release.Comments;
+
+                        // Hack to prevent adding non-specified catogery, since API doesn't seem to be working
+                        string categories = string.Join(";", MapTorznabCapsToTrackers(query));
+
+                        if (!string.IsNullOrEmpty(categories))
+                        {
+                            if (categories.Contains("45") || categories.Contains("2040"))
+                            {
+                                if (torrent_info.Value<string>("quality") == "720p")
+                                {
+                                    release.Category = MapTrackerCatToNewznab("45");
+                                    releases.Add(release);
+                                }
+                            }
+                            if (categories.Contains("44") || categories.Contains("2040"))
+                            {
+                                if (torrent_info.Value<string>("quality") == "1080p")
+                                {
+                                    release.Category = MapTrackerCatToNewznab("44");
+                                    releases.Add(release);
+                                }
+                            }
+                            if (categories.Contains("47"))
+                            {
+                                if (torrent_info.Value<string>("quality") == "3D")
+                                {
+                                    release.Category = MapTrackerCatToNewznab("47");
+                                    releases.Add(release);
+                                }
+                            }
+                        }
+                        else
+                        {
+                            release.Category = MapTrackerCatToNewznab("45");
+                            releases.Add(release);
+                        }
+                    }
+                }
+            }
+            catch (Exception ex)
+            {
+                OnParseError(response.Content, ex);
+            }
+
+            return releases;
+        }
+    }
+}

--- a/src/Jackett/Jackett.csproj
+++ b/src/Jackett/Jackett.csproj
@@ -183,6 +183,7 @@
     <Compile Include="Indexers\cgpeers.cs" />
     <Compile Include="Indexers\PiXELHD.cs" />
     <Compile Include="Indexers\Hardbay.cs" />
+    <Compile Include="Indexers\yts.cs" />
     <Compile Include="Indexers\Rarbg.cs" />
     <Compile Include="Indexers\Psytorrents.cs" />
     <Compile Include="Indexers\BrokenStones.cs" />


### PR DESCRIPTION
Hi!

I installed Radarr and noticed there was no yts.ag! Since that's the only place I want movies from, I added it. Seems to be working great for me (search and RSS feed) - let me know if there is anything else I should do with this.

Note: I had to hack around a few things because the YTS api didn't seem to cooperate (comments left in the code).

![jackett settings](https://user-images.githubusercontent.com/1916171/28446105-8bf6248a-6d96-11e7-80d5-2173c132ca3b.PNG)
![radarr add](https://user-images.githubusercontent.com/1916171/28446107-8bf6969a-6d96-11e7-9ec0-769242052aee.PNG)
![radarr search](https://user-images.githubusercontent.com/1916171/28446106-8bf65acc-6d96-11e7-8805-e9e078da7127.PNG)
![search 1080p](https://user-images.githubusercontent.com/1916171/28446103-8bf42b9e-6d96-11e7-8c91-c31e8300f54e.PNG)
![search all](https://user-images.githubusercontent.com/1916171/28446104-8bf576a2-6d96-11e7-99d1-ee1aa5317ae5.PNG)
![search list](https://user-images.githubusercontent.com/1916171/28446108-8bfa3aca-6d96-11e7-98a3-3693a316d2eb.PNG)





