### PR TITLE
Fixed "Unknown series" on sonarr for tracker manicomioshare

### DIFF
--- a/src/Jackett/Definitions/manicomioshare.yml
+++ b/src/Jackett/Definitions/manicomioshare.yml
@@ -240,6 +240,8 @@
         filters:
           - name: replace
             args: ["|", ""]
+          - name: replace
+            args: ["Ep. "," "]
       size:
         selector: td:nth-child(4)
       grabs:

--- a/src/Jackett/Definitions/manicomioshare.yml
+++ b/src/Jackett/Definitions/manicomioshare.yml
@@ -241,7 +241,7 @@
           - name: replace
             args: ["|", ""]
           - name: replace
-            args: ["Ep. "," "]
+            args: ["Ep. ","E"]
       size:
         selector: td:nth-child(4)
       grabs:


### PR DESCRIPTION
Sonarr does not understand the name of the series because of the word "Ep.". Changing to "E", he starts to consider the episode number correctly.