### PR TITLE
Quik fix to size row

### DIFF
--- a/src/Jackett.Common/Definitions/isohunt2.yml
+++ b/src/Jackett.Common/Definitions/isohunt2.yml
@@ -77,6 +77,9 @@
         attribute: href
       size:
         selector: td.size-row
+        filters:
+          - name: re_replace
+            args: ["(\\d+).(?=\\d{3}(\\D|$))", "$1"]
       seeders:
         selector: td.sn
       date:


### PR DESCRIPTION
Sometimes when parsing, the size of the rel was not enough to have Gb instead Mb or Kb to Mb or whatever
So the size in row is for example 1.015.22 Mb (less than 1024)
So in this case the parser return error

I searched a way to replace this, I found a solution, hope that works in a log way