### PR TITLE
Encode "&#039;" for magnet URL

### DIFF
--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -122,6 +122,8 @@
       - name: urldecode
       - name: replace
         args: [" ⭐", ""]
+      - name: replace
+        args: ["&#039;", "%27"]
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -117,13 +117,9 @@
   download:
     # the .torrent url is on the on the details page 
     selector: ul li a[href^="{{ .Config.downloadlink }}"]
-    # temp fix for #5372
-    filters: 
-      - name: urldecode
-      - name: replace
-        args: [" ⭐", ""]
-      - name: replace
-        args: ["&#039;", "%27"]
+    filters:
+      - name: replace # temp fix for #5372
+        args: ["%E2%AD%90", ""]
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/extratorrent-ag.yml
+++ b/src/Jackett.Common/Definitions/extratorrent-ag.yml
@@ -957,11 +957,9 @@
       download:
         selector: td a[href^="magnet:?xt="]
         attribute: href
-        # temp fix for #5372
-        filters: 
-          - name: urldecode
-          - name: replace
-            args: [" ⭐", ""]
+        filters:
+          - name: replace # temp fix for #5372
+            args: ["%E2%AD%90", ""]
       date:
         selector: td:nth-last-of-type(5)
         filters:

--- a/src/Jackett.Common/Definitions/isohunt2.yml
+++ b/src/Jackett.Common/Definitions/isohunt2.yml
@@ -47,11 +47,8 @@
     filters:
       - name: querystring
         args: url
-      - name: urldecode
-      # temp fix for #5372
-      - name: replace
-        args: [" ⭐", ""]
-
+      - name: replace # temp fix for #5372
+        args: ["%E2%AD%90", ""]
   search:
     paths:
       - path: torrents

--- a/src/Jackett.Common/Definitions/katcrs.yml
+++ b/src/Jackett.Common/Definitions/katcrs.yml
@@ -64,11 +64,9 @@
       magnet:
         selector: td:nth-child(1) div div a[data-nop=""]
         attribute: href
-        # temp fix for #5372
-        filters: 
-          - name: urldecode
-          - name: replace
-            args: [" ⭐", ""]
+        filters:
+          - name: replace # temp fix for #5372
+            args: ["%E2%AD%90", ""]
       size:
         selector: td:nth-child(2)
       date:

--- a/src/Jackett.Common/Definitions/kickasstorrent-kathow.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrent-kathow.yml
@@ -55,10 +55,8 @@
         filters:
           - name: querystring
             args: url
-          - name: urldecode
-          # temp fix for #5372
-          - name: replace
-            args: [" ⭐", ""]
+          - name: replace # temp fix for #5372
+            args: ["%E2%AD%90", ""]
       size:
         selector: td:nth-child(2)
         filters:


### PR DESCRIPTION
Magnet links with "&#039;" in the &dn= parameter fail when being sent to qBittorrent. Encoding as %27 allows the download to start. (Example: Schindler's List - Tigole/QxR)