### PR TITLE
Improved search adding language tags

### DIFF
--- a/src/Jackett.Common/Definitions/torrentland.yml
+++ b/src/Jackett.Common/Definitions/torrentland.yml
@@ -132,10 +132,21 @@
           - name: querystring
             args: category
       title:
-        selector: td:nth-child(2) a
+        selector: td:nth-child(2) a:contains("VOSE")
+        optional: true
         filters:
           - name: re_replace
             args: ["(?i)\\bT(\\d+)", "S$1"]
+          - name: append
+            args: " [English]"
+      title:
+        selector: td:nth-child(2) a:not(:contains("VOSE"))
+        optional: true
+        filters:
+          - name: re_replace
+            args: ["(?i)\\bT(\\d+)", "S$1"]
+          - name: append
+            args: " [Spanish]"
       banner:
         optional: true
         selector: td:nth-child(2) a


### PR DESCRIPTION
Fixed the problem identifing results always as English now they will be identified as Spanish or English depending of title..