### PR TITLE
fix parse error in EliteTracker indexer

### DIFF
--- a/src/Jackett.Common/Indexers/EliteTracker.cs
+++ b/src/Jackett.Common/Indexers/EliteTracker.cs
@@ -236,7 +236,7 @@ namespace Jackett.Common.Indexers
                             banner.Remove();
                         }
 
-                        tooltip.QuerySelector("div:contains(\"Total Hits : \")").Remove();
+                        tooltip.QuerySelector("div:contains(\"Total Hits\")").Remove();
 
                         var longtitle = tooltip.QuerySelectorAll("div").First();
                         release.Title = longtitle.TextContent;


### PR DESCRIPTION
fix parse error in EliteTracker indexer (again).
EliteTracker has revert a modification on his tooltip.
Normally this fix will work in all cases.