### PR TITLE
Fix UHDBits definition

### DIFF
--- a/src/Jackett.Common/Definitions/uhdbits.yml
+++ b/src/Jackett.Common/Definitions/uhdbits.yml
@@ -68,6 +68,8 @@
         remove: span, div.tags
         filters:
           - name: replace
+            args: ["\t\t\t\t", " "]
+          - name: replace
             args: [" / Free", ""]
           - name: replace
             args: [" / ViE", ""]


### PR DESCRIPTION
Fix error 'Invalid non-ASCII or control character in header: 0x0009' on download (Tab character, upstream bug in kestrel)