### PR TITLE
Get title from href to get format info

### DIFF
--- a/src/Jackett.Common/Definitions/elitetorrent-biz.yml
+++ b/src/Jackett.Common/Definitions/elitetorrent-biz.yml
@@ -49,8 +49,13 @@
     fields:
       title:
         selector: .meta a
+        attribute: href
         # normalize to SXXEYY format
         filters:
+          - name: re_replace
+            args: [".*/([^/]*)/$", "$1"]
+          - name: replace
+            args: ["-", " "]
           - name: re_replace
             args: ["(\\d{2})×(\\d{2})", "S$1E$2"]
           - name: re_replace


### PR DESCRIPTION
Some links in result are like these ones:
```html
<a class="nombre" href="https://www.elitetorrent.one/peliculas/dumbo-1080p-castellano/" title="Dumbo">Dumbo</a>
<a class="nombre" href="https://www.elitetorrent.one/peliculas/dumbo-hdrip-vose/" title="Dumbo">Dumbo</a>
```

If many results are found, text in a is the same for all of them, but link is different and include info about quality or language, so it would be nice to have them in title returned by jackett.