### PR TITLE
Update ygg

### DIFF
--- a/src/Jackett.Common/Definitions/yggtorrent.yml
+++ b/src/Jackett.Common/Definitions/yggtorrent.yml
@@ -218,11 +218,6 @@
         filters:
           - name: re_replace
             args: ["(?i)^(?:(.+?)((?:[\\.\\-\\s_\\[]+(?:imax|(?:dvd|bd|tv)(?:rip|scr)|bluray(?:\\-?rip)?|720\\s*p?|1080\\s*p?|vof?|vost(?:fr)?|multi|vf(?:f|q)?[1-3]?|(?:true)?french|eng?)[\\.\\-\\s_\\]]*)*)([\\(\\[]?(?:20|1[7-9])\\d{2}[\\)\\]]?)(.*)$|(.*))$", "$1 $3 $2 $4 $5"]
-          # Replace Saison/saison by 'S' to match for Full season search Sonarrv3 and tidy up
-          - name: re_replace
-            args: ["([Ss]aison|[Ss]aison )(\\d{1,4})", "S$2"]
-          - name: re_replace
-            args: ["S(\\d+)E(\\d+)(\\D+)", "S$1E$2 $3"]
           - name: re_replace
             args: ["([Mm][Uu][Ll][Tt][Ii])", "MULTi"]
           # End tidy up for sonarrv3 season search


### PR DESCRIPTION
Some saisons don't appears as saison in sonarr, sonarr allow parsing 'saison' now 
https://github.com/Sonarr/Sonarr/commit/ceaaec5378aa6a0eae4fa614abaab69deb7175bb

Check ticket https://github.com/Jackett/Jackett/issues/6207

Please update your docker image to be able to use it on docker.
To do that just put the pre-release as latest release