### PR TITLE
Add the new 4K category for TorrentLeech

### DIFF
--- a/src/Jackett/Indexers/TorrentLeech.cs
+++ b/src/Jackett/Indexers/TorrentLeech.cs
@@ -54,8 +54,8 @@ namespace Jackett.Indexers
             AddCategoryMapping(14, TorznabCatType.MoviesHD);
             AddCategoryMapping(15, TorznabCatType.Movies); // Boxsets
             AddCategoryMapping(29, TorznabCatType.TVDocumentary);
-            AddCategoryMapping(41, TorznabCatType.MoviesHD, "Movies/4K");
-            AddCategoryMapping(47, TorznabCatType.MoviesHD, "Movies/4K");
+            AddCategoryMapping(41, TorznabCatType.MoviesHD, "4K Upscaled");
+            AddCategoryMapping(47, TorznabCatType.MoviesHD, "Real 4K UltraHD HDR");
             AddCategoryMapping(36, TorznabCatType.MoviesForeign);
             AddCategoryMapping(37, TorznabCatType.MoviesWEBDL);
             AddCategoryMapping(43, TorznabCatType.MoviesSD, "Movies/HDRip");

--- a/src/Jackett/Indexers/TorrentLeech.cs
+++ b/src/Jackett/Indexers/TorrentLeech.cs
@@ -55,6 +55,7 @@ namespace Jackett.Indexers
             AddCategoryMapping(15, TorznabCatType.Movies); // Boxsets
             AddCategoryMapping(29, TorznabCatType.TVDocumentary);
             AddCategoryMapping(41, TorznabCatType.MoviesHD, "Movies/4K");
+            AddCategoryMapping(47, TorznabCatType.MoviesHD, "Movies/4K");
             AddCategoryMapping(36, TorznabCatType.MoviesForeign);
             AddCategoryMapping(37, TorznabCatType.MoviesWEBDL);
             AddCategoryMapping(43, TorznabCatType.MoviesSD, "Movies/HDRip");


### PR DESCRIPTION
TorrentLeech renamed the existing 4k category and added a new "Real 4K UltraHD HDR" category. This PR adds the new category (but leaves the old one too).