### PR TITLE
Improved [PuyaSubs!] tag

### DIFF
--- a/src/Jackett.Common/Definitions/nyaasi.yml
+++ b/src/Jackett.Common/Definitions/nyaasi.yml
@@ -121,8 +121,8 @@
         selector: td:nth-child(2) a:last-of-type:contains("[PuyaSubs!] ")
         optional: true
         filters:
-          - name: replace
-            args: ["[PuyaSubs!] ", "[PuyaSubs!] [Spanish] "]
+          - name: append
+            args: " [Spanish]"
       details:
         selector: td:nth-child(2) a:last-of-type
         attribute: href

--- a/src/Jackett.Common/Definitions/nyaasi.yml
+++ b/src/Jackett.Common/Definitions/nyaasi.yml
@@ -122,9 +122,7 @@
         optional: true
         filters:
           - name: replace
-            args: ["[PuyaSubs!] ", ""]
-          - name: append
-            args:  " Spanish"
+            args: ["[PuyaSubs!] ", "[PuyaSubs!] [Spanish] "]
       details:
         selector: td:nth-child(2) a:last-of-type
         attribute: href


### PR DESCRIPTION
Now will show [PuyaSubs!] and [Spanish] in the previous version [PuyaSubs!] was deleted and only show [Spanish] at the end of the file, now will be less confusing because you will be able to see original name but with [Spanish] after [PuyaSubs!]