### PR TITLE
Bugfixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -197,3 +197,4 @@ FakesAssemblies/
 /Build.mono
 /Build.windows
 /Output
+*.DS_Store

--- a/src/Jackett.Console/Program.cs
+++ b/src/Jackett.Console/Program.cs
@@ -21,21 +21,11 @@ namespace JackettConsole
 {
     public class Program
     {
+      
         static void Main(string[] args)
         {
             try
             {
-                // Initialize autofac, logger, etc.
-                Engine.BuildContainer(new WebApi2Module());
-            }
-            catch (Exception e)
-            {
-                Engine.Logger.Error(e, $"Could not register WebApi2Module {e.Message}");
-            }
-
-            try
-            {
-
                 var options = new ConsoleOptions();
                 if (!Parser.Default.ParseArguments(args, options) || options.ShowHelp == true)
                 {
@@ -43,7 +33,7 @@ namespace JackettConsole
                     {
                         var help = new HelpText();
                         var errors = help.RenderParsingErrorsText(options, 2); // indent with two spaces
-                        Console.WriteLine("Jackett v" + Engine.ConfigService.GetVersion());
+                        Console.WriteLine("Jackett v" + JackettStartup.JackettVersion);
                         Console.WriteLine("Switch error: " + errors);
                         Console.WriteLine("See --help for further details on switches.");
                         Environment.ExitCode = 1;
@@ -62,64 +52,36 @@ namespace JackettConsole
                 }
                 else
                 {
+                    SetJacketOptions(options);
+                    // Initialize autofac, logger, etc. We cannot use any calls to Engine before the container is set up.
+                    Engine.BuildContainer(new WebApi2Module());
                     
-
-                    // Logging
-                    if (options.Logging)
-                        JackettStartup.LogRequests = true;
-
-                    // Tracing
-                    if (options.Tracing)
-                        JackettStartup.TracingEnabled = true;
-
-
-                    // Log after the fact as using the logger will cause the options above to be used
-
                     if (options.Logging)
                         Engine.Logger.Info("Logging enabled.");
 
                     if (options.Tracing)
                         Engine.Logger.Info("Tracing enabled.");
 
-                    if (options.ListenPublic && options.ListenPrivate)
+                    if (options.IgnoreSslErrors == true)
                     {
-                        Console.WriteLine("You can only use listen private OR listen publicly.");
-                        Environment.ExitCode = 1;
-                        return;
-                    }
-                    /*  ======     Options    =====  */
-
-                    // SSL Fix
-                    JackettStartup.DoSSLFix = options.SSLFix;
-
-                    // Use curl
-                    if (options.Client != null)
-                        JackettStartup.ClientOverride = options.Client.ToLowerInvariant();
-
-                    // Use Proxy
-                    if (options.ProxyConnection != null)
-                    {
-                        JackettStartup.ProxyConnection = options.ProxyConnection.ToLowerInvariant();
-                        Engine.Logger.Info("Proxy enabled. " + JackettStartup.ProxyConnection);
+                        Engine.Logger.Info("Jackett will ignore SSL certificate errors.");
                     }
 
                     if (options.SSLFix == true)
                         Engine.Logger.Info("SSL ECC workaround enabled.");
                     else if (options.SSLFix == false)
                         Engine.Logger.Info("SSL ECC workaround has been disabled.");
-
-                    // Ignore SSL errors on Curl
-                    JackettStartup.IgnoreSslErrors = options.IgnoreSslErrors;
-                    if (options.IgnoreSslErrors == true)
-                    {
-                        Engine.Logger.Info("Jackett will ignore SSL certificate errors.");
-                    }
-
                     // Choose Data Folder
                     if (!string.IsNullOrWhiteSpace(options.DataFolder))
                     {
-                        JackettStartup.CustomDataFolder = options.DataFolder.Replace("\"", string.Empty).Replace("'", string.Empty).Replace(@"\\", @"\");
                         Engine.Logger.Info("Jackett Data will be stored in: " + JackettStartup.CustomDataFolder);
+                    }
+
+
+                    // Use Proxy
+                    if (options.ProxyConnection != null)
+                    {
+                        Engine.Logger.Info("Proxy enabled. " + JackettStartup.ProxyConnection);
                     }
 
                     /*  ======     Actions    =====  */
@@ -232,8 +194,6 @@ namespace JackettConsole
                             Engine.SaveServerConfig();
                         }
                     }
-
-                    JackettStartup.NoRestart = options.NoRestart;
                 }
 
                 Engine.Server.Initalize();
@@ -246,6 +206,48 @@ namespace JackettConsole
                 Engine.Logger.Error(e, "Top level exception");
             }
         }
+
+        static void SetJacketOptions(ConsoleOptions options)
+        {
+            // Logging
+            if (options.Logging)
+                JackettStartup.LogRequests = true;
+
+            // Tracing
+            if (options.Tracing)
+                JackettStartup.TracingEnabled = true;
+
+            if (options.ListenPublic && options.ListenPrivate)
+            {
+                Console.WriteLine("You can only use listen private OR listen publicly.");
+                Environment.ExitCode = 1;
+                return;
+            }
+
+            // SSL Fix
+            JackettStartup.DoSSLFix = options.SSLFix;
+
+            // Use curl
+            if (options.Client != null)
+                JackettStartup.ClientOverride = options.Client.ToLowerInvariant();
+
+            // Use Proxy
+            if (options.ProxyConnection != null)
+            {
+                JackettStartup.ProxyConnection = options.ProxyConnection.ToLowerInvariant();
+            }
+
+
+
+            // Ignore SSL errors on Curl
+            JackettStartup.IgnoreSslErrors = options.IgnoreSslErrors;
+
+
+
+            JackettStartup.NoRestart = options.NoRestart;
+
+        }
+
     }
 }
 

--- a/src/Jackett.Console/Program.cs
+++ b/src/Jackett.Console/Program.cs
@@ -25,6 +25,17 @@ namespace JackettConsole
         {
             try
             {
+                // Initialize autofac, logger, etc.
+                Engine.BuildContainer(new WebApi2Module());
+            }
+            catch (Exception e)
+            {
+                Engine.Logger.Error(e, $"Could not register WebApi2Module {e.Message}");
+            }
+
+            try
+            {
+
                 var options = new ConsoleOptions();
                 if (!Parser.Default.ParseArguments(args, options) || options.ShowHelp == true)
                 {
@@ -61,8 +72,6 @@ namespace JackettConsole
                     if (options.Tracing)
                         JackettStartup.TracingEnabled = true;
 
-                    // Initialize autofac, logger, etc.
-                    Engine.BuildContainer(new WebApi2Module());
 
                     // Log after the fact as using the logger will cause the options above to be used
 


### PR DESCRIPTION
Just a few things that needed cleaning up:

1) Command line parameters will now be listened to if provided
2) Troubleshooting on a mac caused me to notice we were not excluding .DSStore files, so lets do this.
3) --Help will no longer crash Jackett

In future I really want to axe JacketStartup, as I don't like static objects that require prior knowledge of them being set up or not.