### PR TITLE
core: increase log size to 2 MB

### DIFF
--- a/src/Jackett.Common/Utils/LoggingSetup.cs
+++ b/src/Jackett.Common/Utils/LoggingSetup.cs
@@ -25,7 +25,7 @@ namespace Jackett.Common.Utils
             logFile.Layout = "${longdate} ${level} ${message} ${exception:format=ToString}";
             logFile.FileName = Path.Combine(settings.DataFolder, logFileName);
             logFile.ArchiveFileName = Path.Combine(settings.DataFolder, logFileName + ".{#####}.txt");
-            logFile.ArchiveAboveSize = 500000;
+            logFile.ArchiveAboveSize = 2097152; // 2 MB
             logFile.MaxArchiveFiles = 5;
             logFile.KeepFileOpen = false;
             logFile.ArchiveNumbering = ArchiveNumberingMode.DateAndSequence;


### PR DESCRIPTION
There is no standard size, but a value between 1 MB and 10 MB is more reasonable than having a lot of small files. 2 MB file can be send through email or uploaded to GitHub.
