### PR TITLE
add AudioMP3 / 3010 for headphones search support

### DIFF
--- a/src/Jackett.Common/Indexers/TorrentDay.cs
+++ b/src/Jackett.Common/Indexers/TorrentDay.cs
@@ -89,7 +89,6 @@ namespace Jackett.Common.Indexers
             AddCategoryMapping(48, TorznabCatType.Movies, "Movies/x265");
             AddCategoryMapping(1, TorznabCatType.MoviesSD, "Movies/XviD");
 
-            AddCategoryMapping(17, TorznabCatType.Audio, "Music/Audio");
             AddCategoryMapping(17, TorznabCatType.AudioMP3, "Music/Audio");
             AddCategoryMapping(23, TorznabCatType.AudioForeign, "Music/Non-English");
             AddCategoryMapping(41, TorznabCatType.Audio, "Music/Packs");

--- a/src/Jackett.Common/Indexers/TorrentDay.cs
+++ b/src/Jackett.Common/Indexers/TorrentDay.cs
@@ -90,6 +90,7 @@ namespace Jackett.Common.Indexers
             AddCategoryMapping(1, TorznabCatType.MoviesSD, "Movies/XviD");
 
             AddCategoryMapping(17, TorznabCatType.Audio, "Music/Audio");
+            AddCategoryMapping(17, TorznabCatType.AudioMP3, "Music/Audio");
             AddCategoryMapping(23, TorznabCatType.AudioForeign, "Music/Non-English");
             AddCategoryMapping(41, TorznabCatType.Audio, "Music/Packs");
             AddCategoryMapping(16, TorznabCatType.AudioVideo, "Music/Video");


### PR DESCRIPTION
Headphones sends audio/album searches to category 3010 (and 3050) but 3010 isn't populated for this tracker.

If having two Torznab categories mapping to the same ID is illegal then maybe we can probably just remove line 92?