### PR TITLE
Remove apostrophes from search in BroadcastTheNet

### DIFF
--- a/src/Jackett.Common/Indexers/BroadcastTheNet.cs
+++ b/src/Jackett.Common/Indexers/BroadcastTheNet.cs
@@ -84,6 +84,7 @@ namespace Jackett.Common.Indexers
 
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {
+            query.SearchTerm = query.SearchTerm.Replace("'", "");
             var searchString = query.GetQueryString();
             var btnResults = query.Limit;
             if (btnResults == 0)


### PR DESCRIPTION
Based on the approach from #3315 

This allows searching for "Grey's Anatomy". 

Note: I couldn't test it since I don't have the development environment set up. If anyone can check if it works, it would be great. Otherwise, I'll update the PR once I have some free time