### PR TITLE
core: add global configuration to disable cache. resolves #4088 #4966

### DIFF
--- a/src/Jackett.Common/Content/custom.css
+++ b/src/Jackett.Common/Content/custom.css
@@ -165,7 +165,7 @@ hr {
     text-align: center;
 }
 
-#jackett-allowext, #jackett-allowupdate, #jackett-logging, #jackett-prerelease {
+#jackett-allowext, #jackett-allowupdate, #jackett-logging, #jackett-prerelease, #jackett-cachedisabled {
     width: 25px;
 }
 

--- a/src/Jackett.Common/Content/custom.js
+++ b/src/Jackett.Common/Content/custom.js
@@ -98,6 +98,12 @@ function loadJackettSettings() {
         $("#jackett-allowext").attr('checked', data.external);
         $("#jackett-allowupdate").attr('checked', data.updatedisabled);
         $("#jackett-prerelease").attr('checked', data.prerelease);
+
+        $("#jackett-cachedisabled").attr('checked', data.cachedisabled);
+        if (data.cachedisabled) {
+            $("#jackett-show-releases").attr("disabled", true);
+        }
+
         $("#jackett-logging").attr('checked', data.logging);
         $("#jackett-omdbkey").val(data.omdbkey);
         $("#jackett-omdburl").val(data.omdburl);
@@ -1211,6 +1217,7 @@ function bindUIButtons() {
         var jackett_external = $("#jackett-allowext").is(':checked');
         var jackett_update = $("#jackett-allowupdate").is(':checked');
         var jackett_prerelease = $("#jackett-prerelease").is(':checked');
+        var jackett_cachedisabled = $("#jackett-cachedisabled").is(':checked');
         var jackett_logging = $("#jackett-logging").is(':checked');
         var jackett_omdb_key = $("#jackett-omdbkey").val();
         var jackett_omdb_url = $("#jackett-omdburl").val();
@@ -1226,6 +1233,7 @@ function bindUIButtons() {
             external: jackett_external,
             updatedisabled: jackett_update,
             prerelease: jackett_prerelease,
+            cachedisabled: jackett_cachedisabled,
             blackholedir: $("#jackett-savedir").val(),
             logging: jackett_logging,
             basepathoverride: jackett_basepathoverride,

--- a/src/Jackett.Common/Content/custom_mobile.css
+++ b/src/Jackett.Common/Content/custom_mobile.css
@@ -157,7 +157,7 @@ hr {
     text-align: center;
 }
 
-#jackett-allowext, #jackett-allowupdate, #jackett-logging, #jackett-prerelease {
+#jackett-allowext, #jackett-allowupdate, #jackett-logging, #jackett-prerelease, #jackett-cachedisabled {
     width: 25px;
 }
 

--- a/src/Jackett.Common/Content/index.html
+++ b/src/Jackett.Common/Content/index.html
@@ -185,6 +185,10 @@
 
         </div>
         <div class="input-area">
+            <span class="input-header">Disable cache: </span>
+            <input id="jackett-cachedisabled" class="form-control input-right" type="checkbox" />
+        </div>
+        <div class="input-area">
             <span class="input-header">Enhanced logging: </span>
             <input id="jackett-logging" class="form-control input-right" type="checkbox" />
         </div>

--- a/src/Jackett.Common/Models/Config/ServerConfig.cs
+++ b/src/Jackett.Common/Models/Config/ServerConfig.cs
@@ -25,6 +25,7 @@ namespace Jackett.Common.Models.Config
         public string BlackholeDir { get; set; }
         public bool UpdateDisabled { get; set; }
         public bool UpdatePrerelease { get; set; }
+        public bool CacheDisabled { get; set; }
         public string BasePathOverride { get; set; }
         public string OmdbApiKey { get; set; }
         public string OmdbApiUrl { get; set; }

--- a/src/Jackett.Common/Models/DTO/ServerConfig.cs
+++ b/src/Jackett.Common/Models/DTO/ServerConfig.cs
@@ -22,6 +22,8 @@ namespace Jackett.Common.Models.DTO
         [DataMember]
         public bool prerelease { get; set; }
         [DataMember]
+        public bool cachedisabled { get; set; }
+        [DataMember]
         public string password { get; set; }
         [DataMember]
         public bool logging { get; set; }
@@ -58,6 +60,7 @@ namespace Jackett.Common.Models.DTO
             blackholedir = config.BlackholeDir;
             updatedisabled = config.UpdateDisabled;
             prerelease = config.UpdatePrerelease;
+            cachedisabled = config.CacheDisabled;
             password = string.IsNullOrEmpty(config.AdminPassword) ? string.Empty : config.AdminPassword.Substring(0, 10);
             logging = config.RuntimeSettings.TracingEnabled;
             basepathoverride = config.BasePathOverride;

--- a/src/Jackett.Server/Controllers/ServerConfigurationController.cs
+++ b/src/Jackett.Server/Controllers/ServerConfigurationController.cs
@@ -78,6 +78,7 @@ namespace Jackett.Server.Controllers
             var saveDir = config.blackholedir;
             var updateDisabled = config.updatedisabled;
             var preRelease = config.prerelease;
+            var cacheDisabled = config.cachedisabled;
             var logging = config.logging;
             var basePathOverride = config.basepathoverride;
             if (basePathOverride != null)
@@ -97,6 +98,7 @@ namespace Jackett.Server.Controllers
 
             serverConfig.UpdateDisabled = updateDisabled;
             serverConfig.UpdatePrerelease = preRelease;
+            serverConfig.CacheDisabled = cacheDisabled;
             serverConfig.BasePathOverride = basePathOverride;
             serverConfig.RuntimeSettings.BasePath = serverService.BasePath();
             configService.SaveConfig(serverConfig);


### PR DESCRIPTION
Current implementation of the cache can be useful for heavy users which perform a lot of queries and have a lot of free RAM. For the average user, the cache is almost useless because the 1 hour cache TTL and the big amount of memory it requires.
This is how the Jackett memory looks in my server after few days with the cache enabled.
![image](https://user-images.githubusercontent.com/10577978/73611186-8d5e1c00-45df-11ea-92a9-99a0470c342e.png)
I'm going to test this PR in my server for a week and I will come back with the results. I think this will be useful for users with low resources.