### PR TITLE
Cloudflare Bypass: Replaced CloudFlareUtilities with CloudflareSolverRe

### DIFF
--- a/src/Jackett.Common/Jackett.Common.csproj
+++ b/src/Jackett.Common/Jackett.Common.csproj
@@ -11,7 +11,7 @@
     <PackageReference Include="Autofac" Version="4.9.2" />
     <PackageReference Include="AutoMapper" Version="8.1.0" />
     <PackageReference Include="BencodeNET" Version="2.3.0" />
-    <PackageReference Include="CloudFlareUtilities" Version="1.3.0" />
+    <PackageReference Include="CloudflareSolverRe" Version="1.0.5" />
     <PackageReference Include="CommandLineParser" Version="2.5.0" />
     <PackageReference Include="CsQuery.NETStandard" Version="1.3.6.1" />
     <PackageReference Include="DotNet4.SocksProxy" Version="1.4.0.1" />

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
@@ -9,7 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using com.LandonKey.SocksWebProxy;
 using com.LandonKey.SocksWebProxy.Proxy;
-using CloudFlareUtilities;
+using CloudflareSolverRe;
 using Jackett.Common.Models.Config;
 using Jackett.Common.Services.Interfaces;
 using NLog;
@@ -154,9 +154,11 @@ namespace Jackett.Common.Utils.Clients
                 }
             }
 
-            using (ClearanceHandler clearanceHandlr = new ClearanceHandler())
+            string userAgent = webRequest.EmulateBrowser.Value ? BrowserUtil.ChromeUserAgent : "Jackett/" + configService.GetVersion();
+
+            using (ClearanceHandler clearanceHandlr = new ClearanceHandler(userAgent))
             {
-                clearanceHandlr.MaxRetries = 30;
+                clearanceHandlr.MaxTries = 30;
                 using (HttpClientHandler clientHandlr = new HttpClientHandler
                 {
                     CookieContainer = cookies,

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
@@ -9,7 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using com.LandonKey.SocksWebProxy;
 using com.LandonKey.SocksWebProxy.Proxy;
-using CloudFlareUtilities;
+using CloudflareSolverRe;
 using Jackett.Common.Models.Config;
 using Jackett.Common.Services.Interfaces;
 using NLog;
@@ -122,8 +122,8 @@ namespace Jackett.Common.Utils.Clients
 
         public void CreateClient()
         {
-            clearanceHandlr = new ClearanceHandler();
-            clearanceHandlr.MaxRetries = 30;
+            clearanceHandlr = new ClearanceHandler(BrowserUtil.ChromeUserAgent);
+            clearanceHandlr.MaxTries = 30;
             clientHandlr = new HttpClientHandler
             {
                 CookieContainer = cookies,

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2NetCore.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2NetCore.cs
@@ -9,7 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using com.LandonKey.SocksWebProxy;
 using com.LandonKey.SocksWebProxy.Proxy;
-using CloudFlareUtilities;
+using CloudflareSolverRe;
 using Jackett.Common.Models.Config;
 using Jackett.Common.Services.Interfaces;
 using NLog;
@@ -118,8 +118,8 @@ namespace Jackett.Common.Utils.Clients
 
         public void CreateClient()
         {
-            clearanceHandlr = new ClearanceHandler();
-            clearanceHandlr.MaxRetries = 30;
+            clearanceHandlr = new ClearanceHandler(BrowserUtil.ChromeUserAgent);
+            clearanceHandlr.MaxTries = 30;
             clientHandlr = new HttpClientHandler
             {
                 CookieContainer = cookies,
@@ -169,10 +169,10 @@ namespace Jackett.Common.Utils.Clients
             request.Headers.ExpectContinue = false;
             request.RequestUri = new Uri(webRequest.Url);
 
-            if (webRequest.EmulateBrowser == true)
-                request.Headers.UserAgent.ParseAdd(BrowserUtil.ChromeUserAgent);
-            else
-                request.Headers.UserAgent.ParseAdd("Jackett/" + configService.GetVersion());
+            //if (webRequest.EmulateBrowser == true)
+            //    request.Headers.UserAgent.ParseAdd(BrowserUtil.ChromeUserAgent);
+            //else
+            //    request.Headers.UserAgent.ParseAdd("Jackett/" + configService.GetVersion());
 
             // clear cookies from cookiecontainer
             var oldCookies = cookies.GetCookies(request.RequestUri);

--- a/src/Jackett.Common/Utils/Clients/HttpWebClientNetCore.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClientNetCore.cs
@@ -9,7 +9,7 @@ using System.Text;
 using System.Threading.Tasks;
 using com.LandonKey.SocksWebProxy;
 using com.LandonKey.SocksWebProxy.Proxy;
-using CloudFlareUtilities;
+using CloudflareSolverRe;
 using Jackett.Common.Models.Config;
 using Jackett.Common.Services.Interfaces;
 using NLog;
@@ -150,9 +150,11 @@ namespace Jackett.Common.Utils.Clients
                 }
             }
 
-            using (ClearanceHandler clearanceHandlr = new ClearanceHandler())
+            string userAgent = webRequest.EmulateBrowser.Value ? BrowserUtil.ChromeUserAgent : "Jackett/" + configService.GetVersion();
+
+            using (ClearanceHandler clearanceHandlr = new ClearanceHandler(userAgent))
             {
-                clearanceHandlr.MaxRetries = 30;
+                clearanceHandlr.MaxTries = 30;
                 using (HttpClientHandler clientHandlr = new HttpClientHandler
                 {
                     CookieContainer = cookies,
@@ -169,10 +171,10 @@ namespace Jackett.Common.Utils.Clients
                     clearanceHandlr.InnerHandler = clientHandlr;
                     using (var client = new HttpClient(clearanceHandlr))
                     {
-                        if (webRequest.EmulateBrowser == true)
-                            client.DefaultRequestHeaders.Add("User-Agent", BrowserUtil.ChromeUserAgent);
-                        else
-                            client.DefaultRequestHeaders.Add("User-Agent", "Jackett/" + configService.GetVersion());
+                        //if (webRequest.EmulateBrowser == true)
+                        //    client.DefaultRequestHeaders.Add("User-Agent", BrowserUtil.ChromeUserAgent);
+                        //else
+                        //    client.DefaultRequestHeaders.Add("User-Agent", "Jackett/" + configService.GetVersion());
 
                         HttpResponseMessage response = null;
                         using (var request = new HttpRequestMessage())


### PR DESCRIPTION
Fixes #4982 
Test it, it works for me, it should be working.
The only problem is with user-agent, it's now fixed with the BrowserUtil.ChromeUserAgent value.
A website that is protected by cloudflare, once bypassed with some user-agent, it cannot be changed (it must be one during the same session).
If you need some different user-agent with some websites (static during the same session), you have to separate the EmulateBrowser property from the request, it shoud be linked with the HttpWebClient classes.