### PR TITLE
Zeros are removed from Imdb ID after "tt" in Potato API result

### DIFF
--- a/src/Jackett.Server/Controllers/ResultsController.cs
+++ b/src/Jackett.Server/Controllers/ResultsController.cs
@@ -502,7 +502,7 @@ namespace Jackett.Server.Controllers
                     torrent_id = release.Guid.ToString(),
                     details_url = release.Comments.ToString(),
                     download_url = (release.Link != null ? release.Link.ToString() : release.MagnetUri.ToString()),
-                    imdb_id = release.Imdb.HasValue ? "tt" + release.Imdb : null,
+                    imdb_id = release.Imdb.HasValue ? ParseUtil.GetFullImdbID("tt" + release.Imdb) : null,
                     freeleech = (release.DownloadVolumeFactor == 0 ? true : false),
                     type = "movie",
                     size = (long)release.Size / (1024 * 1024), // This is in MB

--- a/src/Jackett/Controllers/ResultsController.cs
+++ b/src/Jackett/Controllers/ResultsController.cs
@@ -440,7 +440,7 @@ namespace Jackett.Controllers
                     torrent_id = release.Guid.ToString(),
                     details_url = release.Comments.ToString(),
                     download_url = (release.Link != null ? release.Link.ToString() : release.MagnetUri.ToString()),
-                    imdb_id = release.Imdb.HasValue ? "tt" + release.Imdb : null,
+                    imdb_id = release.Imdb.HasValue ? ParseUtil.GetFullImdbID("tt" + release.Imdb) : null,
                     freeleech = (release.DownloadVolumeFactor == 0 ? true : false),
                     type = "movie",
                     size = (long)release.Size / (1024 * 1024), // This is in MB


### PR DESCRIPTION
I'm running following with "linuxserver/jackett" docker image:
```
Jackett 0.8.1209.0
Environment version: 4.0.30319.42000 (/usr/lib/mono/4.5)
OS version: Unix 4.4.0.119 (64bit OS) (64bit process)
mono version: 5.12.0.226 (tarball Thu May  3 09:48:32 UTC 2018)
```
and making request to Potato feed with only apikey and imdb ID with example of "tt0859635" but in the result the ID is as "tt859635":
```
{
  "results": [
    {
      "release_name": "Super....",
      "torrent_id": "magnet:?...",
      "details_url": "https://torr...",
      "download_url": "magnet:?...",
      "imdb_id": "tt859635",
      "freeleech": true,
      "type": "movie",
...
```

I assume the change that could solve this is to wrap the value with `ParseUtil.GetFullImdbID` function call as `release.Imdb` might be `long`.

Tested the change by building the code and fetching the API, it now had "tt0859635" in results.