### PR TITLE
Update NLog configuration

### DIFF
--- a/src/Jackett.Common/Utils/LoggingSetup.cs
+++ b/src/Jackett.Common/Utils/LoggingSetup.cs
@@ -38,9 +38,19 @@ namespace Jackett.Common.Utils
                 logConfig.AddTarget("console", logConsole);
 
                 logConsole.Layout = "${simpledatetime} ${level} ${message} ${exception:format=ToString}";
+
+                if (!settings.TracingEnabled)
+                {
+                    var logMicrosoftConsoleRule = new LoggingRule();
+                    logMicrosoftConsoleRule.LoggerNamePattern = "Microsoft.*";
+                    logMicrosoftConsoleRule.SetLoggingLevels(LogLevel.Debug, LogLevel.Info);
+                    logMicrosoftConsoleRule.Final = true;
+                    logConfig.LoggingRules.Add(logMicrosoftConsoleRule);
+                }
+
                 var logConsoleRule = new LoggingRule("*", logLevel, logConsole);
                 logConfig.LoggingRules.Add(logConsoleRule);
-
+                
                 var logService = new LogCacheService();
                 logConfig.AddTarget("service", logService);
                 var serviceRule = new LoggingRule("*", logLevel, logService);

--- a/src/Jackett.Server/Program.cs
+++ b/src/Jackett.Server/Program.cs
@@ -7,7 +7,7 @@ using Jackett.Common.Utils;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
-using NLog;
+using Microsoft.Extensions.Logging;
 using NLog.Web;
 using System;
 using System.Collections.Generic;
@@ -62,8 +62,8 @@ namespace Jackett.Server
                 runtimeDictionary = GetValues(Settings);
             });
 
-            LogManager.Configuration = LoggingSetup.GetLoggingConfiguration(Settings);
-            Logger logger = LogManager.GetCurrentClassLogger();
+            NLog.LogManager.Configuration = LoggingSetup.GetLoggingConfiguration(Settings);
+            NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
             logger.Info("Starting Jackett v" + EnvironmentUtil.JackettVersion);
 
             // create PID file early
@@ -167,7 +167,7 @@ namespace Jackett.Server
                         Console.WriteLine("Deleting PID file " + PIDFile);
                         File.Delete(PIDFile);
                     }
-                    LogManager.Shutdown();
+                    NLog.LogManager.Shutdown();
                 }
             }
             catch (Exception ex)
@@ -184,6 +184,11 @@ namespace Jackett.Server
                 .PreferHostingUrls(true)
                 .UseConfiguration(Configuration)
                 .UseStartup<Startup>()
+                .ConfigureLogging(logging =>
+                {
+                    logging.ClearProviders();
+                    logging.SetMinimumLevel(LogLevel.Trace);
+                })
                 .UseNLog();
     }
 }

--- a/src/Jackett.Server/Program.cs
+++ b/src/Jackett.Server/Program.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
+using NLog;
 using NLog.Web;
 using System;
 using System.Collections.Generic;
@@ -62,8 +63,8 @@ namespace Jackett.Server
                 runtimeDictionary = GetValues(Settings);
             });
 
-            NLog.LogManager.Configuration = LoggingSetup.GetLoggingConfiguration(Settings);
-            NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
+            LogManager.Configuration = LoggingSetup.GetLoggingConfiguration(Settings);
+            Logger logger = LogManager.GetCurrentClassLogger();
             logger.Info("Starting Jackett v" + EnvironmentUtil.JackettVersion);
 
             // create PID file early
@@ -167,7 +168,7 @@ namespace Jackett.Server
                         Console.WriteLine("Deleting PID file " + PIDFile);
                         File.Delete(PIDFile);
                     }
-                    NLog.LogManager.Shutdown();
+                    LogManager.Shutdown();
                 }
             }
             catch (Exception ex)
@@ -187,7 +188,7 @@ namespace Jackett.Server
                 .ConfigureLogging(logging =>
                 {
                     logging.ClearProviders();
-                    logging.SetMinimumLevel(LogLevel.Trace);
+                    logging.SetMinimumLevel(Microsoft.Extensions.Logging.LogLevel.Trace);
                 })
                 .UseNLog();
     }


### PR DESCRIPTION
Microsoft log are now corretly supported by NLog.
These are now filtered and not showed under level info if tracing is not enabled.