### PR TITLE
Adding TorrentKim first version

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ Developer note: The software implements the [Torznab](https://github.com/Sonarr/
  * Torlock
  * Torrent Downloads
  * Torrent9
+ * TorrentKim
  * Torrentz2
  * World Wide Torrents
  * YIFY (YTS)

--- a/src/Jackett.Common/Definitions/torrentkim.yml
+++ b/src/Jackett.Common/Definitions/torrentkim.yml
@@ -8,7 +8,7 @@
   links:
     - https://torrentkim12.com/
   legacylinks:
-    - https://torrentkim10.net
+    - https://torrentkim10.net/
 
   caps:
     categorymappings:

--- a/src/Jackett.Common/Definitions/torrentkim.yml
+++ b/src/Jackett.Common/Definitions/torrentkim.yml
@@ -1,0 +1,65 @@
+---
+  site: torrentkim
+  name: TorrentKim
+  description: "TorrentKim is a free Korean tracker of pretty much anything Korean."
+  language: ko-KR
+  type: public
+  encoding: UTF-8
+  links:
+    - https://torrentkim12.com/
+  legacylinks:
+    - https://torrentkim10.net
+
+  caps:
+    categorymappings:
+      - {id: "torrent_variety", cat: TV, desc: "TV - Variety shows"}
+      - {id: "torrent_tv", cat: TV, desc: "TV - Dramas"}
+      - {id: "torrent_mid", cat: TV/FOREIGN, desc: "TV - American Series"}
+
+    modes:
+      search: [q]
+      tv-search: [q]
+      movie-search: [q]
+
+  settings: []
+
+  search:
+    paths:
+      - path: "{{ if .Keywords }}/bbs/s-1-{{ .Keywords }}{{else}}/bbs/s-1-미운우리새끼{{end}}"
+    rows:
+      selector: "table.board_list > tbody > tr.bg1:nth-child(n+3)"
+    fields:
+      magnet:
+        selector: td:nth-child(1) a[href^="javascript:"]
+        attribute: href
+        filters:
+          - name: replace
+            args: ["javascript:Mag_dn('", ""]
+          - name: replace
+            args: ["')", ""]
+          - name: prepend
+            args: "magnet:?xt=urn:btih:"
+      seeders:
+        selector: "td:nth-child(2) font:nth-child(2)"
+      leechers:
+        selector: "td:nth-child(2) font:nth-child(1)"
+      category:
+        selector: td:nth-child(3) a[href^="/bbs/bc.php?bo_table="]
+        attribute: href
+        filters:
+          - name: querystring
+            args: bo_table
+      title:
+        selector: td:nth-child(3) a:last-of-type
+      details:
+        selector: td:nth-child(3) a:last-of-type
+        attribute: href
+      date:
+        selector: td:nth-child(3) a:last-of-type
+        filters:
+          - name: split
+            args: ['.', 2]
+          - name: dateparse
+            args: "060102"
+      size:
+        selector: td:nth-child(5)


### PR DESCRIPTION
This site is pretty awful, most of the search list differs from one another and the best list is hidden, using the search bar on top only returns google results that are un-usable.

Still, it should be working pretty great for a first release.

Please note:

1: The site does not provide a correctly formatted list for "newest" releases and when you make an empty search, you are redirected to the google search page. As such, when doing the "test" from Jackett's webUI, we will be searching for 미운우리새끼 because I know for a fact that results are available.

2: For the seeds / peers, I'm not 100% sure what the first number is and what the second is since I wasn't able to find a torrent with enough activity to confirm. I went with my guts feeling. Might need to be updated later on.

3: My ONLY goal with this tracker is to download the show 미운우리새끼 so that's pretty much all I tested so I'm only releasing it with the variety shows, dramas and american series categories enabled.
Adding the other ones shouldn't be too hard if needed.

4: Finding out to generate the download link was a real pain, thankfully I can speak decent Korean.

I'm using it through Sonarr and I successfully caught back the 2 missing episodes, so I believe it is mature enough for a first release.