### PR TITLE
[UI] Changing the locks

### DIFF
--- a/src/Jackett/Content/custom.js
+++ b/src/Jackett/Content/custom.js
@@ -109,7 +109,7 @@ function reloadIndexers() {
                 item.state = "error";
             else
                 item.state = "success";
-                       
+
             if (item.type == "public") {
                 item.type_label = "success";
             }
@@ -122,7 +122,7 @@ function reloadIndexers() {
             else {
                 item.type_label = "default";
             }
-                       
+
             var main_cats_list = item.caps.filter(function(c) {
                 return c.ID < 100000;
             }).map(function(c) {

--- a/src/Jackett/Content/custom.js
+++ b/src/Jackett/Content/custom.js
@@ -110,19 +110,6 @@ function reloadIndexers() {
             else
                 item.state = "success";
 
-            if (item.type == "public") {
-                item.type_icon_content = "🔓\uFE0E";
-            }
-            else if (item.type == "private") {
-                item.type_icon_content = "🔐\uFE0E";
-            }
-            else if (item.type == "semi-private") {
-                item.type_icon_content = "🔒\uFE0E";
-            }
-            else {
-                item.type_icon_content = "";
-            }
-
             var main_cats_list = item.caps.filter(function(c) {
                 return c.ID < 100000;
             }).map(function(c) {

--- a/src/Jackett/Content/custom.js
+++ b/src/Jackett/Content/custom.js
@@ -109,7 +109,20 @@ function reloadIndexers() {
                 item.state = "error";
             else
                 item.state = "success";
-
+                       
+            if (item.type == "public") {
+                item.type_label = "success";
+            }
+            else if (item.type == "private") {
+                item.type_label = "danger";
+            }
+            else if (item.type == "semi-private") {
+                item.type_label = "warning";
+            }
+            else {
+                item.type_label = "default";
+            }
+                       
             var main_cats_list = item.caps.filter(function(c) {
                 return c.ID < 100000;
             }).map(function(c) {

--- a/src/Jackett/Content/index.html
+++ b/src/Jackett/Content/index.html
@@ -236,7 +236,7 @@
                 <tbody>
                     {{#each indexers}}
                     <tr class="configured-indexer-row">
-                        <td><a target="_blank" href="{{site_link}}" title="{{description}}">{{name}}</a> <span title="{{type}}" class="type-{{type}} glyphicon glyphicon-lock"></span></td>
+                        <td><a target="_blank" href="{{site_link}}" title="{{description}}">{{name}}</a> <span title="{{type}}" class="label label-{{type_label}}" style="text-transform: capitalize;">{{type}}</span></td>
                         <td class="fit">
                             <div class="indexer-buttons">
                                 <a href="{{torznab_host}}" title="{{torznab_host}}" role="button" class="indexer-button-copy btn btn-xs btn-info">Copy Torznab Feed</a>
@@ -287,7 +287,7 @@
                     <tr class="unconfigured-indexer-row">
                         <td><a target="_blank" href="{{site_link}}" title="{{description}}">{{name}}</a></td>
                         <td>{{mains_cats}}</td>
-                        <td class="fit"><span title="{{type}}" class="type-{{type}} glyphicon glyphicon-lock"></span></td>
+                        <td class="fit"><span title="{{type}}" class="label label-{{type_label}}" style="text-transform: capitalize;">{{type}}</span></td>
                         <td>{{type}}</td>
                         <td class="fit">{{language}}</td>
                         <td class="fit">

--- a/src/Jackett/Content/index.html
+++ b/src/Jackett/Content/index.html
@@ -622,6 +622,6 @@
     </script>
 
     <script type="text/javascript" src="../libs/api.js?changed=2017083001"></script>
-    <script type="text/javascript" src="../custom.js?changed=2017083001"></script>
+    <script type="text/javascript" src="../custom.js?changed=2017090501"></script>
 </body>
 </html>

--- a/src/Jackett/Content/index.html
+++ b/src/Jackett/Content/index.html
@@ -236,7 +236,7 @@
                 <tbody>
                     {{#each indexers}}
                     <tr class="configured-indexer-row">
-                        <td><a target="_blank" href="{{site_link}}" title="{{description}}">{{name}}</a> <span title="{{type}}" class="type-{{type}}">{{type_icon_content}}</span></td>
+                        <td><a target="_blank" href="{{site_link}}" title="{{description}}">{{name}}</a> <span title="{{type}}" class="type-{{type}} glyphicon glyphicon-lock"></span></td>
                         <td class="fit">
                             <div class="indexer-buttons">
                                 <a href="{{torznab_host}}" title="{{torznab_host}}" role="button" class="indexer-button-copy btn btn-xs btn-info">Copy Torznab Feed</a>
@@ -287,7 +287,7 @@
                     <tr class="unconfigured-indexer-row">
                         <td><a target="_blank" href="{{site_link}}" title="{{description}}">{{name}}</a></td>
                         <td>{{mains_cats}}</td>
-                        <td class="fit"><span title="{{type}}" class="type-{{type}}">{{type_icon_content}}</span></td>
+                        <td class="fit"><span title="{{type}}" class="type-{{type}} glyphicon glyphicon-lock"></span></td>
                         <td>{{type}}</td>
                         <td class="fit">{{language}}</td>
                         <td class="fit">


### PR DESCRIPTION
For as long as I can remember, Jackett's coloured lock glyphs next to a tracker's name never displayed correctly on macOS. On Chrome (which I usually use), they show up as red, orange or green coloured empty square boxes and on Safari as the Lock or Lock with Key emoji (with no colour applied). Weirdly enough, the Chrome squares actually are the same emoji but they don't render (I'm guessing because it’s stubbornly trying to apply Helvetica).

Since this works flawlessly on Windows, it should also work just as well on macOS. That’s why I’ve changed them to use the standard Bootstrap lock glyph. These locks do look a little more "fat" though and don't add the key when the tracker is of type `private` but it doesn't rely on OS/Browser-dependent handling of emojis and provides a more uniform experience.

What do you think? 

EDIT: Would this be an issue for colourblind people? The current solution is a no-go on that front too since on Chrome (macOS) all you see is boxes...