### PR TITLE
add EliteHD

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Developer note: The software implements the [Torznab](https://github.com/Sonarr/
  * DigitalHive
  * Dragonworld Reloaded
  * Dream Team
+ * EliteHD  [![(invite needed)][inviteneeded]](#)
  * Elite-Tracker
  * EoT-Forum
  * eStone

--- a/src/Jackett/Definitions/elitehd.yml
+++ b/src/Jackett/Definitions/elitehd.yml
@@ -1,0 +1,98 @@
+---
+  site: elitehd
+  name: EliteHD
+  language: ru-ru
+  type: private
+  encoding: windows-1251
+  links:
+    - https://elitehd.org/
+
+  caps:
+    categorymappings:
+      - {id: 70, cat: Movies, desc: "Animation"}
+      - {id: 71, cat: Movies, desc: "Movie"}
+      - {id: 81, cat: Audio, desc: "HD Audio"}
+      - {id: 78, cat: TV/Documentary, desc: "Documentary"}
+      - {id: 68, cat: Audio/Video, desc: "Music Video"}
+      - {id: 64, cat: TV, desc: "TV Show"}
+      - {id: 62, cat: TV/Sport, desc: "Sport"}
+      - {id: 82, cat: Other, desc: "Demo"}
+
+    modes:
+      search: [q]
+      tv-search: [q, season, ep]
+
+  login:
+    path: login.php
+    method: form
+    form: form[action="takelogin.php"]
+    captcha:
+      type: image
+      image: img#captcha
+      input: imagestring
+    inputs:
+      username: "{{ .Config.username }}"
+      password: "{{ .Config.password }}"
+    error:
+      - selector: td.embedded > div.error
+    test:
+      path: browse.php
+      selector: td.main_bottom
+      
+  search:
+    path: browse.php
+    inputs:
+      $raw: "{{range .Categories}}c{{.}}=1&{{end}}"
+      search: "{{ .Query.Keywords }}"
+      dsearch: ""
+      stype: "or"
+      incldead: "1"
+      webdl: "0"
+      3d: "0"
+    rows:
+      selector: tbody#highlighted > tr
+    fields:
+      download:
+        selector: a[href^="details.php?id="]
+        attribute: href
+        filters:
+          - name: replace
+            args: ["details.php", "download.php"]
+      title:
+        selector: a[href^="details.php?id="]
+      details:
+        selector: a[href^="details.php?id="]
+        attribute: href
+      category:
+        selector: a[href^="browse.php?cat="]
+        attribute: href
+        filters:
+          - name: querystring
+            args: cat
+      date:
+        selector: div#frame > div#cleft > font
+        filters:
+          - name: append
+            args: " +02:00"
+          - name: dateparse
+            args: "2006-01-02 15:04:05 -07:00"
+      seeders:
+        selector: td:nth-child(5)
+      leechers:
+        selector: td:nth-child(6)
+      grabs:
+        selector: td:nth-child(7) b
+        filters:
+          - name: regexp
+            args: ([\d,]+)
+      size:
+        selector: td:nth-child(7)
+        remove: a, br, b
+      downloadvolumefactor:
+        case:
+          img[src="pic/freedownload.gif"]: "0"
+          img[src="pic/silver.gif"]: "0.5"
+          "*": "1"
+      uploadvolumefactor:
+        case:
+          "*": "1"

--- a/src/Jackett/Definitions/elitehd.yml
+++ b/src/Jackett/Definitions/elitehd.yml
@@ -1,6 +1,7 @@
 ---
   site: elitehd
   name: EliteHD
+  description: "EliteHD (HDClub) is a RUSSIAN Private Torrent Tracker for HD MOVIES / TV / GENERAL"
   language: ru-ru
   type: private
   encoding: windows-1251


### PR DESCRIPTION
HDClub is back as EliteHD according to TF article https://torrentfreak.com/hdclub-russias-leading-hd-only-torrent-site-returns-as-elitehd-170930/     
This definition is untested, as it requires an invitation or an existing login carried over from HDClub.     
The assumption is that only the domain has changed.