### PR TITLE
torrentz2: Fix sorting of torrents

### DIFF
--- a/src/Jackett.Common/Definitions/torrentz2.yml
+++ b/src/Jackett.Common/Definitions/torrentz2.yml
@@ -47,7 +47,7 @@
       "adult tattoo": XXX
       "other": Other
       "images": Other
-      
+
 
     modes:
       search: [q]
@@ -70,15 +70,16 @@
     - name: sort
       type: select
       label: Sort requested from site
-      default: "A"
+      default: "_"
       options:
+        "_": "peers"
+        "N": "rating"
         "A": "created"
-        "P": "seeders"
         "S": "size"
 
   search:
     paths:
-      - path: "{{if .Config.filter-verified }}verified{{else}}search{{end}}{{ .Config.sort }}"
+      - path: "{{if .Config.filter-verified }}verified{{else}}search{{end}}{{ re_replace .Config.sort \"_\" \"\" }}"
     inputs:
        f: "{{ if .Keywords }}title: {{ .Keywords }}{{else}}{{end}}"
        safe: "{{ if .Config.filter-safe }}1{{else}}0{{end}}"

--- a/src/Jackett.Common/Definitions/torrentz2.yml
+++ b/src/Jackett.Common/Definitions/torrentz2.yml
@@ -70,7 +70,7 @@
     - name: sort
       type: select
       label: Sort requested from site
-      default: "_"
+      default: "A"
       options:
         "_": "peers"
         "N": "rating"


### PR DESCRIPTION
`searchP` is not existing anymore, and the default (without any suffix) is `peers`

