### PR TITLE
TorrentBytes: Don't use truncated release names

### DIFF
--- a/src/Jackett.Common/Indexers/TorrentBytes.cs
+++ b/src/Jackett.Common/Indexers/TorrentBytes.cs
@@ -156,7 +156,14 @@ namespace Jackett.Common.Indexers
                     var link = row.Cq().Find("td:eq(1) a:eq(1)").First();
                     release.Guid = new Uri(SiteLink + link.Attr("href"));
                     release.Comments = release.Guid;
-                    release.Title = link.Get(0).FirstChild.ToString();
+                    release.Title = link.Attr("title");
+
+                    // There isn't a title attribute if the release name isn't truncated.
+                    if (string.IsNullOrWhiteSpace(release.Title))
+                    {
+                        release.Title = link.Get(0).FirstChild.ToString();
+                    }
+
                     release.Description = release.Title;
 
                     // If we search an get no results, we still get a table just with no info.


### PR DESCRIPTION
When a release name is too long, TorrentBytes truncates it and adds "..." at the end (presumably in order to not break the layout). 

Luckily they do add the full release name as the title of the link, so with this change the title will be used if it exists and Jackett will no longer use release names with "..." at the end.