### PR TITLE
Update metal-iplay-ro.yml

### DIFF
--- a/src/Jackett.Common/Definitions/metal-iplay-ro.yml
+++ b/src/Jackett.Common/Definitions/metal-iplay-ro.yml
@@ -6,7 +6,7 @@
   type: private
   encoding: UTF-8
   links:
-    - https://metal.stream.bike/
+    - https://metal.iplay.ro/
 
   caps:
     categories:

--- a/src/Jackett.Common/Definitions/metal-iplay-ro.yml
+++ b/src/Jackett.Common/Definitions/metal-iplay-ro.yml
@@ -7,6 +7,8 @@
   encoding: UTF-8
   links:
     - https://metal.iplay.ro/
+  legacylinks:
+    - https://metal.stream.bike/
 
   caps:
     categories:


### PR DESCRIPTION
revert back the domain

post from the tracker 

```
2018-10-14 22:02:00 GMT (1 day ago) 
Security Upgrade
Fellow metalheads, we have added additional security to the site, specifically SSL. We used a temporary domain (stream.bike) for tests. 
Our domain is (with SSL) https://metal.iplay.ro . All should be in working order, if you run into problems, please report to us. Thank you and sorry for the inconveniences we caused.
```