### PR TITLE
Fixed search to match with Sonarr and Radarr standards.

### DIFF
--- a/src/Jackett.Common/Indexers/BJShare.cs
+++ b/src/Jackett.Common/Indexers/BJShare.cs
@@ -29,7 +29,7 @@ namespace Jackett.Common.Indexers
             { "agents of shield", "Agents of S.H.I.E.L.D."},
             { "greys anatomy", "grey's anatomy"},
     };
-        
+
         public override string[] LegacySiteLinks { get; protected set; } = new string[] {
             "https://bj-share.me/"
         };
@@ -116,24 +116,43 @@ namespace Jackett.Common.Indexers
             // the season (wrong season) and episode as absolute, eg: One Piece - S08E836
             // 836 is the latest episode in absolute numbering, that is correct, but S08 is not the current season...
             // So for this show, i don't see a other way to make it work...
-            //                               
+            //
             // All others animes that i tested is with correct season and episode set, so i can't remove the season from all
             // or will break everything else
-            //                               
+            //
             // In this indexer, it looks that it is added "automatically", so all current and new releases will be broken
             // until they or the source from where they get that info fix it...
 
-            return title.Contains("One Piece") ? Regex.Replace(title, @"(Ep[\.]?[ ]?)|([S]\d\d[Ee])", "E") : title;
+            if (title.Contains("One Piece"))
+            {
+               title = Regex.Replace(title, @"(Ep[\.]?[ ]?)|([S]\d\d[Ee])", "E");
+               return title;
+            }
+            else if (title.Contains("[Novela]"))
+            {
+                title = Regex.Replace(title, @"(Cap[\.]?[ ]?)", "S01E");
+                title = Regex.Replace(title, @"(\[Novela\]\ )", "");
+                title = Regex.Replace(title, @"(\ \-\s*Completo)", " - S01");
+                return title;
+            }
+            else
+            {
+              return title;
+            }
+
+
+
+            // return title.Contains("One Piece") ? Regex.Replace(title, @"(Ep[\.]?[ ]?)|([S]\d\d[Ee])", "E") : title;
         }
 
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {
             query = query.Clone(); // avoid modifing the original query
-            
+
 
             var releases = new List<ReleaseInfo>();
 
-            
+
 
             // if the search string is empty use the "last 24h torrents" view
             if (string.IsNullOrWhiteSpace(query.SearchTerm) && !query.IsImdbQuery)
@@ -318,14 +337,15 @@ namespace Jackett.Common.Indexers
                             var title = qDetailsLink.TextContent;
                             ICollection<int> category = null;
                             string yearStr = null;
-                            
+
+
 
                             if (row.ClassList.Contains("group") || row.ClassList.Contains("torrent")) // group/ungrouped headers
                             {
                                 var qCatLink = row.QuerySelector("a[href^=\"/torrents.php?filter_cat\"]");
                                 categoryStr = qCatLink.GetAttribute("href").Split('=')[1].Split('&')[0];
                                 category = MapTrackerCatToNewznab(categoryStr);
-                                
+
                                 yearStr = qDetailsLink.NextSibling.TextContent.Trim().TrimStart('[').TrimEnd(']');
 
                                 title = FixAbsoluteNumbering(title);
@@ -361,7 +381,7 @@ namespace Jackett.Common.Indexers
                                 var cleanTitle = Regex.Replace(groupTitle, @" - ((S(\d{2}))?E(\d{1,4}))", "");
                                 title = Regex.Replace(title.Trim(), @"\s+", " ");
                                 var seasonEp = Regex.Replace(title, @"((S\d{2})?(E\d{2,4})?) .*", "$1");
-                                
+
                                 // do not include year to animes
                                 if (categoryStr == "14")
                                 {
@@ -377,6 +397,7 @@ namespace Jackett.Common.Indexers
                             {
                                 var qDescription = row.QuerySelector("div.torrent_info");
                                 release.Description = qDescription.TextContent;
+                                title = FixAbsoluteNumbering(title);
 
                                 var cleanTitle = Regex.Replace(title, @" - ((S\d{2})?(E\d{2,4})?)", "");
                                 var seasonEp = Regex.Replace(title, @"^(.*?) - ((S\d{2})?(E\d{2,4})?)", "$2");
@@ -386,11 +407,17 @@ namespace Jackett.Common.Indexers
                                 {
                                     release.Title = cleanTitle + " " + seasonEp;
                                 }
-                                else
+                                // the seasonEp RegEx is getting all when done with movies, and then cleaning again when getting international name,
+                                // so it was cutting of the year of movies and getting clonflict in Radarr
+                                else if (categoryStr == "2" || categoryStr == "6")
                                 {
                                     release.Title = cleanTitle + " " + yearStr + " " + seasonEp;
                                 }
-                                
+                                else
+                                {
+                                    release.Title = cleanTitle + " " + yearStr;
+                                }
+
                                 release.Category = category;
                             }
 
@@ -399,11 +426,29 @@ namespace Jackett.Common.Indexers
                             release.Description = release.Description.Replace("/ HD / ", "/ 720p /");
                             release.Description = release.Description.Replace(" / HD]", " / 720p]");
                             release.Description = release.Description.Replace("4K", "2160p");
+                            release.Description = release.Description.Replace("SD", "480p");
+
+                            // Adjust the description in order to can be read by Radarr and Sonarr
+
+                            var cleanDescription = release.Description.Trim().TrimStart('[').TrimEnd(']');
+                            String[] titleElements;
+
+                            string[] stringSeparators = new string[] {" / "};
+                            titleElements = cleanDescription.Split(stringSeparators,StringSplitOptions.None);
+
+                            if (titleElements[titleElements.Length - 1] == "3D")
+                            {
+                              release.Title += " " + titleElements[titleElements.Length - 2] + " " + titleElements[titleElements.Length - 1] + " " + titleElements[3] + " " + titleElements[2] + " " + titleElements[1] + " " + titleElements[4];
+                            }
+                            else
+                            {
+                              release.Title += " " + titleElements[titleElements.Length - 1] + " " + titleElements[3] + " " + titleElements[2] + " " + titleElements[1] + " " + titleElements[4];
+                            }
+
 
                             // Get international title if available, or use the full title if not
                             release.Title = Regex.Replace(release.Title, @".* \[(.*?)\](.*)", "$1$2");
-                            release.Title += " " + release.Description; // add year and Description to the release Title to add some meaning to it
-                            
+
                             // This tracker does not provide an publish date to search terms (only on last 24h page)
                             release.PublishDate = DateTime.Today;
 


### PR DESCRIPTION
It fixes the search of BJ-Share to match radarr and sonarr standards. Fix issue #4365 too.