### PR TITLE
Update metal-iplay-ro.yml

### DIFF
--- a/src/Jackett.Common/Definitions/metal-iplay-ro.yml
+++ b/src/Jackett.Common/Definitions/metal-iplay-ro.yml
@@ -57,7 +57,7 @@
     inputs:
       "search": "{{if .Query.Artist}}{{ .Query.Artist }}{{else}}{{ .Keywords }}{{end}}"
     rows:
-      selector: table.torrents_table tbody tr
+      selector: table.torrents_table tbody tr:has(a[href^="download2.php?id="])
     fields:
       title:
         selector: td a[href^="details.php?id="]


### PR DESCRIPTION
Selector update, else it would also take the table header, leading in HTML errors too, like rockbox.

I don't get why if i use 
```
selector: tr:has(a[href^="download2.php?id="])
```

it won't work fine either