### PR TITLE
Fixed definition of greekteam tracker

### DIFF
--- a/src/Jackett.Common/Definitions/greekteam.yml
+++ b/src/Jackett.Common/Definitions/greekteam.yml
@@ -121,20 +121,20 @@
       download:
         text: "download2.php?torrent={{ .Result._id }}"
       size:
-        selector: td:nth-last-child(4)
+        selector: td:nth-last-child(3)
       date:
-        selector: td:nth-last-child(6) > nobr
+        selector: td:nth-last-child(5) > nobr
         filters:
           - name: append
             args: " +02:00"
           - name: dateparse
             args: "2006-01-0215:04:05 -07:00"
       files:
-        selector: td:nth-last-child(8)
+        selector: td:nth-last-child(7)
       seeders:
-        selector: td:nth-last-child(3)
-      leechers:
         selector: td:nth-last-child(2)
+      leechers:
+        selector: td:nth-last-child(1)
       downloadvolumefactor:
         case:
           "img[src=\"pic/free.png\"]": "0"


### PR DESCRIPTION
The tracker has updated it's html layout and removed a column from the browse list. I have adapted and tested the definition to the new table format.