### PR TITLE
VOSTFR option added to "Replace MULTI" on YggTorrent

### DIFF
--- a/src/Jackett.Common/Definitions/yggtorrent.yml
+++ b/src/Jackett.Common/Definitions/yggtorrent.yml
@@ -117,6 +117,8 @@
         MULTI.FRENCH: "MULTI.FRENCH"
         ENGLISH: "ENGLISH"
         MULTI.ENGLISH: "MULTI.ENGLISH"
+        VOSTFR: "VOSTFR"
+        MULTI.VOSTFR: "MULTI.VOSTFR"
     - name: vostfr
       type: checkbox
       label: Replace VOSTFR with ENGLISH


### PR DESCRIPTION
Jackett allows to replace MULTI with FRENCH, which might be useful to grab dubbed releases only.

For people, such as me, who prefers sub over dub, this would allow us to blacklist the word "FRENCH", commonly used for dubbed content.
It has been tested on my personal setup and works as expected.