### PR TITLE
Fix for #3010

### DIFF
--- a/src/Jackett.Common/Indexers/TorrentDay.cs
+++ b/src/Jackett.Common/Indexers/TorrentDay.cs
@@ -49,7 +49,7 @@ namespace Jackett.Common.Indexers
         public TorrentDay(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
             : base(name: "TorrentDay",
                 description: "TorrentDay (TD) is a Private site for TV / MOVIES / GENERAL",
-                link: "https://torrentday.com/",
+                link: "https://www.torrentday.com/",
                 caps: TorznabUtil.CreateDefaultTorznabTVCaps(),
                 configService: configService,
                 client: wc,


### PR DESCRIPTION
This will fix the problem with torrentday.it being down and https:///torrentday.com will redirect you to https://www.torrentday.com. And since we don't allow redirects, this will not work without the www.