### PR TITLE
Fix Hounddawgs grabs/seeders/peers

### DIFF
--- a/src/Jackett/Indexers/Hounddawgs.cs
+++ b/src/Jackett/Indexers/Hounddawgs.cs
@@ -197,8 +197,9 @@ namespace Jackett.Indexers
                         var sizeStr = row.ChildElements.ElementAt(5).Cq().Text();
                         release.Size = ReleaseInfo.GetBytes(sizeStr);
 
-                        release.Seeders = ParseUtil.CoerceInt(row.ChildElements.ElementAt(6).Cq().Text());
-                        release.Peers = ParseUtil.CoerceInt(row.ChildElements.ElementAt(7).Cq().Text()) + release.Seeders;
+                        release.Grabs = ParseUtil.CoerceInt(row.ChildElements.ElementAt(6).Cq().Text());
+                        release.Seeders = ParseUtil.CoerceInt(row.ChildElements.ElementAt(7).Cq().Text());
+                        release.Peers = ParseUtil.CoerceInt(row.ChildElements.ElementAt(8).Cq().Text()) + release.Seeders;
 
                         var files = row.Cq().Find("td:nth-child(4)").Text();
                         release.Files = ParseUtil.CoerceInt(files);


### PR DESCRIPTION
There was a bug where Jackett would report the number of grabs as seeders which breaks functionality that relies on those number. This PR fixes that.