### PR TITLE
hyperay: update link and add description

### DIFF
--- a/src/Jackett/Definitions/hyperay.yml
+++ b/src/Jackett/Definitions/hyperay.yml
@@ -1,10 +1,13 @@
 ﻿---
   site: hyperay
   name: Hyperay
+  description: "Hyperay is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
   language: zh-cn
   type: private
   encoding: UTF-8
   links:
+    - https://www.hyperay.org
+  legacylinks:
     - https://www.hyperay.cc
 
   caps:


### PR DESCRIPTION
hyperay switched domains in feb '17
source: opentrackers.org