### PR TITLE
HorribleSubs Indexer - Make sure release title contains "[HorribleSubs]"

### DIFF
--- a/src/Jackett.Common/Indexers/HorribleSubs.cs
+++ b/src/Jackett.Common/Indexers/HorribleSubs.cs
@@ -135,6 +135,13 @@ namespace Jackett.Common.Indexers
                         continue;
                     }
 
+                    // Ensure fansub group name is present in the title
+                    // This is needed for things like configuring tag restrictions in Sonarr
+                    if (title.Contains("[HorribleSubs]") == false)
+                    {
+                        title = "[HorribleSubs] " + title;
+                    }
+
                     DateTime releasedate;
                     if (dateStr == "Today")
                     {


### PR DESCRIPTION
* This is needed for things like configuring tag restrictions in Sonarr