### PR TITLE
Manage multi to french for ygg and downloadville

### DIFF
--- a/src/Jackett.Common/Definitions/downloadville.yml
+++ b/src/Jackett.Common/Definitions/downloadville.yml
@@ -128,6 +128,10 @@
         "2" : "Argent (Silver)"
         "3" : "Or (Gold)"
         "4" : "Argent & Or (Both)"
+    - name: multilang
+      type: checkbox
+      label: Replace MULTI by FRENCH in release name
+      default:  false
 
   login:
     path: tracker/index.php?page=login
@@ -168,8 +172,15 @@
     rows:
       selector: table > tbody > tr > td > table.lista > tbody > tr:has(td[onmouseover="this.className='post'"])
     fields:
-      title:
+      title_phase1:
         selector: a[onmouseover][href^="index.php?page=torrent-details&id="]
+      title_multilang:
+        text: "{{ .Result.title_phase1 }}r"
+        filters:
+          - name: re_replace
+            args: ["[\\.\\s\\[\\-[Mm][Uu][Ll][Tt][Ii][\\.i\\s\\]\\-]", ".FRENCH."] 
+      title:
+        text: "{{if .Config.multilang }}{{ .Result.title_multilang }}{{else}}{{ .Result.title_phase1 }}{{end}}"
       details:
         selector: a[onmouseover][href^="index.php?page=torrent-details&id="]
         attribute: href

--- a/src/Jackett.Common/Definitions/yggtorrent.yml
+++ b/src/Jackett.Common/Definitions/yggtorrent.yml
@@ -96,6 +96,10 @@
       type: checkbox
       label: Try to normalize releases names by moving year after the title
       default: false
+    - name: multilang
+      type: checkbox
+      label: Replace MULTI by FRENCH in release name
+      default:  false
 
   login:
     method: form
@@ -140,8 +144,15 @@
           - name: re_replace
             args: ["(\\s{2,5})", " "]
           - name: trim
-      title:
+      title_phase1:
         text: "{{if .Config.filter_title }}{{ .Result.title_filtered }}{{else}}{{ .Result.title_normal }}{{end}}"
+      title_multilang:
+        text: "{{ .Result.title_phase1 }}r"
+        filters:
+          - name: re_replace
+            args: ["[\\.\\s\\[\\-[Mm][Uu][Ll][Tt][Ii][\\.i\\s\\]\\-]", ".FRENCH."]
+      title:
+        text: "{{if .Config.multilang }}{{ .Result.title_multilang }}{{else}}{{ .Result.title_phase1 }}{{end}}"
       details:
         selector: ":nth-child(2) > a"
         attribute: href


### PR DESCRIPTION
In french tracker , multi mean original lang + french

Sonarr and radarr match multi as "English" , so MULTI never match french.
This PR fix it !