### PR TITLE
Added support to search Complete Seasons

### DIFF
--- a/src/Jackett.Common/Definitions/hdcity.yml
+++ b/src/Jackett.Common/Definitions/hdcity.yml
@@ -146,6 +146,8 @@
         args: ["S0?(\\d{1,2})E(\\d{1,2})", "$1x$2"]
       - name: re_replace
         args: ["[^a-zA-Z0-9]+", " "]
+      - name: re_replace
+        args: ["(?i)\\bS0*(\\d+)\\b", "T$1"]
     inputs:
       page: "torrents"
       $raw: "&category={{range .Categories}}{{.}};{{end}}"
@@ -166,12 +168,16 @@
         filters:
           - name: append
             args: " [english]"
+          - name: re_replace
+          args: ["(?i)T\\s?(\\d{1,2})\\b", "S$1"]
       title:
         selector: td[valign="middle"] a:not(:contains("VOSE"))
         optional: true
         filters:
           - name: append
             args: " [spanish] [english]"
+          - name: re_replace
+            args: ["(?i)T\\s?(\\d{1,2})\\b", "S$1"]
       details:
         selector: td[valign="middle"] a
         attribute: href

--- a/src/Jackett.Common/Definitions/hdcity.yml
+++ b/src/Jackett.Common/Definitions/hdcity.yml
@@ -167,7 +167,7 @@
         optional: true
         filters:
           - name: append
-            args: " [english]"
+            args: " [English]"
           - name: re_replace
           args: ["(?i)T\\s?(\\d{1,2})\\b", "S$1"]
       title:
@@ -175,7 +175,7 @@
         optional: true
         filters:
           - name: append
-            args: " [spanish] [english]"
+            args: " [Spanish]"
           - name: re_replace
             args: ["(?i)T\\s?(\\d{1,2})\\b", "S$1"]
       details:


### PR DESCRIPTION
HDCity uses for complete seasons the definition T+[season], when clients like sonnar search for complete seasons append to search S[season]. With this modification allow to replace S for T in search seasons.