### PR TITLE
Update Mejortorrent.cs

### DIFF
--- a/src/Jackett.Common/Indexers/MejorTorrent.cs
+++ b/src/Jackett.Common/Indexers/MejorTorrent.cs
@@ -18,7 +18,7 @@ namespace Jackett.Common.Indexers
 {
     class MejorTorrent : BaseWebIndexer
     {
-        public static Uri WebUri = new Uri("http://www.mejortorrentt.com/");
+        public static Uri WebUri = new Uri("http://www.mejortorrentt.org/");
         public static Uri DownloadUri = new Uri(WebUri, "secciones.php?sec=descargas&ap=contar_varios");
         private static Uri SearchUriBase = new Uri(WebUri, "secciones.php");
         public static Uri NewTorrentsUri = new Uri(WebUri, "secciones.php?sec=ultimos_torrents");
@@ -27,6 +27,7 @@ namespace Jackett.Common.Indexers
         public override string[] LegacySiteLinks { get; protected set; } = new string[] {
             "http://www.mejortorrent.org/",
             "http://www.mejortorrent.tv/",
+            "http://www.mejortorrentt.com/",
         };
 
         public MejorTorrent(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
@@ -711,9 +712,9 @@ namespace Jackett.Common.Indexers
                 try
                 {
                     var title = titleSelector.TextContent;
-                    if (title.Contains("(") && title.Contains(")") && title.Contains("4k"))
+                    if (title.Contains("(") && title.Contains(")") && title.Contains("3D"))
                     {
-                        release.CategoryText = "2160p";
+                        release.CategoryText = "3D";
                     }
                 }
                 catch { }


### PR DESCRIPTION
1. Update new domain.
2. Since the options for filtering 4k do not work in this indexer, it has been changed to the 3D category that should work better.

I'm doing it trial and error, as I have no knowledge of C#.