### PR TITLE
Update hdspain.yml with Megapack, edited audios...

### DIFF
--- a/src/Jackett.Common/Definitions/hdspain.yml
+++ b/src/Jackett.Common/Definitions/hdspain.yml
@@ -58,13 +58,28 @@
         filters:
           - name: querystring
             args: cat
+      extras:
+        text: ""
+      extras:
+        optional: true
+        selector: td.titulo a[class]
+        filters:
+          - name: prepend
+            args: "["
+          - name: append
+            args: "]"
       title:
         selector: td.titulo a[id]
         filters:
+          - name: prepend
+            args: "{{ .Result.extras }} "
           - name: append
-            args: " [spanish]"
+            args: " [Spanish]"
       details:
-        selector: td.titulo a
+        selector: td.titulo a[id]
+        attribute: href
+      comments:
+        selector: td.foro a
         attribute: href
       size:
         selector: td.tamano
@@ -142,3 +157,10 @@
         filters:
           - name: replace
             args: ["Freeleech X2", "2"]
+      minimumratio:
+        text: "1.0"
+      minimumseedtime:
+        text: "345600"
+      description:
+        optional: true
+        selector: td.titulo a[class]


### PR DESCRIPTION
- Fixed details url, now when click on a torrent name will open the torrent url correctly
- Added comments (link to topic in forum)
- Added minimum ratio and minimum seed time
- Added "Megapack / Audio Editado" labels as to the title torrent and description.

"Edited audios" and "Megapacks" use the "extras" variable