### PR TITLE
Convert functions and properties to expression bodies when able

### DIFF
--- a/src/DateTimeRoutines/DateTimeRoutines.cs
+++ b/src/DateTimeRoutines/DateTimeRoutines.cs
@@ -285,10 +285,7 @@ namespace DateTimeRoutines
         /// <param name="default_format">format to be used preferably in ambivalent instances</param>
         /// <param name="parsed_time">parsed date-time output</param>
         /// <returns>true if time was found, else false</returns>
-        public static bool TryParseTime(this string str, DateTimeFormat default_format, out ParsedDateTime parsed_time)
-        {
-            return TryParseTime(str, default_format, out parsed_time, null);
-        }
+        public static bool TryParseTime(this string str, DateTimeFormat default_format, out ParsedDateTime parsed_time) => TryParseTime(str, default_format, out parsed_time, null);
 
         /// <summary>
         /// Tries to find date and/or time within the passed string and return it as ParsedDateTime object. 

--- a/src/DateTimeRoutines/DateTimeRoutines.cs
+++ b/src/DateTimeRoutines/DateTimeRoutines.cs
@@ -285,7 +285,8 @@ namespace DateTimeRoutines
         /// <param name="default_format">format to be used preferably in ambivalent instances</param>
         /// <param name="parsed_time">parsed date-time output</param>
         /// <returns>true if time was found, else false</returns>
-        public static bool TryParseTime(this string str, DateTimeFormat default_format, out ParsedDateTime parsed_time) => TryParseTime(str, default_format, out parsed_time, null);
+        public static bool TryParseTime(this string str, DateTimeFormat default_format, out ParsedDateTime parsed_time)
+            => TryParseTime(str, default_format, out parsed_time, null);
 
         /// <summary>
         /// Tries to find date and/or time within the passed string and return it as ParsedDateTime object. 

--- a/src/DateTimeRoutines/DateTimeRoutines.csproj
+++ b/src/DateTimeRoutines/DateTimeRoutines.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
 </Project>

--- a/src/Jackett.Common/ExceptionWithConfigData.cs
+++ b/src/Jackett.Common/ExceptionWithConfigData.cs
@@ -9,9 +9,7 @@ namespace Jackett.Common
         public ConfigurationData ConfigData { get; private set; }
         public ExceptionWithConfigData(string message, ConfigurationData data)
             : base(message)
-        {
-            ConfigData = data;
-        }
+            => ConfigData = data;
 
     }
 }

--- a/src/Jackett.Common/Helpers/CookieContainerExtensions.cs
+++ b/src/Jackett.Common/Helpers/CookieContainerExtensions.cs
@@ -44,14 +44,8 @@ namespace Jackett.Common.Helpers
             }
         }
 
-        public static void DumpToJson(this CookieContainer cookies, string uri, JToken json)
-        {
-            DumpToJson(cookies, new Uri(uri), json);
-        }
+        public static void DumpToJson(this CookieContainer cookies, string uri, JToken json) => DumpToJson(cookies, new Uri(uri), json);
 
-        public static void DumpToJson(this CookieContainer cookies, Uri uri, JToken json)
-        {
-            json["cookie_header"] = cookies.GetCookieHeader(uri);
-        }
+        public static void DumpToJson(this CookieContainer cookies, Uri uri, JToken json) => json["cookie_header"] = cookies.GetCookieHeader(uri);
     }
 }

--- a/src/Jackett.Common/IndexerException.cs
+++ b/src/Jackett.Common/IndexerException.cs
@@ -9,9 +9,7 @@ namespace Jackett.Common
 
         public IndexerException(IIndexer Indexer, string message, Exception innerException)
             : base(message, innerException)
-        {
-            this.Indexer = Indexer;
-        }
+            => this.Indexer = Indexer;
 
         public IndexerException(IIndexer Indexer, string message)
             : this(Indexer, message, null)

--- a/src/Jackett.Common/Indexers/Abnormal.cs
+++ b/src/Jackett.Common/Indexers/Abnormal.cs
@@ -27,15 +27,15 @@ namespace Jackett.Common.Indexers
     /// </summary>
     public class Abnormal : BaseCachingWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "login.php"; } }
-        private string SearchUrl { get { return SiteLink + "torrents.php"; } }
-        private string TorrentCommentUrl { get { return TorrentDescriptionUrl; } }
-        private string TorrentDescriptionUrl { get { return SiteLink + "torrents.php?id="; } }
-        private string TorrentDownloadUrl { get { return SiteLink + "torrents.php?action=download&id={id}&authkey={auth_key}&torrent_pass={torrent_pass}"; } }
-        private string ReplaceMulti { get { return ConfigData.ReplaceMulti.Value; } }
-        private bool Latency { get { return ConfigData.Latency.Value; } }
-        private bool DevMode { get { return ConfigData.DevMode.Value; } }
-        private bool CacheMode { get { return ConfigData.HardDriveCache.Value; } }
+        private string LoginUrl => SiteLink + "login.php";
+        private string SearchUrl => SiteLink + "torrents.php";
+        private string TorrentCommentUrl => TorrentDescriptionUrl;
+        private string TorrentDescriptionUrl => SiteLink + "torrents.php?id=";
+        private string TorrentDownloadUrl => SiteLink + "torrents.php?action=download&id={id}&authkey={auth_key}&torrent_pass={torrent_pass}";
+        private string ReplaceMulti => ConfigData.ReplaceMulti.Value;
+        private bool Latency => ConfigData.Latency.Value;
+        private bool DevMode => ConfigData.DevMode.Value;
+        private bool CacheMode => ConfigData.HardDriveCache.Value;
         private static string Directory => Path.Combine(Path.GetTempPath(), Assembly.GetExecutingAssembly().GetName().Name.ToLower(), MethodBase.GetCurrentMethod().DeclaringType?.Name.ToLower());
 
         private readonly Dictionary<string, string> emulatedBrowserHeaders = new Dictionary<string, string>();
@@ -43,8 +43,8 @@ namespace Jackett.Common.Indexers
 
         private ConfigurationDataAbnormal ConfigData
         {
-            get { return (ConfigurationDataAbnormal)configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataAbnormal)configData;
+            set => base.configData = value;
         }
 
         public Abnormal(IIndexerConfigurationService configService, Utils.Clients.WebClient w, Logger l, IProtectionService ps)
@@ -633,12 +633,8 @@ namespace Jackett.Common.Indexers
         /// Find torrent rows in search pages
         /// </summary>
         /// <returns>JQuery Object</returns>
-        private CQ findTorrentRows()
-        {
-            // Return all occurencis of torrents found
-            return fDom[".torrent_table > tbody > tr"].Not(".colhead");
-        }
-
+        // Return all occurences of torrents found
+        private CQ findTorrentRows() => fDom[".torrent_table > tbody > tr"].Not(".colhead");
 
         /// <summary>
         /// Output message for logging or developpment (console)

--- a/src/Jackett.Common/Indexers/Abstract/CouchPotatoTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/CouchPotatoTracker.cs
@@ -15,12 +15,12 @@ namespace Jackett.Common.Indexers.Abstract
     public abstract class CouchPotatoTracker : BaseWebIndexer
     {
         protected string endpoint;
-        protected string APIUrl { get { return SiteLink + endpoint; } }
+        protected string APIUrl => SiteLink + endpoint;
 
         private new ConfigurationDataUserPasskey configData
         {
-            get { return (ConfigurationDataUserPasskey)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataUserPasskey)base.configData;
+            set => base.configData = value;
         }
 
         public CouchPotatoTracker(IIndexerConfigurationService configService, WebClient client, Logger logger, IProtectionService p, ConfigurationDataUserPasskey configData, string name, string description, string link, string endpoint)
@@ -47,11 +47,8 @@ namespace Jackett.Common.Indexers.Abstract
             return await Task.FromResult(IndexerConfigurationStatus.RequiresTesting);
         }
 
-        protected virtual string GetSearchString(TorznabQuery query)
-        {
-            // can be overriden to alter the search string
-            return query.GetQueryString();
-        }
+        // can be overriden to alter the search string
+        protected virtual string GetSearchString(TorznabQuery query) => query.GetQueryString();
 
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {
@@ -96,10 +93,12 @@ namespace Jackett.Common.Indexers.Abstract
             {
                 foreach (JObject r in json["results"])
                 {
-                    var release = new ReleaseInfo();
-                    release.Title = (string)r["release_name"];
-                    release.Comments = new Uri((string)r["details_url"]);
-                    release.Link = new Uri((string)r["download_url"]);
+                    var release = new ReleaseInfo
+                    {
+                        Title = (string)r["release_name"],
+                        Comments = new Uri((string)r["details_url"]),
+                        Link = new Uri((string)r["download_url"])
+                    };
                     release.Guid = release.Link;
                     release.Imdb = ParseUtil.GetImdbID((string)r["imdb_id"]);
                     var freeleech = (bool)r["freeleech"];

--- a/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
@@ -18,10 +18,10 @@ namespace Jackett.Common.Indexers.Abstract
 {
     public abstract class GazelleTracker : BaseWebIndexer
     {
-        protected string LoginUrl { get { return SiteLink + "login.php"; } }
-        protected string APIUrl { get { return SiteLink + "ajax.php"; } }
-        protected string DownloadUrl { get { return SiteLink + "torrents.php?action=download&usetoken=" + (useTokens ? "1" : "0") + "&id="; } }
-        protected string DetailsUrl { get { return SiteLink + "torrents.php?torrentid="; } }
+        protected string LoginUrl => SiteLink + "login.php";
+        protected string APIUrl => SiteLink + "ajax.php";
+        protected string DownloadUrl => SiteLink + "torrents.php?action=download&usetoken=" + (useTokens ? "1" : "0") + "&id=";
+        protected string DetailsUrl => SiteLink + "torrents.php?torrentid=";
         protected bool supportsFreeleechTokens;
         protected bool imdbInTags;
         protected bool supportsCategories = true; // set to false if the tracker doesn't include the categories in the API search results
@@ -30,8 +30,8 @@ namespace Jackett.Common.Indexers.Abstract
 
         private new ConfigurationDataBasicLogin configData
         {
-            get { return (ConfigurationDataBasicLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLogin)base.configData;
+            set => base.configData = value;
         }
 
         public GazelleTracker(IIndexerConfigurationService configService, Utils.Clients.WebClient webClient, Logger logger, IProtectionService protectionService, string name, string desc, string link, bool supportsFreeleechTokens, bool imdbInTags = false, bool has2Fa = false)
@@ -138,10 +138,7 @@ namespace Jackett.Common.Indexers.Abstract
         }
 
         // hook to adjust the search term
-        protected virtual string GetSearchTerm(TorznabQuery query)
-        {
-            return query.GetQueryString();
-        }
+        protected virtual string GetSearchTerm(TorznabQuery query) => query.GetQueryString();
 
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {
@@ -269,10 +266,7 @@ namespace Jackett.Common.Indexers.Abstract
         }
 
         // hook to add/modify the parsed information, return false to exclude the torrent from the results
-        protected virtual bool ReleaseInfoPostParse(ReleaseInfo release, JObject torrent, JObject result)
-        {
-            return true;
-        }
+        protected virtual bool ReleaseInfoPostParse(ReleaseInfo release, JObject torrent, JObject result) => true;
 
         private void FillReleaseInfoFromJson(ReleaseInfo release, JObject torrent)
         {

--- a/src/Jackett.Common/Indexers/AlphaRatio.cs
+++ b/src/Jackett.Common/Indexers/AlphaRatio.cs
@@ -7,17 +7,11 @@ namespace Jackett.Common.Indexers
 {
     public class AlphaRatio : GazelleTracker
     {
-        public AlphaRatio(IIndexerConfigurationService configService, Utils.Clients.WebClient webClient, Logger logger, IProtectionService protectionService)
-            : base(name: "AlphaRatio",
-                desc: "AlphaRatio (AR) is a Private Torrent Tracker for 0DAY / GENERAL",
-                link: "https://alpharatio.cc/",
-                configService: configService,
-                logger: logger,
-                protectionService: protectionService,
-                webClient: webClient,
-                supportsFreeleechTokens: true,
-                imdbInTags: true
-                )
+        public AlphaRatio(IIndexerConfigurationService configService, Utils.Clients.WebClient webClient, Logger logger,
+                          IProtectionService protectionService) : base(
+            name: "AlphaRatio", desc: "AlphaRatio (AR) is a Private Torrent Tracker for 0DAY / GENERAL",
+            link: "https://alpharatio.cc/", configService: configService, logger: logger,
+            protectionService: protectionService, webClient: webClient, supportsFreeleechTokens: true, imdbInTags: true)
         {
             Language = "en-us";
             Type = "private";
@@ -55,6 +49,7 @@ namespace Jackett.Common.Indexers
             AddCategoryMapping(30, TorznabCatType.Other, "Misc");
         }
 
-        protected override string GetSearchTerm(TorznabQuery query) => query.GetQueryString().Replace(".", " "); // Alpharatio can't handle dots in the searchstr
+        // Alpharatio can't handle dots in the searchstr
+        protected override string GetSearchTerm(TorznabQuery query) => query.GetQueryString().Replace(".", " ");
     }
 }

--- a/src/Jackett.Common/Indexers/AlphaRatio.cs
+++ b/src/Jackett.Common/Indexers/AlphaRatio.cs
@@ -55,9 +55,6 @@ namespace Jackett.Common.Indexers
             AddCategoryMapping(30, TorznabCatType.Other, "Misc");
         }
 
-        protected override string GetSearchTerm(TorznabQuery query)
-        {
-            return query.GetQueryString().Replace(".", " "); // Alpharatio can't handle dots in the searchstr
-        }
+        protected override string GetSearchTerm(TorznabQuery query) => query.GetQueryString().Replace(".", " "); // Alpharatio can't handle dots in the searchstr
     }
 }

--- a/src/Jackett.Common/Indexers/AniDub.cs
+++ b/src/Jackett.Common/Indexers/AniDub.cs
@@ -83,8 +83,8 @@ namespace Jackett.Common.Indexers
 
         private ConfigurationDataAniDub Configuration
         {
-            get { return (ConfigurationDataAniDub)configData; }
-            set { configData = value; }
+            get => (ConfigurationDataAniDub)configData;
+            set => configData = value;
         }
 
         /// <summary>
@@ -134,18 +134,11 @@ namespace Jackett.Common.Indexers
             return await base.Download(link);
         }
 
+        // If the search string is empty use the latest releases
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
-        {
-            // If the search string is empty use the latest releases
-            if (query.IsTest || query.SearchTerm.IsNullOrEmptyOrWhitespace())
-            {
-                return await FetchNewReleases();
-            }
-            else
-            {
-                return await PerformSearch(query);
-            }
-        }
+            => query.IsTest || query.SearchTerm.IsNullOrEmptyOrWhitespace()
+            ? await FetchNewReleases()
+            : await PerformSearch(query);
 
         private async Task EnsureAuthorized()
         {
@@ -258,11 +251,8 @@ namespace Jackett.Common.Indexers
             return releases;
         }
 
-        private static string GetReleaseGuid(string url, IElement tabNode)
-        {
-            // Appending id to differentiate between different quality versions
-            return QueryHelpers.AddQueryString(url, "id", GetTorrentId(tabNode));
-        }
+        // Appending id to differentiate between different quality versions
+        private static string GetReleaseGuid(string url, IElement tabNode) => QueryHelpers.AddQueryString(url, "id", GetTorrentId(tabNode));
 
         private static int GetReleaseLeechers(IElement tabNode)
         {
@@ -443,15 +433,9 @@ namespace Jackett.Common.Indexers
             return defaultSeason;
         }
 
-        private string StripRussianTitle(string title)
-        {
-            if (Configuration.StripRussianTitle.Value)
-            {
-                return StripRussianTitleRegex.Value.Replace(title, string.Empty);
-            }
-
-            return title;
-        }
+        private string StripRussianTitle(string title) => Configuration.StripRussianTitle.Value
+            ? StripRussianTitleRegex.Value.Replace(title, string.Empty)
+            : title;
 
         private static string FixBookInfo(string title) =>
             title.Replace("[Главы ", "[");

--- a/src/Jackett.Common/Indexers/AnimeBytes.cs
+++ b/src/Jackett.Common/Indexers/AnimeBytes.cs
@@ -19,17 +19,17 @@ namespace Jackett.Common.Indexers
 {
     public class AnimeBytes : BaseCachingWebIndexer
     {
-        private string ScrapeUrl { get { return SiteLink + "scrape.php"; } }
-        private string TorrentsUrl { get { return SiteLink + "torrents.php"; } }
-        public bool AllowRaws { get { return configData.IncludeRaw.Value; } }
-        public bool PadEpisode { get { return configData.PadEpisode != null && configData.PadEpisode.Value; } }
-        public bool AddSynonyms { get { return configData.AddSynonyms.Value; } }
-        public bool FilterSeasonEpisode { get { return configData.FilterSeasonEpisode.Value; } }
+        private string ScrapeUrl => SiteLink + "scrape.php";
+        private string TorrentsUrl => SiteLink + "torrents.php";
+        public bool AllowRaws => configData.IncludeRaw.Value;
+        public bool PadEpisode => configData.PadEpisode != null && configData.PadEpisode.Value;
+        public bool AddSynonyms => configData.AddSynonyms.Value;
+        public bool FilterSeasonEpisode => configData.FilterSeasonEpisode.Value;
 
         private new ConfigurationDataAnimeBytes configData
         {
-            get { return (ConfigurationDataAnimeBytes)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataAnimeBytes)base.configData;
+            set => base.configData = value;
         }
 
         public AnimeBytes(IIndexerConfigurationService configService, Utils.Clients.WebClient client, Logger l, IProtectionService ps)
@@ -74,12 +74,10 @@ namespace Jackett.Common.Indexers
             AddCategoryMapping("printedtype[artbook]", TorznabCatType.BooksComics, "Artbook");
 
         }
+        // Prevent filtering
+        protected override IEnumerable<ReleaseInfo> FilterResults(TorznabQuery query, IEnumerable<ReleaseInfo> input) =>
 
-        protected override IEnumerable<ReleaseInfo> FilterResults(TorznabQuery query, IEnumerable<ReleaseInfo> input)
-        {
-            // Prevent filtering
-            return input;
-        }
+            input;
 
         public override async Task<IndexerConfigurationStatus> ApplyConfiguration(JToken configJson)
         {
@@ -365,24 +363,26 @@ namespace Jackett.Common.Indexers
                                     releaseTitle = string.Format("{0}{1} {2} {3}", releasegroup, title, releaseInfo, infoString);
                                 }
 
-                                var release = new ReleaseInfo();
-                                release.MinimumRatio = 1;
-                                release.MinimumSeedTime = MinimumSeedTime;
-                                release.Title = releaseTitle;
-                                release.Comments = CommentsLinkUri;
-                                release.Guid = new Uri(CommentsLinkUri + "&nh=" + StringUtil.Hash(title)); // Sonarr should dedupe on this url - allow a url per name.
-                                release.Link = LinkUri;
-                                release.BannerUrl = ImageUrl;
-                                release.PublishDate = PublushDate;
-                                release.Category = Category;
-                                release.Description = Description;
-                                release.Size = Size;
-                                release.Seeders = Seeders;
-                                release.Peers = Peers;
-                                release.Grabs = Snatched;
-                                release.Files = FileCount;
-                                release.DownloadVolumeFactor = RawDownMultiplier;
-                                release.UploadVolumeFactor = RawUpMultiplier;
+                                var release = new ReleaseInfo
+                                {
+                                    MinimumRatio = 1,
+                                    MinimumSeedTime = MinimumSeedTime,
+                                    Title = releaseTitle,
+                                    Comments = CommentsLinkUri,
+                                    Guid = new Uri(CommentsLinkUri + "&nh=" + StringUtil.Hash(title)), // Sonarr should dedupe on this url - allow a url per name.
+                                    Link = LinkUri,
+                                    BannerUrl = ImageUrl,
+                                    PublishDate = PublushDate,
+                                    Category = Category,
+                                    Description = Description,
+                                    Size = Size,
+                                    Seeders = Seeders,
+                                    Peers = Peers,
+                                    Grabs = Snatched,
+                                    Files = FileCount,
+                                    DownloadVolumeFactor = RawDownMultiplier,
+                                    UploadVolumeFactor = RawUpMultiplier
+                                };
 
                                 releases.Add(release);
                             }

--- a/src/Jackett.Common/Indexers/AnimeTorrents.cs
+++ b/src/Jackett.Common/Indexers/AnimeTorrents.cs
@@ -19,14 +19,14 @@ namespace Jackett.Common.Indexers
 {
     public class AnimeTorrents : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "login.php"; } }
-        private string SearchUrl { get { return SiteLink + "ajax/torrents_data.php"; } }
-        private string SearchUrlReferer { get { return SiteLink + "torrents.php?cat=0&searchin=filename&search="; } }
+        private string LoginUrl => SiteLink + "login.php";
+        private string SearchUrl => SiteLink + "ajax/torrents_data.php";
+        private string SearchUrlReferer => SiteLink + "torrents.php?cat=0&searchin=filename&search=";
 
         private new ConfigurationDataBasicLogin configData
         {
-            get { return (ConfigurationDataBasicLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLogin)base.configData;
+            set => base.configData = value;
         }
 
         public AnimeTorrents(IIndexerConfigurationService configService, WebClient c, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/BB.cs
+++ b/src/Jackett.Common/Indexers/BB.cs
@@ -20,15 +20,15 @@ namespace Jackett.Common.Indexers
 
     public class BB : BaseWebIndexer
     {
-        private string BaseUrl { get { return StringUtil.FromBase64("aHR0cHM6Ly9iYWNvbmJpdHMub3JnLw=="); } }
-        private Uri BaseUri { get { return new Uri(BaseUrl); } }
-        private string LoginUrl { get { return BaseUri + "login.php"; } }
-        private string SearchUrl { get { return BaseUri + "torrents.php?searchtags=&tags_type=0&order_by=s3&order_way=desc&disablegrouping=1&"; } }
+        private string BaseUrl => StringUtil.FromBase64("aHR0cHM6Ly9iYWNvbmJpdHMub3JnLw==");
+        private Uri BaseUri => new Uri(BaseUrl);
+        private string LoginUrl => BaseUri + "login.php";
+        private string SearchUrl => BaseUri + "torrents.php?searchtags=&tags_type=0&order_by=s3&order_way=desc&disablegrouping=1&";
 
         private new ConfigurationDataBasicLogin configData
         {
-            get { return (ConfigurationDataBasicLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLogin)base.configData;
+            set => base.configData = value;
         }
 
         public BB(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/BakaBT.cs
+++ b/src/Jackett.Common/Indexers/BakaBT.cs
@@ -22,8 +22,8 @@ namespace Jackett.Common.Indexers
 
         private new ConfigurationDataBasicLogin configData
         {
-            get { return (ConfigurationDataBasicLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLogin)base.configData;
+            set => base.configData = value;
         }
 
         public BakaBT(IIndexerConfigurationService configService, Utils.Clients.WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/BaseIndexer.cs
+++ b/src/Jackett.Common/Indexers/BaseIndexer.cs
@@ -18,10 +18,7 @@ namespace Jackett.Common.Indexers
 {
     public abstract class BaseIndexer : IIndexer
     {
-        public static string GetIndexerID(Type type)
-        {
-            return type.Name.ToLowerInvariant().StripNonAlphaNumeric();
-        }
+        public static string GetIndexerID(Type type) => type.Name.ToLowerInvariant().StripNonAlphaNumeric();
 
         public string SiteLink { get; protected set; }
         public virtual string[] LegacySiteLinks { get; protected set; }
@@ -31,7 +28,7 @@ namespace Jackett.Common.Indexers
         public string DisplayName { get; protected set; }
         public string Language { get; protected set; }
         public string Type { get; protected set; }
-        public virtual string ID { get { return GetIndexerID(GetType()); } }
+        public virtual string ID => GetIndexerID(GetType());
 
         [JsonConverter(typeof(EncodingJsonConverter))]
         public Encoding Encoding { get; protected set; }
@@ -45,13 +42,13 @@ namespace Jackett.Common.Indexers
 
         protected string CookieHeader
         {
-            get { return configData.CookieHeader.Value; }
-            set { configData.CookieHeader.Value = value; }
+            get => configData.CookieHeader.Value;
+            set => configData.CookieHeader.Value = value;
         }
 
         public string LastError
         {
-            get { return configData.LastError.Value; }
+            get => configData.LastError.Value;
             set
             {
                 var SaveNeeded = configData.LastError.Value != value && IsConfigured;
@@ -82,10 +79,7 @@ namespace Jackett.Common.Indexers
                 LoadValuesFromJson(null);
         }
 
-        public virtual Task<ConfigurationData> GetConfigurationForSetup()
-        {
-            return Task.FromResult<ConfigurationData>(configData);
-        }
+        public virtual Task<ConfigurationData> GetConfigurationForSetup() => Task.FromResult<ConfigurationData>(configData);
 
         public virtual void ResetBaseConfig()
         {
@@ -93,10 +87,7 @@ namespace Jackett.Common.Indexers
             IsConfigured = false;
         }
 
-        public virtual void SaveConfig()
-        {
-            configurationService.Save(this as IIndexer, configData.ToJson(protectionService, forDisplay: false));
-        }
+        public virtual void SaveConfig() => configurationService.Save(this as IIndexer, configData.ToJson(protectionService, forDisplay: false));
 
         protected void LoadLegacyCookieConfig(JToken jsonConfig)
         {
@@ -273,10 +264,9 @@ namespace Jackett.Common.Indexers
             if (query.Categories.Length == 0)
                 return results;
 
-            var filteredResults = results.Where(result =>
-            {
-                return result.Category.IsEmptyOrNull() || query.Categories.Intersect(result.Category).Any() || TorznabCatType.QueryContainsParentCategory(query.Categories, result.Category);
-            });
+            var filteredResults = results.Where(
+                result => result.Category.IsEmptyOrNull() || query.Categories.Intersect(result.Category).Any() ||
+                          TorznabCatType.QueryContainsParentCategory(query.Categories, result.Category));
 
             return filteredResults;
         }
@@ -372,10 +362,7 @@ namespace Jackett.Common.Indexers
 
         // minimal constructor used by e.g. cardigann generic indexer
         protected BaseWebIndexer(IIndexerConfigurationService configService, WebClient client, Logger logger, IProtectionService p)
-            : base("", "/", "", configService, logger, null, p)
-        {
-            webclient = client;
-        }
+            : base("", "/", "", configService, logger, null, p) => webclient = client;
 
         public virtual async Task<byte[]> Download(Uri link)
         {
@@ -671,10 +658,7 @@ namespace Jackett.Common.Indexers
             }
         }
 
-        protected List<string> GetAllTrackerCategories()
-        {
-            return categoryMapping.Select(x => x.TrackerCategory).ToList();
-        }
+        protected List<string> GetAllTrackerCategories() => categoryMapping.Select(x => x.TrackerCategory).ToList();
 
         protected void AddCategoryMapping(string trackerCategory, TorznabCategory newznabCategory, string trackerCategoryDesc = null)
         {
@@ -703,10 +687,7 @@ namespace Jackett.Common.Indexers
             }
         }
 
-        protected void AddCategoryMapping(int trackerCategory, TorznabCategory newznabCategory, string trackerCategoryDesc = null)
-        {
-            AddCategoryMapping(trackerCategory.ToString(), newznabCategory, trackerCategoryDesc);
-        }
+        protected void AddCategoryMapping(int trackerCategory, TorznabCategory newznabCategory, string trackerCategoryDesc = null) => AddCategoryMapping(trackerCategory.ToString(), newznabCategory, trackerCategoryDesc);
 
         protected void AddMultiCategoryMapping(TorznabCategory newznabCategory, params int[] trackerCategories)
         {

--- a/src/Jackett.Common/Indexers/BitCityReloaded.cs
+++ b/src/Jackett.Common/Indexers/BitCityReloaded.cs
@@ -17,14 +17,14 @@ namespace Jackett.Common.Indexers
 {
     public class BitCityReloaded : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "login/index.php"; } }
-        private string BrowseUrl { get { return SiteLink + "uebersicht.php"; } }
+        private string LoginUrl => SiteLink + "login/index.php";
+        private string BrowseUrl => SiteLink + "uebersicht.php";
         private readonly TimeZoneInfo germanyTz = TimeZoneInfo.CreateCustomTimeZone("W. Europe Standard Time", new TimeSpan(1, 0, 0), "W. Europe Standard Time", "W. Europe Standard Time");
 
         private new ConfigurationDataBasicLoginWithRSSAndDisplay configData
         {
-            get { return (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData;
+            set => base.configData = value;
         }
 
         public BitCityReloaded(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/BitHdtv.cs
+++ b/src/Jackett.Common/Indexers/BitHdtv.cs
@@ -18,15 +18,15 @@ namespace Jackett.Common.Indexers
 {
     public class BitHdtv : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "login.php"; } }
-        private string TakeLoginUrl { get { return SiteLink + "takelogin.php"; } }
-        private string SearchUrl { get { return SiteLink + "torrents.php?"; } }
-        private string DownloadUrl { get { return SiteLink + "download.php?id={0}"; } }
+        private string LoginUrl => SiteLink + "login.php";
+        private string TakeLoginUrl => SiteLink + "takelogin.php";
+        private string SearchUrl => SiteLink + "torrents.php?";
+        private string DownloadUrl => SiteLink + "download.php?id={0}";
 
         private new ConfigurationDataRecaptchaLogin configData
         {
-            get { return (ConfigurationDataRecaptchaLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataRecaptchaLogin)base.configData;
+            set => base.configData = value;
         }
 
         public BitHdtv(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/BroadcastTheNet.cs
+++ b/src/Jackett.Common/Indexers/BroadcastTheNet.cs
@@ -22,8 +22,8 @@ namespace Jackett.Common.Indexers
 
         private new ConfigurationDataAPIKey configData
         {
-            get { return (ConfigurationDataAPIKey)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataAPIKey)base.configData;
+            set => base.configData = value;
         }
 
         public BroadcastTheNet(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -26,7 +26,7 @@ namespace Jackett.Common.Indexers
     public class CardigannIndexer : BaseWebIndexer
     {
         protected IndexerDefinition Definition;
-        public override string ID { get { return (Definition != null ? Definition.Site : GetIndexerID(GetType())); } }
+        public override string ID => (Definition != null ? Definition.Site : GetIndexerID(GetType()));
 
         protected WebClientStringResult landingResult;
         protected IHtmlDocument landingResultDocument;
@@ -35,8 +35,8 @@ namespace Jackett.Common.Indexers
 
         private new ConfigurationData configData
         {
-            get { return base.configData; }
-            set { base.configData = value; }
+            get => base.configData;
+            set => base.configData = value;
         }
 
         protected readonly string[] OptionalFileds = new string[] { "imdb", "rageid", "tvdbid", "banner" };
@@ -764,15 +764,9 @@ namespace Jackett.Common.Indexers
             return null;
         }
 
-        protected string getRedirectDomainHint(WebClientByteResult result)
-        {
-            return getRedirectDomainHint(result.Request.Url, result.RedirectingTo);
-        }
+        protected string getRedirectDomainHint(WebClientByteResult result) => getRedirectDomainHint(result.Request.Url, result.RedirectingTo);
 
-        protected string getRedirectDomainHint(WebClientStringResult result)
-        {
-            return getRedirectDomainHint(result.Request.Url, result.RedirectingTo);
-        }
+        protected string getRedirectDomainHint(WebClientStringResult result) => getRedirectDomainHint(result.Request.Url, result.RedirectingTo);
 
         protected async Task<bool> TestLogin()
         {
@@ -1188,13 +1182,7 @@ namespace Jackett.Common.Indexers
             return applyFilters(ParseUtil.NormalizeSpace(value), Selector.Filters, variables);
         }
 
-        protected Uri resolvePath(string path, Uri currentUrl = null)
-        {
-            if (currentUrl == null)
-                currentUrl = new Uri(SiteLink);
-
-            return new Uri(currentUrl, path);
-        }
+        protected Uri resolvePath(string path, Uri currentUrl = null) => new Uri(currentUrl ?? new Uri(SiteLink), path);
 
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {

--- a/src/Jackett.Common/Indexers/CinemaZ.cs
+++ b/src/Jackett.Common/Indexers/CinemaZ.cs
@@ -16,8 +16,6 @@ namespace Jackett.Common.Indexers
                 protectionService: protectionService,
                 webClient: webClient
                 )
-        {
-            Type = "private";
-        }
+            => Type = "private";
     }
 }

--- a/src/Jackett.Common/Indexers/DanishBits.cs
+++ b/src/Jackett.Common/Indexers/DanishBits.cs
@@ -19,8 +19,8 @@ namespace Jackett.Common.Indexers
 
         private new ConfigurationDataUserPasskey configData
         {
-            get { return (ConfigurationDataUserPasskey)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataUserPasskey)base.configData;
+            set => base.configData = value;
         }
 
         public DanishBits(IIndexerConfigurationService configService, WebClient c, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/DigitalHive.cs
+++ b/src/Jackett.Common/Indexers/DigitalHive.cs
@@ -17,14 +17,14 @@ namespace Jackett.Common.Indexers
 {
     public class DigitalHive : BaseWebIndexer
     {
-        private string SearchUrl { get { return SiteLink + "browse.php"; } }
-        private string LoginUrl { get { return SiteLink + "login.php?returnto=%2F"; } }
-        private string AjaxLoginUrl { get { return SiteLink + "takelogin.php"; } }
+        private string SearchUrl => SiteLink + "browse.php";
+        private string LoginUrl => SiteLink + "login.php?returnto=%2F";
+        private string AjaxLoginUrl => SiteLink + "takelogin.php";
 
         private new ConfigurationDataRecaptchaLogin configData
         {
-            get { return (ConfigurationDataRecaptchaLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataRecaptchaLogin)base.configData;
+            set => base.configData = value;
         }
 
         public DigitalHive(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/EliteTracker.cs
+++ b/src/Jackett.Common/Indexers/EliteTracker.cs
@@ -18,17 +18,15 @@ namespace Jackett.Common.Indexers
 {
     internal class EliteTracker : BaseWebIndexer
     {
-        private string LoginUrl
-        { get { return SiteLink + "takelogin.php"; } }
-        private string BrowseUrl
-        { get { return SiteLink + "browse.php"; } }
+        private string LoginUrl => SiteLink + "takelogin.php";
+        private string BrowseUrl => SiteLink + "browse.php";
         private bool TorrentHTTPSMode => configData.TorrentHTTPSMode.Value;
         private string ReplaceMulti => configData.ReplaceMulti.Value;
         private new ConfigurationDataEliteTracker configData
 
         {
-            get { return (ConfigurationDataEliteTracker)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataEliteTracker)base.configData;
+            set => base.configData = value;
         }
 
         public EliteTracker(IIndexerConfigurationService configService, WebClient webClient, Logger logger, IProtectionService protectionService)

--- a/src/Jackett.Common/Indexers/FileList.cs
+++ b/src/Jackett.Common/Indexers/FileList.cs
@@ -23,13 +23,13 @@ namespace Jackett.Common.Indexers
             "http://filelist.ro/",
         };
 
-        private string LoginUrl { get { return SiteLink + "takelogin.php"; } }
-        private string BrowseUrl { get { return SiteLink + "browse.php"; } }
+        private string LoginUrl => SiteLink + "takelogin.php";
+        private string BrowseUrl => SiteLink + "browse.php";
 
         private new ConfigurationDataFileList configData
         {
-            get { return (ConfigurationDataFileList)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataFileList)base.configData;
+            set => base.configData = value;
         }
 
         public FileList(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/FunFile.cs
+++ b/src/Jackett.Common/Indexers/FunFile.cs
@@ -16,13 +16,13 @@ namespace Jackett.Common.Indexers
 {
     public class FunFile : BaseWebIndexer
     {
-        private string SearchUrl { get { return SiteLink + "browse.php"; } }
-        private string LoginUrl { get { return SiteLink + "takelogin.php"; } }
+        private string SearchUrl => SiteLink + "browse.php";
+        private string LoginUrl => SiteLink + "takelogin.php";
 
         private new ConfigurationDataBasicLoginWithRSSAndDisplay configData
         {
-            get { return (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData;
+            set => base.configData = value;
         }
 
         public FunFile(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/Fuzer.cs
+++ b/src/Jackett.Common/Indexers/Fuzer.cs
@@ -23,14 +23,14 @@ namespace Jackett.Common.Indexers
             "https://fuzer.me/",
         };
 
-        private string SearchUrl { get { return SiteLink + "browse.php"; } }
-        private string LoginUrl { get { return SiteLink + "login.php"; } }
+        private string SearchUrl => SiteLink + "browse.php";
+        private string LoginUrl => SiteLink + "login.php";
         private const int MAXPAGES = 3;
 
         private new ConfigurationDataRecaptchaLogin configData
         {
-            get { return (ConfigurationDataRecaptchaLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataRecaptchaLogin)base.configData;
+            set => base.configData = value;
         }
 
         public Fuzer(IIndexerConfigurationService configService, Utils.Clients.WebClient w, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/GazelleGames.cs
+++ b/src/Jackett.Common/Indexers/GazelleGames.cs
@@ -18,13 +18,13 @@ namespace Jackett.Common.Indexers
 {
     public class GazelleGames : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "login.php"; } }
-        private string BrowseUrl { get { return SiteLink + "torrents.php"; } }
+        private string LoginUrl => SiteLink + "login.php";
+        private string BrowseUrl => SiteLink + "torrents.php";
 
         private new ConfigurationDataCookie configData
         {
-            get { return (ConfigurationDataCookie)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataCookie)base.configData;
+            set => base.configData = value;
         }
 
         public GazelleGames(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/GimmePeers.cs
+++ b/src/Jackett.Common/Indexers/GimmePeers.cs
@@ -24,8 +24,8 @@ namespace Jackett.Common.Indexers
 
         private new ConfigurationDataBasicLogin configData
         {
-            get { return (ConfigurationDataBasicLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLogin)base.configData;
+            set => base.configData = value;
         }
 
         public GimmePeers(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/HDBitsApi.cs
+++ b/src/Jackett.Common/Indexers/HDBitsApi.cs
@@ -15,12 +15,12 @@ namespace Jackett.Common.Indexers
 {
     public class HDBitsApi : BaseWebIndexer
     {
-        private string APIUrl { get { return SiteLink + "api/"; } }
+        private string APIUrl => SiteLink + "api/";
 
         private new ConfigurationDataHDBitsApi configData
         {
-            get { return (ConfigurationDataHDBitsApi)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataHDBitsApi)base.configData;
+            set => base.configData = value;
         }
 
         public HDBitsApi(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/HDOlimpo.cs
+++ b/src/Jackett.Common/Indexers/HDOlimpo.cs
@@ -26,8 +26,8 @@ namespace Jackett.Common.Indexers
 
         private new ConfigurationDataBasicLoginWithEmail configData
         {
-            get { return (ConfigurationDataBasicLoginWithEmail)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLoginWithEmail)base.configData;
+            set => base.configData = value;
         }
 
         public HDOlimpo(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/HDSpace.cs
+++ b/src/Jackett.Common/Indexers/HDSpace.cs
@@ -19,13 +19,13 @@ namespace Jackett.Common.Indexers
 {
     public class HDSpace : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "index.php?page=login"; } }
-        private string SearchUrl { get { return SiteLink + "index.php?page=torrents&"; } }
+        private string LoginUrl => SiteLink + "index.php?page=login";
+        private string SearchUrl => SiteLink + "index.php?page=torrents&";
 
         private new ConfigurationDataBasicLogin configData
         {
-            get { return (ConfigurationDataBasicLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLogin)base.configData;
+            set => base.configData = value;
         }
 
         public HDSpace(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/HDTorrents.cs
+++ b/src/Jackett.Common/Indexers/HDTorrents.cs
@@ -17,15 +17,15 @@ namespace Jackett.Common.Indexers
 {
     public class HDTorrents : BaseWebIndexer
     {
-        private string SearchUrl { get { return SiteLink + "torrents.php?"; } }
-        private string LoginUrl { get { return SiteLink + "login.php"; } }
+        private string SearchUrl => SiteLink + "torrents.php?";
+        private string LoginUrl => SiteLink + "login.php";
         private const int MAXPAGES = 3;
         public override string[] AlternativeSiteLinks { get; protected set; } = new string[] { "https://hdts.ru/", "https://hd-torrents.org/", "https://hd-torrents.net/", "https://hd-torrents.me/" };
 
         private new ConfigurationDataBasicLogin configData
         {
-            get { return (ConfigurationDataBasicLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLogin)base.configData;
+            set => base.configData = value;
         }
 
         public HDTorrents(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps)
@@ -92,11 +92,9 @@ namespace Jackett.Common.Indexers
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, loginPage.Cookies, true, null, LoginUrl);
 
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("If your browser doesn't have javascript enabled"), () =>
-            {
-                var errorMessage = "Couldn't login";
-                throw new ExceptionWithConfigData(errorMessage, configData);
-            });
+            await ConfigureIfOK(
+                result.Cookies, result.Content?.Contains("If your browser doesn't have javascript enabled") == true,
+                () => throw new ExceptionWithConfigData("Couldn't login", configData));
             return IndexerConfigurationStatus.RequiresTesting;
         }
 

--- a/src/Jackett.Common/Indexers/Hebits.cs
+++ b/src/Jackett.Common/Indexers/Hebits.cs
@@ -17,14 +17,14 @@ namespace Jackett.Common.Indexers
 {
     public class Hebits : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "login.php"; } }
-        private string LoginPostUrl { get { return SiteLink + "takeloginAjax.php"; } }
-        private string SearchUrl { get { return SiteLink + "browse.php?sort=4&type=desc"; } }
+        private string LoginUrl => SiteLink + "login.php";
+        private string LoginPostUrl => SiteLink + "takeloginAjax.php";
+        private string SearchUrl => SiteLink + "browse.php?sort=4&type=desc";
 
         private new ConfigurationDataBasicLogin configData
         {
-            get { return (ConfigurationDataBasicLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLogin)base.configData;
+            set => base.configData = value;
         }
 
         public Hebits(IIndexerConfigurationService configService, Utils.Clients.WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/HorribleSubs.cs
+++ b/src/Jackett.Common/Indexers/HorribleSubs.cs
@@ -19,7 +19,7 @@ namespace Jackett.Common.Indexers
 {
     internal class HorribleSubs : BaseWebIndexer
     {
-        private string ApiEndpoint { get { return SiteLink + "api.php"; } }
+        private string ApiEndpoint => SiteLink + "api.php";
 
         public override string[] LegacySiteLinks { get; protected set; } = new string[] {
             "http://horriblesubs.info/"

--- a/src/Jackett.Common/Indexers/ImmortalSeed.cs
+++ b/src/Jackett.Common/Indexers/ImmortalSeed.cs
@@ -17,9 +17,9 @@ namespace Jackett.Common.Indexers
 {
     public class ImmortalSeed : BaseWebIndexer
     {
-        private string BrowsePage { get { return SiteLink + "browse.php"; } }
-        private string LoginUrl { get { return SiteLink + "takelogin.php"; } }
-        private string QueryString { get { return "?do=search&keywords={0}&search_type=t_name&category=0&include_dead_torrents=no"; } }
+        private string BrowsePage => SiteLink + "browse.php";
+        private string LoginUrl => SiteLink + "takelogin.php";
+        private string QueryString => "?do=search&keywords={0}&search_type=t_name&category=0&include_dead_torrents=no";
 
         public override string[] LegacySiteLinks { get; protected set; } = new string[] {
             "http://immortalseed.me/",
@@ -27,8 +27,8 @@ namespace Jackett.Common.Indexers
 
         private new ConfigurationDataBasicLogin configData
         {
-            get { return (ConfigurationDataBasicLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLogin)base.configData;
+            set => base.configData = value;
         }
 
         public ImmortalSeed(IIndexerConfigurationService configService, Utils.Clients.WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/LostFilm.cs
+++ b/src/Jackett.Common/Indexers/LostFilm.cs
@@ -24,20 +24,20 @@ namespace Jackett.Common.Indexers
         private static readonly Regex parsePlayEpisodeRegex = new Regex("PlayEpisode\\('(?<id>\\d{1,3})(?<season>\\d{3})(?<episode>\\d{3})'\\)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex parseReleaseDetailsRegex = new Regex("Видео:\\ (?<quality>.+).\\ Размер:\\ (?<size>.+).\\ Перевод", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
-        private string LoginUrl { get { return SiteLink + "login"; } }
+        private string LoginUrl => SiteLink + "login";
 
         // http://www.lostfilm.tv/login
-        private string ApiUrl { get { return SiteLink + "ajaxik.php"; } }
+        private string ApiUrl => SiteLink + "ajaxik.php";
 
         // http://www.lostfilm.tv/new
-        private string DiscoveryUrl { get { return SiteLink + "new"; } }
+        private string DiscoveryUrl => SiteLink + "new";
 
         // http://www.lostfilm.tv/search?q=breaking+bad
-        private string SearchUrl { get { return SiteLink + "search"; } }
+        private string SearchUrl => SiteLink + "search";
 
         // PlayEpisode function produce urls like this:
         // https://www.lostfilm.tv/v_search.php?c=119&s=5&e=16
-        private string ReleaseUrl { get { return SiteLink + "v_search.php"; } }
+        private string ReleaseUrl => SiteLink + "v_search.php";
 
 
         internal class TrackerUrlDetails
@@ -63,6 +63,7 @@ namespace Jackett.Common.Indexers
                 episode = match.Groups["episode"].Value.TrimStart('0');
             }
 
+            // TODO: see if query.GetEpisodeString() is sufficient
             internal string GetEpisodeString()
             {
                 var result = string.Empty;
@@ -83,8 +84,8 @@ namespace Jackett.Common.Indexers
 
         private new ConfigurationDataCaptchaLogin configData
         {
-            get { return (ConfigurationDataCaptchaLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataCaptchaLogin)base.configData;
+            set => base.configData = value;
         }
 
         public LostFilm(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/Meta/BaseMetaIndexer.cs
+++ b/src/Jackett.Common/Indexers/Meta/BaseMetaIndexer.cs
@@ -31,10 +31,7 @@ namespace Jackett.Common.Indexers.Meta
             return base.CanHandleQuery(query);
         }
 
-        public override Task<IndexerConfigurationStatus> ApplyConfiguration(JToken configJson)
-        {
-            return Task.FromResult(IndexerConfigurationStatus.Completed);
-        }
+        public override Task<IndexerConfigurationStatus> ApplyConfiguration(JToken configJson) => Task.FromResult(IndexerConfigurationStatus.Completed);
 
         public override async Task<IndexerResult> ResultsForQuery(TorznabQuery query)
         {
@@ -102,32 +99,11 @@ namespace Jackett.Common.Indexers.Meta
             return result;
         }
 
-        public override TorznabCapabilities TorznabCaps
-        {
-            get
-            {
-                return validIndexers.Select(i => i.TorznabCaps).Aggregate(new TorznabCapabilities(), TorznabCapabilities.Concat);
-            }
-        }
+        public override TorznabCapabilities TorznabCaps => validIndexers.Select(i => i.TorznabCaps).Aggregate(new TorznabCapabilities(), TorznabCapabilities.Concat);
 
-        public override bool IsConfigured
-        {
-            get
-            {
-                return Indexers != null;
-            }
-        }
+        public override bool IsConfigured => Indexers != null;
 
-        private IEnumerable<IIndexer> validIndexers
-        {
-            get
-            {
-                if (Indexers == null)
-                    return null;
-
-                return Indexers.Where(i => i.IsConfigured && filterFunc(i));
-            }
-        }
+        private IEnumerable<IIndexer> validIndexers => Indexers?.Where(i => i.IsConfigured && filterFunc(i));
 
         public IEnumerable<IIndexer> Indexers;
 

--- a/src/Jackett.Common/Indexers/Meta/Fallbacks.cs
+++ b/src/Jackett.Common/Indexers/Meta/Fallbacks.cs
@@ -19,18 +19,12 @@ namespace Jackett.Common.Indexers.Meta
 
     public class NoFallbackStrategy : IFallbackStrategy
     {
-        public Task<IEnumerable<TorznabQuery>> FallbackQueries()
-        {
-            return Task.FromResult<IEnumerable<TorznabQuery>>(new List<TorznabQuery>());
-        }
+        public Task<IEnumerable<TorznabQuery>> FallbackQueries() => Task.FromResult<IEnumerable<TorznabQuery>>(new List<TorznabQuery>());
     }
 
     public class NoFallbackStrategyProvider : IFallbackStrategyProvider
     {
-        public IEnumerable<IFallbackStrategy> FallbackStrategiesForQuery(TorznabQuery query)
-        {
-            return (new NoFallbackStrategy()).ToEnumerable();
-        }
+        public IEnumerable<IFallbackStrategy> FallbackStrategiesForQuery(TorznabQuery query) => (new NoFallbackStrategy()).ToEnumerable();
     }
 
     public class ImdbFallbackStrategy : IFallbackStrategy
@@ -44,9 +38,8 @@ namespace Jackett.Common.Indexers.Meta
 
         public async Task<IEnumerable<TorznabQuery>> FallbackQueries()
         {
-            if (titles == null)
-                titles = (await resolver.MovieForId(query.ImdbID.ToNonNull())).Title?.ToEnumerable() ?? Enumerable.Empty<string>();
-            return titles.Select(t => query.CreateFallback(t));
+            titles ??= (await resolver.MovieForId(query.ImdbID.ToNonNull())).Title?.ToEnumerable() ?? Enumerable.Empty<string>();
+            return titles.Select(query.CreateFallback);
         }
 
         private readonly IImdbResolver resolver;
@@ -56,10 +49,7 @@ namespace Jackett.Common.Indexers.Meta
 
     public class ImdbFallbackStrategyProvider : IFallbackStrategyProvider
     {
-        public ImdbFallbackStrategyProvider(IImdbResolver resolver)
-        {
-            this.resolver = resolver;
-        }
+        public ImdbFallbackStrategyProvider(IImdbResolver resolver) => this.resolver = resolver;
 
         public IEnumerable<IFallbackStrategy> FallbackStrategiesForQuery(TorznabQuery query)
         {

--- a/src/Jackett.Common/Indexers/Meta/MetaIndexers.cs
+++ b/src/Jackett.Common/Indexers/Meta/MetaIndexers.cs
@@ -8,13 +8,7 @@ namespace Jackett.Common.Indexers.Meta
 {
     public class AggregateIndexer : BaseMetaIndexer
     {
-        public override string ID
-        {
-            get
-            {
-                return "all";
-            }
-        }
+        public override string ID => "all";
         public AggregateIndexer(IFallbackStrategyProvider fallbackStrategyProvider, IResultFilterProvider resultFilterProvider, IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
             : base("AggregateSearch", "This feed includes all configured trackers", fallbackStrategyProvider, resultFilterProvider, configService, wc, l, new ConfigurationData(), ps, x => true)
         {

--- a/src/Jackett.Common/Indexers/Meta/ResultFilters.cs
+++ b/src/Jackett.Common/Indexers/Meta/ResultFilters.cs
@@ -30,7 +30,8 @@ namespace Jackett.Common.Indexers.Meta
             long? imdbId = null;
             try
             {
-                var normalizedImdbId = string.Concat(query.ImdbID.Where(c => char.IsDigit(c)));
+                // Convert from try/catch to long.TryParse since we're not handling the failure
+                var normalizedImdbId = string.Concat(query.ImdbID.Where(char.IsDigit));
                 imdbId = long.Parse(normalizedImdbId);
             }
             catch
@@ -70,11 +71,8 @@ namespace Jackett.Common.Indexers.Meta
             return filteredResults;
         }
 
-        private static string RemoveSpecialChars(string title)
-        {
-            // TODO improve character replacement with invalid chars
-            return title.Replace(":", "");
-        }
+        // TODO improve character replacement with invalid chars
+        private static string RemoveSpecialChars(string title) => title.Replace(":", "");
 
         private static IEnumerable<string> GenerateTitleVariants(string title)
         {
@@ -94,26 +92,17 @@ namespace Jackett.Common.Indexers.Meta
 
     public class NoFilter : IResultFilter
     {
-        public Task<IEnumerable<ReleaseInfo>> FilterResults(IEnumerable<ReleaseInfo> results)
-        {
-            return Task.FromResult(results);
-        }
+        public Task<IEnumerable<ReleaseInfo>> FilterResults(IEnumerable<ReleaseInfo> results) => Task.FromResult(results);
     }
 
     public class NoResultFilterProvider : IResultFilterProvider
     {
-        public IEnumerable<IResultFilter> FiltersForQuery(TorznabQuery query)
-        {
-            return (new NoFilter()).ToEnumerable();
-        }
+        public IEnumerable<IResultFilter> FiltersForQuery(TorznabQuery query) => (new NoFilter()).ToEnumerable();
     }
 
     public class ImdbTitleResultFilterProvider : IResultFilterProvider
     {
-        public ImdbTitleResultFilterProvider(IImdbResolver resolver)
-        {
-            this.resolver = resolver;
-        }
+        public ImdbTitleResultFilterProvider(IImdbResolver resolver) => this.resolver = resolver;
 
         public IEnumerable<IResultFilter> FiltersForQuery(TorznabQuery query)
         {

--- a/src/Jackett.Common/Indexers/MyAnonamouse.cs
+++ b/src/Jackett.Common/Indexers/MyAnonamouse.cs
@@ -18,13 +18,13 @@ namespace Jackett.Common.Indexers
 {
     public class Myanonamouse : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "takelogin.php"; } }
-        private string SearchUrl { get { return SiteLink + "tor/js/loadSearchJSONbasic.php"; } }
+        private string LoginUrl => SiteLink + "takelogin.php";
+        private string SearchUrl => SiteLink + "tor/js/loadSearchJSONbasic.php";
 
         private new ConfigurationDataMyAnonamouse configData
         {
-            get { return (ConfigurationDataMyAnonamouse)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataMyAnonamouse)base.configData;
+            set => base.configData = value;
         }
 
         public Myanonamouse(IIndexerConfigurationService configService, WebClient c, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/NCore.cs
+++ b/src/Jackett.Common/Indexers/NCore.cs
@@ -18,14 +18,14 @@ namespace Jackett.Common.Indexers
 {
     public class NCore : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "login.php"; } }
-        private string SearchUrl { get { return SiteLink + "torrents.php"; } }
+        private string LoginUrl => SiteLink + "login.php";
+        private string SearchUrl => SiteLink + "torrents.php";
         private readonly string[] LanguageCats = new string[] { "xvidser", "dvdser", "hdser", "xvid", "dvd", "dvd9", "hd", "mp3", "lossless", "ebook" };
 
         private new ConfigurationDataNCore configData
         {
-            get { return (ConfigurationDataNCore)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataNCore)base.configData;
+            set => base.configData = value;
         }
 
         public NCore(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/NewRealWorld.cs
+++ b/src/Jackett.Common/Indexers/NewRealWorld.cs
@@ -17,13 +17,13 @@ namespace Jackett.Common.Indexers
 {
     public class NewRealWorld : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "login.php"; } }
-        private string BrowseUrl { get { return SiteLink + "browse.php"; } }
+        private string LoginUrl => SiteLink + "login.php";
+        private string BrowseUrl => SiteLink + "browse.php";
 
         private new ConfigurationDataBasicLoginWithRSSAndDisplay configData
         {
-            get { return (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData;
+            set => base.configData = value;
         }
 
         public NewRealWorld(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/Newpct.cs
+++ b/src/Jackett.Common/Indexers/Newpct.cs
@@ -49,10 +49,7 @@ namespace Jackett.Common.Indexers
                 Score = copyFrom.Score;
             }
 
-            public override object Clone()
-            {
-                return new NewpctRelease(this);
-            }
+            public override object Clone() => new NewpctRelease(this);
         }
 
         private class DownloadMatcher
@@ -156,10 +153,8 @@ namespace Jackett.Common.Indexers
             configData.LoadValuesFromJson(configJson);
             var releases = await PerformQuery(new TorznabQuery());
 
-            await ConfigureIfOK(string.Empty, releases.Count() > 0, () =>
-            {
-                throw new Exception("Could not find releases from this URL");
-            });
+            await ConfigureIfOK(string.Empty, releases.Any(), () =>
+                                    throw new Exception("Could not find releases from this URL"));
 
             return IndexerConfigurationStatus.Completed;
         }
@@ -837,13 +832,10 @@ namespace Jackett.Common.Indexers
             }
         }
 
-        private ReleaseType ReleaseTypeFromQuality(string quality)
-        {
-            if (quality.Trim().ToLower().StartsWith("hdtv"))
-                return ReleaseType.TV;
-            else
-                return ReleaseType.Movie;
-        }
+        private static ReleaseType ReleaseTypeFromQuality(string quality) =>
+            quality.Trim().ToLower().StartsWith("hdtv")
+                ? ReleaseType.TV
+                : ReleaseType.Movie;
 
         private NewpctRelease GetReleaseFromData(ReleaseType releaseType, string title, string detailsUrl, string quality, string language, long size, DateTime publishDate)
         {

--- a/src/Jackett.Common/Indexers/Partis.cs
+++ b/src/Jackett.Common/Indexers/Partis.cs
@@ -18,13 +18,13 @@ namespace Jackett.Common.Indexers
 {
     public class Partis : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "user/login/"; } }
-        private string SearchUrl { get { return SiteLink + "torrent/show/"; } }
+        private string LoginUrl => SiteLink + "user/login/";
+        private string SearchUrl => SiteLink + "torrent/show/";
 
         private new ConfigurationDataBasicLogin configData
         {
-            get { return (ConfigurationDataBasicLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLogin)base.configData;
+            set => base.configData = value;
         }
 
         public Partis(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
@@ -141,7 +141,7 @@ namespace Jackett.Common.Indexers
             results = await RequestStringWithCookies(searchUrl, null, SearchUrl, heder);
             await FollowIfRedirect(results, null, null, null, true);
 
-            /// are we logged in?
+            // are we logged in?
             if (!results.Content.Contains("/odjava"))
             {
                 await ApplyConfiguration(null);

--- a/src/Jackett.Common/Indexers/PassThePopcorn.cs
+++ b/src/Jackett.Common/Indexers/PassThePopcorn.cs
@@ -17,16 +17,16 @@ namespace Jackett.Common.Indexers
 {
     public class PassThePopcorn : BaseWebIndexer
     {
-        private string LoginUrl { get { return "https://passthepopcorn.me/ajax.php?action=login"; } }
-        private string indexUrl { get { return "https://passthepopcorn.me/ajax.php?action=login"; } }
-        private string SearchUrl { get { return "https://passthepopcorn.me/torrents.php"; } }
-        private string DetailURL { get { return "https://passthepopcorn.me/torrents.php?torrentid="; } }
+        private string LoginUrl => "https://passthepopcorn.me/ajax.php?action=login";
+        private string indexUrl => "https://passthepopcorn.me/ajax.php?action=login";
+        private string SearchUrl => "https://passthepopcorn.me/torrents.php";
+        private string DetailURL => "https://passthepopcorn.me/torrents.php?torrentid=";
         private string AuthKey { get; set; }
 
         private new ConfigurationDataAPILoginWithUserAndPasskeyAndFilter configData
         {
-            get { return (ConfigurationDataAPILoginWithUserAndPasskeyAndFilter)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataAPILoginWithUserAndPasskeyAndFilter)base.configData;
+            set => base.configData = value;
         }
 
         public PassThePopcorn(IIndexerConfigurationService configService, Utils.Clients.WebClient c, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/PiXELHD.cs
+++ b/src/Jackett.Common/Indexers/PiXELHD.cs
@@ -17,15 +17,13 @@ namespace Jackett.Common.Indexers
 {
     public class PiXELHD : BaseWebIndexer
     {
-        private string LoginUrl
-        { get { return SiteLink + "login.php"; } }
-        private string BrowseUrl
-        { get { return SiteLink + "torrents.php"; } }
+        private string LoginUrl => SiteLink + "login.php";
+        private string BrowseUrl => SiteLink + "torrents.php";
 
         private new ConfigurationDataCaptchaLogin configData
         {
-            get { return (ConfigurationDataCaptchaLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataCaptchaLogin)base.configData;
+            set => base.configData = value;
         }
 
         private string input_captcha = null;

--- a/src/Jackett.Common/Indexers/PirateTheNet.cs
+++ b/src/Jackett.Common/Indexers/PirateTheNet.cs
@@ -18,16 +18,16 @@ namespace Jackett.Common.Indexers
 {
     public class PirateTheNet : BaseWebIndexer
     {
-        private string SearchUrl { get { return SiteLink + "torrentsutils.php"; } }
-        private string LoginUrl { get { return SiteLink + "takelogin.php"; } }
-        private string CaptchaUrl { get { return SiteLink + "simpleCaptcha.php?numImages=1"; } }
+        private string SearchUrl => SiteLink + "torrentsutils.php";
+        private string LoginUrl => SiteLink + "takelogin.php";
+        private string CaptchaUrl => SiteLink + "simpleCaptcha.php?numImages=1";
         private readonly TimeZoneInfo germanyTz = TimeZoneInfo.CreateCustomTimeZone("W. Europe Standard Time", new TimeSpan(1, 0, 0), "W. Europe Standard Time", "W. Europe Standard Time");
         private readonly List<string> categories = new List<string>() { "1080P", "720P", "BDRip", "BluRay", "BRRip", "DVDR", "DVDRip", "FLAC", "MP3", "MP4", "Packs", "R5", "Remux", "TVRip", "WebRip" };
 
         private new ConfigurationDataBasicLoginWithRSSAndDisplay configData
         {
-            get { return (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData;
+            set => base.configData = value;
         }
 
         public PirateTheNet(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/PolishTracker.cs
+++ b/src/Jackett.Common/Indexers/PolishTracker.cs
@@ -15,9 +15,9 @@ namespace Jackett.Common.Indexers
 {
     public class PolishTracker : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "login"; } }
-        private string TorrentApiUrl { get { return SiteLink + "apitorrents"; } }
-        private string CDNUrl { get { return "https://cdn.pte.nu/"; } }
+        private string LoginUrl => SiteLink + "login";
+        private string TorrentApiUrl => SiteLink + "apitorrents";
+        private string CDNUrl => "https://cdn.pte.nu/";
 
         public override string[] LegacySiteLinks { get; protected set; } = new string[] {
             "https://polishtracker.net/",
@@ -25,8 +25,8 @@ namespace Jackett.Common.Indexers
 
         private new ConfigurationDataBasicLoginWithEmail configData
         {
-            get { return (ConfigurationDataBasicLoginWithEmail)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLoginWithEmail)base.configData;
+            set => base.configData = value;
         }
 
         public PolishTracker(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/Pretome.cs
+++ b/src/Jackett.Common/Indexers/Pretome.cs
@@ -18,16 +18,16 @@ namespace Jackett.Common.Indexers
 {
     public class Pretome : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "takelogin.php"; } }
-        private string LoginReferer { get { return SiteLink + "index.php?cat=1"; } }
-        private string SearchUrl { get { return SiteLink + "browse.php"; } }
+        private string LoginUrl => SiteLink + "takelogin.php";
+        private string LoginReferer => SiteLink + "index.php?cat=1";
+        private string SearchUrl => SiteLink + "browse.php";
 
         private readonly List<CategoryMapping> resultMapping = new List<CategoryMapping>();
 
         private new ConfigurationDataPinNumber configData
         {
-            get { return (ConfigurationDataPinNumber)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataPinNumber)base.configData;
+            set => base.configData = value;
         }
 
         public Pretome(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/PrivateHD.cs
+++ b/src/Jackett.Common/Indexers/PrivateHD.cs
@@ -16,8 +16,6 @@ namespace Jackett.Common.Indexers
                 protectionService: protectionService,
                 webClient: webClient
                 )
-        {
-            Type = "private";
-        }
+            => Type = "private";
     }
 }

--- a/src/Jackett.Common/Indexers/Rarbg.cs
+++ b/src/Jackett.Common/Indexers/Rarbg.cs
@@ -24,16 +24,16 @@ namespace Jackett.Common.Indexers
 
         private Uri BaseUri
         {
-            get { return new Uri(configData.Url.Value); }
-            set { configData.Url.Value = value.ToString(); }
+            get => new Uri(configData.Url.Value);
+            set => configData.Url.Value = value.ToString();
         }
 
-        private string ApiEndpoint { get { return BaseUri + "pubapi_v2.php"; } }
+        private string ApiEndpoint => BaseUri + "pubapi_v2.php";
 
         private new ConfigurationDataUrl configData
         {
-            get { return (ConfigurationDataUrl)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataUrl)base.configData;
+            set => base.configData = value;
         }
 
         private DateTime lastTokenFetch;
@@ -44,7 +44,7 @@ namespace Jackett.Common.Indexers
 
         private readonly TimeSpan TOKEN_DURATION = TimeSpan.FromMinutes(10);
 
-        private bool HasValidToken { get { return !string.IsNullOrEmpty(token) && lastTokenFetch > DateTime.Now - TOKEN_DURATION; } }
+        private bool HasValidToken => !string.IsNullOrEmpty(token) && lastTokenFetch > DateTime.Now - TOKEN_DURATION;
 
         public Rarbg(IIndexerConfigurationService configService, Utils.Clients.WebClient wc, Logger l, IProtectionService ps)
             : base(name: "RARBG",
@@ -145,10 +145,7 @@ namespace Jackett.Common.Indexers
             return IndexerConfigurationStatus.Completed;
         }
 
-        protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
-        {
-            return await PerformQuery(query, 0);
-        }
+        protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query) => await PerformQuery(query, 0);
 
         private async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query, int attempts)
         {

--- a/src/Jackett.Common/Indexers/RevolutionTT.cs
+++ b/src/Jackett.Common/Indexers/RevolutionTT.cs
@@ -19,17 +19,17 @@ namespace Jackett.Common.Indexers
 {
     public class RevolutionTT : BaseWebIndexer
     {
-        private string LandingPageURL { get { return SiteLink + "login.php"; } }
-        private string LoginUrl { get { return SiteLink + "takelogin.php"; } }
-        private string GetRSSKeyUrl { get { return SiteLink + "getrss.php"; } }
-        private string RSSUrl { get { return SiteLink + "rss.php?feed=dl&passkey="; } }
-        private string SearchUrl { get { return SiteLink + "browse.php"; } }
-        private string DetailsURL { get { return SiteLink + "details.php?id={0}&hit=1"; } }
+        private string LandingPageURL => SiteLink + "login.php";
+        private string LoginUrl => SiteLink + "takelogin.php";
+        private string GetRSSKeyUrl => SiteLink + "getrss.php";
+        private string RSSUrl => SiteLink + "rss.php?feed=dl&passkey=";
+        private string SearchUrl => SiteLink + "browse.php";
+        private string DetailsURL => SiteLink + "details.php?id={0}&hit=1";
 
         private new ConfigurationDataBasicLoginWithRSS configData
         {
-            get { return (ConfigurationDataBasicLoginWithRSS)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLoginWithRSS)base.configData;
+            set => base.configData = value;
         }
 
         public RevolutionTT(IIndexerConfigurationService configService, Utils.Clients.WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/SceneHD.cs
+++ b/src/Jackett.Common/Indexers/SceneHD.cs
@@ -17,12 +17,12 @@ namespace Jackett.Common.Indexers
 {
     public class SceneHD : BaseWebIndexer
     {
-        private string SearchUrl { get { return SiteLink + "browse.php"; } }
+        private string SearchUrl => SiteLink + "browse.php";
 
         private new ConfigurationDataCookie configData
         {
-            get { return (ConfigurationDataCookie)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataCookie)base.configData;
+            set => base.configData = value;
         }
 
         public SceneHD(IIndexerConfigurationService configService, WebClient c, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/SceneTime.cs
+++ b/src/Jackett.Common/Indexers/SceneTime.cs
@@ -19,16 +19,16 @@ namespace Jackett.Common.Indexers
 {
     public class SceneTime : BaseWebIndexer
     {
-        private string StartPageUrl { get { return SiteLink + "login.php"; } }
-        private string LoginUrl { get { return SiteLink + "takelogin.php"; } }
-        private string SearchUrl { get { return SiteLink + "browse.php"; } }
-        private string DownloadUrl { get { return SiteLink + "download.php/{0}/download.torrent"; } }
+        private string StartPageUrl => SiteLink + "login.php";
+        private string LoginUrl => SiteLink + "takelogin.php";
+        private string SearchUrl => SiteLink + "browse.php";
+        private string DownloadUrl => SiteLink + "download.php/{0}/download.torrent";
 
 
         private new ConfigurationDataSceneTime configData
         {
-            get { return (ConfigurationDataSceneTime)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataSceneTime)base.configData;
+            set => base.configData = value;
         }
 
         public SceneTime(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/Shazbat.cs
+++ b/src/Jackett.Common/Indexers/Shazbat.cs
@@ -62,8 +62,8 @@ namespace Jackett.Common.Indexers
             var firstRequest = await RequestStringWithCookiesAndRetry(LoginUrl);
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, LoginUrl);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("glyphicon-log-out"), () =>
-                                    throw new ExceptionWithConfigData("The username and password entered do not match.", configData));
+            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("glyphicon-log-out"),
+                () => throw new ExceptionWithConfigData("The username and password entered do not match.", configData));
 
             var rssProfile = await RequestStringWithCookiesAndRetry(RSSProfile);
             CQ rssDom = rssProfile.Content;

--- a/src/Jackett.Common/Indexers/Shazbat.cs
+++ b/src/Jackett.Common/Indexers/Shazbat.cs
@@ -17,16 +17,16 @@ namespace Jackett.Common.Indexers
 {
     public class Shazbat : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "login"; } }
-        private string SearchUrl { get { return SiteLink + "search"; } }
-        private string TorrentsUrl { get { return SiteLink + "torrents"; } }
-        private string ShowUrl { get { return SiteLink + "show?id="; } }
-        private string RSSProfile { get { return SiteLink + "rss_feeds"; } }
+        private string LoginUrl => SiteLink + "login";
+        private string SearchUrl => SiteLink + "search";
+        private string TorrentsUrl => SiteLink + "torrents";
+        private string ShowUrl => SiteLink + "show?id=";
+        private string RSSProfile => SiteLink + "rss_feeds";
 
         private new ConfigurationDataBasicLoginWithRSS configData
         {
-            get { return (ConfigurationDataBasicLoginWithRSS)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLoginWithRSS)base.configData;
+            set => base.configData = value;
         }
 
         public Shazbat(IIndexerConfigurationService configService, WebClient c, Logger l, IProtectionService ps)
@@ -63,9 +63,7 @@ namespace Jackett.Common.Indexers
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, LoginUrl);
             await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("glyphicon-log-out"), () =>
-            {
-                throw new ExceptionWithConfigData("The username and password entered do not match.", configData);
-            });
+                                    throw new ExceptionWithConfigData("The username and password entered do not match.", configData));
 
             var rssProfile = await RequestStringWithCookiesAndRetry(RSSProfile);
             CQ rssDom = rssProfile.Content;

--- a/src/Jackett.Common/Indexers/ShowRSS.cs
+++ b/src/Jackett.Common/Indexers/ShowRSS.cs
@@ -17,15 +17,15 @@ namespace Jackett.Common.Indexers
 {
     public class ShowRSS : BaseWebIndexer
     {
-        private string SearchAllUrl { get { return SiteLink + "other/all.rss"; } }
+        private string SearchAllUrl => SiteLink + "other/all.rss";
         public override string[] LegacySiteLinks { get; protected set; } = new string[] {
             "http://showrss.info/",
         };
 
         private new ConfigurationData configData
         {
-            get { return base.configData; }
-            set { base.configData = value; }
+            get => base.configData;
+            set => base.configData = value;
         }
 
         public ShowRSS(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
@@ -49,18 +49,13 @@ namespace Jackett.Common.Indexers
             configData.LoadValuesFromJson(configJson);
             var releases = await PerformQuery(new TorznabQuery());
 
-            await ConfigureIfOK(string.Empty, releases.Count() > 0, () =>
-            {
-                throw new Exception("Could not find releases from this URL");
-            });
+            await ConfigureIfOK(string.Empty, releases.Any(),
+                                () => throw new Exception("Could not find releases from this URL"));
 
             return IndexerConfigurationStatus.RequiresTesting;
         }
 
-        public override Task<byte[]> Download(Uri link)
-        {
-            throw new NotImplementedException();
-        }
+        public override Task<byte[]> Download(Uri link) => throw new NotImplementedException();
 
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {

--- a/src/Jackett.Common/Indexers/SpeedCD.cs
+++ b/src/Jackett.Common/Indexers/SpeedCD.cs
@@ -18,13 +18,13 @@ namespace Jackett.Common.Indexers
 {
     public class SpeedCD : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "take_login.php"; } }
-        private string SearchUrl { get { return SiteLink + "browse.php"; } }
+        private string LoginUrl => SiteLink + "take_login.php";
+        private string SearchUrl => SiteLink + "browse.php";
 
         private new ConfigurationDataBasicLogin configData
         {
-            get { return (ConfigurationDataBasicLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLogin)base.configData;
+            set => base.configData = value;
         }
 
         public SpeedCD(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
@@ -167,6 +167,8 @@ namespace Jackett.Common.Indexers
                     var cat = torrentData.Find("img[class^='Tcat']").First().Parent().Attr("href").Trim().Remove(0, 5);
                     long.TryParse(cat, out var category);
 
+                    // This fixes the mixed initializer issue, so it's just inconsistent in the code base.
+                    // https://github.com/Jackett/Jackett/pull/7166#discussion_r376817517
                     var release = new ReleaseInfo();
 
                     release.Title = title;

--- a/src/Jackett.Common/Indexers/Superbits.cs
+++ b/src/Jackett.Common/Indexers/Superbits.cs
@@ -18,13 +18,13 @@ namespace Jackett.Common.Indexers
 {
     public class Superbits : BaseWebIndexer
     {
-        private string SearchUrl { get { return SiteLink + "api/v1/torrents"; } }
-        private string LoginUrl { get { return SiteLink + "api/v1/auth"; } }
+        private string SearchUrl => SiteLink + "api/v1/torrents";
+        private string LoginUrl => SiteLink + "api/v1/auth";
 
         private new ConfigurationDataCookie configData
         {
-            get { return (ConfigurationDataCookie)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataCookie)base.configData;
+            set => base.configData = value;
         }
 
         public Superbits(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps)
@@ -97,6 +97,8 @@ namespace Jackett.Common.Indexers
 
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {
+            // And this was option one from
+            // https://github.com/Jackett/Jackett/pull/7166#discussion_r376817517
             var releases = new List<ReleaseInfo>();
             var queryCollection = new NameValueCollection();
             var searchString = query.GetQueryString();

--- a/src/Jackett.Common/Indexers/TVVault.cs
+++ b/src/Jackett.Common/Indexers/TVVault.cs
@@ -58,8 +58,8 @@ namespace Jackett.Common.Indexers
             };
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, LoginUrl, true);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("logout.php"), () =>
-                                    throw new ExceptionWithConfigData(result.Content, configData));
+            await ConfigureIfOK(result.Cookies, result.Content?.Contains("logout.php") == true,
+                                () => throw new ExceptionWithConfigData(result.Content, configData));
             return IndexerConfigurationStatus.RequiresTesting;
         }
 

--- a/src/Jackett.Common/Indexers/TVVault.cs
+++ b/src/Jackett.Common/Indexers/TVVault.cs
@@ -17,13 +17,13 @@ namespace Jackett.Common.Indexers
 {
     public class TVVault : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "login.php"; } }
-        private string BrowseUrl { get { return SiteLink + "torrents.php"; } }
+        private string LoginUrl => SiteLink + "login.php";
+        private string BrowseUrl => SiteLink + "torrents.php";
 
         private new ConfigurationDataBasicLoginWithRSSAndDisplay configData
         {
-            get { return (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData;
+            set => base.configData = value;
         }
 
         public TVVault(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
@@ -59,10 +59,7 @@ namespace Jackett.Common.Indexers
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, LoginUrl, true);
             await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("logout.php"), () =>
-            {
-                var errorMessage = result.Content;
-                throw new ExceptionWithConfigData(errorMessage, configData);
-            });
+                                    throw new ExceptionWithConfigData(result.Content, configData));
             return IndexerConfigurationStatus.RequiresTesting;
         }
 

--- a/src/Jackett.Common/Indexers/TVstore.cs
+++ b/src/Jackett.Common/Indexers/TVstore.cs
@@ -68,9 +68,8 @@ namespace Jackett.Common.Indexers
             };
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, loginPage.Cookies, true, referer: SiteLink);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("Főoldal"), () =>
-                                    throw new ExceptionWithConfigData("Error while trying to login with: Username: " + configData.Username.Value +
-                                                                      " Password: " + configData.Password.Value, configData));
+            await ConfigureIfOK(result.Cookies, result.Content?.Contains("Főoldal") == true, () => throw new ExceptionWithConfigData(
+                $"Error while trying to login with: Username: {configData.Username.Value} Password: {configData.Password.Value}", configData));
 
             return IndexerConfigurationStatus.RequiresTesting;
         }

--- a/src/Jackett.Common/Indexers/TVstore.cs
+++ b/src/Jackett.Common/Indexers/TVstore.cs
@@ -19,18 +19,18 @@ namespace Jackett.Common.Indexers
     public class TVstore : BaseWebIndexer
     {
 
-        private string LoginUrl { get { return SiteLink + "takelogin.php"; } }
-        private string LoginPageUrl { get { return SiteLink + "login.php?returnto=%2F"; } }
-        private string SearchUrl { get { return SiteLink + "torrent/br_process.php"; } }
-        private string DownloadUrl { get { return SiteLink + "torrent/download.php"; } }
-        private string BrowseUrl { get { return SiteLink + "torrent/browse.php"; } }
+        private string LoginUrl => SiteLink + "takelogin.php";
+        private string LoginPageUrl => SiteLink + "login.php?returnto=%2F";
+        private string SearchUrl => SiteLink + "torrent/br_process.php";
+        private string DownloadUrl => SiteLink + "torrent/download.php";
+        private string BrowseUrl => SiteLink + "torrent/browse.php";
         private readonly List<SeriesDetail> series = new List<SeriesDetail>();
         private readonly Regex _searchStringRegex = new Regex(@"(.+?)S0?(\d+)(E0?(\d+))?$", RegexOptions.IgnoreCase);
 
         private new ConfigurationDataTVstore configData
         {
-            get { return (ConfigurationDataTVstore)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataTVstore)base.configData;
+            set => base.configData = value;
         }
 
         public TVstore(IIndexerConfigurationService configService, Utils.Clients.WebClient wc, Logger l, IProtectionService ps)
@@ -69,10 +69,8 @@ namespace Jackett.Common.Indexers
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, loginPage.Cookies, true, referer: SiteLink);
             await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("Főoldal"), () =>
-            {
-                throw new ExceptionWithConfigData("Error while trying to login with: Username: " + configData.Username.Value +
-                                                  " Password: " + configData.Password.Value, configData);
-            });
+                                    throw new ExceptionWithConfigData("Error while trying to login with: Username: " + configData.Username.Value +
+                                                                      " Password: " + configData.Password.Value, configData));
 
             return IndexerConfigurationStatus.RequiresTesting;
         }

--- a/src/Jackett.Common/Indexers/TorrentBytes.cs
+++ b/src/Jackett.Common/Indexers/TorrentBytes.cs
@@ -17,13 +17,13 @@ namespace Jackett.Common.Indexers
 {
     public class TorrentBytes : BaseWebIndexer
     {
-        private string BrowseUrl { get { return SiteLink + "browse.php"; } }
-        private string LoginUrl { get { return SiteLink + "takelogin.php"; } }
+        private string BrowseUrl => SiteLink + "browse.php";
+        private string LoginUrl => SiteLink + "takelogin.php";
 
         private new ConfigurationDataBasicLogin configData
         {
-            get { return (ConfigurationDataBasicLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLogin)base.configData;
+            set => base.configData = value;
         }
 
         public TorrentBytes(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/TorrentDay.cs
+++ b/src/Jackett.Common/Indexers/TorrentDay.cs
@@ -18,9 +18,9 @@ namespace Jackett.Common.Indexers
 {
     public class TorrentDay : BaseWebIndexer
     {
-        private string StartPageUrl { get { return SiteLink + "login.php"; } }
-        private string LoginUrl { get { return SiteLink + "tak3login.php"; } }
-        private string SearchUrl { get { return SiteLink + "t.json"; } }
+        private string StartPageUrl => SiteLink + "login.php";
+        private string LoginUrl => SiteLink + "tak3login.php";
+        private string SearchUrl => SiteLink + "t.json";
 
         public override string[] LegacySiteLinks { get; protected set; } = new string[] {
             "https://torrentday.com/",
@@ -47,8 +47,8 @@ namespace Jackett.Common.Indexers
 
         private new ConfigurationDataRecaptchaLogin configData
         {
-            get { return (ConfigurationDataRecaptchaLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataRecaptchaLogin)base.configData;
+            set => base.configData = value;
         }
 
         public TorrentDay(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/TorrentHeaven.cs
+++ b/src/Jackett.Common/Indexers/TorrentHeaven.cs
@@ -23,13 +23,13 @@ namespace Jackett.Common.Indexers
             "https://torrentheaven.myfqdn.info/",
         };
 
-        private string IndexUrl { get { return SiteLink + "index.php"; } }
-        private string LoginCompleteUrl { get { return SiteLink + "index.php?strWebValue=account&strWebAction=login_complete&ancestry=verify"; } }
+        private string IndexUrl => SiteLink + "index.php";
+        private string LoginCompleteUrl => SiteLink + "index.php?strWebValue=account&strWebAction=login_complete&ancestry=verify";
 
         private new ConfigurationDataCaptchaLogin configData
         {
-            get { return (ConfigurationDataCaptchaLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataCaptchaLogin)base.configData;
+            set => base.configData = value;
         }
 
         public TorrentHeaven(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/TorrentLeech.cs
+++ b/src/Jackett.Common/Indexers/TorrentLeech.cs
@@ -23,13 +23,13 @@ namespace Jackett.Common.Indexers
             "https://v4.torrentleech.org/",
         };
 
-        private string LoginUrl { get { return SiteLink + "user/account/login/"; } }
-        private string SearchUrl { get { return SiteLink + "torrents/browse/list/"; } }
+        private string LoginUrl => SiteLink + "user/account/login/";
+        private string SearchUrl => SiteLink + "torrents/browse/list/";
 
         private new ConfigurationDataRecaptchaLogin configData
         {
-            get { return (ConfigurationDataRecaptchaLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataRecaptchaLogin)base.configData;
+            set => base.configData = value;
         }
 
         public TorrentLeech(IIndexerConfigurationService configService, Utils.Clients.WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/TorrentNetwork.cs
+++ b/src/Jackett.Common/Indexers/TorrentNetwork.cs
@@ -17,7 +17,7 @@ namespace Jackett.Common.Indexers
 {
     public class TorrentNetwork : BaseWebIndexer
     {
-        private string APIUrl { get { return SiteLink + "api/"; } }
+        private string APIUrl => SiteLink + "api/";
         private string passkey;
 
         private readonly Dictionary<string, string> APIHeaders = new Dictionary<string, string>()
@@ -27,8 +27,8 @@ namespace Jackett.Common.Indexers
 
         private new ConfigurationDataBasicLoginWithRSSAndDisplay configData
         {
-            get { return (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData;
+            set => base.configData = value;
         }
 
         public TorrentNetwork(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/TorrentSyndikat.cs
+++ b/src/Jackett.Common/Indexers/TorrentSyndikat.cs
@@ -19,15 +19,15 @@ namespace Jackett.Common.Indexers
 {
     public class TorrentSyndikat : BaseWebIndexer
     {
-        private string SearchUrl { get { return SiteLink + "browse.php"; } }
-        private string LoginUrl { get { return SiteLink + "eing2.php"; } }
-        private string CaptchaUrl { get { return SiteLink + "simpleCaptcha.php?numImages=1"; } }
+        private string SearchUrl => SiteLink + "browse.php";
+        private string LoginUrl => SiteLink + "eing2.php";
+        private string CaptchaUrl => SiteLink + "simpleCaptcha.php?numImages=1";
         private readonly TimeZoneInfo germanyTz;
 
         private new ConfigurationDataBasicLoginWithRSSAndDisplay configData
         {
-            get { return (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData;
+            set => base.configData = value;
         }
 
         public TorrentSyndikat(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps)
@@ -121,11 +121,8 @@ namespace Jackett.Common.Indexers
 
             var result2 = await RequestLoginAndFollowRedirect(LoginUrl, pairs, result1.Cookies, true, null, null, true);
 
-            await ConfigureIfOK(result2.Cookies, result2.Content.Contains("/logout.php"), () =>
-            {
-                var errorMessage = result2.Content;
-                throw new ExceptionWithConfigData(errorMessage, configData);
-            });
+            await ConfigureIfOK(result2.Cookies, result2.Content.Contains("/logout.php"),
+                () => throw new ExceptionWithConfigData(result2.Content, configData));
             return IndexerConfigurationStatus.RequiresTesting;
         }
 

--- a/src/Jackett.Common/Indexers/Torrentech.cs
+++ b/src/Jackett.Common/Indexers/Torrentech.cs
@@ -20,13 +20,13 @@ namespace Jackett.Common.Indexers
 {
     public class Torrentech : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "index.php?act=Login&CODE=01&CookieDate=1"; } }
-        private string IndexUrl { get { return SiteLink + "index.php"; } }
+        private string LoginUrl => SiteLink + "index.php?act=Login&CODE=01&CookieDate=1";
+        private string IndexUrl => SiteLink + "index.php";
 
         private new ConfigurationDataBasicLoginWithRSSAndDisplay configData
         {
-            get { return (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData;
+            set => base.configData = value;
         }
 
         public Torrentech(IIndexerConfigurationService configService, Utils.Clients.WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/Torrentscsv.cs
+++ b/src/Jackett.Common/Indexers/Torrentscsv.cs
@@ -17,12 +17,12 @@ namespace Jackett.Common.Indexers
     public class Torrentscsv : BaseWebIndexer
     {
 
-        private string ApiEndpoint { get { return SiteLink + "service/search"; } }
+        private string ApiEndpoint => SiteLink + "service/search";
 
         private new ConfigurationData configData
         {
-            get { return base.configData; }
-            set { base.configData = value; }
+            get => base.configData;
+            set => base.configData = value;
         }
 
         public Torrentscsv(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps) : base(
@@ -68,10 +68,7 @@ namespace Jackett.Common.Indexers
             return IndexerConfigurationStatus.Completed;
         }
 
-        protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
-        {
-            return await PerformQuery(query, 0);
-        }
+        protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query) => await PerformQuery(query, 0);
 
         public async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query, int attempts)
         {

--- a/src/Jackett.Common/Indexers/TransmitheNet.cs
+++ b/src/Jackett.Common/Indexers/TransmitheNet.cs
@@ -17,13 +17,13 @@ namespace Jackett.Common.Indexers
 {
     public class TransmitheNet : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "login.php"; } }
-        private string SearchUrl { get { return SiteLink + "torrents.php?action=basic&order_by=time&order_way=desc&search_type=0&taglist=&tags_type=0"; } }
+        private string LoginUrl => SiteLink + "login.php";
+        private string SearchUrl => SiteLink + "torrents.php?action=basic&order_by=time&order_way=desc&search_type=0&taglist=&tags_type=0";
 
         private new ConfigurationDataBasicLogin configData
         {
-            get { return (ConfigurationDataBasicLogin)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLogin)base.configData;
+            set => base.configData = value;
         }
 
         public TransmitheNet(IIndexerConfigurationService configService, Utils.Clients.WebClient c, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/XSpeeds.cs
+++ b/src/Jackett.Common/Indexers/XSpeeds.cs
@@ -29,8 +29,8 @@ namespace Jackett.Common.Indexers
 
         private new ConfigurationDataBasicLoginWithRSSAndDisplay configData
         {
-            get { return (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData;
+            set => base.configData = value;
         }
 
         public XSpeeds(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/Xthor.cs
+++ b/src/Jackett.Common/Indexers/Xthor.cs
@@ -136,6 +136,10 @@ namespace Jackett.Common.Indexers
         /// </summary>
         /// <param name="configJson">Our params in Json</param>
         /// <returns>Configuration state</returns>
+
+        // Warning 1998 is async method with no await calls inside
+        // TODO: Remove pragma by wrapping return in Task.FromResult and removing async
+        
 #pragma warning disable 1998
 
         public override async Task<IndexerConfigurationStatus> ApplyConfiguration(JToken configJson)
@@ -322,10 +326,7 @@ namespace Jackett.Common.Indexers
             public string download_link { get; set; }
             public int tmdb_id { get; set; }
 
-            public override string ToString()
-            {
-                return string.Format("[XthorTorrent: id={0}, category={1}, seeders={2}, leechers={3}, name={4}, times_completed={5}, size={6}, added={7}, freeleech={8}, numfiles={9}, release_group={10}, download_link={11}, tmdb_id={12}]", id, category, seeders, leechers, name, times_completed, size, added, freeleech, numfiles, release_group, download_link, tmdb_id);
-            }
+            public override string ToString() => string.Format("[XthorTorrent: id={0}, category={1}, seeders={2}, leechers={3}, name={4}, times_completed={5}, size={6}, added={7}, freeleech={8}, numfiles={9}, release_group={10}, download_link={11}, tmdb_id={12}]", id, category, seeders, leechers, name, times_completed, size, added, freeleech, numfiles, release_group, download_link, tmdb_id);
         }
 
         /// <summary>

--- a/src/Jackett.Common/Indexers/digitalcore.cs
+++ b/src/Jackett.Common/Indexers/digitalcore.cs
@@ -18,13 +18,13 @@ namespace Jackett.Common.Indexers
 {
     public class Digitalcore : BaseWebIndexer
     {
-        private string SearchUrl { get { return SiteLink + "api/v1/torrents"; } }
-        private string LoginUrl { get { return SiteLink + "api/v1/auth"; } }
+        private string SearchUrl => SiteLink + "api/v1/torrents";
+        private string LoginUrl => SiteLink + "api/v1/auth";
 
         private new ConfigurationDataCookie configData
         {
-            get { return (ConfigurationDataCookie)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataCookie)base.configData;
+            set => base.configData = value;
         }
 
 

--- a/src/Jackett.Common/Indexers/myAmity.cs
+++ b/src/Jackett.Common/Indexers/myAmity.cs
@@ -17,13 +17,13 @@ namespace Jackett.Common.Indexers
 {
     public class myAmity : BaseWebIndexer
     {
-        private string LoginUrl { get { return SiteLink + "account-login.php"; } }
-        private string BrowseUrl { get { return SiteLink + "torrents-search.php"; } }
+        private string LoginUrl => SiteLink + "account-login.php";
+        private string BrowseUrl => SiteLink + "torrents-search.php";
 
         private new ConfigurationDataBasicLoginWithRSSAndDisplay configData
         {
-            get { return (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataBasicLoginWithRSSAndDisplay)base.configData;
+            set => base.configData = value;
         }
 
         public myAmity(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/pornolab.cs
+++ b/src/Jackett.Common/Indexers/pornolab.cs
@@ -18,18 +18,16 @@ namespace Jackett.Common.Indexers
 {
     public class Pornolab : BaseWebIndexer
     {
-        private string LoginUrl
-        { get { return SiteLink + "forum/login.php"; } }
-        private string SearchUrl
-        { get { return SiteLink + "forum/tracker.php"; } }
+        private string LoginUrl => SiteLink + "forum/login.php";
+        private string SearchUrl => SiteLink + "forum/tracker.php";
 
         protected string cap_sid = null;
         protected string cap_code_field = null;
 
         private new ConfigurationDataPornolab configData
         {
-            get { return (ConfigurationDataPornolab)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataPornolab)base.configData;
+            set => base.configData = value;
         }
 
         public Pornolab(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/rutracker.cs
+++ b/src/Jackett.Common/Indexers/rutracker.cs
@@ -18,18 +18,16 @@ namespace Jackett.Common.Indexers
 {
     public class RuTracker : BaseWebIndexer
     {
-        private string LoginUrl
-        { get { return SiteLink + "forum/login.php"; } }
-        private string SearchUrl
-        { get { return SiteLink + "forum/tracker.php"; } }
+        private string LoginUrl => SiteLink + "forum/login.php";
+        private string SearchUrl => SiteLink + "forum/tracker.php";
 
         protected string cap_sid = null;
         protected string cap_code_field = null;
 
         private new ConfigurationDataRutracker configData
         {
-            get { return (ConfigurationDataRutracker)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataRutracker)base.configData;
+            set => base.configData = value;
         }
 
         public RuTracker(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/toloka.cs
+++ b/src/Jackett.Common/Indexers/toloka.cs
@@ -17,18 +17,16 @@ namespace Jackett.Common.Indexers
 {
     public class Toloka : BaseWebIndexer
     {
-        private string LoginUrl
-        { get { return SiteLink + "/login.php"; } }
-        private string SearchUrl
-        { get { return SiteLink + "/tracker.php"; } }
+        private string LoginUrl => SiteLink + "/login.php";
+        private string SearchUrl => SiteLink + "/tracker.php";
 
         protected string cap_sid = null;
         protected string cap_code_field = null;
 
         private new ConfigurationDataToloka configData
         {
-            get { return (ConfigurationDataToloka)base.configData; }
-            set { base.configData = value; }
+            get => (ConfigurationDataToloka)base.configData;
+            set => base.configData = value;
         }
 
         public Toloka(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)

--- a/src/Jackett.Common/Indexers/yts.cs
+++ b/src/Jackett.Common/Indexers/yts.cs
@@ -63,8 +63,8 @@ namespace Jackett.Common.Indexers
             configData.LoadValuesFromJson(configJson);
             var releases = await PerformQuery(new TorznabQuery());
 
-            await ConfigureIfOK(string.Empty, releases.Count() > 0, () =>
-                                    throw new Exception("Could not find releases from this URL"));
+            await ConfigureIfOK(string.Empty, releases.Count() > 0,
+                                () => throw new Exception("Could not find releases from this URL"));
 
             return IndexerConfigurationStatus.Completed;
         }

--- a/src/Jackett.Common/Indexers/yts.cs
+++ b/src/Jackett.Common/Indexers/yts.cs
@@ -23,12 +23,12 @@ namespace Jackett.Common.Indexers
             "https://yts.lt/",
         };
 
-        private string ApiEndpoint { get { return SiteLink + "api/v2/list_movies.json"; } }
+        private string ApiEndpoint => SiteLink + "api/v2/list_movies.json";
 
         private new ConfigurationData configData
         {
-            get { return base.configData; }
-            set { base.configData = value; }
+            get => base.configData;
+            set => base.configData = value;
         }
 
         public Yts(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
@@ -64,17 +64,12 @@ namespace Jackett.Common.Indexers
             var releases = await PerformQuery(new TorznabQuery());
 
             await ConfigureIfOK(string.Empty, releases.Count() > 0, () =>
-            {
-                throw new Exception("Could not find releases from this URL");
-            });
+                                    throw new Exception("Could not find releases from this URL"));
 
             return IndexerConfigurationStatus.Completed;
         }
 
-        protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
-        {
-            return await PerformQuery(query, 0);
-        }
+        protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query) => await PerformQuery(query, 0);
 
         public async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query, int attempts)
         {

--- a/src/Jackett.Common/Jackett.Common.csproj
+++ b/src/Jackett.Common/Jackett.Common.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>0.0.0</Version>
     <NoWarn>NU1605</NoWarn>
+    <LangVersion>8</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Jackett.Common/Models/CachedQueryResult.cs
+++ b/src/Jackett.Common/Models/CachedQueryResult.cs
@@ -6,29 +6,18 @@ namespace Jackett.Common.Models
     public class CachedQueryResult
     {
         private readonly List<ReleaseInfo> results;
-        private readonly DateTime created;
-        private readonly string query;
 
         public CachedQueryResult(string query, List<ReleaseInfo> results)
         {
             this.results = results;
-            created = DateTime.Now;
-            this.query = query;
+            Created = DateTime.Now;
+            Query = query;
         }
 
-        public IReadOnlyList<ReleaseInfo> Results
-        {
-            get { return results.AsReadOnly(); }
-        }
+        public IReadOnlyList<ReleaseInfo> Results => results.AsReadOnly();
 
-        public DateTime Created
-        {
-            get { return created; }
-        }
+        public DateTime Created { get; }
 
-        public string Query
-        {
-            get { return query; }
-        }
+        public string Query { get; }
     }
 }

--- a/src/Jackett.Common/Models/Config/ServerConfig.cs
+++ b/src/Jackett.Common/Models/Config/ServerConfig.cs
@@ -42,22 +42,12 @@ namespace Jackett.Common.Models.Config
         public string ProxyUsername { get; set; }
         public string ProxyPassword { get; set; }
 
-        public bool ProxyIsAnonymous
-        {
-            get
-            {
-                return string.IsNullOrWhiteSpace(ProxyUsername) || string.IsNullOrWhiteSpace(ProxyPassword);
-            }
-        }
+        public bool ProxyIsAnonymous => string.IsNullOrWhiteSpace(ProxyUsername) || string.IsNullOrWhiteSpace(ProxyPassword);
 
-        public string GetProxyAuthString()
-        {
-            if (!ProxyIsAnonymous)
-            {
-                return $"{ProxyUsername}:{ProxyPassword}";
-            }
-            return null;
-        }
+        public string GetProxyAuthString() =>
+            !ProxyIsAnonymous
+                ? $"{ProxyUsername}:{ProxyPassword}"
+                : null;
 
         public string GetProxyUrl(bool withCreds = false)
         {
@@ -138,12 +128,7 @@ namespace Jackett.Common.Models.Config
             }
         }
 
-        public void ConfigChanged()
-        {
-            foreach (var obs in observers)
-            {
-                obs.OnNext(this);
-            }
-        }
+        public void ConfigChanged() =>
+            observers.ForEach(obs=>obs.OnNext(this));
     }
 }

--- a/src/Jackett.Common/Models/DTO/ServerConfig.cs
+++ b/src/Jackett.Common/Models/DTO/ServerConfig.cs
@@ -47,10 +47,7 @@ namespace Jackett.Common.Models.DTO
         [DataMember]
         public string proxy_password { get; set; }
 
-        public ServerConfig()
-        {
-            notices = new string[0];
-        }
+        public ServerConfig() => notices = new string[0];
 
         public ServerConfig(IEnumerable<string> notices, Models.Config.ServerConfig config, string version, bool canRunNetCore)
         {

--- a/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationDataPornolab.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationDataPornolab.cs
@@ -5,9 +5,6 @@ namespace Jackett.Common.Models.IndexerConfig.Bespoke
         public BoolItem StripRussianLetters { get; private set; }
 
         public ConfigurationDataPornolab()
-            : base()
-        {
-            StripRussianLetters = new BoolItem() { Name = "Strip Russian Letters", Value = false };
-        }
+            => StripRussianLetters = new BoolItem() { Name = "Strip Russian Letters", Value = false };
     }
 }

--- a/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationDataToloka.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationDataToloka.cs
@@ -5,9 +5,6 @@ namespace Jackett.Common.Models.IndexerConfig.Bespoke
         public BoolItem StripCyrillicLetters { get; private set; }
 
         public ConfigurationDataToloka()
-            : base()
-        {
-            StripCyrillicLetters = new BoolItem() { Name = "Strip Cyrillic Letters", Value = true };
-        }
+            => StripCyrillicLetters = new BoolItem() { Name = "Strip Cyrillic Letters", Value = true };
     }
 }

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationData.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationData.cs
@@ -33,10 +33,7 @@ namespace Jackett.Common.Models.IndexerConfig
 
         }
 
-        public ConfigurationData(JToken json, IProtectionService ps)
-        {
-            LoadValuesFromJson(json, ps);
-        }
+        public ConfigurationData(JToken json, IProtectionService ps) => LoadValuesFromJson(json, ps);
 
         public void LoadValuesFromJson(JToken json, IProtectionService ps = null)
         {
@@ -188,11 +185,9 @@ namespace Jackett.Common.Models.IndexerConfig
             return properties.ToArray();
         }
 
-        public void AddDynamic(string ID, Item item)
-        {
-            dynamics[ID] = item;
-        }
+        public void AddDynamic(string ID, Item item) => dynamics[ID] = item;
 
+        // TODO Convert to TryGetValue to avoid throwing exception
         public Item GetDynamic(string ID)
         {
             try
@@ -206,15 +201,13 @@ namespace Jackett.Common.Models.IndexerConfig
         }
 
         public Item GetDynamicByName(string Name)
-        {
-            return dynamics.Values.Where(i => string.Equals(i.Name, Name, StringComparison.InvariantCultureIgnoreCase)).FirstOrDefault();
-        }
+            => dynamics.Values.FirstOrDefault(i => string.Equals(i.Name, Name, StringComparison.InvariantCultureIgnoreCase));
 
         public class Item
         {
             public ItemType ItemType { get; set; }
             public string Name { get; set; }
-            public string ID { get { return Name.Replace(" ", "").ToLower(); } }
+            public string ID => Name.Replace(" ", "").ToLower();
         }
 
         public class HiddenItem : StringItem
@@ -240,10 +233,7 @@ namespace Jackett.Common.Models.IndexerConfig
             public string SiteKey { get; set; }
             public string Value { get; set; }
             public string Cookie { get; set; }
-            public StringItem()
-            {
-                ItemType = ConfigurationData.ItemType.InputString;
-            }
+            public StringItem() => ItemType = ItemType.InputString;
         }
 
         public class RecaptchaItem : StringItem
@@ -253,26 +243,20 @@ namespace Jackett.Common.Models.IndexerConfig
             public RecaptchaItem()
             {
                 Version = "2";
-                ItemType = ConfigurationData.ItemType.Recaptcha;
+                ItemType = ItemType.Recaptcha;
             }
         }
 
         public class BoolItem : Item
         {
             public bool Value { get; set; }
-            public BoolItem()
-            {
-                ItemType = ConfigurationData.ItemType.InputBool;
-            }
+            public BoolItem() => ItemType = ItemType.InputBool;
         }
 
         public class ImageItem : Item
         {
             public byte[] Value { get; set; }
-            public ImageItem()
-            {
-                ItemType = ConfigurationData.ItemType.DisplayImage;
-            }
+            public ImageItem() => ItemType = ItemType.DisplayImage;
         }
 
         public class CheckboxItem : Item

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataAPIKey.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataAPIKey.cs
@@ -2,11 +2,8 @@ namespace Jackett.Common.Models.IndexerConfig
 {
     public class ConfigurationDataAPIKey : ConfigurationData
     {
-        public ConfigurationData.StringItem Key { get; private set; }
+        public StringItem Key { get; private set; }
 
-        public ConfigurationDataAPIKey()
-        {
-            Key = new ConfigurationData.StringItem { Name = "APIKey", Value = string.Empty };
-        }
+        public ConfigurationDataAPIKey() => Key = new StringItem { Name = "APIKey", Value = string.Empty };
     }
 }

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataLoginTokin.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataLoginTokin.cs
@@ -11,14 +11,8 @@ namespace Jackett.Common.Models.IndexerConfig
 
         public DateTime LastTokenFetchDateTime
         {
-            get
-            {
-                return DateTimeUtil.UnixTimestampToDateTime(ParseUtil.CoerceDouble(LastTokenFetchDate.Value));
-            }
-            set
-            {
-                LastTokenFetchDate.Value = DateTimeUtil.DateTimeToUnixTimestamp(value).ToString(CultureInfo.InvariantCulture);
-            }
+            get => DateTimeUtil.UnixTimestampToDateTime(ParseUtil.CoerceDouble(LastTokenFetchDate.Value));
+            set => LastTokenFetchDate.Value = DateTimeUtil.DateTimeToUnixTimestamp(value).ToString(CultureInfo.InvariantCulture);
         }
 
         public ConfigurationDataLoginTokin() : base()

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataPinNumber.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataPinNumber.cs
@@ -4,9 +4,6 @@ namespace Jackett.Common.Models.IndexerConfig
     {
         public StringItem Pin { get; private set; }
 
-        public ConfigurationDataPinNumber() : base()
-        {
-            Pin = new StringItem { Name = "Login Pin Number" };
-        }
+        public ConfigurationDataPinNumber() => Pin = new StringItem { Name = "Login Pin Number" };
     }
 }

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataUrl.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataUrl.cs
@@ -6,14 +6,8 @@ namespace Jackett.Common.Models.IndexerConfig
     {
         public StringItem Url { get; private set; }
 
-        public ConfigurationDataUrl(Uri defaultUrl)
-        {
-            Url = new StringItem { Name = "Url", Value = defaultUrl.ToString() };
-        }
+        public ConfigurationDataUrl(Uri defaultUrl) => Url = new StringItem { Name = "Url", Value = defaultUrl.ToString() };
 
-        public ConfigurationDataUrl(string defaultUrl)
-        {
-            Url = new StringItem { Name = "Url", Value = defaultUrl };
-        }
+        public ConfigurationDataUrl(string defaultUrl) => Url = new StringItem { Name = "Url", Value = defaultUrl };
     }
 }

--- a/src/Jackett.Common/Models/IndexerDefinition.cs
+++ b/src/Jackett.Common/Models/IndexerDefinition.cs
@@ -8,52 +8,22 @@ namespace Jackett.Common.Models
     {
         public selectorBlock this[string key]
         {
-            get
-            {
-                throw new NotImplementedException();
-            }
+            get => throw new NotImplementedException();
 
-            set
-            {
-                base.Add(new KeyValuePair<string, selectorBlock>(key, value));
-            }
+            set => Add(new KeyValuePair<string, selectorBlock>(key, value));
         }
 
-        public ICollection<string> Keys
-        {
-            get
-            {
-                throw new NotImplementedException();
-            }
-        }
+        public ICollection<string> Keys => throw new NotImplementedException();
 
-        public ICollection<selectorBlock> Values
-        {
-            get
-            {
-                throw new NotImplementedException();
-            }
-        }
+        public ICollection<selectorBlock> Values => throw new NotImplementedException();
 
-        public void Add(string key, selectorBlock value)
-        {
-            base.Add(new KeyValuePair<string, selectorBlock>(key, value));
-        }
+        public void Add(string key, selectorBlock value) => Add(new KeyValuePair<string, selectorBlock>(key, value));
 
-        public bool ContainsKey(string key)
-        {
-            throw new NotImplementedException();
-        }
+        public bool ContainsKey(string key) => throw new NotImplementedException();
 
-        public bool Remove(string key)
-        {
-            throw new NotImplementedException();
-        }
+        public bool Remove(string key) => throw new NotImplementedException();
 
-        public bool TryGetValue(string key, out selectorBlock value)
-        {
-            throw new NotImplementedException();
-        }
+        public bool TryGetValue(string key, out selectorBlock value) => throw new NotImplementedException();
     }
 
     // Cardigann yaml classes
@@ -106,7 +76,7 @@ namespace Jackett.Common.Models
     {
         public string Type { get; set; }
         public string Selector { get; set; }
-        public string Image { get { throw new Exception("Deprecated, please use Login.Captcha.Selector instead"); } set { throw new Exception("Deprecated, please use login/captcha/selector instead of image"); } }
+        public string Image { get => throw new Exception("Deprecated, please use Login.Captcha.Selector instead"); set => throw new Exception("Deprecated, please use login/captcha/selector instead of image"); }
         public string Input { get; set; }
     }
 

--- a/src/Jackett.Common/Models/ReleaseInfo.cs
+++ b/src/Jackett.Common/Models/ReleaseInfo.cs
@@ -36,14 +36,9 @@ namespace Jackett.Common.Models
         [JsonIgnore] // don't export the Origin to the manul search API, otherwise each result line contains a full recursive indexer JSON structure
         public IIndexer Origin;
 
-        public double? Gain
-        {
-            get
-            {
-                var sizeInGB = Size / 1024.0 / 1024.0 / 1024.0;
-                return Seeders * sizeInGB;
-            }
-        }
+
+        private static double? GigabytesFromBytes(double? size) => size / 1024.0 / 1024.0 / 1024.0; 
+        public double? Gain => Seeders * GigabytesFromBytes(Size);
 
         public ReleaseInfo()
         {
@@ -75,10 +70,7 @@ namespace Jackett.Common.Models
             UploadVolumeFactor = copyFrom.UploadVolumeFactor;
         }
 
-        public virtual object Clone()
-        {
-            return new ReleaseInfo(this);
-        }
+        public virtual object Clone() => new ReleaseInfo(this);
 
         // ex: " 3.5  gb   "
         public static long GetBytes(string str)
@@ -103,29 +95,15 @@ namespace Jackett.Common.Models
             return (long)value;
         }
 
-        public static long BytesFromTB(float tb)
-        {
-            return BytesFromGB(tb * 1024f);
-        }
+        public static long BytesFromTB(float tb) => BytesFromGB(tb * 1024f);
 
-        public static long BytesFromGB(float gb)
-        {
-            return BytesFromMB(gb * 1024f);
-        }
+        public static long BytesFromGB(float gb) => BytesFromMB(gb * 1024f);
 
-        public static long BytesFromMB(float mb)
-        {
-            return BytesFromKB(mb * 1024f);
-        }
+        public static long BytesFromMB(float mb) => BytesFromKB(mb * 1024f);
 
-        public static long BytesFromKB(float kb)
-        {
-            return (long)(kb * 1024f);
-        }
+        public static long BytesFromKB(float kb) => (long)(kb * 1024f);
 
-        public override string ToString()
-        {
-            return string.Format("[ReleaseInfo: Title={0}, Guid={1}, Link={2}, Comments={3}, PublishDate={4}, Category={5}, Size={6}, Files={7}, Grabs={8}, Description={9}, RageID={10}, TVDBId={11}, Imdb={12}, TMDb={13}, Seeders={14}, Peers={15}, BannerUrl={16}, InfoHash={17}, MagnetUri={18}, MinimumRatio={19}, MinimumSeedTime={20}, DownloadVolumeFactor={21}, UploadVolumeFactor={22}, Gain={23}]", Title, Guid, Link, Comments, PublishDate, Category, Size, Files, Grabs, Description, RageID, TVDBId, Imdb, TMDb, Seeders, Peers, BannerUrl, InfoHash, MagnetUri, MinimumRatio, MinimumSeedTime, DownloadVolumeFactor, UploadVolumeFactor, Gain);
-        }
+        public override string ToString() =>
+            $"[ReleaseInfo: Title={Title}, Guid={Guid}, Link={Link}, Comments={Comments}, PublishDate={PublishDate}, Category={Category}, Size={Size}, Files={Files}, Grabs={Grabs}, Description={Description}, RageID={RageID}, TVDBId={TVDBId}, Imdb={Imdb}, TMDb={TMDb}, Seeders={Seeders}, Peers={Peers}, BannerUrl={BannerUrl}, InfoHash={InfoHash}, MagnetUri={MagnetUri}, MinimumRatio={MinimumRatio}, MinimumSeedTime={MinimumSeedTime}, DownloadVolumeFactor={DownloadVolumeFactor}, UploadVolumeFactor={UploadVolumeFactor}, Gain={Gain}]";
     }
 }

--- a/src/Jackett.Common/Models/ResultPage.cs
+++ b/src/Jackett.Common/Models/ResultPage.cs
@@ -29,10 +29,7 @@ namespace Jackett.Common.Models
             return f;
         }
 
-        private XElement getTorznabElement(string name, object value)
-        {
-            return value == null ? null : new XElement(torznabNs + "attr", new XAttribute("name", name), new XAttribute("value", value));
-        }
+        private XElement getTorznabElement(string name, object value) => value == null ? null : new XElement(torznabNs + "attr", new XAttribute("name", name), new XAttribute("value", value));
 
         public string ToXml(Uri selfAtom)
         {

--- a/src/Jackett.Common/Models/TorznabCapabilities.cs
+++ b/src/Jackett.Common/Models/TorznabCapabilities.cs
@@ -7,8 +7,8 @@ namespace Jackett.Common.Models
 {
     public class TorznabCapabilities
     {
-        public int? LimitsMax { get; set; } = null;
-        public int? LimitsDefault { get; set; } = null;
+        public int? LimitsMax { get; set; }
+        public int? LimitsDefault { get; set; }
 
         public bool SearchAvailable { get; set; }
 
@@ -22,13 +22,7 @@ namespace Jackett.Common.Models
 
         public bool SupportsImdbTVSearch { get; set; }
 
-        public bool MusicSearchAvailable
-        {
-            get
-            {
-                return (SupportedMusicSearchParamsList.Count > 0);
-            }
-        }
+        public bool MusicSearchAvailable => (SupportedMusicSearchParamsList.Count > 0);
 
         public List<string> SupportedMusicSearchParamsList;
 
@@ -83,13 +77,7 @@ namespace Jackett.Common.Models
             }
         }
 
-        private string SupportedMusicSearchParams
-        {
-            get
-            {
-                return string.Join(",", SupportedMusicSearchParamsList);
-            }
-        }
+        private string SupportedMusicSearchParams => string.Join(",", SupportedMusicSearchParamsList);
 
         public bool SupportsCategories(int[] categories)
         {
@@ -153,12 +141,9 @@ namespace Jackett.Common.Models
             return xdoc;
         }
 
-        public string ToXml()
-        {
-            var xdoc = GetXDocument();
+        public string ToXml() =>
+            GetXDocument().Declaration + Environment.NewLine + GetXDocument();
 
-            return xdoc.Declaration.ToString() + Environment.NewLine + xdoc.ToString();
-        }
         public static TorznabCapabilities Concat(TorznabCapabilities lhs, TorznabCapabilities rhs)
         {
             lhs.SearchAvailable = lhs.SearchAvailable || rhs.SearchAvailable;

--- a/src/Jackett.Common/Models/TorznabCatType.cs
+++ b/src/Jackett.Common/Models/TorznabCatType.cs
@@ -8,6 +8,14 @@ namespace Jackett.Common.Models
 
         public static bool QueryContainsParentCategory(int[] queryCats, ICollection<int> releaseCats)
         {
+            //return (from releaseCat in releaseCats
+            //        select AllCats.FirstOrDefault(c => c.ID == releaseCat)
+            //        into cat
+            //        where cat != null && queryCats != null
+            //        select cat.SubCategories.Any(c => queryCats.Contains(c.ID)))
+            //    .FirstOrDefault();
+            // Is equal to:
+
             foreach (var releaseCat in releaseCats)
             {
                 var cat = AllCats.FirstOrDefault(c => c.ID == releaseCat);
@@ -20,32 +28,12 @@ namespace Jackett.Common.Models
             return false;
         }
 
-        public static string GetCatDesc(int newznabcat)
-        {
-            var cat = AllCats.FirstOrDefault(c => c.ID == newznabcat);
-            if (cat != null)
-            {
-                return cat.Name;
-            }
+        public static string GetCatDesc(int newznabcat) =>
+            AllCats.FirstOrDefault(c => c.ID == newznabcat)?.Name
+            ?? string.Empty;
 
-            return string.Empty;
-        }
+        public static string NormalizeCatName(string name) => name.Replace(" ", "").ToLower();
 
-        public static string NormalizeCatName(string name)
-        {
-            return name.Replace(" ", "").ToLower();
-        }
-
-        public static TorznabCategory GetCatByName(string name)
-        {
-            var cat = AllCats.FirstOrDefault(c => NormalizeCatName(c.Name) == NormalizeCatName(name));
-            if (cat != null)
-            {
-                return cat;
-            }
-
-            return null;
-        }
-
+        public static TorznabCategory GetCatByName(string name) => AllCats.FirstOrDefault(c => NormalizeCatName(c.Name) == NormalizeCatName(name));
     }
 }

--- a/src/Jackett.Common/Models/TorznabCategory.cs
+++ b/src/Jackett.Common/Models/TorznabCategory.cs
@@ -10,10 +10,7 @@ namespace Jackett.Common.Models
 
         public List<TorznabCategory> SubCategories { get; private set; }
 
-        public TorznabCategory()
-        {
-            SubCategories = new List<TorznabCategory>();
-        }
+        public TorznabCategory() => SubCategories = new List<TorznabCategory>();
 
         public TorznabCategory(int id, string name)
         {
@@ -22,36 +19,20 @@ namespace Jackett.Common.Models
             SubCategories = new List<TorznabCategory>();
         }
 
-        public bool Contains(TorznabCategory cat)
-        {
-            if (this == cat)
-                return true;
+        public bool Contains(TorznabCategory cat) =>
+            Equals(this, cat) || SubCategories.Contains(cat);
 
-            if (SubCategories.Contains(cat))
-                return true;
+        public JToken ToJson() =>
+            new JObject
+            {
+                ["ID"] = ID,
+                ["Name"] = Name
+            };
 
-            return false;
-        }
+        public override bool Equals(object obj) => (obj as TorznabCategory)?.ID == ID;
 
-        public JToken ToJson()
-        {
-            var t = new JObject();
-            t["ID"] = ID;
-            t["Name"] = Name;
-            return t;
-        }
-
-        public override bool Equals(object obj)
-        {
-            if (obj == null || GetType() != obj.GetType())
-                return false;
-
-            return ID == ((TorznabCategory)obj).ID;
-        }
-
-        public override int GetHashCode()
-        {
-            return ID;
-        }
+        // Get Hash code should be calculated off read only properties.
+        // ID is not readonly
+        public override int GetHashCode() => ID;
     }
 }

--- a/src/Jackett.Common/Models/TorznabQuery.cs
+++ b/src/Jackett.Common/Models/TorznabQuery.cs
@@ -31,65 +31,23 @@ namespace Jackett.Common.Models
 
         public bool IsTest { get; set; }
 
-        public string ImdbIDShort { get { return (ImdbID != null ? ImdbID.TrimStart('t') : null); } }
+        public string ImdbIDShort => ImdbID?.TrimStart('t');
 
-        protected string[] QueryStringParts = null;
+        protected string[] QueryStringParts;
 
-        public bool IsSearch
-        {
-            get
-            {
-                return QueryType == "search";
-            }
-        }
+        public bool IsSearch => QueryType == "search";
 
-        public bool IsTVSearch
-        {
-            get
-            {
-                return QueryType == "tvsearch";
-            }
-        }
+        public bool IsTVSearch => QueryType == "tvsearch";
 
-        public bool IsMovieSearch
-        {
-            get
-            {
-                return QueryType == "movie" || (QueryType == "TorrentPotato" && !string.IsNullOrWhiteSpace(SearchTerm));
-            }
-        }
+        public bool IsMovieSearch => QueryType == "movie" || (QueryType == "TorrentPotato" && !string.IsNullOrWhiteSpace(SearchTerm));
 
-        public bool IsMusicSearch
-        {
-            get
-            {
-                return QueryType == "music";
-            }
-        }
+        public bool IsMusicSearch => QueryType == "music";
 
-        public bool IsTVRageSearch
-        {
-            get
-            {
-                return RageID != null;
-            }
-        }
+        public bool IsTVRageSearch => RageID != null;
 
-        public bool IsImdbQuery
-        {
-            get
-            {
-                return ImdbID != null;
-            }
-        }
+        public bool IsImdbQuery => ImdbID != null;
 
-        public bool HasSpecifiedCategories
-        {
-            get
-            {
-                return (Categories != null && Categories.Length > 0);
-            }
-        }
+        public bool HasSpecifiedCategories => (Categories != null && Categories.Length > 0);
 
         public string SanitizedSearchTerm
         {
@@ -99,20 +57,20 @@ namespace Jackett.Common.Models
                 if (SearchTerm == null)
                     term = "";
                 var safetitle = term.Where(c => (char.IsLetterOrDigit(c)
-                                                  || char.IsWhiteSpace(c)
-                                                  || c == '-'
-                                                  || c == '.'
-                                                  || c == '_'
-                                                  || c == '('
-                                                  || c == ')'
-                                                  || c == '@'
-                                                  || c == '/'
-                                                  || c == '\''
-                                                  || c == '['
-                                                  || c == ']'
-                                                  || c == '+'
-                                                  || c == '%'
-                                      )).AsString();
+                                                 || char.IsWhiteSpace(c)
+                                                 || c == '-'
+                                                 || c == '.'
+                                                 || c == '_'
+                                                 || c == '('
+                                                 || c == ')'
+                                                 || c == '@'
+                                                 || c == '/'
+                                                 || c == '\''
+                                                 || c == '['
+                                                 || c == ']'
+                                                 || c == '+'
+                                                 || c == '%'
+                                               )).AsString();
                 return safetitle;
             }
         }
@@ -169,6 +127,7 @@ namespace Jackett.Common.Models
             ret.Year = Year;
             if (Genre != null)
             {
+                // Make a copied list and then don't use it?
                 Genre.Select(item => item.Clone()).ToList();
             }
             if (QueryStringParts != null && QueryStringParts.Length > 0)
@@ -182,10 +141,7 @@ namespace Jackett.Common.Models
             return ret;
         }
 
-        public string GetQueryString()
-        {
-            return (SanitizedSearchTerm + " " + GetEpisodeSearchString()).Trim();
-        }
+        public string GetQueryString() => (SanitizedSearchTerm + " " + GetEpisodeSearchString()).Trim();
 
         // Some trackers don't support AND logic for search terms resulting in unwanted results.
         // Using this method we can AND filter it within jackett.

--- a/src/Jackett.Common/Plumbing/JackettModule.cs
+++ b/src/Jackett.Common/Plumbing/JackettModule.cs
@@ -14,10 +14,7 @@ namespace Jackett.Common.Plumbing
     {
         private readonly RuntimeSettings _runtimeSettings;
 
-        public JackettModule(RuntimeSettings runtimeSettings)
-        {
-            _runtimeSettings = runtimeSettings;
-        }
+        public JackettModule(RuntimeSettings runtimeSettings) => _runtimeSettings = runtimeSettings;
 
         protected override void Load(ContainerBuilder builder)
         {
@@ -41,10 +38,7 @@ namespace Jackett.Common.Plumbing
 
 
             builder.RegisterInstance(_runtimeSettings);
-            builder.Register(ctx =>
-            {
-                return BuildServerConfig(ctx);
-            }).As<ServerConfig>().SingleInstance();
+            builder.Register(BuildServerConfig).As<ServerConfig>().SingleInstance();
             builder.RegisterType<HttpWebClient>();
 
             // Register the best web client for the platform or the override
@@ -69,10 +63,7 @@ namespace Jackett.Common.Plumbing
             }
         }
 
-        private void RegisterWebClient<WebClientType>(ContainerBuilder builder)
-        {
-            builder.RegisterType<WebClientType>().As<WebClient>();
-        }
+        private void RegisterWebClient<WebClientType>(ContainerBuilder builder) => builder.RegisterType<WebClientType>().As<WebClient>();
 
         private ServerConfig BuildServerConfig(IComponentContext ctx)
         {

--- a/src/Jackett.Common/Services/ConfigurationService.cs
+++ b/src/Jackett.Common/Services/ConfigurationService.cs
@@ -29,10 +29,7 @@ namespace Jackett.Common.Services
             CreateOrMigrateSettings();
         }
 
-        public string GetAppDataFolder()
-        {
-            return runtimeSettings.DataFolder;
-        }
+        public string GetAppDataFolder() => runtimeSettings.DataFolder;
 
         public void CreateOrMigrateSettings()
         {
@@ -146,7 +143,7 @@ namespace Jackett.Common.Services
             catch (Exception e)
             {
                 logger.Error(e, "Error reading config file " + fullPath);
-                return default(T);
+                return default;
             }
         }
 
@@ -167,16 +164,12 @@ namespace Jackett.Common.Services
             }
         }
 
-        public string ApplicationFolder()
-        {
-            return Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
-        }
+        public string ApplicationFolder() => Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
 
         public string GetContentFolder()
         {
             // If we are debugging we can use the non copied content.
             var dir = Path.Combine(ApplicationFolder(), "Content");
-            ;
 
 #if DEBUG
             // When we are running in debug use the source files
@@ -206,7 +199,6 @@ namespace Jackett.Common.Services
 
             // If we are debugging we can use the non copied definitions.
             var dir = Path.Combine(ApplicationFolder(), "Definitions");
-            ;
 
 #if DEBUG
             // When we are running in debug use the source files
@@ -222,25 +214,13 @@ namespace Jackett.Common.Services
 
 
 
-        public string GetIndexerConfigDir()
-        {
-            return Path.Combine(GetAppDataFolder(), "Indexers");
-        }
+        public string GetIndexerConfigDir() => Path.Combine(GetAppDataFolder(), "Indexers");
 
-        public string GetConfigFile()
-        {
-            return Path.Combine(GetAppDataFolder(), "config.json");
-        }
+        public string GetConfigFile() => Path.Combine(GetAppDataFolder(), "config.json");
 
-        public string GetSonarrConfigFile()
-        {
-            return Path.Combine(GetAppDataFolder(), "sonarr_api.json");
-        }
+        public string GetSonarrConfigFile() => Path.Combine(GetAppDataFolder(), "sonarr_api.json");
 
-        public string GetVersion()
-        {
-            return EnvironmentUtil.JackettVersion;
-        }
+        public string GetVersion() => EnvironmentUtil.JackettVersion;
 
         public ServerConfig BuildServerConfig(RuntimeSettings runtimeSettings)
         {
@@ -269,11 +249,9 @@ namespace Jackett.Common.Services
                 // Check for legacy settings
 
                 var path = Path.Combine(GetAppDataFolder(), "config.json");
-                ;
-                var jsonReply = new JObject();
                 if (File.Exists(path))
                 {
-                    jsonReply = JObject.Parse(File.ReadAllText(path));
+                    var jsonReply = JObject.Parse(File.ReadAllText(path));
                     config.Port = (int)jsonReply["port"];
                     config.AllowExternal = (bool)jsonReply["public"];
                 }

--- a/src/Jackett.Common/Services/IndexerConfigurationService.cs
+++ b/src/Jackett.Common/Services/IndexerConfigurationService.cs
@@ -141,10 +141,7 @@ namespace Jackett.Common.Services
             }
         }
 
-        private string GetIndexerConfigFilePath(IIndexer indexer)
-        {
-            return Path.Combine(configService.GetIndexerConfigDir(), indexer.ID + ".json");
-        }
+        private string GetIndexerConfigFilePath(IIndexer indexer) => Path.Combine(configService.GetIndexerConfigDir(), indexer.ID + ".json");
 
         private readonly IConfigurationService configService;
         private readonly Logger logger;

--- a/src/Jackett.Common/Services/IndexerManagerService.cs
+++ b/src/Jackett.Common/Services/IndexerManagerService.cs
@@ -208,10 +208,7 @@ namespace Jackett.Common.Services
             throw new Exception("Unknown indexer: " + name);
         }
 
-        public IEnumerable<IIndexer> GetAllIndexers()
-        {
-            return indexers.Values.OrderBy(_ => _.DisplayName);
-        }
+        public IEnumerable<IIndexer> GetAllIndexers() => indexers.Values.OrderBy(_ => _.DisplayName);
 
         public async Task TestIndexer(string name)
         {

--- a/src/Jackett.Common/Services/LogCacheService.cs
+++ b/src/Jackett.Common/Services/LogCacheService.cs
@@ -39,9 +39,6 @@ namespace Jackett.Common.Services
             }
         }
 
-        protected override void Write(LogEventInfo logEvent)
-        {
-            AddLog(logEvent);
-        }
+        protected override void Write(LogEventInfo logEvent) => AddLog(logEvent);
     }
 }

--- a/src/Jackett.Common/Services/ProcessService.cs
+++ b/src/Jackett.Common/Services/ProcessService.cs
@@ -10,10 +10,7 @@ namespace Jackett.Common.Services
     {
         private readonly Logger logger;
 
-        public ProcessService(Logger l)
-        {
-            logger = l;
-        }
+        public ProcessService(Logger l) => logger = l;
 
         private void Run(string exe, string args, bool asAdmin, DataReceivedEventHandler d, DataReceivedEventHandler r)
         {

--- a/src/Jackett.Common/Services/SerializeService.cs
+++ b/src/Jackett.Common/Services/SerializeService.cs
@@ -6,10 +6,7 @@ namespace Jackett.Common.Services
 
     public class SerializeService : ISerializeService
     {
-        public string Serialise(object obj)
-        {
-            return JsonConvert.SerializeObject(obj, Formatting.Indented);
-        }
+        public string Serialise(object obj) => JsonConvert.SerializeObject(obj, Formatting.Indented);
 
         public T DeSerialise<T>(string json)
         {

--- a/src/Jackett.Common/Services/TrayLockService.cs
+++ b/src/Jackett.Common/Services/TrayLockService.cs
@@ -9,10 +9,7 @@ namespace Jackett.Common.Services
     {
         private readonly string EVENT_HANDLE_NAME = @"Global\JACKETT.TRAY";
 
-        private EventWaitHandle GetEventHandle()
-        {
-            return new EventWaitHandle(false, EventResetMode.ManualReset, EVENT_HANDLE_NAME);
-        }
+        private EventWaitHandle GetEventHandle() => new EventWaitHandle(false, EventResetMode.ManualReset, EVENT_HANDLE_NAME);
 
         public void WaitForSignal()
         {

--- a/src/Jackett.Common/Services/UpdateService.cs
+++ b/src/Jackett.Common/Services/UpdateService.cs
@@ -58,10 +58,7 @@ namespace Jackett.Common.Services
             return new FileInfo(location.LocalPath).FullName;
         }
 
-        public void StartUpdateChecker()
-        {
-            Task.Factory.StartNew(UpdateWorkerThread);
-        }
+        public void StartUpdateChecker() => Task.Factory.StartNew(UpdateWorkerThread);
 
         public void CheckForUpdatesNow()
         {
@@ -81,10 +78,7 @@ namespace Jackett.Common.Services
             }
         }
 
-        private bool AcceptCert(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
-        {
-            return true;
-        }
+        private bool AcceptCert(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors) => true;
 
         private async Task CheckForUpdates()
         {
@@ -183,18 +177,11 @@ namespace Jackett.Common.Services
             }
         }
 
-        private string GetUpdaterPath(string tempDirectory)
-        {
-            if (variant == Variants.JackettVariant.CoreMacOs || variant == Variants.JackettVariant.CoreLinuxAmdx64 ||
-                variant == Variants.JackettVariant.CoreLinuxArm32 || variant == Variants.JackettVariant.CoreLinuxArm64)
-            {
-                return Path.Combine(tempDirectory, "Jackett", "JackettUpdater");
-            }
-            else
-            {
-                return Path.Combine(tempDirectory, "Jackett", "JackettUpdater.exe");
-            }
-        }
+        private string GetUpdaterPath(string tempDirectory) =>
+            variant == Variants.JackettVariant.CoreMacOs || variant == Variants.JackettVariant.CoreLinuxAmdx64 ||
+            variant == Variants.JackettVariant.CoreLinuxArm32 || variant == Variants.JackettVariant.CoreLinuxArm64
+                ? Path.Combine(tempDirectory, "Jackett", "JackettUpdater")
+                : Path.Combine(tempDirectory, "Jackett", "JackettUpdater.exe");
 
         private string GetCurrentVersion()
         {
@@ -251,7 +238,7 @@ namespace Jackett.Common.Services
         {
             var variants = new Variants();
             var artifactFileName = variants.GetArtifactFileName(variant);
-            var targetAsset = assets.Where(a => a.Browser_download_url.EndsWith(artifactFileName, StringComparison.OrdinalIgnoreCase) && artifactFileName.Length > 0).FirstOrDefault();
+            var targetAsset = assets.FirstOrDefault(a => a.Browser_download_url.EndsWith(artifactFileName, StringComparison.OrdinalIgnoreCase) && artifactFileName.Length > 0);
 
             if (targetAsset == null)
             {

--- a/src/Jackett.Common/Services/WindowsServiceConfigService.cs
+++ b/src/Jackett.Common/Services/WindowsServiceConfigService.cs
@@ -24,18 +24,10 @@ namespace Jackett.Common.Services
             logger = l;
         }
 
-        public bool ServiceExists()
-        {
-            return GetService(NAME) != null;
-        }
+        public bool ServiceExists() => GetService(NAME) != null;
 
-        public bool ServiceRunning()
-        {
-            var service = GetService(NAME);
-            if (service == null)
-                return false;
-            return service.Status == ServiceControllerStatus.Running;
-        }
+        public bool ServiceRunning() =>
+            GetService(NAME)?.Status == ServiceControllerStatus.Running;
 
         public void Start()
         {
@@ -49,10 +41,7 @@ namespace Jackett.Common.Services
             service.Stop();
         }
 
-        public ServiceController GetService(string serviceName)
-        {
-            return ServiceController.GetServices().FirstOrDefault(c => string.Equals(c.ServiceName, serviceName, StringComparison.InvariantCultureIgnoreCase));
-        }
+        public ServiceController GetService(string serviceName) => ServiceController.GetServices().FirstOrDefault(c => string.Equals(c.ServiceName, serviceName, StringComparison.InvariantCultureIgnoreCase));
 
         public void Install()
         {

--- a/src/Jackett.Common/Utils/BuildDate.cs
+++ b/src/Jackett.Common/Utils/BuildDate.cs
@@ -17,10 +17,7 @@ namespace Jackett.Common.Utils
     [AttributeUsage(AttributeTargets.Assembly)]
     public class BuildDateAttribute : Attribute
     {
-        public BuildDateAttribute(string value)
-        {
-            DateTime = DateTime.ParseExact(value, "yyyyMMddHHmmss", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
-        }
+        public BuildDateAttribute(string value) => DateTime = DateTime.ParseExact(value, "yyyyMMddHHmmss", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal);
 
         public DateTime DateTime { get; }
     }

--- a/src/Jackett.Common/Utils/Clients/BaseWebResult.cs
+++ b/src/Jackett.Common/Utils/Clients/BaseWebResult.cs
@@ -11,16 +11,10 @@ namespace Jackett.Common.Utils.Clients
         public WebRequest Request { get; set; }
         public Dictionary<string, string[]> Headers = new Dictionary<string, string[]>();
 
-        public bool IsRedirect
-        {
-            get
-            {
-                return Status == System.Net.HttpStatusCode.Redirect ||
+        public bool IsRedirect => Status == System.Net.HttpStatusCode.Redirect ||
                         Status == System.Net.HttpStatusCode.RedirectKeepVerb ||
                         Status == System.Net.HttpStatusCode.RedirectMethod ||
                         Status == System.Net.HttpStatusCode.Found ||
                         Status == System.Net.HttpStatusCode.MovedPermanently;
-            }
-        }
     }
 }

--- a/src/Jackett.Common/Utils/Clients/WebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/WebClient.cs
@@ -26,11 +26,8 @@ namespace Jackett.Common.Utils.Clients
         public bool EmulateBrowser = true;
         public double requestDelay
         {
-            get { return requestDelayTimeSpan.TotalSeconds; }
-            set
-            {
-                requestDelayTimeSpan = TimeSpan.FromSeconds(value);
-            }
+            get => requestDelayTimeSpan.TotalSeconds;
+            set => requestDelayTimeSpan = TimeSpan.FromSeconds(value);
         }
 
         protected virtual void OnConfigChange()
@@ -167,20 +164,14 @@ namespace Jackett.Common.Utils.Clients
         }
 
 #pragma warning disable CS1998 // Async method lacks 'await' operators and will run synchronously
-        protected virtual async Task<WebClientByteResult> Run(WebRequest webRequest) { throw new NotImplementedException(); }
+        protected virtual async Task<WebClientByteResult> Run(WebRequest webRequest) => throw new NotImplementedException();
 #pragma warning restore CS1998 // Async method lacks 'await' operators and will run synchronously
 
         public abstract void Init();
 
-        public virtual void OnCompleted()
-        {
-            throw new NotImplementedException();
-        }
+        public virtual void OnCompleted() => throw new NotImplementedException();
 
-        public virtual void OnError(Exception error)
-        {
-            throw new NotImplementedException();
-        }
+        public virtual void OnError(Exception error) => throw new NotImplementedException();
 
         public virtual void OnNext(ServerConfig value)
         {

--- a/src/Jackett.Common/Utils/Clients/WebRequest.cs
+++ b/src/Jackett.Common/Utils/Clients/WebRequest.cs
@@ -82,9 +82,6 @@ namespace Jackett.Common.Utils.Clients
                 return false;
             }
         }
-
-        // Calling base.GetHashCode() is redundant. Remove?
-        public override int GetHashCode() => base.GetHashCode();
     }
 
     public enum RequestType

--- a/src/Jackett.Common/Utils/Clients/WebRequest.cs
+++ b/src/Jackett.Common/Utils/Clients/WebRequest.cs
@@ -83,10 +83,8 @@ namespace Jackett.Common.Utils.Clients
             }
         }
 
-        public override int GetHashCode()
-        {
-            return base.GetHashCode();
-        }
+        // Calling base.GetHashCode() is redundant. Remove?
+        public override int GetHashCode() => base.GetHashCode();
     }
 
     public enum RequestType

--- a/src/Jackett.Common/Utils/EnvironmentUtil.cs
+++ b/src/Jackett.Common/Utils/EnvironmentUtil.cs
@@ -6,21 +6,9 @@ namespace Jackett.Common.Utils
     public static class EnvironmentUtil
     {
 
-        public static string JackettVersion
-        {
-            get
-            {
-                return Assembly.GetExecutingAssembly()?.GetName()?.Version?.ToString() ?? "Unknown Version";
-            }
-        }
+        public static string JackettVersion => Assembly.GetExecutingAssembly()?.GetName()?.Version?.ToString() ?? "Unknown Version";
 
-        public static bool IsWindows
-        {
-            get
-            {
-                return Environment.OSVersion.Platform == PlatformID.Win32NT;
-            }
-        }
+        public static bool IsWindows => Environment.OSVersion.Platform == PlatformID.Win32NT;
 
     }
 }

--- a/src/Jackett.Common/Utils/Extensions.cs
+++ b/src/Jackett.Common/Utils/Extensions.cs
@@ -6,6 +6,7 @@ using System.Xml.Linq;
 
 namespace Jackett.Common.Utils
 {
+    // Prefer built in NullReferenceException || ArgumentNullException || NoNullAllowedException
     public class NonNullException : Exception
     {
         public NonNullException() : base("Parameter cannot be null")
@@ -17,101 +18,66 @@ namespace Jackett.Common.Utils
     {
         public NonNull(T val)
         {
+            // doesn't throw Exception?
             if (val == null)
                 new NonNullException();
 
             Value = val;
         }
 
-        public static implicit operator T(NonNull<T> n)
-        {
-            return n.Value;
-        }
+        public static implicit operator T(NonNull<T> n) => n.Value;
 
         private readonly T Value;
     }
 
     public static class GenericConversionExtensions
     {
-        public static IEnumerable<T> ToEnumerable<T>(this T obj)
-        {
-            return new T[] { obj };
-        }
+        public static IEnumerable<T> ToEnumerable<T>(this T obj) => new T[] { obj };
 
-        public static NonNull<T> ToNonNull<T>(this T obj) where T : class
-        {
-            return new NonNull<T>(obj);
-        }
+        public static NonNull<T> ToNonNull<T>(this T obj) where T : class => new NonNull<T>(obj);
     }
 
     public static class EnumerableExtension
     {
-        public static string AsString(this IEnumerable<char> chars)
-        {
-            return string.Concat(chars);
-        }
+        public static string AsString(this IEnumerable<char> chars) => string.Concat(chars);
 
-        public static bool IsEmpty<T>(this IEnumerable<T> collection)
-        {
-            return collection.Count() > 0;
-        }
+        // Should be collection.Any()
+        // Remove in favor of existing built in function?
+        public static bool IsEmpty<T>(this IEnumerable<T> collection) => collection.Count() > 0;
 
-        public static IEnumerable<T> Flatten<T>(this IEnumerable<IEnumerable<T>> list)
-        {
-            return list.SelectMany(x => x);
-        }
+        public static IEnumerable<T> Flatten<T>(this IEnumerable<IEnumerable<T>> list) => list.SelectMany(x => x);
     }
 
+    // TODO This class should be removed in favor of explicit conversions
     public static class StringExtension
     {
-        public static bool IsNullOrEmptyOrWhitespace(this string str)
-        {
-            return string.IsNullOrEmpty(str) || string.IsNullOrWhiteSpace(str);
-        }
+        // string.IsNullOrWhitespace already checks string.IsNullOrEmpty should remove this?
+        public static bool IsNullOrEmptyOrWhitespace(this string str) => string.IsNullOrEmpty(str) || string.IsNullOrWhiteSpace(str);
 
-        public static DateTime ToDateTime(this string str)
-        {
-            return DateTime.Parse(str);
-        }
+        public static DateTime ToDateTime(this string str) => DateTime.Parse(str);
 
-        public static Uri ToUri(this string str)
-        {
-            return new Uri(str);
-        }
+        public static Uri ToUri(this string str) => new Uri(str);
     }
 
     public static class CollectionExtension
     {
-        public static bool IsEmpty<T>(this ICollection<T> obj)
-        {
-            return obj.Count == 0;
-        }
+        // IEnumerable class above already does this. All ICollection are IEnumerable, so favor IEnumerable?
+        public static bool IsEmpty<T>(this ICollection<T> obj) => obj.Count == 0;
 
-        public static bool IsEmptyOrNull<T>(this ICollection<T> obj)
-        {
-            return obj == null || obj.IsEmpty();
-        }
+
+        public static bool IsEmptyOrNull<T>(this ICollection<T> obj) => obj?.IsEmpty() == true;
     }
 
     public static class XElementExtension
     {
-        public static XElement First(this XElement element, string name)
-        {
-            return element.Descendants(name).First();
-        }
+        public static XElement First(this XElement element, string name) => element.Descendants(name).First();
 
-        public static string FirstValue(this XElement element, string name)
-        {
-            return element.First(name).Value;
-        }
+        public static string FirstValue(this XElement element, string name) => element.First(name).Value;
     }
 
     public static class KeyValuePairsExtension
     {
-        public static IDictionary<Key, Value> ToDictionary<Key, Value>(this IEnumerable<KeyValuePair<Key, Value>> pairs)
-        {
-            return pairs.ToDictionary(x => x.Key, x => x.Value);
-        }
+        public static IDictionary<Key, Value> ToDictionary<Key, Value>(this IEnumerable<KeyValuePair<Key, Value>> pairs) => pairs.ToDictionary(x => x.Key, x => x.Value);
     }
 
     public static class ParseExtension

--- a/src/Jackett.Common/Utils/JsonContent.cs
+++ b/src/Jackett.Common/Utils/JsonContent.cs
@@ -7,13 +7,14 @@ namespace Jackett.Common.Utils
     public class JsonContent : StringContent
     {
         public JsonContent(object value)
-            : this(value, Encoding.UTF8)
-        {
+            : this(value, Encoding.UTF8) =>
             Headers.ContentType.CharSet = "utf-8";
-        }
 
         public JsonContent(object value, Encoding encoding)
-            : base(JsonConvert.SerializeObject(value, Formatting.Indented, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }), encoding, "application/json")
+            : base(
+                JsonConvert.SerializeObject(
+                    value, Formatting.Indented, new JsonSerializerSettings {NullValueHandling = NullValueHandling.Ignore}),
+                encoding, "application/json")
         {
         }
     }

--- a/src/Jackett.Common/Utils/JsonUtil.cs
+++ b/src/Jackett.Common/Utils/JsonUtil.cs
@@ -6,10 +6,7 @@ namespace Jackett.Common.Utils
 {
     public class EncodingJsonConverter : JsonConverter
     {
-        public override bool CanConvert(Type objectType)
-        {
-            return true;
-        }
+        public override bool CanConvert(Type objectType) => true;
 
         public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
         {
@@ -17,14 +14,9 @@ namespace Jackett.Common.Utils
             writer.WriteValue(obj.WebName);
         }
 
-        public override bool CanRead
-        {
-            get { return false; }
-        }
+        public override bool CanRead => false;
 
-        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
-        {
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) =>
             throw new NotImplementedException();
-        }
     }
 }

--- a/src/Jackett.Common/Utils/LoggingSetup.cs
+++ b/src/Jackett.Common/Utils/LoggingSetup.cs
@@ -83,10 +83,8 @@ namespace Jackett.Common.Utils
         [LayoutRenderer("simpledatetime")]
         public class SimpleDateTimeRenderer : LayoutRenderer
         {
-            protected override void Append(StringBuilder builder, LogEventInfo logEvent)
-            {
+            protected override void Append(StringBuilder builder, LogEventInfo logEvent) =>
                 builder.Append(DateTime.Now.ToString("MM-dd HH:mm:ss"));
-            }
         }
     }
 }

--- a/src/Jackett.Common/Utils/ParseUtil.cs
+++ b/src/Jackett.Common/Utils/ParseUtil.cs
@@ -13,69 +13,33 @@ namespace Jackett.Common.Utils
                 RegexOptions.Compiled);
         private static readonly Regex ImdbId = new Regex(@"^(?:tt)?(\d{1,8})$", RegexOptions.Compiled);
 
-        public static string NormalizeSpace(string s)
-        {
-            return s.Trim();
-        }
+        public static string NormalizeSpace(string s) => s.Trim();
 
-        public static string NormalizeMultiSpaces(string s)
-        {
-            return new Regex(@"\s+").Replace(NormalizeSpace(s), " ");
-            ;
-        }
+        public static string NormalizeMultiSpaces(string s) =>
+            new Regex(@"\s+").Replace(NormalizeSpace(s), " ");
 
-        public static string NormalizeNumber(string s)
-        {
-            var normalized = NormalizeSpace(s);
-            normalized = normalized.Replace("-", "0");
-            normalized = normalized.Replace(",", "");
-            return normalized;
-        }
+        public static string NormalizeNumber(string s) =>
+            NormalizeSpace(s)
+                .Replace("-", "0")
+                .Replace(",", "");
 
-        public static string RemoveInvalidXmlChars(string text)
-        {
-            return string.IsNullOrEmpty(text) ? "" : InvalidXmlChars.Replace(text, "");
-        }
+        public static string RemoveInvalidXmlChars(string text) => string.IsNullOrEmpty(text) ? "" : InvalidXmlChars.Replace(text, "");
 
-        public static double CoerceDouble(string str)
-        {
-            return double.Parse(NormalizeNumber(str), NumberStyles.Any, CultureInfo.InvariantCulture);
-        }
+        public static double CoerceDouble(string str) => double.Parse(NormalizeNumber(str), NumberStyles.Any, CultureInfo.InvariantCulture);
 
-        public static float CoerceFloat(string str)
-        {
-            return float.Parse(NormalizeNumber(str), NumberStyles.Any, CultureInfo.InvariantCulture);
-        }
+        public static float CoerceFloat(string str) => float.Parse(NormalizeNumber(str), NumberStyles.Any, CultureInfo.InvariantCulture);
 
-        public static int CoerceInt(string str)
-        {
-            return int.Parse(NormalizeNumber(str), NumberStyles.Any, CultureInfo.InvariantCulture);
-        }
+        public static int CoerceInt(string str) => int.Parse(NormalizeNumber(str), NumberStyles.Any, CultureInfo.InvariantCulture);
 
-        public static long CoerceLong(string str)
-        {
-            return long.Parse(NormalizeNumber(str), NumberStyles.Any, CultureInfo.InvariantCulture);
-        }
+        public static long CoerceLong(string str) => long.Parse(NormalizeNumber(str), NumberStyles.Any, CultureInfo.InvariantCulture);
 
-        public static bool TryCoerceDouble(string str, out double result)
-        {
-            return double.TryParse(NormalizeNumber(str), NumberStyles.Any, CultureInfo.InvariantCulture, out result);
-        }
+        public static bool TryCoerceDouble(string str, out double result) => double.TryParse(NormalizeNumber(str), NumberStyles.Any, CultureInfo.InvariantCulture, out result);
 
-        public static bool TryCoerceFloat(string str, out float result)
-        {
-            return float.TryParse(NormalizeNumber(str), NumberStyles.Any, CultureInfo.InvariantCulture, out result);
-        }
+        public static bool TryCoerceFloat(string str, out float result) => float.TryParse(NormalizeNumber(str), NumberStyles.Any, CultureInfo.InvariantCulture, out result);
 
-        public static bool TryCoerceInt(string str, out int result)
-        {
-            return int.TryParse(NormalizeNumber(str), NumberStyles.Any, CultureInfo.InvariantCulture, out result);
-        }
+        public static bool TryCoerceInt(string str, out int result) => int.TryParse(NormalizeNumber(str), NumberStyles.Any, CultureInfo.InvariantCulture, out result);
 
-        public static bool TryCoerceLong(string str, out long result)
-        {
-            return long.TryParse(NormalizeNumber(str), NumberStyles.Any, CultureInfo.InvariantCulture, out result);
-        }
+        public static bool TryCoerceLong(string str, out long result) => long.TryParse(NormalizeNumber(str), NumberStyles.Any, CultureInfo.InvariantCulture, out result);
 
         public static string GetArgumentFromQueryString(string url, string argument)
         {

--- a/src/Jackett.Common/Utils/StringUtil.cs
+++ b/src/Jackett.Common/Utils/StringUtil.cs
@@ -139,17 +139,12 @@ namespace Jackett.Common.Utils
         }
 
         public static string GetQueryString(this NameValueCollection collection, Encoding encoding = null) =>
-            string
-                .Join(
-                    "&",
-                    collection.AllKeys.Select(
-                        a => a + "=" + WebUtilityHelpers.UrlEncode(collection[a], encoding ?? Encoding.UTF8)));
+            string.Join("&", collection.AllKeys.Select(a =>
+                $"{a}={WebUtilityHelpers.UrlEncode(collection[a], encoding ?? Encoding.UTF8)}"));
 
         public static string GetQueryString(this ICollection<KeyValuePair<string, string>> collection, Encoding encoding = null) =>
-            string
-                .Join(
-                    "&",
-                    collection.Select(a => a.Key + "=" + WebUtilityHelpers.UrlEncode(a.Value, encoding ?? Encoding.UTF8)));
+            string.Join("&", collection.Select(a =>
+                $"{a.Key}={WebUtilityHelpers.UrlEncode(a.Value, encoding ?? Encoding.UTF8)}"));
 
         public static void Add(this ICollection<KeyValuePair<string, string>> collection, string key, string value) => collection.Add(new KeyValuePair<string, string>(key, value));
 

--- a/src/Jackett.Common/Utils/StringUtil.cs
+++ b/src/Jackett.Common/Utils/StringUtil.cs
@@ -15,10 +15,8 @@ namespace Jackett.Common.Utils
 {
     public static class StringUtil
     {
-        public static string StripNonAlphaNumeric(this string str, string replacement = "")
-        {
-            return StripRegex(str, "[^a-zA-Z0-9 -]", replacement);
-        }
+        public static string StripNonAlphaNumeric(this string str, string replacement = "") =>
+            StripRegex(str, "[^a-zA-Z0-9 -]", replacement);
 
         public static string StripRegex(string str, string regex, string replacement = "")
         {
@@ -43,26 +41,16 @@ namespace Jackett.Common.Utils
             return stringBuilder.ToString();
         }
 
-        public static string FromBase64(string str)
-        {
-            return Encoding.UTF8.GetString(Convert.FromBase64String(str));
-        }
+        public static string FromBase64(string str) =>
+            Encoding.UTF8.GetString(Convert.FromBase64String(str));
 
         /// <summary>
         /// Convert an array of bytes to a string of hex digits
         /// </summary>
         /// <param name="bytes">array of bytes</param>
         /// <returns>String of hex digits</returns>
-        public static string HexStringFromBytes(byte[] bytes)
-        {
-            var sb = new StringBuilder();
-            foreach (var b in bytes)
-            {
-                var hex = b.ToString("x2");
-                sb.Append(hex);
-            }
-            return sb.ToString();
-        }
+        public static string HexStringFromBytes(byte[] bytes) =>
+            string.Join("", bytes.Select(b => b.ToString("X2")));
 
         /// <summary>
         /// Compute hash for string encoded as UTF8
@@ -90,6 +78,8 @@ namespace Jackett.Common.Utils
             return HexStringFromBytes(hashBytes);
         }
 
+        // Is never used
+        // remove in favor of Exception.ToString() ?
         public static string GetExceptionDetails(this Exception exception)
         {
             var properties = exception.GetType()
@@ -148,24 +138,20 @@ namespace Jackett.Common.Utils
             return changed ? sb.ToString() : text;
         }
 
-        public static string GetQueryString(this NameValueCollection collection, Encoding encoding = null)
-        {
-            if (encoding == null)
-                encoding = Encoding.UTF8;
-            return string.Join("&", collection.AllKeys.Select(a => a + "=" + WebUtilityHelpers.UrlEncode(collection[a], encoding)));
-        }
+        public static string GetQueryString(this NameValueCollection collection, Encoding encoding = null) =>
+            string
+                .Join(
+                    "&",
+                    collection.AllKeys.Select(
+                        a => a + "=" + WebUtilityHelpers.UrlEncode(collection[a], encoding ?? Encoding.UTF8)));
 
-        public static string GetQueryString(this ICollection<KeyValuePair<string, string>> collection, Encoding encoding = null)
-        {
-            if (encoding == null)
-                encoding = Encoding.UTF8;
-            return string.Join("&", collection.Select(a => a.Key + "=" + WebUtilityHelpers.UrlEncode(a.Value, encoding)));
-        }
+        public static string GetQueryString(this ICollection<KeyValuePair<string, string>> collection, Encoding encoding = null) =>
+            string
+                .Join(
+                    "&",
+                    collection.Select(a => a.Key + "=" + WebUtilityHelpers.UrlEncode(a.Value, encoding ?? Encoding.UTF8)));
 
-        public static void Add(this ICollection<KeyValuePair<string, string>> collection, string key, string value)
-        {
-            collection.Add(new KeyValuePair<string, string>(key, value));
-        }
+        public static void Add(this ICollection<KeyValuePair<string, string>> collection, string key, string value) => collection.Add(new KeyValuePair<string, string>(key, value));
 
         public static string ToHtmlPretty(this IElement element)
         {

--- a/src/Jackett.IntegrationTests/DashboardTests.cs
+++ b/src/Jackett.IntegrationTests/DashboardTests.cs
@@ -67,10 +67,7 @@ namespace Jackett.IntegrationTests
         }
 
         [ClassCleanup]
-        public static void StopBrowser()
-        {
-            _webDriver?.Quit();
-        }
+        public static void StopBrowser() => _webDriver?.Quit();
 
         [TestInitialize]
         public void LoadDashboard()

--- a/src/Jackett.Server/Controllers/IndexerApiController.cs
+++ b/src/Jackett.Server/Controllers/IndexerApiController.cs
@@ -146,10 +146,7 @@ namespace Jackett.Server.Controllers
         [HttpDelete]
         [TypeFilter(typeof(RequiresIndexer))]
         [Route("{indexerid}")]
-        public void Delete()
-        {
-            IndexerService.DeleteIndexer(CurrentIndexer.ID);
-        }
+        public void Delete() => IndexerService.DeleteIndexer(CurrentIndexer.ID);
 
         // TODO
         // This should go to ServerConfigurationController

--- a/src/Jackett.Server/Controllers/ResultsController.cs
+++ b/src/Jackett.Server/Controllers/ResultsController.cs
@@ -25,10 +25,7 @@ namespace Jackett.Server.Controllers
     {
         public IServerService serverService;
 
-        public RequiresApiKey(IServerService ss)
-        {
-            serverService = ss;
-        }
+        public RequiresApiKey(IServerService ss) => serverService = ss;
 
         public void OnActionExecuting(ActionExecutingContext context)
         {
@@ -433,10 +430,7 @@ namespace Jackett.Server.Controllers
         }
 
         [Route("[action]/{ignored?}")]
-        public IActionResult GetErrorXML(int code, string description)
-        {
-            return Content(CreateErrorXML(code, description), "application/xml", Encoding.UTF8);
-        }
+        public IActionResult GetErrorXML(int code, string description) => Content(CreateErrorXML(code, description), "application/xml", Encoding.UTF8);
 
         public static string CreateErrorXML(int code, string description)
         {

--- a/src/Jackett.Server/Controllers/ServerConfigurationController.cs
+++ b/src/Jackett.Server/Controllers/ServerConfigurationController.cs
@@ -56,10 +56,7 @@ namespace Jackett.Server.Controllers
         }
 
         [HttpPost]
-        public void Update()
-        {
-            updater.CheckForUpdatesNow();
-        }
+        public void Update() => updater.CheckForUpdatesNow();
 
         [HttpGet]
         public Common.Models.DTO.ServerConfig Config()
@@ -202,9 +199,6 @@ namespace Jackett.Server.Controllers
         }
 
         [HttpGet]
-        public List<CachedLog> Logs()
-        {
-            return logCache.Logs;
-        }
+        public List<CachedLog> Logs() => logCache.Logs;
     }
 }

--- a/src/Jackett.Server/Helper.cs
+++ b/src/Jackett.Server/Helper.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Text;
 using Autofac;
 using AutoMapper;
@@ -57,45 +57,15 @@ namespace Jackett.Server
             applicationLifetime.StopApplication();
         }
 
-        public static IConfigurationService ConfigService
-        {
-            get
-            {
-                return ApplicationContainer.Resolve<IConfigurationService>();
-            }
-        }
+        public static IConfigurationService ConfigService => ApplicationContainer.Resolve<IConfigurationService>();
 
-        public static IServerService ServerService
-        {
-            get
-            {
-                return ApplicationContainer.Resolve<IServerService>();
-            }
-        }
+        public static IServerService ServerService => ApplicationContainer.Resolve<IServerService>();
 
-        public static IServiceConfigService ServiceConfigService
-        {
-            get
-            {
-                return ApplicationContainer.Resolve<IServiceConfigService>();
-            }
-        }
+        public static IServiceConfigService ServiceConfigService => ApplicationContainer.Resolve<IServiceConfigService>();
 
-        public static ServerConfig ServerConfiguration
-        {
-            get
-            {
-                return ApplicationContainer.Resolve<ServerConfig>();
-            }
-        }
+        public static ServerConfig ServerConfiguration => ApplicationContainer.Resolve<ServerConfig>();
 
-        public static Logger Logger
-        {
-            get
-            {
-                return ApplicationContainer.Resolve<Logger>();
-            }
-        }
+        public static Logger Logger => ApplicationContainer.Resolve<Logger>();
 
         private static void InitAutomapper()
         {
@@ -134,15 +104,8 @@ namespace Jackett.Server
             });
         }
 
-        public static void SetupLogging(ContainerBuilder builder)
-        {
-            var logger = LogManager.GetCurrentClassLogger();
-
-            if (builder != null)
-            {
-                builder.RegisterInstance(logger).SingleInstance();
-            }
-        }
+        public static void SetupLogging(ContainerBuilder builder) =>
+            builder?.RegisterInstance(LogManager.GetCurrentClassLogger()).SingleInstance();
 
         public static void SetLogLevel(LogLevel level)
         {

--- a/src/Jackett.Server/Middleware/CustomExceptionHandler.cs
+++ b/src/Jackett.Server/Middleware/CustomExceptionHandler.cs
@@ -73,9 +73,6 @@ namespace Jackett.Server.Middleware
     // Extension method used to add the middleware to the HTTP request pipeline.
     public static class CustomExceptionHandlerExtensions
     {
-        public static IApplicationBuilder UseCustomExceptionHandler(this IApplicationBuilder builder)
-        {
-            return builder.UseMiddleware<CustomExceptionHandler>();
-        }
+        public static IApplicationBuilder UseCustomExceptionHandler(this IApplicationBuilder builder) => builder.UseMiddleware<CustomExceptionHandler>();
     }
 }

--- a/src/Jackett.Server/Services/FilePermissionService.cs
+++ b/src/Jackett.Server/Services/FilePermissionService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Jackett.Common.Services.Interfaces;
 using NLog;
 #if !NET461
@@ -11,10 +11,8 @@ namespace Jackett.Server.Services
     {
         private readonly Logger logger;
 
-        public FilePermissionService(Logger l)
-        {
+        public FilePermissionService(Logger l) =>
             logger = l;
-        }
 
         public void MakeFileExecutable(string path)
         {

--- a/src/Jackett.Server/Services/FilePermissionService.cs
+++ b/src/Jackett.Server/Services/FilePermissionService.cs
@@ -11,8 +11,7 @@ namespace Jackett.Server.Services
     {
         private readonly Logger logger;
 
-        public FilePermissionService(Logger l) =>
-            logger = l;
+        public FilePermissionService(Logger l) => logger = l;
 
         public void MakeFileExecutable(string path)
         {

--- a/src/Jackett.Server/Services/ProtectionService.cs
+++ b/src/Jackett.Server/Services/ProtectionService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -162,16 +162,11 @@ namespace Jackett.Server.Services
             return Encoding.UTF8.GetString(unprotectedBytes);
         }
 
-        private string ProtectUsingKey(string plainText, string key)
-        {
-            return StringCipher.Encrypt(plainText, key);
-        }
+        private string ProtectUsingKey(string plainText, string key) => StringCipher.Encrypt(plainText, key);
 
-        private string UnProtectUsingKey(string plainText, string key)
-        {
-            return StringCipher.Decrypt(plainText, key);
-        }
+        private string UnProtectUsingKey(string plainText, string key) => StringCipher.Decrypt(plainText, key);
 
+        // Currently unused
         public void Protect<T>(T obj)
         {
             var type = obj.GetType();

--- a/src/Jackett.Server/Services/SecuityService.cs
+++ b/src/Jackett.Server/Services/SecuityService.cs
@@ -1,4 +1,4 @@
-﻿using System.Linq;
+using System.Linq;
 using System.Net.Http;
 using System.Security.Cryptography;
 using System.Text;
@@ -12,10 +12,7 @@ namespace Jackett.Server.Services
         private const string COOKIENAME = "JACKETT";
         private readonly ServerConfig _serverConfig;
 
-        public SecuityService(ServerConfig sc)
-        {
-            _serverConfig = sc;
-        }
+        public SecuityService(ServerConfig sc) => _serverConfig = sc;
 
         public string HashPassword(string input)
         {
@@ -39,17 +36,9 @@ namespace Jackett.Server.Services
             return hex;
         }
 
-        public void Login(HttpResponseMessage response)
-        {
-            // Login
-            response.Headers.Add("Set-Cookie", COOKIENAME + "=" + _serverConfig.AdminPassword + "; path=/");
-        }
+        public void Login(HttpResponseMessage response) => response.Headers.Add("Set-Cookie", COOKIENAME + "=" + _serverConfig.AdminPassword + "; path=/");
 
-        public void Logout(HttpResponseMessage response)
-        {
-            // Logout
-            response.Headers.Add("Set-Cookie", COOKIENAME + "=; path=/");
-        }
+        public void Logout(HttpResponseMessage response) => response.Headers.Add("Set-Cookie", COOKIENAME + "=; path=/");
 
         public bool CheckAuthorised(HttpRequestMessage request)
         {

--- a/src/Jackett.Server/Services/ServerService.cs
+++ b/src/Jackett.Server/Services/ServerService.cs
@@ -29,7 +29,6 @@ namespace Jackett.Server.Services
         private readonly Logger logger;
         private readonly Common.Utils.Clients.WebClient client;
         private readonly IUpdateService updater;
-        private readonly List<string> _notices = new List<string>();
         private readonly ServerConfig config;
         private readonly IProtectionService _protectionService;
         private bool isDotNetCoreCapable;
@@ -47,13 +46,7 @@ namespace Jackett.Server.Services
             _protectionService = protectionService;
         }
 
-        public List<string> notices
-        {
-            get
-            {
-                return _notices;
-            }
-        }
+        public List<string> notices { get; } = new List<string>();
 
         public Uri ConvertToProxyLink(Uri link, string serverUrl, string indexerId, string action = "dl", string file = "t")
         {
@@ -69,6 +62,7 @@ namespace Jackett.Server.Services
 
         public string BasePath()
         {
+            // Use string.IsNullOrEmpty
             if (config.BasePathOverride == null || config.BasePathOverride == "")
             {
                 return "";
@@ -92,7 +86,10 @@ namespace Jackett.Server.Services
                 var x = Environment.OSVersion;
                 var runtimedir = RuntimeEnvironment.GetRuntimeDirectory();
                 logger.Info("Environment version: " + Environment.Version.ToString() + " (" + runtimedir + ")");
-                logger.Info("OS version: " + Environment.OSVersion.ToString() + (Environment.Is64BitOperatingSystem ? " (64bit OS)" : "") + (Environment.Is64BitProcess ? " (64bit process)" : ""));
+                logger.Info(
+                    "OS version: " + Environment.OSVersion.ToString() +
+                    (Environment.Is64BitOperatingSystem ? " (64bit OS)" : "") +
+                    (Environment.Is64BitProcess ? " (64bit process)" : ""));
                 var variants = new Variants();
                 var variant = variants.GetVariant();
                 logger.Info("Jackett variant: " + variant.ToString());
@@ -100,7 +97,9 @@ namespace Jackett.Server.Services
                 try
                 {
                     ThreadPool.GetMaxThreads(out var workerThreads, out var completionPortThreads);
-                    logger.Info("ThreadPool MaxThreads: " + workerThreads + " workerThreads, " + completionPortThreads + " completionPortThreads");
+                    logger.Info(
+                        "ThreadPool MaxThreads: " + workerThreads + " workerThreads, " + completionPortThreads +
+                        " completionPortThreads");
                 }
                 catch (Exception e)
                 {
@@ -145,14 +144,16 @@ namespace Jackett.Server.Services
                         //Hard minimum of 5.8
                         //5.4 throws a SIGABRT, looks related to this which was fixed in 5.8 https://bugzilla.xamarin.com/show_bug.cgi?id=60625
 
-                        logger.Error("Your mono version is too old. Please update to the latest version from http://www.mono-project.com/download/");
+                        logger.Error(
+                            "Your mono version is too old. Please update to the latest version from http://www.mono-project.com/download/");
                         Environment.Exit(2);
                     }
 
                     if (monoVersionO.Major < 5 || (monoVersionO.Major == 5 && monoVersionO.Minor < 8))
                     {
-                        var notice = "A minimum Mono version of 5.8 is required. Please update to the latest version from http://www.mono-project.com/download/";
-                        _notices.Add(notice);
+                        var notice =
+                            "A minimum Mono version of 5.8 is required. Please update to the latest version from http://www.mono-project.com/download/";
+                        notices.Add(notice);
                         logger.Error(notice);
                     }
 
@@ -163,8 +164,9 @@ namespace Jackett.Server.Services
                         var mono_devel_file = Path.Combine(runtimedir, "mono-api-info.exe");
                         if (!File.Exists(mono_devel_file))
                         {
-                            var notice = "It looks like the mono-devel package is not installed, please make sure it's installed to avoid crashes.";
-                            _notices.Add(notice);
+                            var notice =
+                                "It looks like the mono-devel package is not installed, please make sure it's installed to avoid crashes.";
+                            notices.Add(notice);
                             logger.Error(notice);
                         }
                     }
@@ -179,8 +181,9 @@ namespace Jackett.Server.Services
                         var mono_cert_file = Path.Combine(runtimedir, "cert-sync.exe");
                         if (!File.Exists(mono_cert_file))
                         {
-                            var notice = "The ca-certificates-mono package is not installed, HTTPS trackers won't work. Please install it.";
-                            _notices.Add(notice);
+                            var notice =
+                                "The ca-certificates-mono package is not installed, HTTPS trackers won't work. Please install it.";
+                            notices.Add(notice);
                             logger.Error(notice);
                         }
                     }
@@ -210,34 +213,40 @@ namespace Jackett.Server.Services
                             var monoX509StoreManager = monoSecurity.GetType("Mono.Security.X509.X509StoreManager");
                             if (monoX509StoreManager != null)
                             {
-                                var TrustedRootCertificatesProperty = monoX509StoreManager.GetProperty("TrustedRootCertificates");
+                                var TrustedRootCertificatesProperty =
+                                    monoX509StoreManager.GetProperty("TrustedRootCertificates");
                                 var TrustedRootCertificates = (ICollection)TrustedRootCertificatesProperty.GetValue(null);
 
                                 logger.Info("TrustedRootCertificates count: " + TrustedRootCertificates.Count);
 
                                 if (TrustedRootCertificates.Count == 0)
                                 {
-                                    var CACertificatesFiles = new string[] {
-                                    "/etc/ssl/certs/ca-certificates.crt", // Debian based
-                                    "/etc/pki/tls/certs/ca-bundle.c", // RedHat based
-                                    "/etc/ssl/ca-bundle.pem", // SUSE
+                                    var CACertificatesFiles = new string[]
+                                    {
+                                        "/etc/ssl/certs/ca-certificates.crt", // Debian based
+                                        "/etc/pki/tls/certs/ca-bundle.c", // RedHat based
+                                        "/etc/ssl/ca-bundle.pem", // SUSE
                                     };
 
                                     var notice = "The mono certificate store is not initialized.<br/>\n";
                                     var logSpacer = "                     ";
-                                    var CACertificatesFile = CACertificatesFiles.Where(f => File.Exists(f)).FirstOrDefault();
+                                    var CACertificatesFile = CACertificatesFiles.Where(File.Exists).FirstOrDefault();
                                     var CommandRoot = "curl -sS https://curl.haxx.se/ca/cacert.pem | cert-sync /dev/stdin";
-                                    var CommandUser = "curl -sS https://curl.haxx.se/ca/cacert.pem | cert-sync --user /dev/stdin";
+                                    var CommandUser =
+                                        "curl -sS https://curl.haxx.se/ca/cacert.pem | cert-sync --user /dev/stdin";
                                     if (CACertificatesFile != null)
                                     {
                                         CommandRoot = "cert-sync " + CACertificatesFile;
                                         CommandUser = "cert-sync --user " + CACertificatesFile;
                                     }
+
                                     notice += logSpacer + "Please run the following command as root:<br/>\n";
                                     notice += logSpacer + "<pre>" + CommandRoot + "</pre><br/>\n";
-                                    notice += logSpacer + "If you don't have root access or you're running MacOS, please run the following command as the jackett user (" + Environment.UserName + "):<br/>\n";
+                                    notice += logSpacer +
+                                              "If you don't have root access or you're running MacOS, please run the following command as the jackett user (" +
+                                              Environment.UserName + "):<br/>\n";
                                     notice += logSpacer + "<pre>" + CommandUser + "</pre>";
-                                    _notices.Add(notice);
+                                    notices.Add(notice);
                                     logger.Error(Regex.Replace(notice, "<.*?>", string.Empty));
                                 }
                             }
@@ -248,7 +257,6 @@ namespace Jackett.Server.Services
                         }
                     }
                 }
-
             }
             catch (Exception e)
             {
@@ -260,7 +268,7 @@ namespace Jackett.Server.Services
                 if (Environment.UserName == "root")
                 {
                     var notice = "Jackett is running with root privileges. You should run Jackett as an unprivileged user.";
-                    _notices.Add(notice);
+                    notices.Add(notice);
                     logger.Error(notice);
                 }
             }
@@ -278,7 +286,7 @@ namespace Jackett.Server.Services
                 {
                     var version = configService.GetVersion();
                     var notice = $"Your version of Jackett v{version} is very old. Multiple indexers are likely to fail when using an old version. Update to the latest version of Jackett.";
-                    _notices.Add(notice);
+                    notices.Add(notice);
                     logger.Error(notice);
                 }
             }
@@ -324,10 +332,7 @@ namespace Jackett.Server.Services
             updater.CleanupTempDir();
         }
 
-        public void Start()
-        {
-            updater.StartUpdateChecker();
-        }
+        public void Start() => updater.StartUpdateChecker();
 
         public void ReserveUrls(bool doInstall = true)
         {
@@ -342,10 +347,7 @@ namespace Jackett.Server.Services
             }
         }
 
-        private void RunNetSh(string args)
-        {
-            processService.StartProcessAndLog("netsh.exe", args);
-        }
+        private void RunNetSh(string args) => processService.StartProcessAndLog("netsh.exe", args);
 
         public void Stop()
         {
@@ -383,19 +385,10 @@ namespace Jackett.Server.Services
             return serverUrl;
         }
 
-        public string GetBlackholeDirectory()
-        {
-            return config.BlackholeDir;
-        }
+        public string GetBlackholeDirectory() => config.BlackholeDir;
 
-        public string GetApiKey()
-        {
-            return config.APIKey;
-        }
+        public string GetApiKey() => config.APIKey;
 
-        public bool MonoUserCanRunNetCore()
-        {
-            return isDotNetCoreCapable;
-        }
+        public bool MonoUserCanRunNetCore() => isDotNetCoreCapable;
     }
 }

--- a/src/Jackett.Server/Services/ServiceConfigService.cs
+++ b/src/Jackett.Server/Services/ServiceConfigService.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
@@ -25,36 +25,19 @@ namespace Jackett.Server.Services
             processService = new ProcessService(logger);
         }
 
-        public bool ServiceExists()
-        {
-            return GetService(NAME) != null;
-        }
+        public bool ServiceExists() => GetService(NAME) != null;
 
-        public bool ServiceRunning()
-        {
-            var service = GetService(NAME);
-            if (service == null)
-                return false;
-            return service.Status == ServiceControllerStatus.Running;
-        }
+        public bool ServiceRunning() =>
+            GetService(NAME)?.Status == ServiceControllerStatus.Running;
 
-        public void Start()
-        {
+        public void Start() => GetService(NAME).Start();
 
-            var service = GetService(NAME);
-            service.Start();
-        }
+        public void Stop() => GetService(NAME).Stop();
 
-        public void Stop()
-        {
-            var service = GetService(NAME);
-            service.Stop();
-        }
-
-        public ServiceController GetService(string serviceName)
-        {
-            return ServiceController.GetServices().FirstOrDefault(c => string.Equals(c.ServiceName, serviceName, StringComparison.InvariantCultureIgnoreCase));
-        }
+        public ServiceController GetService(string serviceName) =>
+            ServiceController
+                .GetServices()
+                .FirstOrDefault(c => string.Equals(c.ServiceName, serviceName, StringComparison.InvariantCultureIgnoreCase));
 
         public void Install()
         {

--- a/src/Jackett.Server/Startup.cs
+++ b/src/Jackett.Server/Startup.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Diagnostics;
 using System.IO;
 using System.Text;
@@ -29,10 +29,7 @@ namespace Jackett.Server
 {
     public class Startup
     {
-        public Startup(IConfiguration configuration)
-        {
-            Configuration = configuration;
-        }
+        public Startup(IConfiguration configuration) => Configuration = configuration;
 
         public IConfiguration Configuration { get; }
 
@@ -54,29 +51,20 @@ namespace Jackett.Server
 
 
 #if NET461
-            services.AddMvc(config =>
-                    {
-                        var policy = new AuthorizationPolicyBuilder()
-                                            .RequireAuthenticatedUser()
-                                            .Build();
-                        config.Filters.Add(new AuthorizeFilter(policy));
-                    })
-                    .AddJsonOptions(options =>
-                    {
-                        options.SerializerSettings.ContractResolver = new DefaultContractResolver(); //Web app uses Pascal Case JSON
-                    });
+            services.AddMvc(
+                        config => config.Filters.Add(
+                            new AuthorizeFilter(
+                                new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build())))
+                    .AddJsonOptions(options => options.SerializerSettings.ContractResolver =
+                                        new DefaultContractResolver()); //Web app uses Pascal Case JSON);
 #else
-            services.AddControllers(config =>
-                    {
-                        var policy = new AuthorizationPolicyBuilder()
-                                            .RequireAuthenticatedUser()
-                                            .Build();
-                        config.Filters.Add(new AuthorizeFilter(policy));
-                    })
-                    .AddNewtonsoftJson(options =>
-                    {
-                        options.SerializerSettings.ContractResolver = new DefaultContractResolver(); //Web app uses Pascal Case JSON
-                    });
+
+            services.AddControllers(
+                        config => config.Filters.Add(
+                            new AuthorizeFilter(
+                                new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build())))
+                    .AddNewtonsoftJson(
+                        options => options.SerializerSettings.ContractResolver = new DefaultContractResolver());
 #endif
 
             var runtimeSettings = new RuntimeSettings();
@@ -193,10 +181,7 @@ namespace Jackett.Server
 
             app.UseRouting();
 
-            app.UseEndpoints(endpoints =>
-            {
-                endpoints.MapControllers();
-            });
+            app.UseEndpoints(endpoints => endpoints.MapControllers());
         }
 #endif
 

--- a/src/Jackett.Service/Service.cs
+++ b/src/Jackett.Service/Service.cs
@@ -70,10 +70,7 @@ namespace Jackett.Service
             consoleProcess.ErrorDataReceived += ProcessErrorDataReceived;
         }
 
-        private void ProcessErrorDataReceived(object sender, DataReceivedEventArgs e)
-        {
-            logger.Error(e.Data);
-        }
+        private void ProcessErrorDataReceived(object sender, DataReceivedEventArgs e) => logger.Error(e.Data);
 
         private void ProcessExited(object sender, EventArgs e)
         {

--- a/src/Jackett.Test/TestBase.cs
+++ b/src/Jackett.Test/TestBase.cs
@@ -5,9 +5,6 @@ namespace Jackett.Test
     internal abstract class TestBase
     {
         [SetUp]
-        public void Setup()
-        {
-            TestUtil.SetupContainer();
-        }
+        public void Setup() => TestUtil.SetupContainer();
     }
 }

--- a/src/Jackett.Test/TestIIndexerManagerServiceHelper.cs
+++ b/src/Jackett.Test/TestIIndexerManagerServiceHelper.cs
@@ -11,44 +11,20 @@ namespace Jackett.Test
     {
         public JToken LastSavedConfig { get; set; }
 
-        public void DeleteIndexer(string name)
-        {
-            throw new NotImplementedException();
-        }
+        public void DeleteIndexer(string name) => throw new NotImplementedException();
 
-        public IEnumerable<IIndexer> GetAllIndexers()
-        {
-            throw new NotImplementedException();
-        }
+        public IEnumerable<IIndexer> GetAllIndexers() => throw new NotImplementedException();
 
-        public IIndexer GetIndexer(string name)
-        {
-            throw new NotImplementedException();
-        }
+        public IIndexer GetIndexer(string name) => throw new NotImplementedException();
 
-        public IWebIndexer GetWebIndexer(string name)
-        {
-            throw new NotImplementedException();
-        }
+        public IWebIndexer GetWebIndexer(string name) => throw new NotImplementedException();
 
-        public void InitIndexers(IEnumerable<string> path)
-        {
-            throw new NotImplementedException();
-        }
+        public void InitIndexers(IEnumerable<string> path) => throw new NotImplementedException();
 
-        public void SaveConfig(IIndexer indexer, JToken obj)
-        {
-            LastSavedConfig = obj;
-        }
+        public void SaveConfig(IIndexer indexer, JToken obj) => LastSavedConfig = obj;
 
-        public Task TestIndexer(string name)
-        {
-            throw new NotImplementedException();
-        }
+        public Task TestIndexer(string name) => throw new NotImplementedException();
 
-        public void InitAggregateIndexer()
-        {
-            throw new NotImplementedException();
-        }
+        public void InitAggregateIndexer() => throw new NotImplementedException();
     }
 }

--- a/src/Jackett.Test/TestUtil.cs
+++ b/src/Jackett.Test/TestUtil.cs
@@ -29,18 +29,9 @@ namespace Jackett.Test
             testContainer = builder.Build();
         }
 
-        public static TestIndexerManagerServiceHelper IndexManager
-        {
-            get
-            {
-                return testContainer.Resolve<IIndexerManagerService>() as TestIndexerManagerServiceHelper;
-            }
-        }
+        public static TestIndexerManagerServiceHelper IndexManager => testContainer.Resolve<IIndexerManagerService>() as TestIndexerManagerServiceHelper;
 
-        public static IContainer Container
-        {
-            get { return testContainer; }
-        }
+        public static IContainer Container => testContainer;
 
         public static void RegisterByteCall(WebRequest r, Func<WebRequest, WebClientByteResult> f)
         {

--- a/src/Jackett.Test/TestWebClient.cs
+++ b/src/Jackett.Test/TestWebClient.cs
@@ -22,25 +22,13 @@ namespace Jackett.Test
         {
         }
 
-        public void RegisterByteCall(WebRequest req, Func<WebRequest, WebClientByteResult> f)
-        {
-            byteCallbacks.Add(req, f);
-        }
+        public void RegisterByteCall(WebRequest req, Func<WebRequest, WebClientByteResult> f) => byteCallbacks.Add(req, f);
 
-        public void RegisterStringCall(WebRequest req, Func<WebRequest, WebClientStringResult> f)
-        {
-            stringCallbacks.Add(req, f);
-        }
+        public void RegisterStringCall(WebRequest req, Func<WebRequest, WebClientStringResult> f) => stringCallbacks.Add(req, f);
 
-        public override Task<WebClientByteResult> GetBytes(WebRequest request)
-        {
-            return Task.FromResult<WebClientByteResult>(byteCallbacks.Where(r => r.Key.Equals(request)).First().Value.Invoke(request));
-        }
+        public override Task<WebClientByteResult> GetBytes(WebRequest request) => Task.FromResult<WebClientByteResult>(byteCallbacks.Where(r => r.Key.Equals(request)).First().Value.Invoke(request));
 
-        public override Task<WebClientStringResult> GetString(WebRequest request)
-        {
-            return Task.FromResult<WebClientStringResult>(stringCallbacks.Where(r => r.Key.Equals(request)).First().Value.Invoke(request));
-        }
+        public override Task<WebClientStringResult> GetString(WebRequest request) => Task.FromResult<WebClientStringResult>(stringCallbacks.Where(r => r.Key.Equals(request)).First().Value.Invoke(request));
 
         public override void Init()
         {

--- a/src/Jackett.Test/Util/TvCategoryParserTests.cs
+++ b/src/Jackett.Test/Util/TvCategoryParserTests.cs
@@ -18,10 +18,7 @@ namespace Jackett.Test.Util
         [TestCase("The.Blacklist.S02E05", 5000)]
         [TestCase("The.IT.Crowd.S01.DVD.REMUX.DD2.0.MPEG2-DTG", 5030)]
 
-        public void should_parse_quality_from_title(string title, int quality)
-        {
-            Assert.That(TvCategoryParser.ParseTvShowQuality(title), Is.EqualTo(quality));
-        }
+        public void should_parse_quality_from_title(string title, int quality) => Assert.That(TvCategoryParser.ParseTvShowQuality(title), Is.EqualTo(quality));
     }
 }
 

--- a/src/Jackett.Tray/Main.cs
+++ b/src/Jackett.Tray/Main.cs
@@ -126,30 +126,15 @@ namespace Jackett.Tray
             Process.Start(psi);
         }
 
-        private void toolStripMenuItemShutdown_Click(object sender, EventArgs e)
-        {
-            CloseTrayApplication();
-        }
+        private void toolStripMenuItemShutdown_Click(object sender, EventArgs e) => CloseTrayApplication();
 
-        private void toolStripMenuItemAutoStart_CheckedChanged(object sender, EventArgs e)
-        {
-            AutoStart = toolStripMenuItemAutoStart.Checked;
-        }
+        private void toolStripMenuItemAutoStart_CheckedChanged(object sender, EventArgs e) => AutoStart = toolStripMenuItemAutoStart.Checked;
 
-        private string ProgramTitle
-        {
-            get
-            {
-                return Assembly.GetExecutingAssembly().GetName().Name;
-            }
-        }
+        private string ProgramTitle => Assembly.GetExecutingAssembly().GetName().Name;
 
         private bool AutoStart
         {
-            get
-            {
-                return File.Exists(ShortcutPath);
-            }
+            get => File.Exists(ShortcutPath);
             set
             {
                 if (value && !AutoStart)
@@ -163,13 +148,7 @@ namespace Jackett.Tray
             }
         }
 
-        public string ShortcutPath
-        {
-            get
-            {
-                return Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Startup), "Jackett.lnk");
-            }
-        }
+        public string ShortcutPath => Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Startup), "Jackett.lnk");
 
         private void CreateShortcut()
         {
@@ -302,10 +281,7 @@ namespace Jackett.Tray
             consoleProcess.ErrorDataReceived += ProcessErrorDataReceived;
         }
 
-        private void ProcessErrorDataReceived(object sender, DataReceivedEventArgs e)
-        {
-            logger.Error(e.Data);
-        }
+        private void ProcessErrorDataReceived(object sender, DataReceivedEventArgs e) => logger.Error(e.Data);
 
         private void ProcessExited(object sender, EventArgs e)
         {


### PR DESCRIPTION
This PR uses expression bodies (single line => lambdas) where possible for functions and properties. Not all of these were found by the automated tools, so I also went through and simplified a few of them by hand.

I also added some comments for future refactoring fixes that I found didn't make sense while I was going  through the code by hand.