### PR TITLE
Add codec and medium filters to HDBits API

### DIFF
--- a/src/Jackett.Common/Content/custom.css
+++ b/src/Jackett.Common/Content/custom.css
@@ -55,6 +55,14 @@ body {
     max-width: 255px;
 }
 
+.setup-item-inputcheckbox label {
+    padding: 0 1.5em;
+}
+
+.setup-item-inputcheckbox input {
+    height: 20px;
+}
+
 .setup-item-inputbool input {
     max-width: 100px;
     height: 20px;
@@ -277,7 +285,7 @@ table td.fit{
 
 .tooltip-inner img {
     max-width: 250px;
-    height: auto;      
+    height: auto;
 }
 
 .type-public {

--- a/src/Jackett.Common/Content/custom.js
+++ b/src/Jackett.Common/Content/custom.js
@@ -32,7 +32,15 @@ $(document).ready(function () {
 	        return opts.fn(this);
 	    else
 	        return opts.inverse(this);
-	});
+    });
+
+    Handlebars.registerHelper('if_in', function(elem, list, opts) {
+        if(list.indexOf(elem) > -1) {
+            return opts.fn(this);
+        }
+
+        return opts.inverse(this);
+    });
 
     var index = window.location.pathname.indexOf("/UI");
     var pathPrefix = window.location.pathname.substr(0, index);
@@ -608,6 +616,11 @@ function getConfigModalJson(configForm) {
             case "inputbool":
                 itemEntry.value = $el.find(".setup-item-inputbool input").is(":checked");
                 break;
+            case "inputcheckbox":
+                itemEntry.values = [];
+                $el.find(".setup-item-inputcheckbox input:checked").each(function () {
+                  itemEntry.values.push($(this).val());
+                });
             case "inputselect":
                 itemEntry.value = $el.find(".setup-item-inputselect select").val();
                 break;
@@ -877,7 +890,7 @@ function showSearch(selectedIndexer, query, category) {
         enableCaseInsensitiveFiltering: true,
         nonSelectedText: 'All'
     });
-    
+
 
     if (category !== undefined) {
         searchCategory.val(category.split(","));
@@ -1155,8 +1168,8 @@ function bindUIButtons() {
         var jackett_port = Number($("#jackett-port").val());
         var jackett_basepathoverride = $("#jackett-basepathoverride").val();
         var jackett_external = $("#jackett-allowext").is(':checked');
-        var jackett_update = $("#jackett-allowupdate").is(':checked'); 
-        var jackett_prerelease = $("#jackett-prerelease").is(':checked'); 
+        var jackett_update = $("#jackett-allowupdate").is(':checked');
+        var jackett_prerelease = $("#jackett-prerelease").is(':checked');
         var jackett_logging = $("#jackett-logging").is(':checked');
         var jackett_omdb_key = $("#jackett-omdbkey").val();
         var jackett_omdb_url = $("#jackett-omdburl").val();

--- a/src/Jackett.Common/Content/index.html
+++ b/src/Jackett.Common/Content/index.html
@@ -34,7 +34,7 @@
 
     <link rel="stylesheet" type="text/css" href="../bootstrap/bootstrap.min.css?changed=2017083001">
     <link rel="stylesheet" type="text/css" href="../animate.css?changed=2017083001">
-    <link rel="stylesheet" type="text/css" href="../custom.css?changed=20200102" media="only screen and (min-device-width: 480px)">
+    <link rel="stylesheet" type="text/css" href="../custom.css?changed=20200220" media="only screen and (min-device-width: 480px)">
     <link rel="stylesheet" type="text/css" href="../custom_mobile.css?changed=20200102" media="only screen and (max-device-width: 480px)">
     <link rel="stylesheet" type="text/css" href="../css/jquery.dataTables.min.css?changed=2017083001">
     <link rel="stylesheet" type="text/css" href="../css/bootstrap-multiselect.css?changed=2017083001" />
@@ -691,6 +691,6 @@
     </script>
 
     <script type="text/javascript" src="../libs/api.js?changed=2017083001"></script>
-    <script type="text/javascript" src="../custom.js?changed=20200102"></script>
+    <script type="text/javascript" src="../custom.js?changed=20200220"></script>
 </body>
 </html>

--- a/src/Jackett.Common/Content/index.html
+++ b/src/Jackett.Common/Content/index.html
@@ -52,11 +52,11 @@
         </div>
         <hr />
 
-        <div id="can-upgrade-from-mono" hidden class="alert alert-info" role="alert"> 
+        <div id="can-upgrade-from-mono" hidden class="alert alert-info" role="alert">
             <strong>Standalone version of Jackett is now available - Mono not required</strong> <br>
-            To upgrade to the standalone version of Jackett, <a href="https://github.com/Jackett/Jackett#install-on-linux-amdx64" target="_blank" class="alert-link">click here</a> for install instructions. 
-            Upgrading is straight forward, simply install the standalone version and your indexers/configuration will carry over. 
-            Benefits include: increased performance, improved stability and no dependency on Mono. 
+            To upgrade to the standalone version of Jackett, <a href="https://github.com/Jackett/Jackett#install-on-linux-amdx64" target="_blank" class="alert-link">click here</a> for install instructions.
+            Upgrading is straight forward, simply install the standalone version and your indexers/configuration will carry over.
+            Benefits include: increased performance, improved stability and no dependency on Mono.
         </div>
 
         <div class="pull-right">
@@ -233,6 +233,19 @@
             {{else}}
             <input type="checkbox" data-id="{{id}}" class="form-control" />
             {{/if}}
+        </div>
+    </script>
+    <script id="setup-item-inputcheckbox" type="text/x-handlebars-template">
+        <div class="setup-item-inputcheckbox">
+            {{#each options}}
+            <div class="checkbox"><label>
+            {{#if_in @key ../values}}
+            <input type="checkbox" data-id="{{../../id}}" class="form-control" value="{{@key}}" checked />
+            {{else}}
+            <input type="checkbox" data-id="{{../../id}}" class="form-control" value="{{@key}}" />
+            {{/if_in}}
+            {{this}}</label></div>
+            {{/each}}
         </div>
     </script>
     <script id="setup-item-inputselect" type="text/x-handlebars-template">

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -209,21 +209,30 @@ namespace Jackett.Common.Indexers
             variables[".Config.sitelink"] = SiteLink;
             foreach (var Setting in Definition.Settings)
             {
-                string value;
                 var item = configData.GetDynamic(Setting.Name);
-                if (item.GetType() == typeof(BoolItem))
+
+                // CheckBox item is an array of strings
+                if (item.GetType() == typeof(CheckboxItem))
                 {
-                    value = (((BoolItem)item).Value == true ? "true" : "");
-                }
-                else if (item.GetType() == typeof(SelectItem))
-                {
-                    value = ((SelectItem)item).Value;
+                    variables[".Config." + Setting.Name] = ((CheckboxItem)item).Values;
                 }
                 else
                 {
-                    value = ((StringItem)item).Value;
+                    string value;
+                    if (item.GetType() == typeof(BoolItem))
+                    {
+                        value = (((BoolItem)item).Value == true ? "true" : "");
+                    }
+                    else if (item.GetType() == typeof(SelectItem))
+                    {
+                        value = ((SelectItem)item).Value;
+                    }
+                    else
+                    {
+                        value = ((StringItem)item).Value;
+                    }
+                    variables[".Config." + Setting.Name] = value;
                 }
-                variables[".Config." + Setting.Name] = value;
             }
             return variables;
         }

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -118,6 +118,14 @@ namespace Jackett.Common.Indexers
                         case "text":
                             item = new StringItem { Value = Setting.Default };
                             break;
+                        case "multi-select":
+                            if (Setting.Options == null)
+                            {
+                                throw new Exception("Options must be given for the 'multi-select' type.");
+                            }
+
+                            item = new CheckboxItem(Setting.Options) { Values = Setting.Defaults };
+                            break;
                         case "select":
                             if (Setting.Options == null)
                             {
@@ -1235,7 +1243,7 @@ namespace Jackett.Common.Indexers
             variables[".Query.Keywords"] = string.Join(" ", KeywordTokens);
             variables[".Keywords"] = applyFilters((string)variables[".Query.Keywords"], Search.Keywordsfilters);
 
-            // TODO: prepare queries first and then send them parallel 
+            // TODO: prepare queries first and then send them parallel
             var SearchPaths = Search.Paths;
             foreach (var SearchPath in SearchPaths)
             {

--- a/src/Jackett.Common/Indexers/HDBitsApi.cs
+++ b/src/Jackett.Common/Indexers/HDBitsApi.cs
@@ -4,7 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using Jackett.Common.Models;
-using Jackett.Common.Models.IndexerConfig;
+using Jackett.Common.Models.IndexerConfig.Bespoke;
 using Jackett.Common.Services.Interfaces;
 using Jackett.Common.Utils;
 using Jackett.Common.Utils.Clients;
@@ -17,9 +17,9 @@ namespace Jackett.Common.Indexers
     {
         private string APIUrl { get { return SiteLink + "api/"; } }
 
-        private new ConfigurationDataUserPasskey configData
+        private new ConfigurationDataHDBitsApi configData
         {
-            get { return (ConfigurationDataUserPasskey)base.configData; }
+            get { return (ConfigurationDataHDBitsApi)base.configData; }
             set { base.configData = value; }
         }
 
@@ -32,7 +32,7 @@ namespace Jackett.Common.Indexers
                 client: wc,
                 logger: l,
                 p: ps,
-                configData: new ConfigurationDataUserPasskey())
+                configData: new ConfigurationDataHDBitsApi())
         {
             Encoding = Encoding.UTF8;
             Language = "en-us";
@@ -96,6 +96,26 @@ namespace Jackett.Common.Indexers
                 foreach (var cat in categories)
                 {
                     requestData["category"].Add(new JValue(cat));
+                }
+            }
+
+            if (configData.Codecs.Values.Length > 0)
+            {
+                requestData["codec"] = new JArray();
+
+                foreach (var codec in configData.Codecs.Values)
+                {
+                    requestData["codec"].Add(new JValue(int.Parse(codec)));
+                }
+            }
+
+            if (configData.Mediums.Values.Length > 0)
+            {
+                requestData["medium"] = new JArray();
+
+                foreach (var medium in configData.Mediums.Values)
+                {
+                    requestData["medium"].Add(new JValue(int.Parse(medium)));
                 }
             }
 

--- a/src/Jackett.Common/Models/DTO/Config.cs
+++ b/src/Jackett.Common/Models/DTO/Config.cs
@@ -4,6 +4,7 @@ namespace Jackett.Common.Models.DTO
     {
         public string id { get; set; }
         public string value { get; set; }
+        public string[] values { get; set; } // for array data (e.g. checkboxes)
         public string cookie { get; set; } // for cookie alternative login (captcha needed + remote host)
         public string challenge { get; set; } // for reCaptcha V1 compatibility
         public string version { get; set; } // for reCaptcha V1 compatibility

--- a/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationHDBitsApi.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationHDBitsApi.cs
@@ -1,0 +1,34 @@
+using System.Collections.Generic;
+
+namespace Jackett.Common.Models.IndexerConfig.Bespoke
+{
+    internal class ConfigurationDataHDBitsApi : ConfigurationDataUserPasskey
+    {
+        public CheckboxItem Codecs { get; private set; }
+        public CheckboxItem Mediums { get; private set; }
+
+        public ConfigurationDataHDBitsApi(): base()
+        {
+            Codecs = new CheckboxItem(new Dictionary<string, string>()
+                {
+                    {"1", "H.264"},
+                    {"5", "HEVC"},
+                    {"2", "MPEG-2"},
+                    {"3", "VC-1"},
+                    {"6", "VP9"},
+                    {"4", "XviD"}
+                })
+            { Name = "Codec", Values = new string[]{ "1", "5", "2", "3", "6", "4" } };
+
+            Mediums = new CheckboxItem(new Dictionary<string, string>()
+                {
+                    {"1", "Blu-ray/HD DVD"},
+                    {"4", "Capture"},
+                    {"3", "Encode"},
+                    {"5", "Remux"},
+                    {"6", "WEB-DL"}
+                })
+            { Name = "Medium", Values = new string[]{ "1", "4", "3", "5", "6" } };
+        }
+    }
+}

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationData.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationData.cs
@@ -16,6 +16,7 @@ namespace Jackett.Common.Models.IndexerConfig
         {
             InputString,
             InputBool,
+            InputCheckbox,
             InputSelect,
             DisplayImage,
             DisplayInfo,
@@ -83,6 +84,11 @@ namespace Jackett.Common.Models.IndexerConfig
                     case ItemType.InputBool:
                         ((BoolItem)item).Value = arrItem.Value<bool>("value");
                         break;
+                    case ItemType.InputCheckbox:
+                        var values = arrItem.Value<JArray>("values");
+                        if (values != null)
+                            ((CheckboxItem)item).Values = values.Values<string>().ToArray();
+                        break;
                     case ItemType.InputSelect:
                         ((SelectItem)item).Value = arrItem.Value<string>("value");
                         break;
@@ -130,6 +136,15 @@ namespace Jackett.Common.Models.IndexerConfig
                     case ItemType.InputBool:
                         jObject["value"] = ((BoolItem)item).Value;
                         break;
+                    case ItemType.InputCheckbox:
+                        jObject["values"] = new JArray(((CheckboxItem)item).Values);
+                        jObject["options"] = new JObject();
+
+                        foreach (var option in ((CheckboxItem)item).Options)
+                        {
+                            jObject["options"][option.Key] = option.Value;
+                        }
+                        break;
                     case ItemType.InputSelect:
                         jObject["value"] = ((SelectItem)item).Value;
                         jObject["options"] = new JObject();
@@ -166,7 +181,7 @@ namespace Jackett.Common.Models.IndexerConfig
             if (!forDisplay)
             {
                 properties = properties
-                    .Where(p => p.ItemType == ItemType.HiddenData || p.ItemType == ItemType.InputBool || p.ItemType == ItemType.InputString || p.ItemType == ItemType.InputSelect || p.ItemType == ItemType.Recaptcha || p.ItemType == ItemType.DisplayInfo)
+                    .Where(p => p.ItemType == ItemType.HiddenData || p.ItemType == ItemType.InputBool || p.ItemType == ItemType.InputString || p.ItemType == ItemType.InputCheckbox || p.ItemType == ItemType.InputSelect || p.ItemType == ItemType.Recaptcha || p.ItemType == ItemType.DisplayInfo)
                     .ToList();
             }
 
@@ -257,6 +272,19 @@ namespace Jackett.Common.Models.IndexerConfig
             public ImageItem()
             {
                 ItemType = ConfigurationData.ItemType.DisplayImage;
+            }
+        }
+
+        public class CheckboxItem : Item
+        {
+            public string[] Values { get; set; }
+
+            public Dictionary<string, string> Options { get; }
+
+            public CheckboxItem(Dictionary<string, string> options)
+            {
+                ItemType = ItemType.InputCheckbox;
+                Options = options;
             }
         }
 

--- a/src/Jackett.Common/Models/IndexerDefinition.cs
+++ b/src/Jackett.Common/Models/IndexerDefinition.cs
@@ -83,6 +83,7 @@ namespace Jackett.Common.Models
         public string Type { get; set; }
         public string Label { get; set; }
         public string Default { get; set; }
+        public string[] Defaults { get; set; }
         public Dictionary<string, string> Options { get; set; }
     }
 


### PR DESCRIPTION
This PR adds some more configuration to the HDBits API so one easily can select which codecs and mediums one's interested in. I thought about adding them as additional categories at first, but they're more like filters - so it wasn't really feasible to do in a usable and logical way.

In order to achieve this and make it configurable in a nicer way, I also took the liberty of adding support for checkboxes to the indexer configuration. The final result looks like this:

![Screenshot_2020-02-13 Jackett](https://user-images.githubusercontent.com/264300/74483917-d3f12780-4eb7-11ea-90b8-6ac279d5ca58.png)

