### PR TITLE
manage Microsoft logs by NLog

### DIFF
--- a/src/Jackett.Common/Utils/LoggingSetup.cs
+++ b/src/Jackett.Common/Utils/LoggingSetup.cs
@@ -46,7 +46,7 @@ namespace Jackett.Common.Utils
 
                 var serviceMicrosoftRule = new LoggingRule();
                 serviceMicrosoftRule.LoggerNamePattern = "Microsoft.*";
-                serviceMicrosoftRule.SetLoggingLevels(logLevel, LogLevel.Info);
+                serviceMicrosoftRule.SetLoggingLevels(LogLevel.Debug, LogLevel.Info);
                 serviceMicrosoftRule.Final = true;
                 if (settings.TracingEnabled)
                 {

--- a/src/Jackett.Common/Utils/LoggingSetup.cs
+++ b/src/Jackett.Common/Utils/LoggingSetup.cs
@@ -43,6 +43,17 @@ namespace Jackett.Common.Utils
 
                 var logService = new LogCacheService();
                 logConfig.AddTarget("service", logService);
+
+                var serviceMicrosoftRule = new LoggingRule();
+                serviceMicrosoftRule.LoggerNamePattern = "Microsoft.*";
+                serviceMicrosoftRule.SetLoggingLevels(logLevel, LogLevel.Info);
+                serviceMicrosoftRule.Final = true;
+                if (settings.TracingEnabled)
+                {
+                    serviceMicrosoftRule.Targets.Add(logService);
+                }
+                logConfig.LoggingRules.Add(serviceMicrosoftRule);
+
                 var serviceRule = new LoggingRule("*", logLevel, logService);
                 logConfig.LoggingRules.Add(serviceRule);
             }

--- a/src/Jackett.Common/Utils/LoggingSetup.cs
+++ b/src/Jackett.Common/Utils/LoggingSetup.cs
@@ -38,19 +38,9 @@ namespace Jackett.Common.Utils
                 logConfig.AddTarget("console", logConsole);
 
                 logConsole.Layout = "${simpledatetime} ${level} ${message} ${exception:format=ToString}";
-
-                if (!settings.TracingEnabled)
-                {
-                    var logMicrosoftConsoleRule = new LoggingRule();
-                    logMicrosoftConsoleRule.LoggerNamePattern = "Microsoft.*";
-                    logMicrosoftConsoleRule.SetLoggingLevels(LogLevel.Debug, LogLevel.Info);
-                    logMicrosoftConsoleRule.Final = true;
-                    logConfig.LoggingRules.Add(logMicrosoftConsoleRule);
-                }
-
                 var logConsoleRule = new LoggingRule("*", logLevel, logConsole);
                 logConfig.LoggingRules.Add(logConsoleRule);
-                
+
                 var logService = new LogCacheService();
                 logConfig.AddTarget("service", logService);
                 var serviceRule = new LoggingRule("*", logLevel, logService);

--- a/src/Jackett.Common/Utils/LoggingSetup.cs
+++ b/src/Jackett.Common/Utils/LoggingSetup.cs
@@ -42,6 +42,7 @@ namespace Jackett.Common.Utils
                 logConfig.LoggingRules.Add(logConsoleRule);
 
                 var logService = new LogCacheService();
+                logService.Name = "service";
                 logConfig.AddTarget("service", logService);
 
                 var serviceMicrosoftRule = new LoggingRule();

--- a/src/Jackett.Common/Utils/LoggingSetup.cs
+++ b/src/Jackett.Common/Utils/LoggingSetup.cs
@@ -38,9 +38,19 @@ namespace Jackett.Common.Utils
                 logConfig.AddTarget("console", logConsole);
 
                 logConsole.Layout = "${simpledatetime} ${level} ${message} ${exception:format=ToString}";
+
+                if (!settings.TracingEnabled)
+                {
+                    var logMicrosoftConsoleRule = new LoggingRule();
+                    logMicrosoftConsoleRule.LoggerNamePattern = "Microsoft.*";
+                    logMicrosoftConsoleRule.SetLoggingLevels(LogLevel.Debug, LogLevel.Info);
+                    logMicrosoftConsoleRule.Final = true;
+                    logConfig.LoggingRules.Add(logMicrosoftConsoleRule);
+                }
+
                 var logConsoleRule = new LoggingRule("*", logLevel, logConsole);
                 logConfig.LoggingRules.Add(logConsoleRule);
-
+                
                 var logService = new LogCacheService();
                 logConfig.AddTarget("service", logService);
                 var serviceRule = new LoggingRule("*", logLevel, logService);

--- a/src/Jackett.Server/Helper.cs
+++ b/src/Jackett.Server/Helper.cs
@@ -140,6 +140,20 @@ namespace Jackett.Server
         {
             foreach (var rule in LogManager.Configuration.LoggingRules)
             {
+                if (rule.LoggerNamePattern == "Microsoft.*")
+                {
+                    var target = LogManager.Configuration.ConfiguredNamedTargets.First(t => t.Name == "service");
+                    if (level == LogLevel.Debug)
+                    {
+                        rule.Targets.Add(target);
+                    }
+                    else
+                    {
+                        rule.Targets.Remove(target);
+                    }
+                    continue;
+                }
+
                 if (level == LogLevel.Debug)
                 {
                     if (!rule.Levels.Contains(LogLevel.Debug))

--- a/src/Jackett.Server/Program.cs
+++ b/src/Jackett.Server/Program.cs
@@ -7,7 +7,7 @@ using Jackett.Common.Utils;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
-using NLog;
+using Microsoft.Extensions.Logging;
 using NLog.Web;
 using System;
 using System.Collections.Generic;
@@ -62,8 +62,8 @@ namespace Jackett.Server
                 runtimeDictionary = GetValues(Settings);
             });
 
-            LogManager.Configuration = LoggingSetup.GetLoggingConfiguration(Settings);
-            Logger logger = LogManager.GetCurrentClassLogger();
+            NLog.LogManager.Configuration = LoggingSetup.GetLoggingConfiguration(Settings);
+            NLog.Logger logger = NLog.LogManager.GetCurrentClassLogger();
             logger.Info("Starting Jackett v" + EnvironmentUtil.JackettVersion);
 
             // create PID file early
@@ -167,7 +167,7 @@ namespace Jackett.Server
                         Console.WriteLine("Deleting PID file " + PIDFile);
                         File.Delete(PIDFile);
                     }
-                    LogManager.Shutdown();
+                    NLog.LogManager.Shutdown();
                 }
             }
             catch (Exception ex)
@@ -184,6 +184,11 @@ namespace Jackett.Server
                 .PreferHostingUrls(true)
                 .UseConfiguration(Configuration)
                 .UseStartup<Startup>()
+                .ConfigureLogging(logging =>
+                {
+                    logging.ClearProviders();
+                    logging.SetMinimumLevel(LogLevel.Trace);
+                })
                 .UseNLog();
     }
 }


### PR DESCRIPTION
Microsoft logs are now correctly log by NLog.
By default, these are deactivated for service log.
You can set tracing enabled option or Enhanced logging to true for log again.