### PR TITLE
[Fix Tracker] The Resurrection downloading .torrent

### DIFF
--- a/src/Jackett.Common/Definitions/theresurrection.yml
+++ b/src/Jackett.Common/Definitions/theresurrection.yml
@@ -120,8 +120,6 @@
       details:
         selector: a[href^="index.php?page=torrent-details"]
         attribute: href
-      # https://the-resurrection.pro/index.php?page=downloadcheck&id=c48be660fb089aa14a00b4ef04b1d6ce1eb4752e
-      # https://the-resurrection.pro/download.php?id=c48be660fb089aa14a00b4ef04b1d6ce1eb4752e&f=Die.fantastische.Reise.des.Dr.Dolittle.2020.German.DL.LD.1080p.WEBRip.x264-PRD.torrent&key=0
       download:
         selector: a[href^="index.php?page=downloadcheck"]
         attribute: href

--- a/src/Jackett.Common/Definitions/theresurrection.yml
+++ b/src/Jackett.Common/Definitions/theresurrection.yml
@@ -86,6 +86,10 @@
     test:
       path: index.php
 
+  download:
+    selector: a[href^="download.php?id="]
+    attribute: href
+
   search:
     paths:
       - path: index.php
@@ -115,7 +119,9 @@
             args: category
       details:
         selector: a[href^="index.php?page=torrent-details"]
-        attribute: href            
+        attribute: href
+      # https://the-resurrection.pro/index.php?page=downloadcheck&id=c48be660fb089aa14a00b4ef04b1d6ce1eb4752e
+      # https://the-resurrection.pro/download.php?id=c48be660fb089aa14a00b4ef04b1d6ce1eb4752e&f=Die.fantastische.Reise.des.Dr.Dolittle.2020.German.DL.LD.1080p.WEBRip.x264-PRD.torrent&key=0
       download:
         selector: a[href^="index.php?page=downloadcheck"]
         attribute: href


### PR DESCRIPTION
The Resurrection needs you to do a "downloadcheck" before giving back the download url to the .torrent-file. This has now been fixed as I've overlooke it last night.