### PR TITLE
core: fix form encoding. resolves #4346 #3061

### DIFF
--- a/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
@@ -214,7 +214,7 @@ namespace Jackett.Common.Utils.Clients
                             else if (webRequest.Type == RequestType.POST)
                             {
                                 if (webRequest.PostData != null)
-                                    request.Content = new FormUrlEncodedContent(webRequest.PostData);
+                                    request.Content = FormUrlEncodedContentWithEncoding(webRequest.PostData, webRequest.Encoding);
                                 request.Method = HttpMethod.Post;
                             }
                             else

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
@@ -234,7 +234,7 @@ namespace Jackett.Common.Utils.Clients
             else if (webRequest.Type == RequestType.POST)
             {
                 if (webRequest.PostData != null)
-                    request.Content = new FormUrlEncodedContent(webRequest.PostData);
+                    request.Content = FormUrlEncodedContentWithEncoding(webRequest.PostData, webRequest.Encoding);
                 request.Method = HttpMethod.Post;
             }
             else

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2NetCore.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2NetCore.cs
@@ -230,7 +230,7 @@ namespace Jackett.Common.Utils.Clients
             else if (webRequest.Type == RequestType.POST)
             {
                 if (webRequest.PostData != null)
-                    request.Content = new FormUrlEncodedContent(webRequest.PostData);
+                    request.Content = FormUrlEncodedContentWithEncoding(webRequest.PostData, webRequest.Encoding);
                 request.Method = HttpMethod.Post;
             }
             else
@@ -250,7 +250,7 @@ namespace Jackett.Common.Utils.Clients
             }
 
             // some cloudflare clients are using a refresh header
-            // Pull it out manually 
+            // Pull it out manually
             if (response.StatusCode == System.Net.HttpStatusCode.ServiceUnavailable && response.Headers.Contains("Refresh"))
             {
                 var refreshHeaders = response.Headers.GetValues("Refresh");

--- a/src/Jackett.Common/Utils/Clients/HttpWebClientNetCore.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClientNetCore.cs
@@ -213,7 +213,7 @@ namespace Jackett.Common.Utils.Clients
                             else if (webRequest.Type == RequestType.POST)
                             {
                                 if (webRequest.PostData != null)
-                                    request.Content = new FormUrlEncodedContent(webRequest.PostData);
+                                    request.Content = FormUrlEncodedContentWithEncoding(webRequest.PostData, webRequest.Encoding);
                                 request.Method = HttpMethod.Post;
                             }
                             else

--- a/src/Jackett.Common/Utils/StringUtil.cs
+++ b/src/Jackett.Common/Utils/StringUtil.cs
@@ -49,11 +49,6 @@ namespace Jackett.Common.Utils
             return Encoding.UTF8.GetString(Convert.FromBase64String(str));
         }
 
-        public static string PostDataFromDict(IEnumerable<KeyValuePair<string, string>> dict)
-        {
-            return new FormUrlEncodedContent(dict).ReadAsStringAsync().Result;
-        }
-
         /// <summary>
         /// Convert an array of bytes to a string of hex digits
         /// </summary>


### PR DESCRIPTION
This change should fix ALL POST REQUESTS in Jackett with encoding != UTF8. That mean searches #4346, login #3061 ...
