### PR TITLE
Windows service and Tray: NET Core only

### DIFF
--- a/src/Jackett.Service/Jackett.Service.csproj
+++ b/src/Jackett.Service/Jackett.Service.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
   
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <AssemblyName>JackettService</AssemblyName>
     <ApplicationIcon>jackett.ico</ApplicationIcon>

--- a/src/Jackett.Tray/Jackett.Tray.csproj
+++ b/src/Jackett.Tray/Jackett.Tray.csproj
@@ -1,7 +1,7 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <TargetFrameworks>netcoreapp3.1</TargetFrameworks>
     <OutputType>WinExe</OutputType>
     <UseWindowsForms>true</UseWindowsForms>
     <AssemblyName>JackettTray</AssemblyName>


### PR DESCRIPTION
We no longer need to support NET461 for Tray and Windows service since these are for Windows users only