### PR TITLE
DotNet Core preparation

### DIFF
--- a/src/Jackett.Common/Services/Interfaces/IServerService.cs
+++ b/src/Jackett.Common/Services/Interfaces/IServerService.cs
@@ -12,7 +12,9 @@ namespace Jackett.Common.Services.Interfaces
         void ReserveUrls(bool doInstall = true);
         Uri ConvertToProxyLink(Uri link, string serverUrl, string indexerId, string action = "dl", string file = "t");
         string BasePath();
-        string GetServerUrl(HttpRequestMessage Request);
-        List<string> notices { get; } 
+        string GetServerUrl(object Request); //TODO: Once Mono is removed, change type to HttpRequest
+        List<string> notices { get; }
+        string GetBlackholeDirectory();
+        string GetApiKey();
     }
 }


### PR DESCRIPTION
.NET core uses HttpRequest instead of HttpRequestMessage