### PR TITLE
Fix file location bug in paths with spaces during updates

### DIFF
--- a/src/Jackett.Common/Services/UpdateService.cs
+++ b/src/Jackett.Common/Services/UpdateService.cs
@@ -51,8 +51,11 @@ namespace Jackett.Common.Services
 
         private string ExePath()
         {
-            var location = new Uri(Assembly.GetEntryAssembly().GetName().CodeBase);
-            return new FileInfo(location.AbsolutePath).FullName;
+            // Use EscapedCodeBase to avoid Uri reserved characters from causing bugs
+            // https://stackoverflow.com/questions/896572
+            var location = new Uri(Assembly.GetEntryAssembly().GetName().EscapedCodeBase);
+            // Use LocalPath instead of AbsolutePath to avoid needing to unescape Uri format.
+            return new FileInfo(location.LocalPath).FullName;
         }
 
         public void StartUpdateChecker()

--- a/src/Jackett.Updater/Program.cs
+++ b/src/Jackett.Updater/Program.cs
@@ -553,8 +553,11 @@ namespace Jackett.Updater
 
         private string GetUpdateLocation()
         {
-            var location = new Uri(Assembly.GetEntryAssembly().GetName().CodeBase);
-            return new FileInfo(WebUtility.UrlDecode(location.AbsolutePath)).DirectoryName;
+	        // Use EscapedCodeBase to avoid Uri reserved characters from causing bugs
+	        // https://stackoverflow.com/questions/896572
+            var location = new Uri(Assembly.GetEntryAssembly().GetName().EscapedCodeBase);
+            // Use LocalPath instead of AbsolutePath to avoid needing to unescape Uri format.
+            return new FileInfo(location.LocalPath).DirectoryName;
         }
 
         private string GetJackettConsolePath(string directoryPath)


### PR DESCRIPTION
@ngosang per your comment in #6677 I've separated the pull requests. This one just fixes the bug in both update scripts, and will close #6671 

I'll be sending 2 additional pull requests, one to cleanup code style for readability, and one to convert spaces to tabs in just these two files.