### PR TITLE
No need to install Tar now

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -147,7 +147,7 @@ Task("Package-Mono-Full-Framework")
 
 		DeleteFile(buildOutputPath + "/System.Runtime.InteropServices.RuntimeInformation.dll");
 
-		InstallMsysTar();
+		CheckForGzipAndTar();
 		Gzip("./BuildOutput/net461/linux-x64", $"./{artifactsDirName}", "Jackett", "Jackett.Binaries.Mono.tar.gz");
 	});
 
@@ -437,20 +437,8 @@ private void Gzip(string sourceFolder, string outputDirectory, string tarCdirect
 	}	
 }
 
-private void InstallMsysTar()
+private void CheckForGzipAndTar()
 {
-	//Gzip is included by default with MSYS2, but not tar. Use the package manager to install tar
-
-	var startInfo = new System.Diagnostics.ProcessStartInfo()
-	{
-		Arguments = "-S --noconfirm tar",
-		FileName = @"C:\msys64\usr\bin\pacman.exe",
-		UseShellExecute = false
-	};
-
-	var process = System.Diagnostics.Process.Start(startInfo);
-	process.WaitForExit();
-
 	if (FileExists(@"C:\msys64\usr\bin\tar.exe") && FileExists(@"C:\msys64\usr\bin\gzip.exe"))
 	{
 		Information("tar.exe and gzip.exe were found");


### PR DESCRIPTION
Latest version of msys2 includes tar, so no need to manually install it

Should make build fractionally faster and remove below errors

![image](https://user-images.githubusercontent.com/22320807/72202575-361fcc80-34b5-11ea-8d40-645f325541ca.png)
