### PR TITLE
fix audiobookbay categorymappings id type

### DIFF
--- a/src/Jackett.Common/Definitions/audiobookbay.yml
+++ b/src/Jackett.Common/Definitions/audiobookbay.yml
@@ -54,7 +54,7 @@
       - {id: Sports, cat: Audio/Audiobook, desc: "Sports"}
       - {id: Suspense, cat: Audio/Audiobook, desc: "Suspense"}
       - {id: Thriller, cat: Audio/Audiobook, desc: "Thriller"}
-      - {id: True, cat: Audio/Audiobook, desc: "True Crime"}
+      - {id: "True", cat: Audio/Audiobook, desc: "True Crime"}
       - {id: Tutorial, cat: Audio/Audiobook, desc: "Tutorial"}
       - {id: Westerns, cat: Audio/Audiobook, desc: "Westerns"}
       - {id: Anthology, cat: Audio/Audiobook, desc: "Anthology"}


### PR DESCRIPTION
True without quotes is boolean in yaml, should be string