### PR TITLE
[720pier] Fix login and search parsing for indexer 720pier

### DIFF
--- a/src/Jackett.Common/Indexers/720pier.cs
+++ b/src/Jackett.Common/Indexers/720pier.cs
@@ -1,10 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Specialized;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using AngleSharp.Html.Parser;
+﻿using AngleSharp.Html.Parser;
 using Jackett.Common.Models;
 using Jackett.Common.Models.IndexerConfig;
 using Jackett.Common.Services.Interfaces;
@@ -12,18 +6,24 @@ using Jackett.Common.Utils;
 using Jackett.Common.Utils.Clients;
 using Newtonsoft.Json.Linq;
 using NLog;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
 
 namespace Jackett.Common.Indexers
 {
     public class Pier720 : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "ucp.php?mode=login"; } }
-        private string SearchUrl { get { return SiteLink + "search.php"; } }
+        private string LoginUrl => SiteLink + "ucp.php?mode=login";
+        private string SearchUrl => SiteLink + "search.php";
 
         private new ConfigurationDataBasicLoginWithRSSAndDisplay configData
         {
-            get { return (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData;
+            set => base.configData = value;
         }
 
         public Pier720(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
@@ -40,7 +40,7 @@ namespace Jackett.Common.Indexers
             Encoding = Encoding.UTF8;
             Language = "ru-ru";
             Type = "private";
-            
+
             AddCategoryMapping(32, TorznabCatType.TVSport, "Basketball");
             AddCategoryMapping(34, TorznabCatType.TVSport, "Basketball - NBA");
             AddCategoryMapping(87, TorznabCatType.TVSport, "Basketball - NBA Playoffs");
@@ -113,14 +113,20 @@ namespace Jackett.Common.Indexers
 
             var pairs = new Dictionary<string, string>
             {
-                { "username", configData.Username.Value },
-                { "password", configData.Password.Value },
-                { "redirect", "/" },
-                { "login", "Login" }
+                {"username", configData.Username.Value},
+                {"password", configData.Password.Value},
+                {"redirect", "/"},
+                {"login", "Login"},
+                {"autologin", "on"}
             };
+            var htmlParser = new HtmlParser();
+            var loginDocument = htmlParser.ParseDocument((await RequestStringWithCookies(LoginUrl)).Content);
+            pairs["creation_time"] = loginDocument.GetElementsByName("creation_time")[0].GetAttribute("value");
+            pairs["form_token"] = loginDocument.GetElementsByName("form_token")[0].GetAttribute("value");
+            pairs["sid"] = loginDocument.GetElementsByName("sid")[0].GetAttribute("value");
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, LoginUrl, true);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("ucp.php?mode=logout&"), () =>
+            await ConfigureIfOK(result.Cookies, result.Content?.Contains("ucp.php?mode=logout&") == true, () =>
             {
                 var errorMessage = result.Content;
                 throw new ExceptionWithConfigData(errorMessage, configData);
@@ -133,16 +139,18 @@ namespace Jackett.Common.Indexers
             var releases = new List<ReleaseInfo>();
             var searchString = query.GetQueryString();
 
-            WebClientStringResult results = null;
-            var queryCollection = new NameValueCollection();
+            var queryCollection = new NameValueCollection
+            {
+                {"st", "0"},
+                {"sd", "d"},
+                {"sk", "t"},
+                {"tracker_search", "torrent"},
+                {"t", "0"},
+                {"submit", "Search"},
+                {"sr", "topics"},
+                {"ot", "1" }
+            };
 
-            queryCollection.Add("st", "0");
-            queryCollection.Add("sd", "d");
-            queryCollection.Add("sk", "t");
-            queryCollection.Add("tracker_search", "torrent");
-            queryCollection.Add("t", "0");
-            queryCollection.Add("submit", "Search");
-            queryCollection.Add("sr", "topics");
             //queryCollection.Add("sr", "posts");
             //queryCollection.Add("ch", "99999");
 
@@ -150,7 +158,6 @@ namespace Jackett.Common.Indexers
             if (string.IsNullOrWhiteSpace(searchString))
             {
                 queryCollection.Add("search_id", "active_topics");
-                queryCollection.Add("ot", "1");
             }
             else // use the normal search
             {
@@ -159,11 +166,10 @@ namespace Jackett.Common.Indexers
                 queryCollection.Add("sf", "titleonly");
                 queryCollection.Add("sr", "topics");
                 queryCollection.Add("pt", "t");
-                queryCollection.Add("ot", "1");
             }
 
             var searchUrl = SearchUrl + "?" + queryCollection.GetQueryString();
-            results = await RequestStringWithCookies(searchUrl);
+            var results = await RequestStringWithCookies(searchUrl);
             if (!results.Content.Contains("ucp.php?mode=logout"))
             {
                 await ApplyConfiguration(null);
@@ -171,47 +177,53 @@ namespace Jackett.Common.Indexers
             }
             try
             {
-                string RowsSelector = "ul.topics > li.row";
+                const string rowsSelector = "ul.topics > li.row";
 
-                var ResultParser = new HtmlParser();
-                var SearchResultDocument = ResultParser.ParseDocument(results.Content);
-                var Rows = SearchResultDocument.QuerySelectorAll(RowsSelector);
-                foreach (var Row in Rows)
+                var resultParser = new HtmlParser();
+                var searchResultDocument = resultParser.ParseDocument(results.Content);
+                var rows = searchResultDocument.QuerySelectorAll(rowsSelector);
+                foreach (var row in rows)
                 {
                     try
-                    {    
-                        var release = new ReleaseInfo();
+                    {
+                        var release = new ReleaseInfo
+                        {
+                            MinimumRatio = 1,
+                            MinimumSeedTime = 0,
+                            DownloadVolumeFactor = 1,
+                            UploadVolumeFactor = 1,
+                            Seeders = ParseUtil.CoerceInt(row.QuerySelector("span.seed").TextContent),
+                            Grabs = ParseUtil.CoerceLong(row.QuerySelector("span.complet").TextContent),
+                        };
+                        release.Peers = ParseUtil.CoerceInt(row.QuerySelector("span.leech").TextContent) + release.Seeders;
 
-                        release.MinimumRatio = 1;
-                        release.MinimumSeedTime = 0;
-
-                        var qDetailsLink = Row.QuerySelector("a.topictitle");
+                        var qDetailsLink = row.QuerySelector("a.topictitle");
 
                         release.Title = qDetailsLink.TextContent;
                         release.Comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
                         release.Guid = release.Comments;
 
                         var detailsResult = await RequestStringWithCookies(SiteLink + qDetailsLink.GetAttribute("href"));
-                        var DetailsResultDocument = ResultParser.ParseDocument(detailsResult.Content);
-                        var qDownloadLink = DetailsResultDocument.QuerySelector("table.table2 > tbody > tr > td > a[href^=\"/download/torrent.php?id\"]");
+                        var detailsResultDocument = resultParser.ParseDocument(detailsResult.Content);
+                        var qDownloadLink = detailsResultDocument.QuerySelector("table.table2 > tbody > tr > td > a[href^=\"/download/torrent\"]");
 
                         release.Link = new Uri(SiteLink + qDownloadLink.GetAttribute("href").TrimStart('/'));
 
-                        release.Seeders = ParseUtil.CoerceInt(Row.QuerySelector("span.seed").TextContent);
-                        release.Peers = ParseUtil.CoerceInt(Row.QuerySelector("span.leech").TextContent) + release.Seeders;
-                        release.Grabs = ParseUtil.CoerceLong(Row.QuerySelector("span.complet").TextContent);
-
-                        var author = Row.QuerySelector("dd.lastpost > span");
-                        var timestr = author.TextContent.Split('\n')[4].Trim();
+                        var author = row.QuerySelector("dd.lastpost > span");
+                        var timestr = author.TextContent.Split('\n')
+                            .Where(str => !str.IsNullOrEmptyOrWhitespace()) //Filter blank lines
+                            .Skip(1) //Skip author name
+                            .FirstOrDefault()
+                            .Trim();
 
                         release.PublishDate = DateTimeUtil.FromUnknown(timestr, "UK");
 
-                        var forum = Row.QuerySelector("a[href^=\"./viewforum.php?f=\"]");
+                        var forum = row.QuerySelector("a[href^=\"./viewforum.php?f=\"]");
                         var forumid = forum.GetAttribute("href").Split('=')[1];
 
                         release.Category = MapTrackerCatToNewznab(forumid);
 
-                        var size = Row.QuerySelector("dl.row-item > dt > div.list-inner > div[style^=\"float:right\"]").TextContent;
+                        var size = row.QuerySelector("dl.row-item > dt > div.list-inner > div[style^=\"float:right\"]").TextContent;
                         size = size.Replace("GiB", "GB");
                         size = size.Replace("MiB", "MB");
                         size = size.Replace("KiB", "KB");
@@ -222,14 +234,11 @@ namespace Jackett.Common.Indexers
 
                         release.Size = ReleaseInfo.GetBytes(size);
 
-                        release.DownloadVolumeFactor = 1;
-                        release.UploadVolumeFactor = 1;
-
                         releases.Add(release);
                     }
                     catch (Exception ex)
                     {
-                        logger.Error(string.Format("{0}: Error while parsing row '{1}':\n\n{2}", ID, Row.OuterHtml, ex));
+                        logger.Error($"{ID}: Error while parsing row '{row.OuterHtml}':\n\n{ex}");
                     }
                 }
             }


### PR DESCRIPTION
Fix for #6368 

The login script needed more fields that needed to be downloaded from a current login form. This downloads the login page and extracts the needed hidden fields. It now checks the remember me box on login as well.

While testing I found that `PerfomQuery` also failed because the code for `release.Link` and `release.PublishDate` weren't selecting the right fields. I fixed those to be more generic so they should be more resistant to future changes.

I made a couple readability changes as well. Made the names more consistent, var everywhere instead of only a couple places, moved some things around to utilize language features, sort & remove usings.

I was curious why we're overriding `configData` when all it's doing is pointing back to base. Doesn't make sense but I left it in case there was a reason.