### PR TITLE
Added TorrentWal Support and updated tracker list.

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ Developer note: The software implements the [Torznab](https://github.com/Sonarr/
  * AniDUB
  * ArenaBG
  * BaibaKo
+ * BookTracker
  * Crazy's Corner
  * CzTorrent
  * Deildu

--- a/src/Jackett.Common/Definitions/booktracker.yml
+++ b/src/Jackett.Common/Definitions/booktracker.yml
@@ -1,0 +1,74 @@
+﻿---
+  site: booktracker
+  name: BookTracker
+  description: "BookTracker is a RUSSIAN Semi-Private Torrent Tracker for EBOOKS"
+  language: ru-ru
+  type: private
+  encoding: UTF-8
+  links:
+    - https://booktracker.org/
+
+  caps:
+    categorymappings:
+      - {id: 1, cat: Books/Ebook, desc: "Ebooks"}
+
+    modes:
+      search: [q]
+
+  login:
+    path: login.php
+    method: form
+    form: form[action$="/login.php"]
+    inputs:
+      login_username: "{{ .Config.username }}"
+      login_password: "{{ .Config.password }}"
+      redirect: "index.php"
+      autologin: 1
+    selectorinputs:
+      cookie_test:
+        selector: input[name="cookie_test"]
+        attribute: value
+    error:
+      - selector: h4.warnColor1
+    test:
+      path: index.php
+      selector: a[href="./login.php?logout=1"]
+
+  search:
+    paths:
+      - path: tracker.php
+    inputs:
+      nm: "{{ .Keywords }}"
+      o: 1
+      s: 2
+      tm: -1
+      sns: -1
+
+    rows:
+      selector: tr[id^="tor_"]:has(a[href^="./download.php?id="])
+
+    fields:
+      title:
+        selector: a.tLink
+      details:
+        selector: a.tLink
+        attribute: href
+      download:
+        selector: a[href^="./download.php?id="]
+        attribute: href
+      category:
+        text: 1
+      size:
+        selector: td:nth-child(6) > u
+      seeders:
+        selector: td.seedmed > b
+      leechers:
+        selector: td.leechmed > b
+      grabs:
+        selector: td:nth-child(9)
+      date:
+        selector: td:last-child > u
+      downloadvolumefactor:
+        text: "1"
+      uploadvolumefactor:
+        text: "1"

--- a/src/Jackett.Common/Definitions/torrentwal.yml
+++ b/src/Jackett.Common/Definitions/torrentwal.yml
@@ -1,118 +1,81 @@
-# Internal name of the indexer
-# (all lower case, typically the display name without any special characters, same as filename)
-site: torrentwal
+---
+  site: torrentwal
+  name: TorrentWal (토렌트왈)
+  description: "Torrent Wal is a free Korean tracker for Korean media."
+  language: ko-KR
+  type: public 
+  encoding: UTF-8
+  links: 
+    - https://torrentwal.com/
+  legacylinks:
+    - https://torrentwal1.com/
 
-# Display name (The full name of the tracker)
-name: TorrentWal (토렌트왈)
+  caps:
+    categorymappings:
+      - {id: "torrent_movie", cat: Movies, desc: "토렌트영화 (Movies)"}
+      - {id: "torrent_variety", cat: TV, desc: "TV예능 (TV Variety Shows)"}
+      - {id: "torrent_tv", cat: TV, desc: "TV드라마 (TV Dramas)"}
+      - {id: "torrent_docu", cat: TV/Documentary, desc: "다큐/시사 (Documentaries)"}
+      - {id: "torrent_sports", cat: TV/Sport, desc: "스포츠 (Sports)"}
+      - {id: "torrent_util", cat: PC, desc: "토렌트유틸 (Utilities)"}
+      - {id: "torrent_ani", cat: TV/Anime, desc: "애니메이션 (Anime)"}
+      - {id: "torrent_song", cat: Audio, desc: "해외음원 (Music)"}
+      - {id: "torrent_game", cat: PC/Games, desc: "토렌트게임 (Games)"}
+      - {id: "torrent_mid", cat: TV/FOREIGN, desc: 해외TV (Foreign TV)"}
+      - {id: "torrent_child", cat: TV, desc: "유아/어린이 (Children's)"}
+      - {id: "torrent_etc", cat: Other, desc: "토렌트 기타 (Other)"}
+      - {id: "torrent_iphone", cat: PC/Phone-Other, desc: "휴대기기 (Phone Apps)"}
+      - {id: "torrent_book", cat: Books, desc: "토렌트도서 (Books)"}
 
-description: "Torrent Wal is a free Korean tracker for Korean media."
+    modes:
+      search: [q]
+      tv-search: [q, season, ep]
+      movie-search: [q]
 
-# Language code of the main language used on the tracker
-# See http://ww.linoes.net/en/translator/langcode.htm
-language: ko-KR
+  settings: []
 
-# Indexer type: # public (no registration required) # semi-private (registration required, but always open)
-# private (registration required. Invite/application needed)
-type: public 
-
-# Website encoding used by the tracker
-encoding: UTF-8
-
-# List of known domains
-# (the first one is the default, must end with /)
-links: 
-  - https://torrentwal.com/
-
-# List of old domains which no longer work
-# If one of these URLs is configured it will be automatically replaced with the default one
-legacylinks:
-  - https://torrentwal1.com/
-
-caps: # Capabilities of the indexer
-  categorymappings: # Mapping between the tracker categories and the
-                    # Newznab categories.
-                    # Not supported by Cardigann.
-                    # - id:      The tracker specific category ID.
-                    #            Can be a string too.
-                    # - cat:     The corresponding newznab predefined category.
-                    #            See this list for valid options:
-                    #            https://github.com/nZEDb/nZEDb/blob/dev/docs/newznab_api_specification.txt#L608-L695
-                    # - desc:    The tracker category name.
-                    #            Optional.
-                    #            If provided it will be used for a 1:1 mapping between
-                    #            tracker and newznab categories.
-                    # - default: default flag, can be true or false (default is false)
-                    #            Optional.
-                    #            Specify if this category should be used as default (if the search query doesn't
-                    #            contain any categories).
-    - {id: "torrent_movie", cat: Movies, desc: "토렌트영화 (Movies)"}
-    - {id: "torrent_variety", cat: TV, desc: "TV예능 (TV Variety Shows)"}
-    - {id: "torrent_tv", cat: TV, desc: "TV드라마 (TV Dramas)"}
-    - {id: "torrent_docu", cat: TV/Documentary, desc: "다큐/시사 (Documentaries)"}
-    - {id: "torrent_sports", cat: TV/Sport, desc: "스포츠 (Sports)"}
-    - {id: "torrent_util", cat: PC, desc: "토렌트유틸 (Utilities)"}
-    - {id: "torrent_ani", cat: TV/Anime, desc: "애니메이션 (Anime)"}
-    - {id: "torrent_song", cat: Audio, desc: "해외음원 (Music)"}
-    - {id: "torrent_game", cat: PC/Games, desc: "토렌트게임 (Games)"}
-    - {id: "torrent_mid", cat: TV/FOREIGN, desc: 해외TV (Foreign TV)"}
-    - {id: "torrent_child", cat: TV, desc: "유아/어린이 (Children's)"}
-    - {id: "torrent_etc", cat: Other, desc: "토렌트 기타 (Other)"}
-    - {id: "torrent_iphone", cat: PC/Phone-Other, desc: "휴대기기 (Phone Apps)"}
-    - {id: "torrent_book", cat: Books, desc: "토렌트도서 (Books)"}
-
-  modes: # Specify which torznab search modes and attributes are supported by the
-         # indexers.
-         # Implementation note: Jackett doesn't care very much about this but you
-         # still should specify the correct modes.
-         # Especially don't include imdbid if the tracker doesn't support
-         # searching by imdbid.
-    search: [q]
-    tv-search: [q]
-    movie-search: [q]
-
-settings: []
-
-search:
-  paths: # list of paths which should be searched
-         # For the most trackers just a single path is needed. but some trackers use
-         # different pages for e.g. porn or scene and non scene releases.
-    - path: "{{ if .Keywords }}bbs/s-1-{{ .Keywords }}{{else}}bbs/s-1-유희열{{end}}"
-  rows:
-    # selector: table.board_list > tbody > tr.bg1:nth-child(n+3)
-    selector: tr.bg1
-  fields:
-    magnet:
-      selector: td:nth-child(1) a[href^="javascript:"]
-      attribute: href
-      filters:
-        - name: replace
-          args: ["javascript:Mag_dn('",""]
-        - name: replace
-          args: ["')",""]
-        - name: prepend
-          args: "magnet:?xt=urn:btih:"
-#   seeders:
-#      selector: td:nth-child(2) font:nth-child(2)
-#   leechers:
-#     selector: td:nth-child(2) font:nth-child(1)
-    category:
-      selector: td:nth-child(2) a[href^="/bbs/bc.php?bo_table="]
-      attribute: href
-      filters:
-        - name: querystring
-          args: bo_table
-    title:
-      selector: td:nth-child(2) a:last-of-type
-    details:
-      selector: td:nth-child(2) a:last-of-type
-      attribute: href
-    date:
-      selector: td:nth-child(3)
-      filters:
-        - name: dateparse
-          args: "01-02"
-    size:
-      selector: td:nth-child(4)
-      filters:
-        - name: append
-          args: "B"
+  search:
+    paths:
+      - path: "{{ if .Keywords }}bbs/s-1-{{ .Keywords }}{{else}}bbs/s-1-유희열{{end}}"
+    rows:
+      selector: tr.bg1
+    fields:
+      magnet:
+        selector: td:nth-child(1) a[href^="javascript:"]
+        attribute: href
+        filters:
+          - name: replace
+            args: ["javascript:Mag_dn('",""]
+          - name: replace
+            args: ["')",""]
+          - name: prepend
+            args: "magnet:?xt=urn:btih:"
+      seeders:
+        text: 1
+      leechers:
+        text: 1
+      category:
+        selector: td:nth-child(2) a[href^="/bbs/bc.php?bo_table="]
+        attribute: href
+        filters:
+          - name: querystring
+            args: bo_table
+      title:
+        selector: td:nth-child(2) a:last-of-type
+      details:
+        selector: td:nth-child(2) a:last-of-type
+        attribute: href
+      date:
+        selector: td:nth-child(3)
+        filters:
+          - name: dateparse
+            args: "01-02"
+      size:
+        selector: td:nth-child(4)
+        filters:
+          - name: append
+            args: "B"
+      downloadvolumefactor:
+        text: 0
+      uploadvolumefactor:
+        text: 1


### PR DESCRIPTION
With TorrentKim going down, I wanted to utilize Jackett with a Korean public tracker so I added a definition for TorrentWal. The format of the website is nearly identical to TorrentKim and the yml is essentially the same as https://github.com/Jackett/Jackett/pull/2620 with some modifications to make sure the data makes sense.

There is no support for seeder/leecher ratios from what I can gather on the website (every torrent seems to have 0/0 ratio and the search URL doesn't even provide those numbers). But everything else should be working! A blank search will pull up "유희열" as the search term. There's no justification for that; I used the previous user's search conditional and I happened to be watching a show called "Yoo Huiyeol's Sketchbook" ("유희열의 스케치북").

I'm not sure how the previous user was able to use TorrentKim for Sonarr because there doesn't seem to be foreign language support and show searching is locked to TVDB in English. I'm trying to see if PyMedusa will serve as an alternative but that's not looking too promising so far either. If anyone has an alternative that allows either for foreign language shows or allows for more customizable searches, it would be appreciated (regex based searches for matched shows?).