### PR TITLE
Append english to the language too

### DIFF
--- a/src/Jackett.Common/Definitions/hdcity.yml
+++ b/src/Jackett.Common/Definitions/hdcity.yml
@@ -161,7 +161,14 @@
           - name: querystring
             args: category
       title:
-        selector: td[valign="middle"] a
+        selector: td[valign="middle"] a:contains("VOSE")
+        optional: true
+        filters:
+          - name: append
+            args: " [english]"
+      title:
+        selector: td[valign="middle"] a:not(:contains("VOSE"))
+        optional: true
         filters:
           - name: append
             args: " [spanish] [english]"

--- a/src/Jackett.Common/Definitions/hdcity.yml
+++ b/src/Jackett.Common/Definitions/hdcity.yml
@@ -164,7 +164,7 @@
         selector: td[valign="middle"] a
         filters:
           - name: append
-            args: " [spanish]"
+            args: " [spanish] [english]"
       details:
         selector: td[valign="middle"] a
         attribute: href


### PR DESCRIPTION
All releases on this tracker are both spanish and english unless "vose" is specified. So english tag should also be appended to title