### PR TITLE
Change release name to use 'title' attribute

### DIFF
--- a/src/Jackett.Common/Indexers/Pretome.cs
+++ b/src/Jackett.Common/Indexers/Pretome.cs
@@ -290,7 +290,7 @@ namespace Jackett.Common.Indexers
                     release.MinimumSeedTime = 172800;
 
                     var qLink = row.ChildElements.ElementAt(1).Cq().Find("a").First();
-                    release.Title = qLink.Text().Trim();
+                    release.Title = qLink.Attr("title");
                     if (qLink.Find("span").Count() == 1 && release.Title.StartsWith("NEW! |"))
                     {
                         release.Title = release.Title.Substring(6).Trim();


### PR DESCRIPTION
Use link 'title' attribute. The text gets truncated by the website automatically if its longer than a certain length causing matching problems.