### PR TITLE
Make Tray compatible with .NET Core

### DIFF
--- a/src/Jackett.Tray/Main.cs
+++ b/src/Jackett.Tray/Main.cs
@@ -114,7 +114,13 @@ namespace Jackett.Tray
 
         private void toolStripMenuItemWebUI_Click(object sender, EventArgs e)
         {
-            Process.Start("http://127.0.0.1:" + serverConfig.Port);
+            ProcessStartInfo psi = new ProcessStartInfo
+            {
+                FileName = "http://127.0.0.1:" + serverConfig.Port,
+                UseShellExecute = true
+            };
+
+            Process.Start(psi);
         }
 
         private void toolStripMenuItemShutdown_Click(object sender, EventArgs e)


### PR DESCRIPTION
By default .NET Core sets UseShellExecute to false due to being cross platform