### PR TITLE
Fixing macOS script

### DIFF
--- a/src/Jackett.Console/install_service_macos.sh
+++ b/src/Jackett.Console/install_service_macos.sh
@@ -3,9 +3,12 @@
 # Stop and unload the service if it's running
 launchctl remove org.user.Jackett
 
+# Move working directory to Jackett's
+cd "$(dirname "$0")"
+
 # Check if we're running from Jackett's directory
 if [ ! -f ./JackettConsole.exe ]; then
-    echo "Couldn't locate JackettConsole.exe. Are you running from the right directory?"
+    echo "Couldn't locate JackettConsole.exe. Is the script in the right directory?"
     exit 1
 fi
 jackettdir="$(pwd)"


### PR DESCRIPTION
Fixes #1784
I'm not sure if and how I should enhance the README. "Run the script from anywhere in the Terminal" or "Run using /path/to/install_service_macos.sh in Terminal"?