### PR TITLE
Added new replace

### DIFF
--- a/src/Jackett.Common/Definitions/xbytes2.yml
+++ b/src/Jackett.Common/Definitions/xbytes2.yml
@@ -61,9 +61,13 @@
           - name: re_replace
             args: ["\\/", " "]
           - name: re_replace
+            args: ["S(\\d{1,2}) E(\\d{1,2})", "S$1E$2"]
+          - name: re_replace
             args: ["\\(", ""]
           - name: re_replace
             args: ["\\)", ""]
+          - name: re_replace
+            args: ["20[0-2][0-9] [0-9][0-9]", ""]
           - name: re_replace
             args: ["20[0-2][0-9]", ""]
       details:


### PR DESCRIPTION
xbytesv2 adds two years in title, when a show has season episodes released in two different years. For example, supergirl season 3, has episodes in 2017 and 2018. In this case xbytesv2 name the episode like this: "Supergirl (2017 18/S03/E13/AMZ WEB DL 1080p/AC3 5 1 /DUAL/SUB) Grupo V2" 
This new filter, removes both years from title.
Please don't remove this replace (S01 E01 -> S01E01):
          - name: re_replace
            args: ["S(\\d{1,2}) E(\\d{1,2})", "S$1E$2"]