### PR TITLE
Jpopsuki add support for torrents with red background

### DIFF
--- a/src/Jackett.Common/Definitions/jpopsuki.yml
+++ b/src/Jackett.Common/Definitions/jpopsuki.yml
@@ -52,6 +52,7 @@
       order_way: desc
       action: basic
       searchsubmit: 1
+      disablegrouping: 1
     rows:
       selector: table#torrent_table > tbody > tr[class^="torrent"]
     fields:
@@ -61,7 +62,7 @@
       description:
         selector: div.tags
       title:
-        selector: td:nth-child(4)
+        selector: td:nth-child(3)
         remove: span, div.tags, a[title="View Comments"]
         filters:
           - name: replace
@@ -78,12 +79,12 @@
         selector: a[href^="torrents.php?id="]
         attribute: href
       banner:
-        selector: td:nth-child(3) img
+        selector: td:nth-child(2) img
         attribute: src
       files:
-        selector: td:nth-child(5)
+        selector: td:nth-child(4)
       date:
-        selector: td:nth-child(6)
+        selector: td:nth-child(5)
         attribute: title
         filters:
           - name: append
@@ -91,13 +92,13 @@
           - name: dateparse
             args: "Jan 02 2006, 15:04 -07:00"
       size:
-        selector: td:nth-child(7)
+        selector: td:nth-child(6)
       grabs:
-        selector: td:nth-child(8)
+        selector: td:nth-child(7)
       seeders:
-        selector: td:nth-child(9)
+        selector: td:nth-child(8)
       leechers:
-        selector: td:nth-child(10)
+        selector: td:nth-child(9)
       downloadvolumefactor:
         case:
           "strong:contains(\"Freeleech!\")": "0"


### PR DESCRIPTION
I noticed that a lot of torrents were missing when comparing the search results for Jpopsuki to their actual website.

It seemed that Jackett didn't support 'grouped torrents' (torrents with multiple releases)
![screen shot 2018-02-17 at 19 42 56](https://user-images.githubusercontent.com/1887585/36344459-cf874cda-141a-11e8-8e1f-def60d2abfc9.png)

So, I disable grouping and fixed the indexes for columns.
![screen shot 2018-02-17 at 19 47 34](https://user-images.githubusercontent.com/1887585/36344489-70dfcbac-141b-11e8-8082-96a0915dbd68.png)

