### PR TITLE
core: show configuration dialog when GetConfigurationForSetup fails

### DIFF
--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -835,7 +835,15 @@ namespace Jackett.Common.Indexers
 
         public override async Task<ConfigurationData> GetConfigurationForSetup()
         {
-            return await GetConfigurationForSetup(false);
+            try
+            {
+                return await GetConfigurationForSetup(false);
+            }
+            catch (Exception e)
+            {
+                logger.Error("Exception in GetConfigurationForSetup (" + ID + "): " + e);
+                return configData;
+            }
         }
 
         public async Task<ConfigurationData> GetConfigurationForSetup(bool automaticlogin)


### PR DESCRIPTION
If you have the link `https://yggtorrent.ws/` in `yggtorrent` tracker.
1. In the current implementation the configuration dialog doesn't show and you have to edit the .json / .yaml manually.
2. With this PR the error will be logged and the dialog will be open (without captcha). I didn't test but I think you will be able to change the link. @garfield69 could you test?

The logged exception will be like this:
```
02-05 19:08:06 Error Exception in GetConfigurationForSetup (yggtorrent): System.Net.Http.HttpRequestException: Name or service not known
 ---> System.Net.Sockets.SocketException (0xFFFDFFFF): Name or service not known
   at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken)
   --- End of inner exception stack trace ---
   at System.Net.Http.ConnectHelper.ConnectAsync(String host, Int32 port, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.ConnectAsync(HttpRequestMessage request, Boolean allowHttp2, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.CreateHttp11ConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.GetHttpConnectionAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpConnectionPool.SendWithRetryAsync(HttpRequestMessage request, Boolean doRequestAuth, CancellationToken cancellationToken)
   at System.Net.Http.DecompressionHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.DiagnosticsHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at CloudflareSolverRe.ClearanceHandler.SendRequestAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at CloudflareSolverRe.ClearanceHandler.SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
   at System.Net.Http.HttpClient.FinishSendAsyncBuffered(Task`1 sendTask, HttpRequestMessage request, CancellationTokenSource cts, Boolean disposeCts)
   at Jackett.Common.Utils.Clients.HttpWebClient2NetCore.Run(WebRequest webRequest) in /home/kizar/repositories/jackett/src/Jackett.Common/Utils/Clients/HttpWebClient2NetCore.cs:line 241
   at Jackett.Common.Utils.Clients.WebClient.GetString(WebRequest request) in /home/kizar/repositories/jackett/src/Jackett.Common/Utils/Clients/WebClient.cs:line 114
   at Jackett.Common.Indexers.BaseWebIndexer.RequestStringWithCookies(String url, String cookieOverride, String referer, Dictionary`2 headers) in /home/kizar/repositories/jackett/src/Jackett.Common/Indexers/BaseIndexer.cs:line 451
   at Jackett.Common.Indexers.CardigannIndexer.GetConfigurationForSetup(Boolean automaticlogin) in /home/kizar/repositories/jackett/src/Jackett.Common/Indexers/CardigannIndexer.cs:line 861
   at Jackett.Common.Indexers.CardigannIndexer.GetConfigurationForSetup() in /home/kizar/repositories/jackett/src/Jackett.Common/Indexers/CardigannIndexer.cs:line 840 
```

