### PR TITLE
jackett_launcher.sh fine tuning

### DIFF
--- a/jackett_launcher.sh
+++ b/jackett_launcher.sh
@@ -1,19 +1,18 @@
-#!/bin/bash
+#!/bin/sh
 
 # Helper script to fix
 # https://github.com/Jackett/Jackett/issues/5208#issuecomment-547565515
 
-JACKETT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# Get full Jackett root path
+JACKETT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Launch Jackett
-${JACKETT_DIR}/jackett
+${JACKETT_DIR}/jackett --NoRestart
 
 # Get user running the service
 JACKETT_USER=$(whoami)
 
 # Wait until the updater ends
-while pgrep -u ${JACKETT_USER} JackettUpdater > /dev/null ; do
+while pgrep -u ${JACKETT_USER} JackettUpdater > /dev/null; do
      sleep 1
 done
-
-echo "Jackett update complete" 


### PR DESCRIPTION
+ Execute script with system default bourne shell. On Debian this is "dash" by default, which has a much lower memory foot print compared to bash. As well systems without bash won't fail. "${BASH_SOURCE[0]}" cannot be used then but "readlink -f" is another reliable method to get a full file path, using another coreutils binary like "dirname".
+ Execute Jackett with "--NoRestart" option. This has currently not effect, but it assures that the updater never attempts to restart the Jackett process, which is done by the systemd unit already. This avoids possible restart collisions if anything about the updater behaviour changes, e.g. to fix the originating issue.
+ Remove the "Jackett update complete" print. This is simply wrong if Jackett was stopped ordinarily and the updater itself logs to the same destination, including a "finished to copy files" after completed.

**Signed-off-by: MichaIng <micha@dietpi.com>**