### PR TITLE
fix #1450

### DIFF
--- a/src/Jackett.Common/Indexers/NCore.cs
+++ b/src/Jackett.Common/Indexers/NCore.cs
@@ -117,11 +117,16 @@ namespace Jackett.Common.Indexers
             return IndexerConfigurationStatus.RequiresTesting;
         }
 
-        protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
+        protected async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query, String seasonep)
         {
             var releases = new List<ReleaseInfo>();
             var searchString = query.GetQueryString();
             var pairs = new List<KeyValuePair<string, string>>();
+
+            if (seasonep != null)
+            {
+                searchString = Regex.Split(query.GetQueryString(), @"(?i)S\d+E?\d+\s?$")[0];
+            }
 
             pairs.Add(new KeyValuePair<string, string>("nyit_sorozat_resz", "true"));
             pairs.Add(new KeyValuePair<string, string>("miben", "name"));
@@ -198,8 +203,18 @@ namespace Jackett.Common.Indexers
                     string catlink = qRow.Find("a:has(img[class='categ_link'])").First().Attr("href");
                     string cat = ParseUtil.GetArgumentFromQueryString(catlink, "tipus");
                     release.Category = MapTrackerCatToNewznab(cat);
+                    if (seasonep == null)
+                        releases.Add(release);
+        
+                    else
+                    {
+                        Match m = Regex.Match(release.Title, @""+ seasonep + @"\s?$", RegexOptions.IgnoreCase);
+                        if (m.Success)
+                        {
+                            releases.Add(release);
+                        }
+                    }
 
-                    releases.Add(release);
                 }
             }
             catch (Exception ex)
@@ -208,6 +223,19 @@ namespace Jackett.Common.Indexers
             }
 
             return releases;
+        }
+
+        protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
+        {
+            var results = await PerformQuery(query, null);
+            if (results.Count()==0 && query.IsTVSearch)
+            {
+                var regex = new Regex(@"(?i)S\d+E?\d+\s?$");
+                String seasonepisode = regex.Match(query.GetQueryString()).Value;
+                results = await PerformQuery(query, seasonepisode.Trim());
+            }
+
+            return results;
         }
     }
 }


### PR DESCRIPTION
Some workoround to "Ncore - not forward all search results to Sonarr, Radarr"
In case of TV shows if nothing is founded, retry the search without SxxExx after the show name.
This will list all torrent also if their title or description are changed.
Than add the result only if it contains the skipped SxxExx