### PR TITLE
bjshare: Remove query.Clone 

### DIFF
--- a/src/Jackett.Common/Indexers/BJShare.cs
+++ b/src/Jackett.Common/Indexers/BJShare.cs
@@ -128,12 +128,8 @@ namespace Jackett.Common.Indexers
 
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {
-            query = query.Clone(); // avoid modifing the original query
-            
 
             var releases = new List<ReleaseInfo>();
-
-            
 
             // if the search string is empty use the "last 24h torrents" view
             if (string.IsNullOrWhiteSpace(query.SearchTerm) && !query.IsImdbQuery)


### PR DESCRIPTION
I don't understand clearly how `query.Clone()` was used there, and per @garfield69 
comment (https://github.com/Jackett/Jackett/issues/4414#issuecomment-472129311), `clone` seems to be destroying the query contents.

Before this change, it would just return the most recent results, as shown in #4414.

Truncated logs:
```
03-12 18:40:04 Info Found 2 (0 new) releases from BJ-Share
03-12 18:40:04 Info Executed action method Jackett.Server.Controllers.ResultsController.Torznab (jackett), returned result Microsoft.AspNetCore.Mvc.ContentResult in 1378.2458ms.
03-12 18:40:04 Info Executing ContentResult with HTTP Response ContentType of application/rss+xml; charset=utf-8
03-12 18:40:04 Debug Response compression is not enabled for the Content-Type 'application/rss+xml'.
03-12 18:40:04 Info Executed action Jackett.Server.Controllers.ResultsController.Torznab (jackett) in 1446.8674ms
03-12 18:40:04 Info Request finished in 1459.4661ms 200 application/rss+xml; charset=utf-8
```

The 2 results are the only availables at the tracker.