### PR TITLE
TorrentLeech - Fix for V5 Interface

### DIFF
--- a/src/Jackett.Common/Jackett.Common.csproj
+++ b/src/Jackett.Common/Jackett.Common.csproj
@@ -117,7 +117,7 @@
     <PackageReference Include="Autofac" Version="4.6.2" />
     <PackageReference Include="AutoMapper" Version="6.2.2" />
     <PackageReference Include="BencodeNET" Version="2.2.24" />
-    <PackageReference Include="CloudFlareUtilities" Version="1.1.0" />
+    <PackageReference Include="CloudFlareUtilities" Version="1.2.0" />
     <PackageReference Include="CommandLineParser" Version="2.2.1" />
     <PackageReference Include="DotNet4.SocksProxy" Version="1.4.0.1" />
     <PackageReference Include="Microsoft.CSharp" Version="4.4.1" />


### PR DESCRIPTION
Following the unveiling of V5 at TorrentLeech.org, the indexer runs into two different problems.  First, the introduction of CloudFlare, and second a rewrite of the UI.

CloudFlareUtilities 1.1.0 seems to dislike the flavor of CloudFlare used by TL so I bumped it to version 1.2.0 to fix the: "Clearance failed after 4 attempt(s)" as referenced in #2882.

The SearchUrl that was used in V4 no longer returns the torrent list in the results as it is hidden in a JavaScript call to a JSON which leads to #2864.  So, instead, we now grab the JSON directly and parse the results into a fully functional release array.

This pull request is to address the several issues raised for this tracker since the change.