### PR TITLE
estrenosdtl: fix old download links. resolves #6924

### DIFF
--- a/src/Jackett.Common/Definitions/estrenosdtl.yml
+++ b/src/Jackett.Common/Definitions/estrenosdtl.yml
@@ -43,6 +43,9 @@
   download:
     selector: a.linktorrent
     attribute: href
+    filters:
+      - name: replace
+        args: ["https://www.estrenosdtl1.net/", "{{ .Config.sitelink }}"]
 
   search:
     paths:


### PR DESCRIPTION
Search `fast and shaw` => Links to an old domain and can be fixed with replacement.
The old domain `https://www.estrenosdtl1.net/` is blocked in Spain where most users come from.