### PR TITLE
Bug in fields args broke HDCity template

### DIFF
--- a/src/Jackett.Common/Definitions/hdcity.yml
+++ b/src/Jackett.Common/Definitions/hdcity.yml
@@ -169,7 +169,7 @@
           - name: append
             args: " [English]"
           - name: re_replace
-          args: ["(?i)T\\s?(\\d{1,2})\\b", "S$1"]
+            args: ["(?i)T\\s?(\\d{1,2})\\b", "S$1"]
       title:
         selector: td[valign="middle"] a:not(:contains("VOSE"))
         optional: true


### PR DESCRIPTION
Missing spaces in fields args that broke the HDCity template.