### PR TITLE
Update linkomanija.yml

### DIFF
--- a/src/Jackett.Common/Definitions/linkomanija.yml
+++ b/src/Jackett.Common/Definitions/linkomanija.yml
@@ -1,7 +1,7 @@
 ---
   site: linkomanija
   name: LinkoManija
-  description: "LinkoManija is an ITALIAN Private site for TV / MOVIES / GENERAL"
+  description: "LinkoManija is an LITHUANIAN Private site for TV / MOVIES / GENERAL"
   language: lt-lt
   type: private
   encoding: UTF-8


### PR DESCRIPTION
It is Lithuanian tracker not Italian, that is often confused because of the .LT versus .IT domain names, however not sure how it happened here.