### PR TITLE
Change cookie SameSite from None to Lax

### DIFF
--- a/src/Jackett.Server/Startup.cs
+++ b/src/Jackett.Server/Startup.cs
@@ -48,7 +48,6 @@ namespace Jackett.Server
                             options.AccessDeniedPath = new PathString("/UI/Login");
                             options.LogoutPath = new PathString("/UI/Logout");
                             options.Cookie.Name = "Jackett";
-                            options.Cookie.SameSite = SameSiteMode.None;
                         });
 
 


### PR DESCRIPTION
Starting in Chrome 80, following [an update](https://tools.ietf.org/html/draft-west-cookie-incrementalism-00) to the `SameSite` draft standard, Chrome rejects cookies with the `SameSite=None` attribute that do not also have the `Secure` attribute.
https://www.chromestatus.com/feature/5633521622188032

Currently the Jackett cookie is configured with `SameSite` set to `None` and the `SecurePolicy` set to the default `SameAsRequest`. This means that HTTP requests will redirect indefinitely because the cookie set by the login page will be rejected.

To fix this, the Jackett cookie should be configured with `SameSite` set the to default `Lax`.

ASP.NET Core was modified to change the behavior of `SameSiteMode.None`. Previously the behavior matched the older 2016 draft and resulted in the `SameSite` attribute being omitted. Now `SameSiteMode.None` results in `SameSite=None` being added to the cookie.
See https://github.com/dotnet/aspnetcore/commit/0a1e208c7637b1895a75b086f938861ed90457a3.

The existing configuration was correct in older version of ASP.NET Core before this change, but is no longer correct.