### PR TITLE
cardigann: add attribute for download selector

### DIFF
--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -140,6 +140,7 @@
   download:
     # the .torrent url is on the on the details page 
     selector: ul li a[href^="{{ .Config.downloadlink }}"]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/acgsou.yml
+++ b/src/Jackett.Common/Definitions/acgsou.yml
@@ -38,6 +38,7 @@
 
   download:
     selector: a[href^="magnet:?xt="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/arabafenice.yml
+++ b/src/Jackett.Common/Definitions/arabafenice.yml
@@ -125,6 +125,7 @@
         thanks: 1
         rndval: "1487013827343"
     selector: a[href^="download.php?id="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/arenabg.yml
+++ b/src/Jackett.Common/Definitions/arenabg.yml
@@ -102,6 +102,7 @@
 
   download:
     selector: a[href*="{{ .Config.downloadlink }}"]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/asiancinema.yml
+++ b/src/Jackett.Common/Definitions/asiancinema.yml
@@ -67,6 +67,7 @@
 
   download:
     selector: a[href*="/download/"]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/bigtorrent.yml
+++ b/src/Jackett.Common/Definitions/bigtorrent.yml
@@ -55,7 +55,8 @@
 
   download:
     selector: a[href^="download.php?id="]
-        
+    attribute: href
+
   search:
     paths:
       - path: browse.php

--- a/src/Jackett.Common/Definitions/bittorrentam.yml
+++ b/src/Jackett.Common/Definitions/bittorrentam.yml
@@ -41,6 +41,7 @@
 
   download:
     selector: a[ href^="magnet:?xt="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/btsow.yml
+++ b/src/Jackett.Common/Definitions/btsow.yml
@@ -21,6 +21,8 @@
 
   download:
     selector: a#magnetOpen
+    attribute: href
+
   search:
     paths:
       - path: "search/{{if .Keywords}}{{ .Keywords}}{{else}}2019{{end}}"

--- a/src/Jackett.Common/Definitions/classix.yml
+++ b/src/Jackett.Common/Definitions/classix.yml
@@ -28,7 +28,8 @@
 
   download:
     selector: a[href^="download.php?id="]
-        
+    attribute: href
+
   search:
     paths:
       - path: torrents-search.php

--- a/src/Jackett.Common/Definitions/crazyscorner.yml
+++ b/src/Jackett.Common/Definitions/crazyscorner.yml
@@ -92,6 +92,7 @@
         infohash: "\"{{ .DownloadUri.Query.id }}\""
         thanks: 1
     selector: a[href^="download.php?id="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/crazyspirits.yml
+++ b/src/Jackett.Common/Definitions/crazyspirits.yml
@@ -142,6 +142,7 @@
         to: "give"
         torrent: "{{ .DownloadUri.Query.id }}"
     selector: a:contains("Télécharger ce torrent")
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/demonoid.yml
+++ b/src/Jackett.Common/Definitions/demonoid.yml
@@ -284,6 +284,7 @@
 
   download:
     selector: a[href^="magnet:?xt="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/downloadville.yml
+++ b/src/Jackett.Common/Definitions/downloadville.yml
@@ -185,6 +185,7 @@
         thanks: 1
         rndval: "1487013827343"
     selector: a[href^="download.php?id="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/dxp.yml
+++ b/src/Jackett.Common/Definitions/dxp.yml
@@ -80,6 +80,7 @@
 
   download:
     selector: a[href^="download.php?id="]
+    attribute: href
 
   search:
     # https://dxp.ru/torrents.php?search=&sort=4&type=desc

--- a/src/Jackett.Common/Definitions/ebooks-shares.yml
+++ b/src/Jackett.Common/Definitions/ebooks-shares.yml
@@ -297,6 +297,7 @@
 
   download:
     selector: a[href^="download.php?id="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/estrenosdtl.yml
+++ b/src/Jackett.Common/Definitions/estrenosdtl.yml
@@ -42,6 +42,7 @@
 
   download:
     selector: a.linktorrent
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/ettv.yml
+++ b/src/Jackett.Common/Definitions/ettv.yml
@@ -96,6 +96,7 @@
   
   download:
     selector: a[href^="{{ .Config.downloadlink }}"]
+    attribute: href
 
   search:
     path: "{{ if .Keywords }}torrents-search.php{{else}}torrents.php{{end}}"

--- a/src/Jackett.Common/Definitions/extremetorrents.yml
+++ b/src/Jackett.Common/Definitions/extremetorrents.yml
@@ -76,6 +76,7 @@
         text: "{{ .Config.thankyou }}"
         submit: Opslaan
     selector: a[href^="download.php?id="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/exttorrents.yml
+++ b/src/Jackett.Common/Definitions/exttorrents.yml
@@ -44,6 +44,7 @@
 
   download:
     selector: a[href^="magnet:?xt="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/finvip.yml
+++ b/src/Jackett.Common/Definitions/finvip.yml
@@ -91,6 +91,7 @@
 
   download:
     selector: a[href^="download.php?id="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/firebit.yml
+++ b/src/Jackett.Common/Definitions/firebit.yml
@@ -32,6 +32,7 @@
 
   download:
     selector: a[href^="/download.php?id="]
+    attribute: href
 
   search:
     # http://firebit.net/index.php?do=search&type=simple&q=2019

--- a/src/Jackett.Common/Definitions/galeriens.yml
+++ b/src/Jackett.Common/Definitions/galeriens.yml
@@ -233,6 +233,7 @@
 
   download:
     selector: a[href*="/Telechargement/"]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/gamestorrents.yml
+++ b/src/Jackett.Common/Definitions/gamestorrents.yml
@@ -30,6 +30,7 @@
 
   download:
     selector: a#download_torrent
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/generationfree.yml
+++ b/src/Jackett.Common/Definitions/generationfree.yml
@@ -179,6 +179,7 @@
         to: "give"
         torrent: "{{ .DownloadUri.Query.id }}"
     selector: a[href^="download.php?id="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/girotorrent.yml
+++ b/src/Jackett.Common/Definitions/girotorrent.yml
@@ -123,6 +123,7 @@
         thanks: "1"
         rndval: "1487013827343"
     selector: a[href^="download.php?id="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/gktorrent.yml
+++ b/src/Jackett.Common/Definitions/gktorrent.yml
@@ -54,6 +54,7 @@
 
   download:
     selector: a[href*="{{ .Config.downloadlink }}"]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/hdreactor.yml
+++ b/src/Jackett.Common/Definitions/hdreactor.yml
@@ -50,6 +50,7 @@
 
   download:
     selector: a[href^="magnet:?xt="]
+    attribute: href
 
   search:
     # https://hdreactor.net/index.php?do=search&subaction=search&showposts=1&story=2019&catlist[]=2001&catlist[]=2006

--- a/src/Jackett.Common/Definitions/isohunt2.yml
+++ b/src/Jackett.Common/Definitions/isohunt2.yml
@@ -52,6 +52,7 @@
 
   download:
     selector: a.btn-magnet
+    attribute: href
     filters:
       - name: querystring
         args: url

--- a/src/Jackett.Common/Definitions/itorrent.yml
+++ b/src/Jackett.Common/Definitions/itorrent.yml
@@ -44,6 +44,7 @@
 
   download:
     selector: a[href^="/torrentfiles/"]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/leporno.yml
+++ b/src/Jackett.Common/Definitions/leporno.yml
@@ -37,6 +37,7 @@
 
   download:
     selector: a[href*="/dl.php?id="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/limetorrents.yml
+++ b/src/Jackett.Common/Definitions/limetorrents.yml
@@ -52,6 +52,7 @@
   download:
     # the .torrent url is on the on the details page 
     selector: a.csprite_dltorrent[href^="{{ .Config.downloadlink }}"]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/monova.yml
+++ b/src/Jackett.Common/Definitions/monova.yml
@@ -30,6 +30,7 @@
 
   download:
     selector: a#download-file
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/movcr.yml
+++ b/src/Jackett.Common/Definitions/movcr.yml
@@ -23,6 +23,7 @@
 
   download:
     selector: a[href^="/torrents/"]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/moviesdvdr.yml
+++ b/src/Jackett.Common/Definitions/moviesdvdr.yml
@@ -20,6 +20,7 @@
 
   download:
     selector: a.torrent_download
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/nntt.yml
+++ b/src/Jackett.Common/Definitions/nntt.yml
@@ -660,6 +660,7 @@
 
   download:
     selector: a[href^="./download/file.php?id="]
+    attribute: href
 
   search:
     # http://www.nntt.org/search.php?sr=topics&sf=titleonly&fp=1&tracker_search=torrent&keywords=2019&fid[]=154

--- a/src/Jackett.Common/Definitions/oxtorrent.yml
+++ b/src/Jackett.Common/Definitions/oxtorrent.yml
@@ -39,6 +39,7 @@
 
   download:
     selector: a[href*="{{ .Config.downloadlink }}"]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/piratbit.yml
+++ b/src/Jackett.Common/Definitions/piratbit.yml
@@ -626,6 +626,7 @@
 
   download:
     selector: a[href^="magnet:?xt="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/prostylex.yml
+++ b/src/Jackett.Common/Definitions/prostylex.yml
@@ -91,6 +91,7 @@
 
   download:
     selector: a[href^="magnet:?"]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/rus-media.yml
+++ b/src/Jackett.Common/Definitions/rus-media.yml
@@ -295,6 +295,7 @@
 
   download:
     selector: a[href^="./download/file.php?id="]
+    attribute: href
 
   search:
     # http://rus-media.org/search.php?tracker_search=torrent&sr=topics&keywords=2019&fid[]=54

--- a/src/Jackett.Common/Definitions/seedfile.yml
+++ b/src/Jackett.Common/Definitions/seedfile.yml
@@ -50,9 +50,10 @@
       - selector: div.recover-error2
     test:
       path: profile.php
-      
+
   download:
     selector: a[href^="download.php/"]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/seedpeer.yml
+++ b/src/Jackett.Common/Definitions/seedpeer.yml
@@ -21,6 +21,7 @@
 
   download:
     selector: a[href*="/torrent/"]
+    attribute: href
 
   search:
     # https://seedpeer.me/today

--- a/src/Jackett.Common/Definitions/siambit.yml
+++ b/src/Jackett.Common/Definitions/siambit.yml
@@ -103,6 +103,7 @@
         _action: "say_thank"
         id: "{{ .DownloadUri.Query.id }}"
     selector: a[href^="downloadnew.php?id="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/soundpark.yml
+++ b/src/Jackett.Common/Definitions/soundpark.yml
@@ -35,6 +35,7 @@
 
   download:
     selector: a[href^="/album/download-torrent/"]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/spacetorrent.yml
+++ b/src/Jackett.Common/Definitions/spacetorrent.yml
@@ -41,6 +41,7 @@
 
   download:
     selector: a[href^="magnet:?xt="]
+    attribute: href
 
   search:
     path: recherche

--- a/src/Jackett.Common/Definitions/sporthd.yml
+++ b/src/Jackett.Common/Definitions/sporthd.yml
@@ -90,7 +90,7 @@
       type: info
       label: How to get the Cookie
       default: "<ol><li>Login to this tracker in your browser<li>Open the <b>DevTools</b> panel by pressing <b>F12</b><li>Select the <b>Network</b> tab<li>Click on the <b>Doc</b> button<li>Refresh the page by pressing <b>F5</b><li>Select the <b>Headers</b> tab<li>Find 'cookie:' in the <b>Request Headers</b> section<li>Copy & paste the whole cookie string to here</ol>"
-          
+
   login:
     method: cookie
     inputs:
@@ -100,7 +100,8 @@
 
   download:
     selector: a[href^="download.php?id="]
-        
+    attribute: href
+
   search:
     paths:
       - path: browse.php

--- a/src/Jackett.Common/Definitions/tazmaniaden.yml
+++ b/src/Jackett.Common/Definitions/tazmaniaden.yml
@@ -35,6 +35,7 @@
         torrent: "{{ .DownloadUri.Query.id }}"
         submit: "Thanks!"
     selector: a[href^="download.php?id="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/tfile.yml
+++ b/src/Jackett.Common/Definitions/tfile.yml
@@ -1,4 +1,4 @@
-﻿---
+---
   site: tfile
   name: TFile
   description: "TFile is a RUSSIAN Public Torrent Tracker for MOVIES / TV / GENERAL"
@@ -844,9 +844,16 @@
       type: checkbox
       label: Strip Russian Letters
       default: false
+    - name: downloadlink
+      type: select
+      label: Download link
+      default: "magnet:?xt"
+      options:
+        "download.php?id" : ".torrent"
+        "magnet:?xt": "magnet"
 
   download:
-    selector: a[href^="download.php?id="]
+    selector: a[href^="{{ .Config.downloadlink }}"]
     attribute: href
 
   search:
@@ -917,3 +924,5 @@
         text: 0
       uploadvolumefactor:
         text: 1
+# engine n/a
+

--- a/src/Jackett.Common/Definitions/tfile.yml
+++ b/src/Jackett.Common/Definitions/tfile.yml
@@ -847,6 +847,7 @@
 
   download:
     selector: a[href^="download.php?id="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/the-madhouse.yml
+++ b/src/Jackett.Common/Definitions/the-madhouse.yml
@@ -103,6 +103,7 @@
       inputs:
         torrentid: "{{ .DownloadUri.Query.id }}"
     selector: a[href*="/download.php?id="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/topnow.yml
+++ b/src/Jackett.Common/Definitions/topnow.yml
@@ -21,6 +21,8 @@
 
   download:
     selector: a#torrent
+    attribute: href
+
   search:
     paths:
     # http://topnow.se/search.php?dayq=mandalorian

--- a/src/Jackett.Common/Definitions/toros.yml
+++ b/src/Jackett.Common/Definitions/toros.yml
@@ -45,6 +45,7 @@
 
   download:
     selector: a[href^="magnet:?xt="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -55,7 +55,7 @@
   download:
     selector: a[href^="magnet:?"]
     attribute: href
-      
+
   search:
     paths:
       - path: "{{ if .Keywords }}/search_torrent/{{ re_replace .Keywords \"[']+\" \"\" }}/page-0{{else}}/top_torrent.html{{end}}"

--- a/src/Jackett.Common/Definitions/torrentdownload.yml
+++ b/src/Jackett.Common/Definitions/torrentdownload.yml
@@ -40,6 +40,7 @@
 
   download:
     selector: a[href^="magnet:?xt="]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/torrentdownloads.yml
+++ b/src/Jackett.Common/Definitions/torrentdownloads.yml
@@ -36,6 +36,7 @@
 
   download:
     selector: a[href^="{{ .Config.downloadlink }}"]
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Definitions/torrentparadise.yml
+++ b/src/Jackett.Common/Definitions/torrentparadise.yml
@@ -67,6 +67,7 @@
 
   download:
     selector: a[href^="magnet:?xt="]
+    attribute: href
 
   search:
     # https://torrentparadise.org/search.php?f=monday+night

--- a/src/Jackett.Common/Definitions/unlimitz.yml
+++ b/src/Jackett.Common/Definitions/unlimitz.yml
@@ -99,6 +99,7 @@
 
   download:
     selector:  a[href^="d.php?keyalert1="]
+    attribute: href
     filters:
       - name: replace
         args: ["d.php?keyalert1=", "/dI.php/"]

--- a/src/Jackett.Common/Definitions/vanila.yml
+++ b/src/Jackett.Common/Definitions/vanila.yml
@@ -1330,6 +1330,7 @@
 
   download:
     selector: a[href^="./download/file.php?id="]:not(img)
+    attribute: href
 
   search:
     paths:

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -1734,13 +1734,23 @@ namespace Jackett.Common.Indexers
                     if (response.IsRedirect)
                         response = await RequestStringWithCookies(response.RedirectingTo);
                     var results = response.Content;
-                    var SearchResultParser = new HtmlParser();
-                    var SearchResultDocument = SearchResultParser.ParseDocument(results);
-                    var DlUri = SearchResultDocument.QuerySelector(selector);
-                    if (DlUri != null)
+                    var searchResultParser = new HtmlParser();
+                    var searchResultDocument = searchResultParser.ParseDocument(results);
+                    var downloadElement = searchResultDocument.QuerySelector(selector);
+                    if (downloadElement != null)
                     {
-                        logger.Debug(string.Format("CardigannIndexer ({0}): Download selector {1} matched:{2}", ID, selector, DlUri.ToHtmlPretty()));
-                        var href = DlUri.GetAttribute("href");
+                        logger.Debug(string.Format("CardigannIndexer ({0}): Download selector {1} matched:{2}", ID, selector, downloadElement.ToHtmlPretty()));
+                        var href = "";
+                        if (Download.Attribute != null)
+                        {
+                            href = downloadElement.GetAttribute(Download.Attribute);
+                            if (href == null)
+                                throw new Exception(string.Format("Attribute \"{0}\" is not set for element {1}", Download.Attribute, downloadElement.ToHtmlPretty()));
+                        }
+                        else
+                        {
+                            href = downloadElement.TextContent;
+                        }
                         href = applyFilters(href, Download.Filters, variables);
                         link = resolvePath(href, link);
                     }

--- a/src/Jackett.Common/Models/IndexerDefinition.cs
+++ b/src/Jackett.Common/Models/IndexerDefinition.cs
@@ -197,6 +197,7 @@ namespace Jackett.Common.Models
     public class downloadBlock
     {
         public string Selector { get; set; }
+        public string Attribute { get; set; }
         public List<filterBlock> Filters { get; set; }
         public string Method { get; set; }
         public requestBlock Before { get; set; }


### PR DESCRIPTION
This PR allows to add attribute selection in download section.
The default behavior changes to be the same as in search selector. If you don't add the attribute, the TextContent of the element will be selected.

Some trackers have download section without selector. These should be fixed in other PRs because I don't know what should be the selector/attribute.
* audiobookbay
* dragonworldreloaded
* hdsky
* metal-iplay-ro

UPDATE: You have to update the docs => https://github.com/Jackett/Jackett/wiki/Definition-format#download
