### PR TITLE
Update GimmePeers.cs for Top 20

### DIFF
--- a/src/Jackett.Common/Indexers/GimmePeers.cs
+++ b/src/Jackett.Common/Indexers/GimmePeers.cs
@@ -131,7 +131,7 @@ namespace Jackett.Indexers
             {
                 CQ dom = results;
 
-                var rows = dom[".browsetable tr"]; //the class for the table changed
+                var rows = dom[".browsetable:last tr"]; //the class for the table changed
                 foreach (var row in rows.Skip(1))
                 {
                     var release = new ReleaseInfo();


### PR DESCRIPTION
modified the ProcessPage Method to select the last table with the browsetable class attribute so that if the Top 20 table is visible it will be ignored and the master list is the only one that will display.  Works with Top 20 on and off.