### PR TITLE
[The Resurrection] Fix multiple logins

### DIFF
--- a/src/Jackett.Common/Definitions/theresurrection.yml
+++ b/src/Jackett.Common/Definitions/theresurrection.yml
@@ -75,16 +75,24 @@
     #    "asc": "asc"
 
   login:
-    path: sbg_login_new.php
-    method: form
+    path: index.php?page=login
+    method: post
     inputs:
       uid: "{{ .Config.username }}"
       pwd: "{{ .Config.password }}"
     error:
-      - selector: div.altertBoxStyle:contains("Passwort falsch")
-      - selector: div.altertBoxStyle:contains("Benutzername falsch")
+      - selector: body[onLoad^="makeAlert('"]
+        message:
+          selector: body[onLoad^="makeAlert('"]
+          attribute: onLoad
+          filters:
+            - name: replace
+              args: ["makeAlert('Error' , '", ""]
+            - name: replace
+              args: ["');", ""]
     test:
       path: index.php
+      selector: a[href="logout.php"]
 
   download:
     selector: a[href^="download.php?id="]


### PR DESCRIPTION
Change login method to post.
Revamped error parsing.
Add test selector.

Somehow accounts were listed online more than once with last version. After testing with this new version this didn't happen any longer.