### PR TITLE
Add more specifity to README in regards to building on Visual Studio

### DIFF
--- a/README.md
+++ b/README.md
@@ -399,6 +399,7 @@ All contributions are welcome just send a pull request.  Jackett's framework all
 
 ### Windows
 * Open the Jackett solution in Visual Studio 2017
+* Install all missing assemblies (Jackett, Jackett.Console, Jackett.Service etc.)
 * Select Jackett.Console as startup project
 * Build/Start the project
 


### PR DESCRIPTION
Build will not go through if this step is not done first.