### PR TITLE
core: fix magnet link encoding. resolves #5372 #4761

### DIFF
--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -139,9 +139,6 @@
   download:
     # the .torrent url is on the on the details page 
     selector: ul li a[href^="{{ .Config.downloadlink }}"]
-    filters:
-      - name: replace # temp fix for #5372
-        args: ["%E2%AD%90", ""]
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/extratorrent-ag.yml
+++ b/src/Jackett.Common/Definitions/extratorrent-ag.yml
@@ -957,9 +957,6 @@
       download:
         selector: td a[href^="magnet:?xt="]
         attribute: href
-        filters:
-          - name: replace # temp fix for #5372
-            args: ["%E2%AD%90", ""]
       date:
         selector: td:nth-last-of-type(5)
         filters:

--- a/src/Jackett.Common/Definitions/isohunt2.yml
+++ b/src/Jackett.Common/Definitions/isohunt2.yml
@@ -55,8 +55,6 @@
     filters:
       - name: querystring
         args: url
-      - name: replace # temp fix for #5372
-        args: ["%E2%AD%90", ""]
   search:
     paths:
       - path: torrents

--- a/src/Jackett.Common/Definitions/kickasstorrent-kathow.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrent-kathow.yml
@@ -74,8 +74,6 @@
         filters:
           - name: querystring
             args: url
-          - name: replace # temp fix for #5372
-            args: ["%E2%AD%90", ""]
       size:
         selector: td:nth-child(2)
         filters:

--- a/src/Jackett.Server/Controllers/DownloadController.cs
+++ b/src/Jackett.Server/Controllers/DownloadController.cs
@@ -63,8 +63,12 @@ namespace Jackett.Server.Controllers
                     && downloadBytes[6] == 0x3a // :
                     )
                 {
-                    var magneturi = Encoding.UTF8.GetString(downloadBytes);
-                    return Redirect(new Uri(magneturi).ToString());
+                    // some sites provide magnet links with non-ascii characters, the only way to be sure the url
+                    // is well encoded is to unscape and escape again
+                    // https://github.com/Jackett/Jackett/issues/5372
+                    // https://github.com/Jackett/Jackett/issues/4761
+                    var magneturi = Uri.EscapeUriString(Uri.UnescapeDataString(Encoding.UTF8.GetString(downloadBytes)));
+                    return Redirect(magneturi);
                 }
 
                 // This will fix torrents where the keys are not sorted, and thereby not supported by Sonarr.


### PR DESCRIPTION
@garfield69 tested with:
* http://127.0.0.1:9117/dl/elitetorrent-biz/?jackett_apikey=ygm5k29tomyy11df26gio7iouhqx9k4&path=Q2ZESjhBYnJEQUIxeGdOQ21admtZdjAzUVB3YW5MdUJxMEdweEJMdl8yd3A2NmNBWVRnYnNMU1RkSk1qSjhsYUQtcUJRZGhTMHpRYmpJWVJwbUttTm84cGtyZW56Vkhzcmo1VWVVbERBUmFFem5mUWdOOW8xUnRILWlBdkp5dVo0bFV1MGlqaFlON0JmYnNjUGxwb2VlUVJ5Q2JpQ2pVRDVZWVhIR3p1cEZmOXpXc1JycS1MdDczeEd3NUd1NHZvTHcyR0p3&file=ispansi+espanoles+dvdrip
* http://127.0.0.1:9117/dl/1337x/?jackett_apikey=ygm5k29tomyy11df26gio7iouhqx9k4&path=Q2ZESjhBYnJEQUIxeGdOQ21admtZdjAzUVB5Vm1YQmlDYkVFRVpKcEJsN2I4Vjd6YVFJdkFGRGF4Slg5Yk8tVjFCU2t1WHNZQ1AyYmpsNFBlQndqeG5vQk02Um1BNXJhajk3VklOX2M5SFBudGo0bGJDYlVYUDZ5Nnl2TEdfRHM0dlNQdXF4TlBoc3VDejAxY2RWdFgwUi1NWHkwaFhIMHY2WXBRQmF2OGxEb0FkWklxVXBOXzRQVTBDLXhRenl2V1VCaHo1MXNGWnBxbWZ5MF9wbTF1LW05Z3JoWHVray05cDNoZmJJNTA3cEhpVEZi&file=Panipat.2019.HINDI.720p.HDCAM.900MB.x264.AAC-BOLLYROCKERS%5BTGx%5D+%E2%AD%90