### PR TITLE
Anime search fix to BJ-Share, B2S-Share and Speed-Share

### DIFF
--- a/src/Jackett.Common/Definitions/b2s-share.yml
+++ b/src/Jackett.Common/Definitions/b2s-share.yml
@@ -227,8 +227,19 @@
       details:
         selector: a[href^="torrents-details.php?id="]
         attribute: href
-      title:
+      is_anime:
+        optional: true
+        selector: a[href^="torrents.php?cat=11"]
+        attribute: href
+      title_anime:
         selector: a[href^="torrents-details.php?id="]
+        filters:
+        - name: re_replace
+          args: ["(Ep[\\.]?[ ]?)|([S]\\d\\d[Ee])", "E"]
+      title_normal:
+        selector: a[href^="torrents-details.php?id="]
+      title:
+        text: "{{if .Result.is_anime }}{{ .Result.title_anime }}{{else}}{{ .Result.title_normal }}{{end}}"
       download:
         selector: a[href^="torrents-details.php?id="]
         attribute: href

--- a/src/Jackett.Common/Definitions/speed-share.yml
+++ b/src/Jackett.Common/Definitions/speed-share.yml
@@ -207,8 +207,29 @@
       details:
         selector: a[href^="torrents-details.php?id="]
         attribute: href
-      title:
+      is_anime:
+        optional: true
+        selector: >
+                  a[href^="torrents.php?cat=240"]
+                  ,a[href^="torrents.php?cat=189"]
+                  ,a[href^="torrents.php?cat=102"]
+                  ,a[href^="torrents.php?cat=103"]
+                  ,a[href^="torrents.php?cat=250"]
+                  ,a[href^="torrents.php?cat=144"]
+                  ,a[href^="torrents.php?cat=251"]
+                  ,a[href^="torrents.php?cat=227"]
+                  ,a[href^="torrents.php?cat=228"]
+                  ,a[href^="torrents.php?cat=191"]
+        attribute: href
+      title_anime:
         selector: a[href^="torrents-details.php?id="]
+        filters:
+        - name: re_replace
+          args: ["(Ep[\\.]?[ ]?)|([S]\\d\\d[Ee])", "E"]
+      title_normal:
+        selector: a[href^="torrents-details.php?id="]
+      title:
+        text: "{{if .Result.is_anime }}{{ .Result.title_anime }}{{else}}{{ .Result.title_normal }}{{end}}"
         filters:
         - name: re_replace
           args: ["^(\\[XXX]\\s)", ""]

--- a/src/Jackett.Common/Indexers/BJShare.cs
+++ b/src/Jackett.Common/Indexers/BJShare.cs
@@ -193,10 +193,10 @@ Encoding = Encoding.UTF8;
             else // use search
             {
                 var searchUrl = BrowseUrl;
-                var isAnime = query.Categories.Any(s => s == TorznabCatType.TVAnime.ID);
+                var isSearchAnime = query.Categories.Any(s => s == TorznabCatType.TVAnime.ID);
 
                 var queryCollection = new NameValueCollection();
-                queryCollection.Add("searchstr", StripSearchString(searchString, isAnime));
+                queryCollection.Add("searchstr", StripSearchString(searchString, isSearchAnime));
                 queryCollection.Add("order_by", "time");
                 queryCollection.Add("order_way", "desc");
                 queryCollection.Add("group_results", "1");
@@ -230,11 +230,6 @@ Encoding = Encoding.UTF8;
                         {
                             var qDetailsLink = Row.QuerySelector("a[href^=\"torrents.php?id=\"]");
                             string Title = qDetailsLink.TextContent;
-                            if (isAnime)
-                            {
-                                Title = Regex.Replace(Title, @"(Ep[\.]?[ ]?)|([S]\d\d[Ee])", "E");
-                            }
-                               
                             ICollection<int> Category = null;
                             string YearStr = null;
                             Nullable<DateTime> YearPublishDate = null;
@@ -244,6 +239,12 @@ Encoding = Encoding.UTF8;
                                 var qCatLink = Row.QuerySelector("a[href^=\"/torrents.php?filter_cat\"]");
                                 string CategoryStr = qCatLink.GetAttribute("href").Split('=')[1].Split('&')[0];
                                 Category = MapTrackerCatToNewznab(CategoryStr);
+
+                                // if result is an anime, convert title from SXXEXX to EXX
+                                if (CategoryStr == "14")
+                                {
+                                    Title = Regex.Replace(Title, @"(Ep[\.]?[ ]?)|([S]\d\d[Ee])", "E");
+                                }
                                 YearStr = qDetailsLink.NextSibling.TextContent.Trim().TrimStart('[').TrimEnd(']');
                                 YearPublishDate = DateTime.SpecifyKind(DateTime.ParseExact(YearStr, "yyyy", CultureInfo.InvariantCulture), DateTimeKind.Unspecified);
 

--- a/src/Jackett.Common/Indexers/BJShare.cs
+++ b/src/Jackett.Common/Indexers/BJShare.cs
@@ -161,6 +161,11 @@ Encoding = Encoding.UTF8;
                             }
 
                             var catStr = qCatLink.GetAttribute("href").Split('=')[1];
+                            // if result is an anime, convert title from SXXEXX to EXX
+                            if (catStr == "14")
+                            {
+                                release.Title = Regex.Replace(release.Title, @"(Ep[\.]?[ ]?)|([S]\d\d[Ee])", "E");
+                            }
                             release.Category = MapTrackerCatToNewznab(catStr);
 
                             release.Link = new Uri(SiteLink + qDLLink.GetAttribute("href"));

--- a/src/Jackett.Test/Jackett.Test.csproj
+++ b/src/Jackett.Test/Jackett.Test.csproj
@@ -1,26 +1,21 @@
-<Project Sdk="Microsoft.NET.Sdk">
-
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>net452</TargetFramework>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
-
   <ItemGroup>
     <Compile Remove="Indexers\**" />
     <EmbeddedResource Remove="Indexers\**" />
     <None Remove="Indexers\**" />
   </ItemGroup>
-
   <ItemGroup>
     <None Remove="Util\Invalid-RSS.xml" />
   </ItemGroup>
-
   <ItemGroup>
     <EmbeddedResource Include="Util\Invalid-RSS.xml" />
   </ItemGroup>
-
   <ItemGroup>
+    <PackageReference Include="Autofac" Version="4.6.2" />
     <PackageReference Include="FluentAssertions" Version="4.19.4" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.5.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="1.2.0" />
@@ -29,17 +24,14 @@
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.7.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.9.0" />
   </ItemGroup>
-
   <ItemGroup>
     <Folder Include="Properties\" />
   </ItemGroup>
-
   <ItemGroup>
+    <ProjectReference Include="..\Jackett.Common\Jackett.Common.csproj" />
     <ProjectReference Include="..\Jackett\Jackett.csproj" />
   </ItemGroup>
-
   <ItemGroup>
     <Reference Include="System.Web" />
   </ItemGroup>
-
 </Project>


### PR DESCRIPTION
BJ-Share:
 - If an anime is being searched, remove the episode number from search, eg: from "Dragon Ball Super 118" to "Dragon Ball Super", and filter later (tracker does not allow direct episode search).

BJ-Share / Speed Share / B2S Share:
- If the row result is an anime, change the output from eg: "Dragon Ball Super S10E118" to "Dragon Ball Super E118", reason: Season numbering to animes is all wrong on these trackers, so sonarr does not accept that result. (tv shows output is not altered)