### PR TITLE
BJShare: Only set quality if available

### DIFF
--- a/src/Jackett.Common/Indexers/BJShare.cs
+++ b/src/Jackett.Common/Indexers/BJShare.cs
@@ -198,18 +198,21 @@ namespace Jackett.Common.Indexers
                             var catStr = qCatLink.GetAttribute("href").Split('=')[1];
                             release.Title = FixAbsoluteNumbering(release.Title);
 
-                            var quality = qQuality.TextContent;
-                            switch (quality)
+                            if (qQuality != null)
                             {
-                                case "Full HD":
-                                    release.Title += " 1080p";
-                                    break;
-                                case "HD":
-                                    release.Title += " 720p";
-                                    break;
-                                default:
-                                    release.Title += " 480p";
-                                    break;
+                                var quality = qQuality.TextContent;
+                                switch (quality)
+                                {
+                                    case "Full HD":
+                                        release.Title += " 1080p";
+                                        break;
+                                    case "HD":
+                                        release.Title += " 720p";
+                                        break;
+                                    default:
+                                        release.Title += " 480p";
+                                        break;
+                                }
                             }
 
                             release.Category = MapTrackerCatToNewznab(catStr);


### PR DESCRIPTION
While researching why this doesn't work: https://github.com/Jackett/Jackett/issues/4414#issuecomment-471376387. I noticed that it would just run `TodayUrl` query and generate a lot of noise (exceptions which are logged because the `<font color="red">` element doesn't exist) on some `<tr>`s that are not video content. 

Instead there should not be an attempt to create a release from that.

I did not shuffle the code around, but it could probably be tested just after qQuality is created. Happy to change that.

If it should just return the content, so perhaps we should just safeguard it from null and let it fall into default case?