### PR TITLE
PublishDate to torrents from current year was handled wrongly.

### DIFF
--- a/src/Jackett.Common/Definitions/bithumen.yml
+++ b/src/Jackett.Common/Definitions/bithumen.yml
@@ -135,13 +135,24 @@
           - name: replace
             args: ["×", ""]
       date:
-        selector: td:nth-child(5)
+        selector: td:nth-child(5):contains('.')
+        optional: true
+        remove: font
+        filters:
+          - name: replace
+            args: [". ", " "]
+          - name: prepend
+            args: "2019."
+          - name: re_replace
+            args: ["([0-9]{4}).([0-9]+).([0-9]+) (.*)", "$2.$3.$1 $4"]
+      date:
+        selector: td:nth-child(5):contains('ma'), td:nth-child(5):contains("tegnap"), td:nth-child(5):contains('-')
+        optional: true
         remove: font
         filters:
           - name: replace
             args: ["ma", "today"]
           - name: replace
             args: ["tegnap", "yesterday"]
-      
       description:
         selector: td:nth-child(2) > div


### PR DESCRIPTION
On site the date is 02.18 08:31  (Without year):

![Screenshot from 2019-03-27 15-29-07](https://user-images.githubusercontent.com/6975928/55084308-46d99000-50a5-11e9-80b0-3ab4f36826ab.png)


Result with previous yml:
```
      <title>Smurfs.The.Lost.Village.2017.2160p.UHD.BluRay.HDR.REMUX.TrueHD.Atmos.7.1.HEVC.HUN-Legacy</title>
      <guid>https://bithumen.be/details.php?id=569959</guid>
      <jackettindexer id="bithumen2">BitHUmen2</jackettindexer>
      <comments>https://bithumen.be/details.php?id=569959</comments>
      <pubDate>Mon, 18 Feb 2008 00:00:00 +0100</pubDate>
```


Result with corrected one:
```
     <title>Smurfs.The.Lost.Village.2017.2160p.UHD.BluRay.HDR.REMUX.TrueHD.Atmos.7.1.HEVC.HUN-Legacy</title>
      <guid>https://bithumen.be/details.php?id=569959</guid>
      <jackettindexer id="bithumen">BitHUmen</jackettindexer>
      <comments>https://bithumen.be/details.php?id=569959</comments>
      <pubDate>Mon, 18 Feb 2019 08:31:00 +0100</pubDate>
```