### PR TITLE
btdb: fix #1900 add support for Sonarr and Radarr

### DIFF
--- a/src/Jackett/Definitions/btdb.yml
+++ b/src/Jackett/Definitions/btdb.yml
@@ -1,6 +1,7 @@
 ---
   site: btdb
   name: BTDB
+  description: "BTDB is a Public BitTorrent DHT search engine. Torrents can be downloaded via magnet links"
   language: en-us
   type: public
   encoding: UTF-8
@@ -9,15 +10,20 @@
 
   caps:
     categorymappings:
-      - {id: 1, cat: TV, desc: "TV"}
-      - {id: 2, cat: Movies, desc: "Movies"}
+      - {id: 1, cat: Other, desc: "Other"}
+      - {id: 2, cat: TV, desc: "TV"}
+      - {id: 3, cat: Movies, desc: ""}
 
     modes:
       search: [q]
       tv-search: [q, season, ep]
       movie-search: [q]
 
-  settings: []
+  settings:
+    - name: info
+      type: info
+      label: Category for Sonarr and Radarr
+      default: BTDB does not use categories. In your Sonarr or Radarr Torznab Indexer settings, set the category to 100001.
 
   search:
     path: "{{if .Keywords}}q/{{ .Keywords}}/?sort=time{{else}}recent{{end}}"
@@ -27,6 +33,8 @@
       title:
         selector: h2[class$="title"] a[href^="/torrent/"]
         attribute: title
+      category:
+        text: "1"
       details:
         selector: h2[class$="title"] a[href^="/torrent/"]
         attribute: href


### PR DESCRIPTION
the btdb site does not use categories and supplies magnets for all sorts of content.
So the btdb definition now always returns category `100001 Other` for all search results.
Added info in settings to provide instructions on setting up btdb on Sonarr and Radarr.
Tested on Jackett Dashboard, Sonarr and Radarr.