### PR TITLE
[Xthor] Fix for anime search for xthor

### DIFF
--- a/src/Jackett.Common/Indexers/Xthor.cs
+++ b/src/Jackett.Common/Indexers/Xthor.cs
@@ -181,7 +181,7 @@ namespace Jackett.Common.Indexers
             searchTerm = searchTerm.Trim();
             searchTerm = searchTerm.ToLower();
 
-            if (EnhancedAnime && query.HasSpecifiedCategories && query.Categories.Contains(TorznabCatType.TVAnime.ID))
+            if (EnhancedAnime && query.HasSpecifiedCategories && (query.Categories.Contains(TorznabCatType.TVAnime.ID) || query.Categories.Contains(100032) || query.Categories.Contains(100101) || query.Categories.Contains(100110)))
             {
                 System.Text.RegularExpressions.Regex regex = new Regex(" ([0-9]+)");
                 searchTerm = regex.Replace(searchTerm, " E$1");


### PR DESCRIPTION
I'm sorry for this disgusting fix, i don't know the language C#.
There is surely a cleaner way to fix that.
The old code only looks just for category 5070, but not for a specific anime category.

Latest release:
![firefox_YAvcNGFopm](https://user-images.githubusercontent.com/26726263/67201941-b92a0d00-f407-11e9-8a66-f81501a32a1a.png)

With the fix:
![firefox_Yy7GDupcsW](https://user-images.githubusercontent.com/26726263/67202058-0d34f180-f408-11e9-829d-85b10a34e63a.png)

