### PR TITLE
Fixed details url and add more things

### DIFF
--- a/src/Jackett.Common/Definitions/hdspain.yml
+++ b/src/Jackett.Common/Definitions/hdspain.yml
@@ -64,7 +64,10 @@
           - name: append
             args: " [spanish]"
       details:
-        selector: td.titulo a
+        selector: td.titulo a[id]
+        attribute: href
+      comments:
+        selector: td.foro a
         attribute: href
       size:
         selector: td.tamano
@@ -142,3 +145,10 @@
         filters:
           - name: replace
             args: ["Freeleech X2", "2"]
+      minimumratio:
+        text: "1.0"
+      minimumseedtime:
+        text: "345600"
+      description:
+        optional: true
+        selector: td.titulo a[class]


### PR DESCRIPTION
- Fixed details url, now when click on a torrent name will open the torrent url correctly
- Added comments (link to topic in forum)
- Added  minimum ratio and minimum seed time
- Added "Megapack / Audio Editado" labels as description