### PR TITLE
Cat 6 is actually XXX/Movies

### DIFF
--- a/src/Jackett.Common/Indexers/TorrentDay.cs
+++ b/src/Jackett.Common/Indexers/TorrentDay.cs
@@ -80,7 +80,6 @@ namespace Jackett.Indexers
             AddCategoryMapping(48, TorznabCatType.MoviesUHD, "Movies/x265");
             AddCategoryMapping(1, TorznabCatType.MoviesSD, "Movies/XviD");
 
-            AddCategoryMapping(6, TorznabCatType.Audio, "Music");
             AddCategoryMapping(17, TorznabCatType.Audio, "Music/Audio");
             AddCategoryMapping(23, TorznabCatType.AudioForeign, "Music/Non-English");
             AddCategoryMapping(41, TorznabCatType.Audio, "Music/Packs");


### PR DESCRIPTION
The top level categories have hyphen in them. -6 is Music, but 6 is XXX/Movies. It looks like -6 is not a searchable category.