### PR TITLE
TorrentSyndikat: Do not filter query, remove wildcard operator.

### DIFF
--- a/src/Jackett.Common/Indexers/TorrentSyndikat.cs
+++ b/src/Jackett.Common/Indexers/TorrentSyndikat.cs
@@ -151,9 +151,7 @@ namespace Jackett.Common.Indexers
                 {
                     // use AND+wildcard operator to avoid getting to many useless results
                     var searchStringArray = Regex.Split(searchString.Trim(), "[ _.-]+", RegexOptions.Compiled).ToList();
-                    searchStringArray = searchStringArray.Where(x => x.Length >= 3).ToList(); //  remove words with less than 3 characters
-                    searchStringArray = searchStringArray.Where(x => !new string[] { "der", "die", "das", "the" }.Contains(x.ToLower())).ToList(); //  remove words with less than 3 characters
-                    searchStringArray = searchStringArray.Select(x => "+" + x + "*").ToList(); // add AND operators+wildcards
+                    searchStringArray = searchStringArray.Select(x => "+" + x).ToList(); // add AND operators
                     var searchStringFinal = String.Join(" ", searchStringArray);
                     queryCollection.Add("search", searchStringFinal);
             }


### PR DESCRIPTION
TS removes too short words automatically, so don't try to handle this client-side.

Adding the wildcard causes problems with not indexed words (stopwords) such as "how" (as in "how to sell drugs online fast"). Searching for terms like this leads to empty results:
"+How* +to* +sell* +drugs*" -> no results
"+How +to +sell +drugs" -> all results

I think at one time, adding the wildcards manually may have been necessary, but this does not seem to be the case with the current TS version.