### PR TITLE
(Update) channelx.yml

### DIFF
--- a/src/Jackett.Common/Definitions/channelx.yml
+++ b/src/Jackett.Common/Definitions/channelx.yml
@@ -42,9 +42,6 @@
       - name: regexp
         args: "Ratio : (\\d+)"
 
-  download:
-    selector: a[href*="/download/"]
-
   search:
     paths:
       - path: filterTorrents

--- a/src/Jackett.Common/Definitions/channelx.yml
+++ b/src/Jackett.Common/Definitions/channelx.yml
@@ -54,6 +54,7 @@
       tvdb: ""
       tmdb: ""
       mal: ""
+      igdb: ""
       sort: created_at
       direction: desc
       qty: 100
@@ -81,6 +82,9 @@
         filters:
           - name: replace
             args: ["https://via.placeholder.com/600x900", ""]
+      comments:
+        selector: a[href*="#comments"]
+        attribute: href
       size:
         selector: td:nth-last-child(4)
       seeders:

--- a/src/Jackett.Common/Definitions/channelx.yml
+++ b/src/Jackett.Common/Definitions/channelx.yml
@@ -72,7 +72,7 @@
       title:
         selector: a.view-torrent
       download:
-        selector: a[href*="/download_check/"]
+        selector: a[href*="/download/"]
         attribute: href
       details:
         selector: a.view-torrent
@@ -140,4 +140,4 @@
           "i[data-original-title=\"Global Double Upload\"]": "2" # Global Double Upload
           "i[data-original-title=\"Featured\"]": "2" # Featured Torrent
           "*": "1"
-# UNIT3D 1.9.2
+# UNIT3D 1.9.4


### PR DESCRIPTION
- it should be noted that UNIT3D has a config option for direct download or download check page. 

```
      download:
        selector: a[href*="/download/"]
        attribute: href
```
VS
```
      download:
        selector: a[href*="/download_check/"]
        attribute: href
```

Im not sure if this can be checked in Jackett as to what is being used. If possible all UNIT3D based trackers yml's should be updated.