### PR TITLE
cpabien: switch to .org domain fix #1933

### DIFF
--- a/src/Jackett/Definitions/cpabien.yml
+++ b/src/Jackett/Definitions/cpabien.yml
@@ -6,7 +6,10 @@
   type: public
   encoding: UTF-8
   links:
+    - http://cpabien.org/
+  legacylinks:
     - http://cpabien.cc/
+    - http://cpabien.co/
 
   caps:
     categorymappings:


### PR DESCRIPTION
this avoids redirection by .cc domain
add .cc as legacylink
also add original .co as legacylink