### PR TITLE
Add missing properties to TorznabQuery#Clone

### DIFF
--- a/src/Jackett.Common/Models/TorznabQuery.cs
+++ b/src/Jackett.Common/Models/TorznabQuery.cs
@@ -175,6 +175,8 @@ namespace Jackett.Common.Models
                 ret.QueryStringParts = new string[QueryStringParts.Length];
                 Array.Copy(QueryStringParts, ret.QueryStringParts, QueryStringParts.Length);
             }
+            ret.RageID = RageID;
+            ret.ImdbID = ImdbID;
 
             return ret;
         }


### PR DESCRIPTION
Those seems to be the only two public properties missing from TorznabQuery#Clone.

This closes #4414.