### PR TITLE
TFA: Remove leading [Release Group] / [Req] combination from title

### DIFF
--- a/src/Jackett.Common/Definitions/thefallingangels.yml
+++ b/src/Jackett.Common/Definitions/thefallingangels.yml
@@ -206,6 +206,11 @@
           ":has(div.kat_cat_pic_name:contains(\"XXX\")):has(div.kat_cat_pic_name_b:contains(\"Pic\"))": 110
       title:
         selector: a.selection_a
+        filters:
+          - name: re_replace
+            args: ["^\\[[\\w ]*\\]\\s?", ""]
+          - name: re_replace
+            args: ["^\\[[\\w ]*\\]\\s?", ""]
       details:
         selector: a.selection_a
         attribute: href


### PR DESCRIPTION
Some titles have included some special tags in the beginning.
This removes one or two of those.