### PR TITLE
cpasbien, cpasbienclone, gktorrent, torrent9, torrent9clone: fix title with MULTI language.

### DIFF
--- a/src/Jackett.Common/Definitions/cpabien.yml
+++ b/src/Jackett.Common/Definitions/cpabien.yml
@@ -69,6 +69,8 @@
           - name: replace
             args: [" FRENCH", " {{ .Result.site_date }} FRENCH"]
           - name: replace
+            args: ["MULTI", "{{ .Result.site_date }} MULTI"]
+          - name: replace
             args: ["TRUEFRENCH", "{{ .Result.site_date }} TRUEFRENCH"]
           - name: replace
             args: ["VOSTFR", "{{ .Result.site_date }} VOSTFR"]

--- a/src/Jackett.Common/Definitions/cpasbienclone.yml
+++ b/src/Jackett.Common/Definitions/cpasbienclone.yml
@@ -52,6 +52,8 @@
           - name: replace
             args: [" FRENCH", " {{ .Result.site_date }} FRENCH"]
           - name: replace
+            args: ["MULTI", "{{ .Result.site_date }} MULTI"]
+          - name: replace
             args: ["TRUEFRENCH", "{{ .Result.site_date }} TRUEFRENCH"]
           - name: replace
             args: ["VOSTFR", "{{ .Result.site_date }} VOSTFR"]

--- a/src/Jackett.Common/Definitions/gktorrent.yml
+++ b/src/Jackett.Common/Definitions/gktorrent.yml
@@ -65,6 +65,8 @@
           - name: replace
             args: [" FRENCH", " {{ .Result.site_date }} FRENCH"]
           - name: replace
+            args: ["MULTI", "{{ .Result.site_date }} MULTI"]
+          - name: replace
             args: ["TRUEFRENCH", "{{ .Result.site_date }} TRUEFRENCH"]
           - name: replace
             args: ["VOSTFR", "{{ .Result.site_date }} VOSTFR"]

--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -65,6 +65,8 @@
           - name: replace
             args: [" FRENCH", " {{ .Result.site_date }} FRENCH"]
           - name: replace
+            args: ["MULTI", "{{ .Result.site_date }} MULTI"]
+          - name: replace
             args: ["TRUEFRENCH", "{{ .Result.site_date }} TRUEFRENCH"]
           - name: replace
             args: ["VOSTFR", "{{ .Result.site_date }} VOSTFR"] 

--- a/src/Jackett.Common/Definitions/torrent9clone.yml
+++ b/src/Jackett.Common/Definitions/torrent9clone.yml
@@ -75,6 +75,8 @@
           - name: replace
             args: [" FRENCH", " {{ .Result.site_date }} FRENCH"]
           - name: replace
+            args: ["MULTI", "{{ .Result.site_date }} MULTI"]
+          - name: replace
             args: ["TRUEFRENCH", "{{ .Result.site_date }} TRUEFRENCH"]
           - name: replace
             args: ["VOSTFR", "{{ .Result.site_date }} VOSTFR"] 


### PR DESCRIPTION
The MULTI was before the year so it was not supported by Radarr,Couchpotato etc..

Now it is handle as the FRENCH and TRUEFRENCH language