### PR TITLE
Update to .NET Core 3.0

### DIFF
--- a/FilePermissionService.cs
+++ b/FilePermissionService.cs
@@ -1,0 +1,41 @@
+﻿using Jackett.Common.Services.Interfaces;
+using NLog;
+using System;
+#if !NET461
+using Mono.Unix;
+#endif
+
+namespace Jackett.Server.Services
+{
+    public class FilePermissionService : IFilePermissionService
+    {
+        private Logger logger;
+
+        public FilePermissionService(Logger l)
+        {
+            logger = l;
+        }
+
+        public void MakeFileExecutable(string path)
+        {
+#if !NET461
+
+            //Calling the file permission service to limit usage to netcoreapp. The Mono.Posix.NETStandard library causes issues outside of .NET Core
+            //https://github.com/xamarin/XamarinComponents/issues/282
+
+            logger.Debug($"Attempting to give execute permission to: {path}");
+            try
+            {
+                UnixFileInfo jackettUpdaterFI = new UnixFileInfo(path)
+                {
+                    FileAccessPermissions = FileAccessPermissions.UserReadWriteExecute | FileAccessPermissions.GroupRead | FileAccessPermissions.OtherRead
+                };
+            }
+            catch (Exception ex)
+            {
+                logger.Error(ex);
+            }
+#endif
+        }
+    }
+}

--- a/Helper.cs
+++ b/Helper.cs
@@ -1,0 +1,196 @@
+﻿using Autofac;
+using AutoMapper;
+using Jackett.Common.Models;
+using Jackett.Common.Models.Config;
+using Jackett.Common.Services.Interfaces;
+using Jackett.Common.Utils.Clients;
+using Microsoft.AspNetCore.Hosting;
+using NLog;
+using System.Linq;
+using System.Text;
+#if !NET461
+using Microsoft.Extensions.Hosting;
+#endif
+
+namespace Jackett.Server
+{
+    public static class Helper
+    {
+        public static IContainer ApplicationContainer { get; set; }
+        private static bool _automapperInitialised = false;
+
+#if NET461
+        public static IApplicationLifetime applicationLifetime;
+#else
+        public static IHostApplicationLifetime applicationLifetime;
+#endif
+
+        public static void Initialize()
+        {
+            if (_automapperInitialised == false)
+            {
+                //Automapper only likes being initialized once per app domain.
+                //Since we can restart Jackett from the command line it's possible that we'll build the container more than once. (tests do this too)
+                InitAutomapper();
+                _automapperInitialised = true;
+            }
+
+            //Load the indexers
+            ServerService.Initalize();
+
+            //Kicks off the update checker
+            ServerService.Start();
+
+            Logger.Debug("Helper initialization complete");
+        }
+
+        public static void RestartWebHost()
+        {
+            Logger.Info("Restart of the web application host (not process) initiated");
+            Program.isWebHostRestart = true;
+            applicationLifetime.StopApplication();
+        }
+
+        public static void StopWebHost()
+        {
+            Logger.Info("Jackett is being stopped");
+            applicationLifetime.StopApplication();
+        }
+
+        public static IConfigurationService ConfigService
+        {
+            get
+            {
+                return ApplicationContainer.Resolve<IConfigurationService>();
+            }
+        }
+
+        public static IServerService ServerService
+        {
+            get
+            {
+                return ApplicationContainer.Resolve<IServerService>();
+            }
+        }
+
+        public static IServiceConfigService ServiceConfigService
+        {
+            get
+            {
+                return ApplicationContainer.Resolve<IServiceConfigService>();
+            }
+        }
+
+        public static ServerConfig ServerConfiguration
+        {
+            get
+            {
+                return ApplicationContainer.Resolve<ServerConfig>();
+            }
+        }
+
+        public static Logger Logger
+        {
+            get
+            {
+                return ApplicationContainer.Resolve<Logger>();
+            }
+        }
+
+        private static void InitAutomapper()
+        {
+            Mapper.Initialize(cfg =>
+            {
+                cfg.CreateMap<WebClientByteResult, WebClientStringResult>().ForMember(x => x.Content, opt => opt.Ignore()).AfterMap((be, str) =>
+                {
+                    var encoding = be.Request.Encoding ?? Encoding.UTF8;
+                    str.Content = encoding.GetString(be.Content);
+                });
+
+                cfg.CreateMap<WebClientStringResult, WebClientByteResult>().ForMember(x => x.Content, opt => opt.Ignore()).AfterMap((str, be) =>
+                {
+                    if (!string.IsNullOrEmpty(str.Content))
+                    {
+                        var encoding = str.Request.Encoding ?? Encoding.UTF8;
+                        be.Content = encoding.GetBytes(str.Content);
+                    }
+                });
+
+                cfg.CreateMap<WebClientStringResult, WebClientStringResult>();
+                cfg.CreateMap<WebClientByteResult, WebClientByteResult>();
+                cfg.CreateMap<ReleaseInfo, ReleaseInfo>();
+
+                cfg.CreateMap<ReleaseInfo, TrackerCacheResult>().AfterMap((r, t) =>
+                {
+                    if (r.Category != null)
+                    {
+                        t.CategoryDesc = string.Join(", ", r.Category.Select(x => TorznabCatType.GetCatDesc(x)).Where(x => !string.IsNullOrEmpty(x)));
+                    }
+                    else
+                    {
+                        t.CategoryDesc = "";
+                    }
+                });
+            });
+        }
+
+        public static void SetupLogging(ContainerBuilder builder)
+        {
+            Logger logger = LogManager.GetCurrentClassLogger();
+
+            if (builder != null)
+            {
+                builder.RegisterInstance(logger).SingleInstance();
+            }
+        }
+
+        public static void SetLogLevel(LogLevel level)
+        {
+            foreach (var rule in LogManager.Configuration.LoggingRules)
+            {
+                if (rule.LoggerNamePattern == "Microsoft.*")
+                {
+                    if (!rule.Levels.Contains(LogLevel.Debug))
+                    {
+                        //don't change the first microsoftRule
+                        continue;
+                    }
+
+                    var targets = LogManager.Configuration.ConfiguredNamedTargets;
+                    if (level == LogLevel.Debug)
+                    {
+                        foreach (var target in targets)
+                        {
+                            rule.Targets.Add(target);
+                        }
+                    }
+                    else
+                    {
+                        foreach (var target in targets)
+                        {
+                            rule.Targets.Remove(target);
+                        }
+                    }
+                    continue;
+                }
+
+                if (level == LogLevel.Debug)
+                {
+                    if (!rule.Levels.Contains(LogLevel.Debug))
+                    {
+                        rule.EnableLoggingForLevel(LogLevel.Debug);
+                    }
+                }
+                else
+                {
+                    if (rule.Levels.Contains(LogLevel.Debug))
+                    {
+                        rule.DisableLoggingForLevel(LogLevel.Debug);
+                    }
+                }
+            }
+
+            LogManager.ReconfigExistingLoggers();
+        }
+    }
+}

--- a/Jackett.Common.csproj
+++ b/Jackett.Common.csproj
@@ -1,0 +1,212 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFrameworks>netstandard2.0</TargetFrameworks>
+    <Version>0.0.0</Version>
+    <NoWarn>NU1605</NoWarn>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="AngleSharp" Version="0.13.0" />
+    <PackageReference Include="Autofac" Version="4.9.4" />
+    <PackageReference Include="AutoMapper" Version="8.1.0" />
+    <PackageReference Include="BencodeNET" Version="2.3.0" />
+    <PackageReference Include="CloudflareSolverRe" Version="1.0.5" />
+    <PackageReference Include="CommandLineParser" Version="2.6.0" />
+    <PackageReference Include="CsQuery.NETStandard" Version="1.3.6.1" />
+    <PackageReference Include="DotNet4.SocksProxy" Version="1.4.0.1" />
+    <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="2.2.0" />
+    <PackageReference Include="Microsoft.CSharp" Version="4.6.0" />
+    <PackageReference Include="MimeMapping" Version="1.0.1.17" />
+    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
+    <PackageReference Include="NLog" Version="4.6.7" />
+    <PackageReference Include="SharpZipLib" Version="1.2.0" />
+    <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.6.0" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.6.0" />
+    <PackageReference Include="YamlDotNet" Version="6.0.0" />    
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Content\animate.css">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\binding_dark.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\bootstrap\bootstrap.min.css">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\bootstrap\bootstrap.min.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\common.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\congruent_outline.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\crissXcross.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\css\bootstrap-multiselect.css">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\css\font-awesome.min.css">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\css\jquery.dataTables.min.css">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\custom.css">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\custom.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\custom_mobile.css">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\favicon.ico">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\fonts\fontawesome-webfont.svg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\fonts\glyphicons-halflings-regular.svg">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\images\sort_asc.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\images\sort_asc_disabled.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\images\sort_both.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\images\sort_desc.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\images\sort_desc_disabled.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\index.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\jacket_medium.png">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\libs\api.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\libs\bootstrap-multiselect.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\libs\bootstrap-notify.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\libs\filesize.min.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\libs\handlebars.min.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\libs\handlebarsextend.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\libs\handlebarsmoment.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\libs\jquery.dataTables.min.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\libs\jquery.min.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\libs\moment.min.js">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Content\login.html">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="Models\TorznabCatType.tt" />
+    <Content Include="Resources\validator_reply.xml" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\DateTimeRoutines\DateTimeRoutines.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="Definitions\**\*.yml">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Update="Models\TorznabCatType.generated.cs">
+      <DependentUpon>TorznabCatType.tt</DependentUpon>
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+    </Compile>
+    <Compile Update="Properties\Resources.Designer.cs">
+      <DesignTime>True</DesignTime>
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+    </Compile>
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Update="Content\fonts\fontawesome-webfont.eot">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Content\fonts\fontawesome-webfont.ttf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Content\fonts\fontawesome-webfont.woff">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Content\fonts\fontawesome-webfont.woff2">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Content\fonts\FontAwesome.otf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Content\fonts\glyphicons-halflings-regular.eot">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Content\fonts\glyphicons-halflings-regular.ttf">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Content\fonts\glyphicons-halflings-regular.woff">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Content\fonts\glyphicons-halflings-regular.woff2">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Update="Models\TorznabCatType.tt">
+      <Generator>TextTemplatingFileGenerator</Generator>
+      <LastGenOutput>TorznabCatType.generated.cs</LastGenOutput>
+    </None>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Service Include="{508349b6-6b84-4df5-91f0-309beebad82d}" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <EmbeddedResource Update="Properties\Resources.resx">
+      <Generator>PublicResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+    </EmbeddedResource>
+  </ItemGroup>
+
+  <!-- Save the compiled date so that we know if the user is running an old version of Jackett -->
+  <ItemGroup>
+    <AssemblyAttribute Include="Jackett.Common.Utils.BuildDateAttribute">
+      <_Parameter1>$([System.DateTime]::UtcNow.ToString("yyyyMMddHHmmss"))</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+  
+</Project>

--- a/Jackett.Server.csproj
+++ b/Jackett.Server.csproj
@@ -1,0 +1,59 @@
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFrameworks>netcoreapp3.0;net461</TargetFrameworks>
+    <ApplicationIcon>jackett.ico</ApplicationIcon>
+    <AssemblyName>JackettConsole</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <NoWarn>NU1605</NoWarn>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(TargetFramework)' != 'net461' and $(RuntimeIdentifier.Contains('win')) == 'false'">
+    <AssemblyName>jackett</AssemblyName>
+  </PropertyGroup>
+  
+  <!-- Conditionally obtain references for the .NET Core App 3.0 target -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.0' ">
+    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.0.0" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.6.0" />
+  </ItemGroup>
+  
+    <!-- Conditionally obtain references for the .NET461 target -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
+    <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.ResponseCompression" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Rewrite" Version="2.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.StaticFiles" Version="2.2.0" />
+  </ItemGroup>
+    
+  <ItemGroup>
+    <PackageReference Include="Autofac" Version="4.9.4" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.4.0" />
+    <PackageReference Include="AutoMapper" Version="8.1.0" />
+    <PackageReference Include="CommandLineParser" Version="2.6.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="2.2.0" />
+    <PackageReference Include="NLog" Version="4.6.7" />
+    <PackageReference Include="NLog.Web.AspNetCore" Version="4.9.0" />
+    <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.6.0" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Jackett.Common\Jackett.Common.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\..\README.md" Visible="false">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+    <Content Include="..\..\LICENSE" Visible="false">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
+  
+</Project>

--- a/Jackett.Test.csproj
+++ b/Jackett.Test.csproj
@@ -1,0 +1,48 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  
+  <PropertyGroup>
+    <TargetFramework>net461</TargetFramework>
+    <PlatformTarget>x86</PlatformTarget>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  
+  <ItemGroup>
+    <Compile Remove="Indexers\**" />
+    <EmbeddedResource Remove="Indexers\**" />
+    <None Remove="Indexers\**" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <None Remove="Util\Invalid-RSS.xml" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <EmbeddedResource Include="Util\Invalid-RSS.xml" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <PackageReference Include="Autofac" Version="4.9.4" />
+    <PackageReference Include="FluentAssertions" Version="5.9.0" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection" Version="2.2.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="2.0.0" />
+    <PackageReference Include="MSTest.TestFramework" Version="2.0.0" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit.ConsoleRunner" Version="3.10.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.15.1" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <ProjectReference Include="..\Jackett.Common\Jackett.Common.csproj" />
+    <ProjectReference Include="..\Jackett.Server\Jackett.Server.csproj" />
+  </ItemGroup>
+  
+  <ItemGroup>
+    <Reference Include="System.Web" />
+  </ItemGroup>
+
+</Project>

--- a/Jackett.Tray.csproj
+++ b/Jackett.Tray.csproj
@@ -1,0 +1,124 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FF9025B1-EC14-4AA9-8081-9F69C5E35B63}</ProjectGuid>
+    <OutputType>WinExe</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>Jackett.Tray</RootNamespace>
+    <AssemblyName>JackettTray</AssemblyName>
+    <TargetFrameworkVersion>v4.6.1</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <RuntimeIdentifier>win</RuntimeIdentifier>
+    <TargetFrameworkProfile />
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup>
+    <ApplicationIcon>jackett.ico</ApplicationIcon>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Configuration" />
+    <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http.WebRequest" />
+    <Reference Include="System.Runtime.Serialization" />
+    <Reference Include="System.ServiceModel" />
+    <Reference Include="System.Transactions" />
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Deployment" />
+    <Reference Include="System.Drawing" />
+    <Reference Include="System.Windows.Forms" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Main.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="Main.Designer.cs">
+      <DependentUpon>Main.cs</DependentUpon>
+    </Compile>
+    <Compile Include="Program.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TrayConsoleOptions.cs" />
+    <EmbeddedResource Include="Main.resx">
+      <DependentUpon>Main.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="Properties\Resources.resx">
+      <Generator>ResXFileCodeGenerator</Generator>
+      <LastGenOutput>Resources.Designer.cs</LastGenOutput>
+      <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <Compile Include="Properties\Resources.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Resources.resx</DependentUpon>
+      <DesignTime>True</DesignTime>
+    </Compile>
+    <None Include="Properties\Settings.settings">
+      <Generator>SettingsSingleFileGenerator</Generator>
+      <LastGenOutput>Settings.Designer.cs</LastGenOutput>
+    </None>
+    <Compile Include="Properties\Settings.Designer.cs">
+      <AutoGen>True</AutoGen>
+      <DependentUpon>Settings.settings</DependentUpon>
+      <DesignTimeSharedInput>True</DesignTimeSharedInput>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <Content Include="jackett.ico" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Jackett.Common\Jackett.Common.csproj">
+      <Project>{6B854A1B-9A90-49C0-BC37-9A35C75BCA73}</Project>
+      <Name>Jackett.Common</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <COMReference Include="IWshRuntimeLibrary">
+      <Guid>{F935DC20-1CF0-11D0-ADB9-00C04FD58A0B}</Guid>
+      <VersionMajor>1</VersionMajor>
+      <VersionMinor>0</VersionMinor>
+      <Lcid>0</Lcid>
+      <WrapperTool>tlbimp</WrapperTool>
+      <Isolated>False</Isolated>
+      <EmbedInteropTypes>True</EmbedInteropTypes>
+    </COMReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="CommandLineParser">
+      <Version>2.6.0</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/Jackett.Updater.csproj
+++ b/Jackett.Updater.csproj
@@ -1,0 +1,16 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  
+  <PropertyGroup>
+    <TargetFrameworks>net461;netcoreapp3.0</TargetFrameworks>
+    <ApplicationIcon>jackett.ico</ApplicationIcon>
+    <AssemblyName>JackettUpdater</AssemblyName>
+    <OutputType>Exe</OutputType>
+    <Version>0.0.0</Version>
+    <ServerGarbageCollection>false</ServerGarbageCollection>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Jackett.Common\Jackett.Common.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/README.md
+++ b/README.md
@@ -610,7 +610,7 @@ All contributions are welcome just send a pull request.
 * Install the .NET Core [SDK](https://www.microsoft.com/net/download/windows)
 * Clone Jackett
 * Open Powershell and from the `src` directory, run `dotnet restore`
-* Open the Jackett solution in Visual Studio 2017 (version 15.9 or above)
+* Open the Jackett solution in Visual Studio 2019 (version 16.3 or above)
 * Right click on the Jackett solution and click 'Rebuild Solution' to restore nuget packages
 * Select Jackett.Server as startup project
 * In the drop down menu of the run button select "Jackett.Server" instead of "IIS Express"
@@ -627,21 +627,21 @@ git clone https://github.com/Jackett/Jackett.git
 cd Jackett/src
 
 # dotnet core version
-dotnet publish Jackett.Server -f netcoreapp2.2 --self-contained -r osx-x64 -c Debug # takes care of everything
-./Jackett.Server/bin/Debug/netcoreapp2.2/osx-x64/jackett # run jackett
+dotnet publish Jackett.Server -f netcoreapp3.0 --self-contained -r osx-x64 -c Debug # takes care of everything
+./Jackett.Server/bin/Debug/netcoreapp3.0/osx-x64/jackett # run jackett
 ```
 
 ### Linux
 
 
 ```bash
-sudo apt install mono-complete nuget msbuild dotnet-sdk-2.2 # install build tools (debian/ubuntu)
+sudo apt install mono-complete nuget msbuild dotnet-sdk-3.0 # install build tools (debian/ubuntu)
 git clone https://github.com/Jackett/Jackett.git
 cd Jackett/src
 
 # dotnet core version
-dotnet publish Jackett.Server -f netcoreapp2.2 --self-contained -r linux-x64 -c Debug # takes care of everything
-./Jackett.Server/bin/Debug/netcoreapp2.2/linux-x64/jackett # run jackett
+dotnet publish Jackett.Server -f netcoreapp3.0 --self-contained -r linux-x64 -c Debug # takes care of everything
+./Jackett.Server/bin/Debug/netcoreapp3.0/linux-x64/jackett # run jackett
 ```
 
 ## Screenshots

--- a/Startup.cs
+++ b/Startup.cs
@@ -1,0 +1,209 @@
+﻿using Autofac;
+using Autofac.Extensions.DependencyInjection;
+using Jackett.Common.Models.Config;
+using Jackett.Common.Plumbing;
+using Jackett.Common.Services.Interfaces;
+using Jackett.Server.Middleware;
+using Jackett.Server.Services;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.DataProtection;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.HttpOverrides;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Authorization;
+using Microsoft.AspNetCore.Rewrite;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json.Serialization;
+using System;
+using System.IO;
+using System.Text;
+#if !NET461
+using Microsoft.Extensions.Hosting;
+#endif
+
+namespace Jackett.Server
+{
+    public class Startup
+    {
+        public Startup(IConfiguration configuration)
+        {
+            Configuration = configuration;
+        }
+
+        public IConfiguration Configuration { get; }
+
+        // This method gets called by the runtime. Use this method to add services to the container.
+        public IServiceProvider ConfigureServices(IServiceCollection services)
+        {
+            services.AddResponseCompression();
+
+            services.AddAuthentication(CookieAuthenticationDefaults.AuthenticationScheme)
+                    .AddCookie(CookieAuthenticationDefaults.AuthenticationScheme,
+                        options =>
+                        {
+                            options.LoginPath = new PathString("/UI/Login");
+                            options.AccessDeniedPath = new PathString("/UI/Login");
+                            options.LogoutPath = new PathString("/UI/Logout");
+                            options.Cookie.Name = "Jackett";
+                            options.Cookie.SameSite = SameSiteMode.None;
+                        });
+
+
+
+#if NET461
+            services.AddMvc(config =>
+                    {
+                        var policy = new AuthorizationPolicyBuilder()
+                                            .RequireAuthenticatedUser()
+                                            .Build();
+                        config.Filters.Add(new AuthorizeFilter(policy));
+                    })
+                    .AddJsonOptions(options =>
+                    {
+                        options.SerializerSettings.ContractResolver = new DefaultContractResolver(); //Web app uses Pascal Case JSON
+                    });
+#else
+            services.AddControllers(config =>
+                    {
+                        var policy = new AuthorizationPolicyBuilder()
+                                            .RequireAuthenticatedUser()
+                                            .Build();
+                        config.Filters.Add(new AuthorizeFilter(policy));
+                    })
+                    .AddNewtonsoftJson(options =>
+                    {
+                        options.SerializerSettings.ContractResolver = new DefaultContractResolver(); //Web app uses Pascal Case JSON
+                    });
+#endif
+
+            RuntimeSettings runtimeSettings = new RuntimeSettings();
+            Configuration.GetSection("RuntimeSettings").Bind(runtimeSettings);
+
+            DirectoryInfo dataProtectionFolder = new DirectoryInfo(Path.Combine(runtimeSettings.DataFolder, "DataProtection"));
+
+            services.AddDataProtection()
+                        .PersistKeysToFileSystem(dataProtectionFolder)
+                        .SetApplicationName("Jackett");
+
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+
+            var builder = new ContainerBuilder();
+
+            Helper.SetupLogging(builder);
+
+            builder.Populate(services);
+            builder.RegisterModule(new JackettModule(runtimeSettings));
+            builder.RegisterType<SecuityService>().As<ISecuityService>().SingleInstance();
+            builder.RegisterType<ServerService>().As<IServerService>().SingleInstance();
+            builder.RegisterType<ProtectionService>().As<IProtectionService>().SingleInstance();
+            builder.RegisterType<ServiceConfigService>().As<IServiceConfigService>().SingleInstance();
+            builder.RegisterType<FilePermissionService>().As<IFilePermissionService>().SingleInstance();
+
+            IContainer container = builder.Build();
+            Helper.ApplicationContainer = container;
+
+            Helper.Logger.Debug("Autofac container built");
+
+            Helper.Initialize();
+
+            return new AutofacServiceProvider(container);
+        }
+
+        // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
+#if NET461
+        public void Configure(IApplicationBuilder app, IHostingEnvironment env, IApplicationLifetime applicationLifetime)
+        {
+            applicationLifetime.ApplicationStopping.Register(OnShutdown);
+            Helper.applicationLifetime = applicationLifetime;
+            app.UseResponseCompression();
+
+            app.UseDeveloperExceptionPage();
+
+            app.UseCustomExceptionHandler();
+
+            string serverBasePath = Helper.ServerService.BasePath() ?? string.Empty;
+
+            if (!string.IsNullOrEmpty(serverBasePath))
+            {
+                app.UsePathBase(serverBasePath);
+            }
+
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                // When adjusting these pareamters make sure it's well tested with various environments
+                // See https://github.com/Jackett/Jackett/issues/3517
+                ForwardLimit = 10,
+                ForwardedHeaders = ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost
+            });
+
+            var rewriteOptions = new RewriteOptions()
+                .AddRewrite(@"^torznab\/([\w-]*)", "api/v2.0/indexers/$1/results/torznab", skipRemainingRules: true) //legacy torznab route
+                .AddRewrite(@"^potato\/([\w-]*)", "api/v2.0/indexers/$1/results/potato", skipRemainingRules: true) //legacy potato route
+                .Add(RedirectRules.RedirectToDashboard);
+
+            app.UseRewriter(rewriteOptions);
+
+            app.UseStaticFiles();
+
+            app.UseAuthentication();
+
+            app.UseMvc();
+        }
+#else
+        public void Configure(IApplicationBuilder app, IWebHostEnvironment env, IHostApplicationLifetime applicationLifetime)
+        {
+            applicationLifetime.ApplicationStopping.Register(OnShutdown);
+            Helper.applicationLifetime = applicationLifetime;
+            app.UseResponseCompression();
+
+            app.UseDeveloperExceptionPage();
+
+            app.UseCustomExceptionHandler();
+
+            string serverBasePath = Helper.ServerService.BasePath() ?? string.Empty;
+
+            if (!string.IsNullOrEmpty(serverBasePath))
+            {
+                app.UsePathBase(serverBasePath);
+            }
+
+            app.UseForwardedHeaders(new ForwardedHeadersOptions
+            {
+                // When adjusting these pareamters make sure it's well tested with various environments
+                // See https://github.com/Jackett/Jackett/issues/3517
+                ForwardLimit = 10,
+                ForwardedHeaders = ForwardedHeaders.XForwardedProto | ForwardedHeaders.XForwardedHost
+            });
+
+            var rewriteOptions = new RewriteOptions()
+                .AddRewrite(@"^torznab\/([\w-]*)", "api/v2.0/indexers/$1/results/torznab", skipRemainingRules: true) //legacy torznab route
+                .AddRewrite(@"^potato\/([\w-]*)", "api/v2.0/indexers/$1/results/potato", skipRemainingRules: true) //legacy potato route
+                .Add(RedirectRules.RedirectToDashboard);
+
+            app.UseRewriter(rewriteOptions);
+
+            app.UseStaticFiles();
+
+            app.UseAuthentication();
+
+            app.UseRouting();
+
+            app.UseEndpoints(endpoints =>
+            {
+                endpoints.MapControllers();
+            });
+        }
+#endif
+
+
+
+        private void OnShutdown()
+        {
+            //this code is called when the application stops
+        }
+    }
+}

--- a/WebUtilityHelpersTests.cs
+++ b/WebUtilityHelpersTests.cs
@@ -1,0 +1,78 @@
+﻿using System.Text;
+using System.Web;
+using Jackett.Common.Helpers;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Jackett.Test
+{
+    [TestClass]
+    public class WebUtilityHelpersTests
+    {
+        private readonly Encoding[] _codePagesToTest;
+        private readonly string[] _stringsToTest;
+
+        public WebUtilityHelpersTests()
+        {
+            _codePagesToTest = new Encoding[]{
+                Encoding.UTF8,
+                Encoding.ASCII,
+                Encoding.GetEncoding("iso-8859-1"),
+                Encoding.GetEncoding("windows-1255"),
+                Encoding.GetEncoding("windows-1252"),
+                Encoding.GetEncoding("windows-1251") }
+            ;
+
+            _stringsToTest = new string[]
+            {
+                "Test! אני לא יודע עברית, אבל אני מאמין שזה טקסט חוקי! $ # 2 אני תוהה אם אמוג'י יהיה נתמך 🐀.",
+                "Å[ÉfÉBÉìÉOÇÕìÔÇµÇ≠Ç»Ç¢",
+                "J͖ͥͨ̑͂̄̈́ḁ̹ͧͦ͡ͅc̲̗̮͍̻͓ͤk̳̥̖͗ͭ̾͌e̖̲̟̽ț̠͕͈͓͎̱t͕͕͓̹̹ͫͧ̆͑ͤ͝ ̼͓̟̣͔̇̒T̻̺̙̣̘͔̤̅͒̈̈͛̅e̥̗̍͟s̖̬̭͈̠t̫̩͙̯̩ͣ̏̕ ̸̰̬̄̀ͧ̀S̨̻̼̜̹̼͓̺ͨ̍ͦt͇̻̺̂́̄͌͗̕r̥͈̙͙̰͈̙͗̆̽̀i͉͔̖̻̹̗̣̍ͭ̒͗n̴̻͔̹̘̱̳͈͐ͦ̃̽͐̓̂g̴͚͙̲ͩ͌̆̉̀̾"
+            };
+
+            //https://docs.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider?view=netcore-2.0
+#if !NET461
+                if (Environment.OSVersion.Platform == PlatformID.Win32NT)
+                {
+                    Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+                }
+#endif
+        }
+
+        
+
+        [TestMethod]
+        public void WebUtilityHelpers_UrlEncode_CorrectlyEncodes()
+        {
+            foreach (var encoding in _codePagesToTest)
+            {
+                foreach (var testString in _stringsToTest)
+                {
+                    //Check our implementation of Decode in .NET Standard Matches the .NET Framework Version                          
+                    var NETString = HttpUtility.UrlEncode(testString, encoding);
+                    var WebUtilityString = WebUtilityHelpers.UrlEncode(testString, encoding);
+                    //Of note is that percent encoding gives lowercase values, where NET Native uses upper case this should be okay according to RFC3986 (https://tools.ietf.org/html/rfc3986#section-2.1)
+                    var NETDecode = HttpUtility.UrlDecode(NETString);
+                    var WebUtilityDecode = HttpUtility.UrlDecode(WebUtilityString);
+
+                    Assert.AreEqual(NETDecode, WebUtilityDecode, $"{testString} did not match the expected decoded string with {encoding.EncodingName})");
+                }
+            }
+        }
+
+        [TestMethod]
+        public void WebUtilityHelpers_UrlDecode_CorrectlyDecodes()
+        {
+            foreach (var encoding in _codePagesToTest)
+            {
+                foreach (var testString in _stringsToTest)
+                {
+                    //Check our implementation of Decode in .NET Standard Matches the .NET Framework Version      
+                    var encodedString = HttpUtility.UrlEncode(testString, encoding);
+                    var NETString = HttpUtility.UrlDecode(encodedString, encoding);
+                    var WebUtilityString = WebUtilityHelpers.UrlDecode(encodedString, encoding);
+                    Assert.AreEqual(NETString, WebUtilityString, $"{testString} did not match the expected decoded value after encoding with {encoding.EncodingName})");
+                }
+            }
+        }
+    }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-version: 0.11.{build}
+version: 0.12.{build}
 skip_tags: true
 image:
   - Ubuntu
@@ -6,10 +6,6 @@ image:
 environment:
   APPVEYOR_YML_DISABLE_PS_LINUX: true
 configuration: Release
-install:
-  #Remove once .NET Core 2.2.5 is deployed to Appveyor
-  - sh: sudo apt-get update
-  - sh: sudo apt-get -y install dotnet-sdk-2.2
 assembly_info:
   patch: true
   file: '**\AssemblyInfo.*'

--- a/build.cake
+++ b/build.cake
@@ -16,7 +16,7 @@ var configuration = Argument("configuration", "Debug");
 var workingDir = MakeAbsolute(Directory("./"));
 string artifactsDirName = "Artifacts";
 string testResultsDirName = "TestResults";
-string netCoreFramework = "netcoreapp2.2";
+string netCoreFramework = "netcoreapp3.0";
 string serverProjectPath = "./src/Jackett.Server/Jackett.Server.csproj";
 string updaterProjectPath = "./src/Jackett.Updater/Jackett.Updater.csproj";
 
@@ -64,7 +64,7 @@ Task("Build-Full-Framework")
 
 		var buildSettings = new MSBuildSettings()
                 .SetConfiguration(configuration)
-                .UseToolVersion(MSBuildToolVersion.VS2017);
+                .UseToolVersion(MSBuildToolVersion.VS2019);
 		
 		MSBuild("./src/Jackett.sln", buildSettings);
 	});
@@ -423,14 +423,31 @@ private void Gzip(string sourceFolder, string outputDirectory, string tarCdirect
 
 private void DotNetCorePublish(string projectPath, string framework, string runtime, string outputPath)
 {
-	var settings = new DotNetCorePublishSettings
-	{
-		Framework = framework,
-		Runtime = runtime,
-		OutputDirectory = outputPath
-	};
+	bool publishSingleFile = false;
 
-	DotNetCorePublish(projectPath, settings);
+	if (publishSingleFile && framework != "net461")
+	{
+		var settings = new DotNetCorePublishSettings
+		{
+			Framework = framework,
+			Runtime = runtime,
+			OutputDirectory = outputPath,
+			ArgumentCustomization = args=>args.Append("/p:PublishSingleFile=true")
+		};
+
+		DotNetCorePublish(projectPath, settings);
+	}
+	else
+	{
+		var settings = new DotNetCorePublishSettings
+		{
+			Framework = framework,
+			Runtime = runtime,
+			OutputDirectory = outputPath
+		};
+
+		DotNetCorePublish(projectPath, settings);
+	}
 }
 
 //////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Updated Jackett so that it runs on .NET Core 3.0 now

.NET Core 3.0 brings the following benefits https://devblogs.microsoft.com/dotnet/announcing-net-core-3-0/
One of the benefits is the ability to create single file executables. I haven't enabled this yet, but its only a one line change to turn it on (would likely also require some changes to the updater).

This means that builds for LinuxAMDx64, LinuxARM32, LinuxARM64 and macOS will now run on .NET Core 3.0 instead of 2.2. Windows and Mono remain on full framework. Once .NET Core 3.1 is released (November) I'll look to moving Windows over to .NET Core as well

Tested on
-Windows 10 x64
-Debian running Jackett with Mono
-Debian running Jackett standalone (.NET Core)