### PR TITLE
Package update

### DIFF
--- a/src/Jackett.Common/Jackett.Common.csproj
+++ b/src/Jackett.Common/Jackett.Common.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="AngleSharp" Version="0.13.0" />
     <PackageReference Include="Autofac" Version="4.9.4" />
     <PackageReference Include="AutoMapper" Version="8.1.0" />
-    <PackageReference Include="BencodeNET" Version="2.3.0" />
+    <PackageReference Include="BencodeNET" Version="3.0.1" />
     <PackageReference Include="CloudflareSolverRe" Version="1.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="CsQuery.NETStandard" Version="1.3.6.1" />
@@ -24,7 +24,7 @@
     <PackageReference Include="SharpZipLib" Version="1.2.0" />
     <PackageReference Include="System.IO.FileSystem.AccessControl" Version="4.7.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="4.7.0" />
-    <PackageReference Include="YamlDotNet" Version="6.0.0" />    
+    <PackageReference Include="YamlDotNet" Version="8.0.0" />    
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Jackett.Common/Services/IndexerManagerService.cs
+++ b/src/Jackett.Common/Services/IndexerManagerService.cs
@@ -93,7 +93,7 @@ namespace Jackett.Common.Services
             logger.Info("Loading Cardigann definitions from: " + string.Join(", ", path));
 
             var deserializer = new DeserializerBuilder()
-                        .WithNamingConvention(new CamelCaseNamingConvention())
+                        .WithNamingConvention(CamelCaseNamingConvention.Instance)
                         .IgnoreUnmatchedProperties()
                         .Build();
 

--- a/src/Jackett.Server/Controllers/DownloadController.cs
+++ b/src/Jackett.Server/Controllers/DownloadController.cs
@@ -1,4 +1,5 @@
-﻿using BencodeNET.Parsing;
+﻿using BencodeNET.Objects;
+using BencodeNET.Parsing;
 using Jackett.Common.Models.Config;
 using Jackett.Common.Services.Interfaces;
 using Jackett.Common.Utils;

--- a/src/Jackett.Server/Jackett.Server.csproj
+++ b/src/Jackett.Server/Jackett.Server.csproj
@@ -3,21 +3,29 @@
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <ApplicationIcon>jackett.ico</ApplicationIcon>
-    <AssemblyName>JackettConsole</AssemblyName>
     <OutputType>Exe</OutputType>
     <NoWarn>NU1605</NoWarn>
     <ServerGarbageCollection>false</ServerGarbageCollection>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net461' and $(RuntimeIdentifier.Contains('win')) == 'false'">
-    <AssemblyName>jackett</AssemblyName>
-  </PropertyGroup>
+  <Choose>
+    <When Condition="'$(TargetFramework)' != 'net461' and $(RuntimeIdentifier.Contains('win')) == 'false'">
+      <PropertyGroup>
+        <AssemblyName>jackett</AssemblyName>
+      </PropertyGroup>
+    </When>
+    <Otherwise>
+      <PropertyGroup>
+        <AssemblyName>JackettConsole</AssemblyName>
+      </PropertyGroup>
+    </Otherwise>
+  </Choose>
   
   <!-- Conditionally obtain references for the .NET Core App 3.1 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'netcoreapp3.1' ">
     <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="3.1.0" />
-    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.6.0" />
+    <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="4.7.0" />
   </ItemGroup>
   
     <!-- Conditionally obtain references for the .NET461 target -->
@@ -33,7 +41,7 @@
     
   <ItemGroup>
     <PackageReference Include="Autofac" Version="4.9.4" />
-    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="4.4.0" />
+    <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="5.0.1" />
     <PackageReference Include="AutoMapper" Version="8.1.0" />
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.1.0" />


### PR DESCRIPTION
4 packages updated -> Jackett is now using the latest version of all packages except for AutoMapper -> Will have a go at that another day -> There is a few changes needed to make it work

-Minor code changes made to support newer version of YamlDotNet and BencodeNET
-Logic update for AssemblyName as I've been experiencing restore 'weirdness'  https://stackoverflow.com/questions/208084/how-to-use-a-different-assembly-name-for-different-configurations