### PR TITLE
API 2.0 - indexers "configured" parameter

### DIFF
--- a/src/Jackett.Server/Controllers/IndexerApiController.cs
+++ b/src/Jackett.Server/Controllers/IndexerApiController.cs
@@ -111,9 +111,10 @@ namespace Jackett.Server.Controllers
 
         [HttpGet]
         [Route("")]
-        public IEnumerable<Common.Models.DTO.Indexer> Indexers()
+        public IEnumerable<Common.Models.DTO.Indexer> Indexers([FromQuery(Name = "configured")] bool configured)
         {
             var dto = IndexerService.GetAllIndexers().Select(i => new Common.Models.DTO.Indexer(i));
+            dto = configured ? dto.Where(i => i.configured) : dto;
             return dto;
         }
 


### PR DESCRIPTION
Add support for a "configured" parameter in the API 2.0. Only return configured indexers if true.

Would be nice to have, no breaking changes.