### PR TITLE
[Torrenting] Resolve Issue with Download Volume Factor

### DIFF
--- a/src/Jackett.Common/Definitions/torrenting.yml
+++ b/src/Jackett.Common/Definitions/torrenting.yml
@@ -86,7 +86,7 @@
         text: "1"
       downloadvolumefactor:
         case:
-          "span:contains(\"Freeleech\")": "0"
+          "span:contains(\"FreeLeech\")": "0"
           "*": "1"
       uploadvolumefactor:
         case:


### PR DESCRIPTION
I apologize for my inexperience, but I was able to resolve an issue, so wanted to share. I noticed that the downloadvolumefactor was not detecting freeleech items properly. From looking at the html through chrome, the span should contain Freeleech just like the existing code was written, but that wasn't working. I enabled enhanced logging, and when looking through the dump from enhanced logging, noticed it should be FreeLeech. I changed the code locally and it resolves the issue.