### PR TITLE
updater: improvements in systemd jackett_launcher

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -185,6 +185,7 @@ Task("Package-DotNetCore-LinuxAMDx64")
 		DeleteDirectory(updaterOutputPath, new DeleteDirectorySettings {Recursive = true, Force = true});
 
 		CopyFileToDirectory("./install_service_systemd.sh", buildOutputPath);
+		CopyFileToDirectory("./jackett_launcher.sh", buildOutputPath);
 
 		Gzip($"./BuildOutput/{netCoreFramework}/{runtimeId}", $"./{artifactsDirName}", "Jackett", "Jackett.Binaries.LinuxAMDx64.tar.gz");
 	});
@@ -204,6 +205,7 @@ Task("Package-DotNetCore-LinuxARM32")
 		DeleteDirectory(updaterOutputPath, new DeleteDirectorySettings {Recursive = true, Force = true});
 
 		CopyFileToDirectory("./install_service_systemd.sh", buildOutputPath);
+		CopyFileToDirectory("./jackett_launcher.sh", buildOutputPath);
 
 		Gzip($"./BuildOutput/{netCoreFramework}/{runtimeId}", $"./{artifactsDirName}", "Jackett", "Jackett.Binaries.LinuxARM32.tar.gz");
 	});
@@ -223,6 +225,7 @@ Task("Package-DotNetCore-LinuxARM64")
 		DeleteDirectory(updaterOutputPath, new DeleteDirectorySettings {Recursive = true, Force = true});
 
 		CopyFileToDirectory("./install_service_systemd.sh", buildOutputPath);
+		CopyFileToDirectory("./jackett_launcher.sh", buildOutputPath);
 
 		Gzip($"./BuildOutput/{netCoreFramework}/{runtimeId}", $"./{artifactsDirName}", "Jackett", "Jackett.Binaries.LinuxARM64.tar.gz");
 	});
@@ -406,16 +409,28 @@ private void Gzip(string sourceFolder, string outputDirectory, string tarCdirect
 		RunLinuxCommand("chmod", $"755 {MakeAbsolute(Directory(sourceFolder))}/Jackett/jackett");
 		RunLinuxCommand("chmod", $"755 {MakeAbsolute(Directory(sourceFolder))}/Jackett/JackettUpdater");
 
+		string macOsServiceScript = MakeAbsolute(Directory(sourceFolder)) + "/Jackett/install_service_macos";
+		if (FileExists(macOsServiceScript))
+		{
+			RunLinuxCommand("chmod", $"755 {macOsServiceScript}");
+		}
+
+		string systemdMonoScript = MakeAbsolute(Directory(sourceFolder)) + "/Jackett/install_service_systemd_mono.sh";
+		if (FileExists(systemdMonoScript))
+		{
+			RunLinuxCommand("chmod", $"755 {systemdMonoScript}");
+		}
+
 		string systemdScript = MakeAbsolute(Directory(sourceFolder)) + "/Jackett/install_service_systemd.sh";
 		if (FileExists(systemdScript))
 		{
 			RunLinuxCommand("chmod", $"755 {systemdScript}");
 		}
 
-		string macOsServiceScript = MakeAbsolute(Directory(sourceFolder)) + "/Jackett/install_service_macos";
-		if (FileExists(macOsServiceScript))
+		string launcherScript = MakeAbsolute(Directory(sourceFolder)) + "/Jackett/jackett_launcher.sh";
+		if (FileExists(launcherScript))
 		{
-			RunLinuxCommand("chmod", $"755 {macOsServiceScript}");
+			RunLinuxCommand("chmod", $"755 {launcherScript}");
 		}
 
 		RunLinuxCommand("tar",  $"-C {sourceFolder} -zcvf {outputDirectory}/{tarFileName}.gz {tarCdirectoryOption}");

--- a/install_service_systemd.sh
+++ b/install_service_systemd.sh
@@ -32,23 +32,6 @@ if [[ $(systemctl status ${jackettservice} | grep "active (running)") ]]; then
     exit 1
 fi
 
-# Write the Jackett's launcher
-cat >"/bin/jackett_launcher.sh" <<EOL
-#!/bin/bash
-
-${jackettdir}/jackett
-
-while pgrep JackettUpdater > /dev/null ; do
-     sleep 1
-done
-
-echo "Jackett update complete"
-
-EOL
-
-# Give execution permissions
-chmod +x "/bin/jackett_launcher.sh"
-
 # Write the systemd service descriptor
 cat >"/etc/systemd/system/${jackettservice}" <<EOL
 [Unit]
@@ -63,7 +46,7 @@ Type=simple
 User=${jackettuser}
 Group=${jackettuser}
 WorkingDirectory=${jackettdir}
-ExecStart=/bin/jackett_launcher.sh
+ExecStart=${jackettdir}/jackett_launcher.sh
 TimeoutStopSec=20
 
 [Install]

--- a/jackett_launcher.sh
+++ b/jackett_launcher.sh
@@ -8,8 +8,11 @@ JACKETT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 # Launch Jackett
 ${JACKETT_DIR}/jackett
 
+# Get user running the service
+JACKETT_USER=$(whoami)
+
 # Wait until the updater ends
-while pgrep JackettUpdater > /dev/null ; do
+while pgrep -u ${JACKETT_USER} JackettUpdater > /dev/null ; do
      sleep 1
 done
 

--- a/jackett_launcher.sh
+++ b/jackett_launcher.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Helper script to fix
+# https://github.com/Jackett/Jackett/issues/5208#issuecomment-547565515
+
+JACKETT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+
+# Launch Jackett
+${JACKETT_DIR}/jackett
+
+# Wait until the updater ends
+while pgrep JackettUpdater > /dev/null ; do
+     sleep 1
+done
+
+echo "Jackett update complete" 

--- a/src/Jackett.Common/Services/UpdateService.cs
+++ b/src/Jackett.Common/Services/UpdateService.cs
@@ -292,7 +292,8 @@ namespace Jackett.Common.Services
                 inStream.Close();
 
                 if (variant == Variants.JackettVariant.CoreMacOs || variant == Variants.JackettVariant.CoreLinuxAmdx64
-                || variant == Variants.JackettVariant.CoreLinuxArm32 || variant == Variants.JackettVariant.CoreLinuxArm64)
+                || variant == Variants.JackettVariant.CoreLinuxArm32 || variant == Variants.JackettVariant.CoreLinuxArm64
+                || variant == Variants.JackettVariant.Mono)
                 {
                     //Calling the file permission service to limit usage to netcoreapp. The Mono.Posix.NETStandard library causes issues outside of .NET Core
                     //https://github.com/xamarin/XamarinComponents/issues/282
@@ -310,10 +311,18 @@ namespace Jackett.Common.Services
                         string macosServicePath = tempDir + "/Jackett/install_service_macos";
                         filePermissionService.MakeFileExecutable(macosServicePath);
                     }
+                    else if (variant == Variants.JackettVariant.Mono)
+                    {
+                        string systemdPath = tempDir + "/Jackett/install_service_systemd_mono.sh";
+                        filePermissionService.MakeFileExecutable(systemdPath);
+                    }
                     else
                     {
                         string systemdPath = tempDir + "/Jackett/install_service_systemd.sh";
                         filePermissionService.MakeFileExecutable(systemdPath);
+
+                        string launcherPath = tempDir + "/Jackett/jackett_launcher.sh";
+                        filePermissionService.MakeFileExecutable(launcherPath);
                     }
                 }
             }


### PR DESCRIPTION
Improvements over #6249
* Moved the launcher script into jacket directory. Can survive updates and can be automatically updated in future releases.
* Fix file permissions in mono variant

NOTE: The mono variant is not affected by issue https://github.com/Jackett/Jackett/issues/5208#issuecomment-547565515
NOTE2: I tested carefully the LinuxCoreARM64 and the LinuxMono variants.