### PR TITLE
RapideTracker: Cleanup after removal.  Closes #1870

### DIFF
--- a/src/Jackett.Updater/Program.cs
+++ b/src/Jackett.Updater/Program.cs
@@ -194,6 +194,7 @@ namespace Jackett.Updater
                 "Definitions/hdclub.yml",
                 "Definitions/polishtracker.yml",
                 "Definitions/zetorrents.yml",
+                "Definitions/rapidetracker.yml",
             };
 
             foreach (var oldFIle in oldFiles)


### PR DESCRIPTION
rapidetracker was removed with 8f869995e9acd631c685fa77ccc4ec552a46b922 but cleanup was not included. 