### PR TITLE
SceneAccess is now permanently free-leech

### DIFF
--- a/src/Jackett/Indexers/SceneAccess.cs
+++ b/src/Jackett/Indexers/SceneAccess.cs
@@ -157,7 +157,7 @@ namespace Jackett.Indexers
                     var grabs = qRow.Find("td.ttr_snatched").Get(0).FirstChild.ToString();
                     release.Grabs = ParseUtil.CoerceInt(grabs);
 
-                    release.DownloadVolumeFactor = 1;
+                    release.DownloadVolumeFactor = 0;
                     release.UploadVolumeFactor = 1;
 
                     releases.Add(release);


### PR DESCRIPTION
SceneAccess is now "free-leech for life", and has been for about a month or so. Can't say I'm familiar with Jackett's codebase, but I looked around a bit and this seems to be the way releases are usually flagged as freeleech (or in this case all releases).

Snippets from recent SceneAccess announcements:

>2) Site is now permanently free-leech. Keep earning those coins as they will become very useful in the future. 

>The site is FREELEECH, this means ALL SECTIONS, ALL RELEASES and NO ratio requirements, the only thing you have to remember is to seed the files!