### PR TITLE
speedtorrent reloaded: removed .tableinborder from row selector

### DIFF
--- a/src/Jackett.Common/Definitions/speedtorrentreloaded.yml
+++ b/src/Jackett.Common/Definitions/speedtorrentreloaded.yml
@@ -69,7 +69,7 @@
       orderby: "added"
       sort: desc
     rows:
-      selector: table.tableinborder > tbody > tr > td > table.tableinborder > tbody > tr:has(a[href^="details.php"])
+      selector: table > tbody > tr > td > table.tableinborder > tbody > tr:has(a[href^="details.php"])
     fields:
       title:
         selector: a[href^="details.php"]


### PR DESCRIPTION
Speedtorrend Reloaded changed their template and removed the class ".tableinborder" from the top level table resulting in jackett not being able to fetch any data.
This is the definition fix for this change.