### PR TITLE
Allow imdb query parameter even for provider without imdb search caps

### DIFF
--- a/src/Jackett/Indexers/BaseIndexer.cs
+++ b/src/Jackett/Indexers/BaseIndexer.cs
@@ -198,8 +198,6 @@ namespace Jackett.Indexers
                 return false;
             if (!caps.SupportsTVRageSearch && query.IsTVRageSearch)
                 return false;
-            if (!caps.SupportsImdbSearch && query.IsImdbQuery)
-                return false;
 
             if (query.HasSpecifiedCategories)
                 if (!caps.SupportsCategories(query.Categories))


### PR DESCRIPTION
Since a lot of providers does not have iMDB capabilities, this should be acceptable. There is an iMDB filtering implemented afterward, so this should not cause any regression (i think).