### PR TITLE
Zamunda.net: Improve torrent titles

### DIFF
--- a/src/Jackett.Common/Definitions/zamundanet.yml
+++ b/src/Jackett.Common/Definitions/zamundanet.yml
@@ -48,7 +48,11 @@
       selector: .responsetop > tbody > tr:has(td.td_newborder)
     fields:
       title:
-        selector: td:nth-child(2) > a:nth-child(1)
+        selector: td:nth-child(2) > a[href^="/download.php"]
+        attribute: href
+        filters:
+          - name: re_replace
+            args: ["^(.*?)download\\.php\\/[0-9]{1,10}\\/|\\.torrent(?=[^.]*$)", ""]
       details:
         selector: td:nth-child(2) > a:nth-child(1)
         attribute: href


### PR DESCRIPTION
Currently Jackett grabs the human readable titles which are in the following format: 
``` {Movie.Title} / {Movie.TitleTranslated} ({Movie.Year})```
That's great for reading, but unfortunately it doesn't provide enough information to radarr and sonarr for automatic detection of movie quality. 

The pull request aims to solve this by extracting the title from the direct download link which usually contains the needed information.

**Important:** 
I'm not .net developer and I couldn't set up usable environment under linux to test this. Please merge with caution as it may be broken.