### PR TITLE
Fix option for padding episode numbers of AnimeBytes results to work …

### DIFF
--- a/src/Jackett.Common/Indexers/AnimeBytes.cs
+++ b/src/Jackett.Common/Indexers/AnimeBytes.cs
@@ -22,7 +22,7 @@ namespace Jackett.Common.Indexers
         private string ScrapeUrl { get { return SiteLink + "scrape.php"; } }
         private string TorrentsUrl { get { return SiteLink + "torrents.php"; } }
         public bool AllowRaws { get { return configData.IncludeRaw.Value; } }
-        public bool InsertSeason { get { return configData.InsertSeason != null && configData.InsertSeason.Value; } }
+        public bool PadEpisode { get { return configData.PadEpisode != null && configData.PadEpisode.Value; } }
         public bool AddSynonyms { get { return configData.AddSynonyms.Value; } }
         public bool FilterSeasonEpisode { get { return configData.FilterSeasonEpisode.Value; } }
 
@@ -237,10 +237,9 @@ namespace Jackett.Common.Indexers
                             releaseInfo = releaseInfo.Replace("Season ", "S");
                             releaseInfo = releaseInfo.Trim();
 
-                            int test = 0;
-                            if (InsertSeason && int.TryParse(releaseInfo, out test) && releaseInfo.Length <= 3)
+                            if (PadEpisode && int.TryParse(releaseInfo, out int test) && releaseInfo.Length == 1)
                             {
-                                releaseInfo = "E0" + releaseInfo;
+                                releaseInfo = "0" + releaseInfo;
                             }
 
                             if (FilterSeasonEpisode)

--- a/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationDataAnimeBytes.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationDataAnimeBytes.cs
@@ -4,7 +4,7 @@
     {
         public BoolItem IncludeRaw { get; private set; }
         //public DisplayItem DateWarning { get; private set; }
-        public BoolItem InsertSeason { get; private set; }
+        public BoolItem PadEpisode { get; private set; }
         public BoolItem AddSynonyms { get; private set; }
         public BoolItem FilterSeasonEpisode { get; private set; }
 
@@ -13,7 +13,7 @@
         {
             IncludeRaw = new BoolItem() { Name = "IncludeRaw", Value = false };
             //DateWarning = new DisplayItem("This tracker does not supply upload dates so they are based off year of release.") { Name = "DateWarning" };
-            InsertSeason = new BoolItem() { Name = "Prefix episode number with E0 for Sonarr Compatability", Value = false };
+            PadEpisode = new BoolItem() { Name = "Pad episode number for Sonarr compatability", Value = false };
             AddSynonyms = new BoolItem() { Name = "Add releases for each synonym title", Value = true };
             FilterSeasonEpisode = new BoolItem() { Name = "Filter results by season/episode", Value = false };
             Instructions = new DisplayItem(instructionMessageOptional) { Name = "" };


### PR DESCRIPTION
…with Sonarr

The current option adds E0 to episode numbers of length 3 and less. This means episode 342 of a series would turn into E0342. Sonarr matches on \d{2,3} so it would mistakenly parse it as E034.

The new option simply adds a "0" to any single digit episode number, which Sonarr will match correctly.