### PR TITLE
Update rockbox.yml

### DIFF
--- a/src/Jackett.Common/Definitions/rockbox.yml
+++ b/src/Jackett.Common/Definitions/rockbox.yml
@@ -38,7 +38,7 @@
     inputs:
       search: "{{if .Query.Artist}}{{ .Query.Artist }}{{else}}{{ .Keywords }}{{end}}"
     rows:
-      selector: tr:has(a[href^="download.php?id="])
+      selector: body:nth-child(2) tbody tr td:nth-child(2) table.lista tbody tr:nth-child(2) table.lista tbody tr:has(a[href^="download.php?id="])
     fields:
       title:
         selector: td a[href^="details.php?id="]


### PR DESCRIPTION
Need to fix the row selector by indicating the right table and the tr:has else there is still a lot of errors with the HTML because it selects the header of the table too. It was working still, but better like that.

I'm not having any html parse errors now.