### PR TITLE
Fix sounpark download for non members accounts

### DIFF
--- a/src/Jackett.Common/Definitions/soundpark.yml
+++ b/src/Jackett.Common/Definitions/soundpark.yml
@@ -61,6 +61,9 @@
       download:
         selector: tr:nth-child(1) td:nth-child(1) h2 a, div h3 a
         attribute: href
+        filters:
+          - name: replace
+            args: ["/album/torrent-", "/album/download/torrent-"]
       # dates come in two flavours:
       # Russian, Spanish and English supported
       date:


### PR DESCRIPTION
I'm getting this errors when downloading:
```
Error downloading soundpark https://sound-park.world/album/torrent-XXX
CardigannIndexer (soundpark): Download selector a[href^="/album/download-torrent/"] didn't match
```