### PR TITLE
Use Artist instead of keyword

### DIFF
--- a/src/Jackett.Common/Definitions/metaltracker.yml
+++ b/src/Jackett.Common/Definitions/metaltracker.yml
@@ -38,7 +38,7 @@
       - path: /torrents/search.html
         method: post
     inputs:
-      "SearchTorrentsForm[nameTorrent]": "{{ .Keywords }}"
+      "SearchTorrentsForm[nameTorrent]": "{{if .Query.Artist}}{{ .Query.Artist }}{{else}}{{ .Keywords }}{{end}}"
       go-search: "Search"
     rows:
       selector: .smallalbum


### PR DESCRIPTION
use artist instead of keyword if artist is supplied to make it somewhat compatible with lidarr(by default supplies artist and album with empty keyword)