### PR TITLE
Allow unit tests to run in non-Windows environments

### DIFF
--- a/src/Jackett.Test/Jackett.Test.csproj
+++ b/src/Jackett.Test/Jackett.Test.csproj
@@ -28,6 +28,7 @@
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="NUnit.ConsoleRunner" Version="3.10.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.16.1" />
+    <PackageReference Include="System.Text.Encoding.CodePages" Version="4.7.0" />
   </ItemGroup>
   
   <ItemGroup>

--- a/src/Jackett.Test/WebUtilityHelpersTests.cs
+++ b/src/Jackett.Test/WebUtilityHelpersTests.cs
@@ -15,12 +15,7 @@ namespace Jackett.Test
         public WebUtilityHelpersTests()
         {
             //https://docs.microsoft.com/en-us/dotnet/api/system.text.codepagesencodingprovider?view=netcore-2.0
-#if !NET461
-            if (Environment.OSVersion.Platform == PlatformID.Win32NT)
-            {
-                Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
-            }
-#endif
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
 
             _codePagesToTest = new Encoding[]{
                 Encoding.UTF8,


### PR DESCRIPTION
This allows unit tests to run on Linux and macOS