### PR TITLE
Make T411v2 public

### DIFF
--- a/src/Jackett/Definitions/t411v2.yml
+++ b/src/Jackett/Definitions/t411v2.yml
@@ -2,7 +2,7 @@
   site: t411v2
   name: t411 v2
   language: fr-fr
-  type: semi-private
+  type: public
   encoding: UTF-8
   links:
     - https://t411.si


### PR DESCRIPTION
I'm 99% sure that since they've resurrected they're fully public (no login needed, no ratio, etc.) and since even Jackett isn't asking for login info, it should be reflected here.