### PR TITLE
Fix magnet link in the blackhole controller

### DIFF
--- a/src/Jackett.Server/Controllers/BlackholeController.cs
+++ b/src/Jackett.Server/Controllers/BlackholeController.cs
@@ -51,7 +51,12 @@ namespace Jackett.Server.Controllers
                 path = protectionService.UnProtect(path);
                 var remoteFile = new Uri(path, UriKind.RelativeOrAbsolute);
                 var fileExtension = ".torrent";
-                var downloadBytes = await indexer.Download(remoteFile);
+
+                byte[] downloadBytes;
+                if (remoteFile.Scheme == "magnet")
+                    downloadBytes = Encoding.UTF8.GetBytes(remoteFile.OriginalString);
+                else
+                    downloadBytes = await indexer.Download(remoteFile);
 
                 // handle magnet URLs
                 if (downloadBytes.Length >= 7


### PR DESCRIPTION
Subclasses of BaseIndexers.cs override the default behaviour when downloading to the blackhole directory.
When the default behaviour is to check if the uri is already a magnet link, some indexers, such as Rarbg.cs, directly call |RequestStringWithCookies| to download the content of a torrent link, but with a magnet link instead resulting in http/https errors.

This pull request puts the default behaviour of the BaseIndexers directly in the Blackhole controller, allowing to download a magnet link into a .magnet file in the blackhole folder when the magnet link is directly available. 