### PR TITLE
Update MejorTorrent.cs

### DIFF
--- a/src/Jackett.Common/Indexers/MejorTorrent.cs
+++ b/src/Jackett.Common/Indexers/MejorTorrent.cs
@@ -662,6 +662,7 @@ namespace Jackett.Common.Indexers
                 release.IsMovie = true;
                 var selectors = html.QuerySelectorAll("b");
                 var titleSelector = html.QuerySelector("span>b");
+                var titleSelector3do4k = html.QuerySelector("span:nth-child(4) > b:nth-child(1)");
                 try
                 {
                     var title = titleSelector.TextContent;
@@ -712,19 +713,41 @@ namespace Jackett.Common.Indexers
                 try
                 {
                     var title = titleSelector.TextContent;
-                    if (title.Contains("(") && title.Contains(")") && title.Contains("4k"))
+                    if (title.Contains("(") && title.Contains(")") && title.Contains("3D"))
                     {
-                        release.CategoryText = "2160p";
+                        release.CategoryText = "3D";
                     }
-                }
-                catch { }
+                } catch { }
+                try
+                {
+                    var title = titleSelector.TextContent;
+                    if (title.Contains("(") && title.Contains(")") && title.Contains("4K"))
+                    {
+                        release.CategoryText = "4K";
+                    }
+                } catch { }
+                try
+                {
+                    var title = titleSelector3do4k.TextContent;
+                    if (title.Contains("[") && title.Contains("]") && title.Contains("3D"))
+                    {
+                        release.CategoryText = "3D";
+                    }
+                } catch { }
+                try
+                {
+                    var title = titleSelector3do4k.TextContent;
+                    if (title.Contains("[") && title.Contains("]") && title.Contains("4K"))
+                    {
+                        release.CategoryText = "4K";
+                    }
+                } catch { }
                 try
                 {
                     var link = html.QuerySelector("a[href*=\"sec=descargas\"]").GetAttribute("href");
                     release.Link = new Uri(WebUri, link);
                     release.Guid = release.Link;
-                }
-                catch { }
+                } catch { }
                 return release;
             }
         }


### PR DESCRIPTION
This indexer was not able to distinguish whether a film is 3D or 4K, which made it totally unusable.

After a lot of fighting with Visual Studio to do tests compiling Jackett, I got the indexer to **differentiate 3D and 4K movies**.

Example screenshot:
![Example screenshot](https://i.imgur.com/cVp2Klc.jpg)

Testing in Visual Studio:
![Example screenshot](https://i.imgur.com/7pGQsBi.jpg)

This update fixes the issue **[#3384](https://github.com/Jackett/Jackett/issues/3384#issue-340839221)**, which is currently open.