### PR TITLE
HDCity: Fix TV Shows search, encoding...

### DIFF
--- a/src/Jackett.Common/Definitions/hdcity.yml
+++ b/src/Jackett.Common/Definitions/hdcity.yml
@@ -4,7 +4,7 @@
   description: "HDCity is a SPANISH site for HD content"
   language: es-es
   type: private
-  encoding: UTF-8
+  encoding: ISO-8859-1
   links:
     - https://hdcity.li/
 
@@ -129,11 +129,14 @@
 
   search:
     path: index.php
+    keywordsfilters:
+      - name: re_replace
+        args: ["S0?(\\d{1,2})E(\\d{1,2})", "$1x$2"]
     inputs:
       page: "torrents"
       $raw: "&category={{range .Categories}}{{.}};{{end}}"
       active: "1"
-      search: "{{ .Query.Keywords }}"
+      search: "{{ .Keywords }}"
     rows:
       selector: "#category+table table tr:not(:first-child):not(:last-child)"
     fields:
@@ -145,6 +148,9 @@
             args: category
       title:
         selector: td[valign="middle"] a
+        filters:
+          - name: append
+            args: " [spanish]"
       details:
         selector: td[valign="middle"] a
         attribute: href


### PR DESCRIPTION
Change TV Shows search format for Spanish style, change encoding in HDCity to ISO-8859-1, now accented characters works perfects and add [spanish] for detected Spanish language in Sonarr/Radarr