### PR TITLE
[Fix Tracker] Change login url for Immortuos

### DIFF
--- a/src/Jackett.Common/Definitions/immortuos.yml
+++ b/src/Jackett.Common/Definitions/immortuos.yml
@@ -6,6 +6,7 @@
   type: private
   encoding: UTF-8
   links:
+    - https://immortuos.life/
     - https://www.immortuos.life/
 
   caps:


### PR DESCRIPTION
Immortuos has done some server changes and currently the old url lead to the login page of the forum.
Include currently working login page in addition to the old one in case they revert the changes.
Adding account and testing connection in Jackett worked on my end.
Fixes #7177 