### PR TITLE
Development Dockerfile

### DIFF
--- a/Dockerfiledev
+++ b/Dockerfiledev
@@ -1,0 +1,40 @@
+FROM lsiobase/ubuntu:bionic
+
+RUN \
+ apt-get update && \
+ apt-get install -y wget gpg && \
+ echo "**** install packages ****" && \
+ wget -qO- https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor > microsoft.asc.gpg && \
+ mv microsoft.asc.gpg /etc/apt/trusted.gpg.d/ && \
+ wget -q https://packages.microsoft.com/config/ubuntu/18.04/prod.list && \
+ mv prod.list /etc/apt/sources.list.d/microsoft-prod.list && \
+ chown root:root /etc/apt/trusted.gpg.d/microsoft.asc.gpg && \
+ chown root:root /etc/apt/sources.list.d/microsoft-prod.list && \
+ apt-get update && \
+ apt-get install -y \
+	mono-complete nuget mono-xbuild aspnetcore-runtime-2.2 dotnet-sdk-2.2 && \
+ echo "**** install jackett ****" && \
+ mkdir -p \
+	/app/Jackett && \
+ chown -R root:root /app/Jackett && \
+ echo "**** cleanup ****" && \
+ apt-get clean && \
+ rm -rf \
+	/tmp/* \
+	/var/lib/apt/lists/* \
+	/var/tmp/*
+
+
+ENV DOTNET_CLI_TELEMETRY_OPTOUT="1"
+RUN echo $DOTNET_CLI_TELEMETRY_OPTOUT 
+
+ENTRYPOINT rm -rf /app/Jackett/* && \
+ cp -R /config/* /app/Jackett/ && \
+ chown -R root:root /app/Jackett && \ 
+ cd /app/Jackett/src && \ 
+ dotnet publish Jackett.Server -f netcoreapp2.2 --self-contained -r linux-x64 -c Debug && \
+ ./Jackett.Server/bin/Debug/netcoreapp2.2/linux-x64/jackett
+
+# ports and volumes
+VOLUME /config /downloads
+EXPOSE 9117

--- a/README.md
+++ b/README.md
@@ -593,6 +593,20 @@ dotnet publish Jackett.Server -f netcoreapp2.2 --self-contained -r linux-x64 -c 
 ./Jackett.Server/bin/Debug/netcoreapp2.2/linux-x64/jackett # run jackett
 ```
 
+### Docker
+```bash
+# build the image once
+docker build -t jackett/jackett:local -f Dockerfiledev .
+
+# run it
+docker run --name jackettdev -d -v <path_to_root>:/config -p 9117:9117 jackett/jackett:local
+
+docker stop jackettdev
+
+# make your changes and start it again. jackett in the container will be wiped
+docker start jackettdev
+```
+
 ## Screenshots
 
 ![screenshot](https://i.imgur.com/0d1nl7g.png "screenshot")

--- a/README.md
+++ b/README.md
@@ -599,11 +599,11 @@ dotnet publish Jackett.Server -f netcoreapp2.2 --self-contained -r linux-x64 -c 
 docker build -t jackett/jackett:local -f Dockerfiledev .
 
 # run it
-docker run --name jackettdev -d -v <path_to_root>:/config -p 9117:9117 jackett/jackett:local
+docker run --name jackettdev -d -v <path_to_root_of_jackett>:/config -p 9117:9117 jackett/jackett:local
 
 docker stop jackettdev
 
-# make your changes and start it again. jackett in the container will be wiped
+# make your changes and start it again. jackett in the container will be wiped and copied from /config volume
 docker start jackettdev
 ```
 


### PR DESCRIPTION
Not sure if this is useful to anyone. Can delete the PR if not. Wanted to make small changes without installing all the dependencies on my host machine.

 - Will install dotnet on build of image
 - on start /app/Jackett folder is wiped, contents of where /config is mapped to is copied into /app/Jackett, and jackett runs
 - named the dockerfile 'Dockerfiledev' implying it's not your standard Dockerfile. I'm a fan of the linuxserver.io based images for actual use.