### PR TITLE
Update hdchina.yml

### DIFF
--- a/src/Jackett.Common/Definitions/hdchina.yml
+++ b/src/Jackett.Common/Definitions/hdchina.yml
@@ -86,11 +86,8 @@
         selector: a[href^="details.php?id="]
         attribute: href    
       download:
-        selector: a[href^="details.php?id="]
+        selector: a[href^="download.php?hash="]
         attribute: href
-        filters:
-          - name: replace
-            args: ["details.php", "download.php"]
       size:
         selector: td.t_size
       grabs:


### PR DESCRIPTION
HDchina.org no longer allows to download torrent from: https://hdchina.org/download.php?id=
Suggest parse download link in pattern https://hdchina.org/download.php?hash=
