### PR TITLE
Fix accents on title for HDCity

### DIFF
--- a/src/Jackett.Common/Definitions/hdcity.yml
+++ b/src/Jackett.Common/Definitions/hdcity.yml
@@ -144,6 +144,8 @@
     keywordsfilters:
       - name: re_replace
         args: ["S0?(\\d{1,2})E(\\d{1,2})", "$1x$2"]
+      - name: re_replace
+        args: ["[^a-zA-Z0-9]+", " "]
     inputs:
       page: "torrents"
       $raw: "&category={{range .Categories}}{{.}};{{end}}"


### PR DESCRIPTION
HDCity queries are sensitive to character accents:
Radarr currently doesn't find the movie called "Alita: Ángel De Combate" because all releases on HDCity are called "Alita Angel De Combate". 
Interestingly testing with Jackett I found out that searching for "Alita ngel De Combate" "Alita ng l De C mbate" or any version of replacing characters with spaces still returns all the results. 

That being the case, my suggestion is simply to replace any non-alphanumeric character with spaces to avoid missing results. This still allows to retrieve titles with accents like "El Sangriento Imperio Romano Calígula" as the query for "El Sangriento Imperio Romano Cal gula" works exactly the same way