### PR TITLE
Added regexp for searching complete seasons in PyMedusa

### DIFF
--- a/src/Jackett.Common/Definitions/hdspain.yml
+++ b/src/Jackett.Common/Definitions/hdspain.yml
@@ -39,6 +39,8 @@
     path: index.php
     keywordsfilters:
       - name: re_replace
+        args: ["(?i)\\bS0*(\\d+)\\b", "T$1"]
+      - name: re_replace
         args: ["S0?(\\d{1,2})E(\\d{1,2})", "$1x$2"]
     inputs:
       sec: listado


### PR DESCRIPTION
In HD-Spain tracker, Sxx format for complete season doesn't work, they are titled Tx (Temporada is the meaning of Season in Spanish, so T is used instead of S).
In this commit, I added an additional regexp that changes S with T, and deletes 0 before S.