### PR TITLE
Manage SUBFRENCH as VOSTFR to avoid "English is wanted, but found French"

### DIFF
--- a/src/Jackett.Common/Definitions/yggtorrent.yml
+++ b/src/Jackett.Common/Definitions/yggtorrent.yml
@@ -226,6 +226,8 @@
         filters:
           - name: re_replace
             args: ["[\\.\\s\\[\\-][Vv][Oo][Ss][Tt][Ff][Rr][\\.\\s\\]\\-]", ".ENGLISH."]
+          - name: re_replace
+            args: ["[\\.\\s\\[\\-][Ss][Uu][Bb][Ff][Rr][Ee][Nn][Cc][Hh][\\.\\s\\]\\-]", ".ENGLISH."]
       title:
         text: "{{if .Config.vostfr }}{{ .Result.title_vostfr }}{{else}}{{ .Result.title_phase2 }}{{end}}"
       details:


### PR DESCRIPTION
Brooklyn.Nine-Nine.S06E17.SUBFRENCH.720p.HDTV.x264-AMB3R is recognized as french content instead of english content, even if "Replace VOSTFR with ENGLISH" is enabled