### PR TITLE
[TorrentBytes] Remove trailing whitespace

### DIFF
--- a/src/Jackett.Common/Indexers/TorrentBytes.cs
+++ b/src/Jackett.Common/Indexers/TorrentBytes.cs
@@ -161,7 +161,7 @@ namespace Jackett.Common.Indexers
                     // There isn't a title attribute if the release name isn't truncated.
                     if (string.IsNullOrWhiteSpace(release.Title))
                     {
-                        release.Title = link.Get(0).FirstChild.ToString();
+                        release.Title = link.Get(0).FirstChild.ToString().Trim();
                     }
 
                     release.Description = release.Title;


### PR DESCRIPTION
The title of a torrent on TorrentBytes is either taken from the text within the `<a>` itself, or from `<a title>` attribute if the text within the `<a>` has been truncated due to the length of the title. Worth noting is that `<a title>` is only present when the title's been truncated, hence why both methods are used. Anyway; so far so good.

Problem arises however on torrents with free leech, more specifically on those who's title hasn't been truncated and thus taken from the text within the `<a>` tag. When a torrent has free leech on TorrentBytes they add `[F L]` to the end of it, so you get something like `My.Awesome.Release.720p.WEBRip.x264-JACKETT [F L]`. The current `.ToString()` method of getting the title already does a great job at removing the `[F L]` part automatically for us (likely due to `[F L]` being inside a `<font>` tag), but it leaves an ill-natured little whitespace at the end that causes some issues. It's gotten very apparent now that TorrentBytes has free leech on everything over the holidays.

This PR simply trims the string and fixes that problem, huzza!

