### PR TITLE
AB fix RAW tag setting

### DIFF
--- a/src/Jackett.Common/Indexers/AnimeBytes.cs
+++ b/src/Jackett.Common/Indexers/AnimeBytes.cs
@@ -344,16 +344,10 @@ namespace Jackett.Common.Indexers
                             {
                                 releasegroup = string.Empty;
                             }
+                            if (!AllowRaws && releaseTags.Contains("raw", StringComparer.InvariantCultureIgnoreCase))
+                                continue;
 
-                            var infoString = "";
-
-                            for (int i = 0; i + 1 < releaseTags.Count(); i++)
-                            {
-                                if (releaseTags[i] == "Raw" && !AllowRaws)
-                                    continue;
-                                infoString += "[" + releaseTags[i] + "]";
-                            }
-
+                            var infoString = releaseTags.Aggregate("", (prev, cur) => prev + "[" + cur + "]" );
                             var MinimumSeedTime = 259200;
                             //  Additional 5 hours per GB
                             MinimumSeedTime += (int)((Size / 1000000000) * 18000);


### PR DESCRIPTION
Fixes what was discussed in the comments on #7027 

AKA fixes, the "Include Raws" setting for AnimeBytes having no effect.