### PR TITLE
Fix IsEmptyOrNull to return true when IsNull

### DIFF
--- a/src/Jackett.Common/Utils/Extensions.cs
+++ b/src/Jackett.Common/Utils/Extensions.cs
@@ -64,8 +64,11 @@ namespace Jackett.Common.Utils
         // IEnumerable class above already does this. All ICollection are IEnumerable, so favor IEnumerable?
         public static bool IsEmpty<T>(this ICollection<T> obj) => obj.Count == 0;
 
-
-        public static bool IsEmptyOrNull<T>(this ICollection<T> obj) => obj?.IsEmpty() == true;
+        // obj == null || obj.IsEmpty() causes VS to suggest merging sequential checks
+        // the result is obj?.IsEmpty() == true which returns false when null
+        // Other options are obj?.IsEmpty() == true || obj == null Or (obj?.IsEmpty()).GetValueOrDefault(true)
+        // All three options remove the suggestion and give the intended result of this function
+        public static bool IsEmptyOrNull<T>(this ICollection<T> obj) => obj?.IsEmpty() ?? true;
     }
 
     public static class XElementExtension


### PR DESCRIPTION
Fixes #7333

`obj == null || obj.IsEmpty()` causes VS to suggest merging sequential checks. The result of the merge is `obj?.IsEmpty() == true` which returns false when null. This is the source of the bug.

I prefer the null coalescing operator `??` for this scenario out of the alternatives. This removes the suggestion and keeps the intended result. Two other code options that would do the same thing but IMO make the code less readable are flipping the operands `obj?.IsEmpty() == true || obj == null` or using the `Nullable<bool>` function that returns a specific value when null `(obj?.IsEmpty()).GetValueOrDefault(true)`

This same information has been committed to the code in a comment above the function.