### PR TITLE
1337x - Remove \u000f from title

### DIFF
--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -143,6 +143,8 @@
         filters:
           - name: replace
             args: ["Grey's Anatomy", "Greys Anatomy"]
+          - name: replace
+            args: ["\u000f", ""] # get rid of unwanted character
       category:
         optional: true
         selector:  td[class^="coll-1"] a[href^="/sub/"]


### PR DESCRIPTION
Very similar to commit e874255.
Fixes "System.ArgumentException: '', hexadecimal value 0x0F, is an invalid character."
(example: a search for "Legend of Korra S02")