### PR TITLE
Prefer object initializers

### DIFF
--- a/src/Jackett.Common/Indexers/720pier.cs
+++ b/src/Jackett.Common/Indexers/720pier.cs
@@ -214,7 +214,7 @@ namespace Jackett.Common.Indexers
                         var link = new Uri(SiteLink + qDownloadLink.GetAttribute("href").TrimStart('/'));
                         var publishDate = DateTimeUtil.FromUnknown(timestr, "UK");
                         var size = ReleaseInfo.GetBytes(sizeString);
-                        releases.Add(new ReleaseInfo
+                        var release = new ReleaseInfo
                         {
                             MinimumRatio = 1,
                             MinimumSeedTime = 0,
@@ -230,7 +230,8 @@ namespace Jackett.Common.Indexers
                             PublishDate = publishDate,
                             Category = MapTrackerCatToNewznab(forumid),
                             Size = size,
-                        });
+                        };
+                        releases.Add(release);
                     }
                     catch (Exception ex)
                     {

--- a/src/Jackett.Common/Indexers/720pier.cs
+++ b/src/Jackett.Common/Indexers/720pier.cs
@@ -201,19 +201,19 @@ namespace Jackett.Common.Indexers
 
                         var forum = row.QuerySelector("a[href^=\"./viewforum.php?f=\"]");
                         var forumid = forum.GetAttribute("href").Split('=')[1];
-                        var size = row.QuerySelector("dl.row-item > dt > div.list-inner > div[style^=\"float:right\"]").TextContent;
-                        size = size.Replace("GiB", "GB");
-                        size = size.Replace("MiB", "MB");
-                        size = size.Replace("KiB", "KB");
-
-                        size = size.Replace("ГБ", "GB");
-                        size = size.Replace("МБ", "MB");
-                        size = size.Replace("КБ", "KB");
+                        var sizeString = row.QuerySelector("dl.row-item > dt > div.list-inner > div[style^=\"float:right\"]")
+                                            .TextContent
+                                            .Replace("GiB", "GB")
+                                            .Replace("MiB", "MB")
+                                            .Replace("KiB", "KB")
+                                            .Replace("ГБ", "GB")
+                                            .Replace("МБ", "MB")
+                                            .Replace("КБ", "KB");
                         var comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
                         var leechers = ParseUtil.CoerceInt(row.QuerySelector("span.leech").TextContent);
                         var link = new Uri(SiteLink + qDownloadLink.GetAttribute("href").TrimStart('/'));
                         var publishDate = DateTimeUtil.FromUnknown(timestr, "UK");
-
+                        var size = ReleaseInfo.GetBytes(sizeString);
                         releases.Add(new ReleaseInfo
                         {
                             MinimumRatio = 1,
@@ -229,7 +229,7 @@ namespace Jackett.Common.Indexers
                             Link = link,
                             PublishDate = publishDate,
                             Category = MapTrackerCatToNewznab(forumid),
-                            Size = ReleaseInfo.GetBytes(size),
+                            Size = size,
                         });
                     }
                     catch (Exception ex)

--- a/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
@@ -220,15 +220,17 @@ namespace Jackett.Common.Indexers.Abstract
                     var description = tags?.Any() == true && !string.IsNullOrEmpty(tags[0].ToString())
                         ? "Tags: " + string.Join(", ", tags) + "\n"
                         : null;
+                    Uri banner = null;
+                    if (!string.IsNullOrEmpty(cover))
+                        banner = new Uri(cover);
                     var release = new ReleaseInfo
                     {
                         PublishDate = groupTime,
                         Title = title.ToString(),
                         Description = description,
+                        BannerUrl = banner
                     };
 
-                    if (!string.IsNullOrEmpty(cover))
-                        release.BannerUrl = new Uri(cover);
 
                     if (imdbInTags)
                     {

--- a/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
@@ -205,27 +205,25 @@ namespace Jackett.Common.Indexers.Abstract
                     var groupTime = DateTimeUtil.UnixTimestampToDateTime(long.Parse((string)r["groupTime"]));
                     var groupName = WebUtility.HtmlDecode((string)r["groupName"]);
                     var artist = WebUtility.HtmlDecode((string)r["artist"]);
-                    if (!string.IsNullOrEmpty(artist))
-                        artist += " - ";
                     var cover = (string)r["cover"];
                     var tags = r["tags"].ToList();
                     var groupYear = (string)r["groupYear"];
-                    groupYear = !string.IsNullOrEmpty(groupYear) && groupYear != "0"
-                        ? $" [{groupYear}]"
-                        : string.Empty;
                     var releaseType = (string)r["releaseType"];
-                    releaseType = !string.IsNullOrEmpty(releaseType) && releaseType != "Unknown"
-                        ? $" [{releaseType}]"
-                        : string.Empty;
-
-                    var description = !string.IsNullOrEmpty(tags?.FirstOrDefault()?.ToObject<string>())
-                        ? $"Tags: {string.Join(", ", tags)}\n"
-                        : string.Empty;
-
+                    var title = new StringBuilder();
+                    if (!string.IsNullOrEmpty(artist))
+                        title.Append(artist + " - ");
+                    title.Append(groupName);
+                    if (!string.IsNullOrEmpty(groupYear) && groupYear != "0")
+                        title.Append(" [" + groupYear + "]");
+                    if (!string.IsNullOrEmpty(releaseType) && releaseType != "Unknown")
+                        title.Append(" [" + releaseType + "]");
+                    var description = tags?.Any() == true && !string.IsNullOrEmpty(tags[0].ToString())
+                        ? "Tags: " + string.Join(", ", tags) + "\n"
+                        : null;
                     var release = new ReleaseInfo
                     {
                         PublishDate = groupTime,
-                        Title = $"{artist}{groupName}{groupYear}{releaseType}",
+                        Title = title.ToString(),
                         Description = description,
                     };
 

--- a/src/Jackett.Common/Indexers/AniDub.cs
+++ b/src/Jackett.Common/Indexers/AniDub.cs
@@ -220,12 +220,11 @@ namespace Jackett.Common.Indexers
                     }
 
                     var seeders = GetReleaseSeeders(tabNode);
-
-
+                    var guid = new Uri(GetReleaseGuid(url, tabNode));
                     var release = new ReleaseInfo
                     {
                         Title = BuildReleaseTitle(baseTitle, tabNode),
-                        Guid = new Uri(GetReleaseGuid(url, tabNode)),
+                        Guid = guid,
                         Comments = uri,
                         Link = GetReleaseLink(tabNode),
                         PublishDate = date,

--- a/src/Jackett.Common/Indexers/AnimeBytes.cs
+++ b/src/Jackett.Common/Indexers/AnimeBytes.cs
@@ -363,13 +363,14 @@ namespace Jackett.Common.Indexers
                                     releaseTitle = string.Format("{0}{1} {2} {3}", releasegroup, title, releaseInfo, infoString);
                                 }
 
+                                var guid = new Uri(CommentsLinkUri + "&nh=" + StringUtil.Hash(title));
                                 var release = new ReleaseInfo
                                 {
                                     MinimumRatio = 1,
                                     MinimumSeedTime = MinimumSeedTime,
                                     Title = releaseTitle,
                                     Comments = CommentsLinkUri,
-                                    Guid = new Uri(CommentsLinkUri + "&nh=" + StringUtil.Hash(title)), // Sonarr should dedupe on this url - allow a url per name.
+                                    Guid = guid, // Sonarr should dedupe on this url - allow a url per name.
                                     Link = LinkUri,
                                     BannerUrl = ImageUrl,
                                     PublishDate = PublushDate,

--- a/src/Jackett.Common/Indexers/AnimeTorrents.cs
+++ b/src/Jackett.Common/Indexers/AnimeTorrents.cs
@@ -99,9 +99,6 @@ namespace Jackett.Common.Indexers
             var ReplaceRegex = new Regex("[^a-zA-Z0-9]+");
             searchString = ReplaceRegex.Replace(searchString, "%");
             var searchUrl = SearchUrl;
-            var queryCollection = new NameValueCollection();
-
-
             var queryCollection = new NameValueCollection
             {
                 {"total", "146"}, // Not sure what this is about but its required!

--- a/src/Jackett.Common/Indexers/AnimeTorrents.cs
+++ b/src/Jackett.Common/Indexers/AnimeTorrents.cs
@@ -98,15 +98,18 @@ namespace Jackett.Common.Indexers
             //  replace any space, special char, etc. with % (wildcard)
             var ReplaceRegex = new Regex("[^a-zA-Z0-9]+");
             searchString = ReplaceRegex.Replace(searchString, "%");
-
             var searchUrl = SearchUrl;
             var queryCollection = new NameValueCollection();
 
-            queryCollection.Add("total", "146"); // Not sure what this is about but its required!
-            queryCollection.Add("cat", MapTorznabCapsToTrackers(query).FirstIfSingleOrDefault("0"));
-            queryCollection.Add("searchin", "filename");
-            queryCollection.Add("search", searchString);
-            queryCollection.Add("page", "1");
+
+            var queryCollection = new NameValueCollection
+            {
+                {"total", "146"}, // Not sure what this is about but its required!
+                {"cat", MapTorznabCapsToTrackers(query).FirstIfSingleOrDefault("0")},
+                {"page", "1"},
+                {"searchin", "filename"},
+                {"search", searchString}
+            };
             searchUrl += "?" + queryCollection.GetQueryString();
 
             var extraHeaders = new Dictionary<string, string>()

--- a/src/Jackett.Common/Indexers/BroadcastTheNet.cs
+++ b/src/Jackett.Common/Indexers/BroadcastTheNet.cs
@@ -139,15 +139,15 @@ namespace Jackett.Common.Indexers
                         if (!string.IsNullOrWhiteSpace(btnResult.Series))
                             descriptions.Add("Youtube Trailer: <a href=\"" + btnResult.YoutubeTrailer + "\">" + btnResult.YoutubeTrailer + "</a>");
                         var imdb = ParseUtil.GetImdbID(btnResult.ImdbID);
-                        var guid = new Uri(btnResult.DownloadURL);
+                        var link = new Uri(btnResult.DownloadURL);
                         var comments = new Uri($"{SiteLink}torrents.php?id={btnResult.GroupID}&torrentid={btnResult.TorrentID}");
                         var publishDate = DateTimeUtil.UnixTimestampToDateTime(btnResult.Time);
                         var item = new ReleaseInfo
                         {
                             Category = MapTrackerCatToNewznab(btnResult.Resolution),
                             Comments = comments,
-                            Guid = guid,
-                            Link = guid,
+                            Guid = link,
+                            Link = link,
                             MinimumRatio = 1,
                             PublishDate = publishDate,
                             RageID = btnResult.TvrageID,

--- a/src/Jackett.Common/Indexers/BroadcastTheNet.cs
+++ b/src/Jackett.Common/Indexers/BroadcastTheNet.cs
@@ -138,17 +138,18 @@ namespace Jackett.Common.Indexers
                             descriptions.Add("Origin: " + btnResult.Origin);
                         if (!string.IsNullOrWhiteSpace(btnResult.Series))
                             descriptions.Add("Youtube Trailer: <a href=\"" + btnResult.YoutubeTrailer + "\">" + btnResult.YoutubeTrailer + "</a>");
-
+                        var imdb = ParseUtil.GetImdbID(btnResult.ImdbID);
                         var guid = new Uri(btnResult.DownloadURL);
+                        var comments = new Uri($"{SiteLink}torrents.php?id={btnResult.GroupID}&torrentid={btnResult.TorrentID}");
+                        var publishDate = DateTimeUtil.UnixTimestampToDateTime(btnResult.Time);
                         var item = new ReleaseInfo
                         {
                             Category = MapTrackerCatToNewznab(btnResult.Resolution),
-                            Comments =
-                                new Uri($"{SiteLink}torrents.php?id={btnResult.GroupID}&torrentid={btnResult.TorrentID}"),
+                            Comments = comments,
                             Guid = guid,
                             Link = guid,
                             MinimumRatio = 1,
-                            PublishDate = DateTimeUtil.UnixTimestampToDateTime(btnResult.Time),
+                            PublishDate = publishDate,
                             RageID = btnResult.TvrageID,
                             Seeders = btnResult.Seeders,
                             Peers = btnResult.Seeders + btnResult.Leechers,
@@ -158,17 +159,13 @@ namespace Jackett.Common.Indexers
                             UploadVolumeFactor = 1,
                             DownloadVolumeFactor = 0, // ratioless
                             Grabs = btnResult.Snatched,
-                            Description = string.Join("<br />\n", descriptions)
+                            Description = string.Join("<br />\n", descriptions),
+                            Imdb = imdb
                         };
-
                         if (!string.IsNullOrEmpty(btnResult.SeriesBanner))
                             item.BannerUrl = new Uri(btnResult.SeriesBanner);
-                        if (item.Category.Count == 0) // default to TV
+                        if (!item.Category.Any()) // default to TV
                             item.Category.Add(TorznabCatType.TV.ID);
-                        if (!string.IsNullOrWhiteSpace(btnResult.ImdbID))
-                            item.Imdb = ParseUtil.CoerceLong(btnResult.ImdbID);
-
-
 
                         releases.Add(item);
                     }

--- a/src/Jackett.Common/Indexers/BroadcastTheNet.cs
+++ b/src/Jackett.Common/Indexers/BroadcastTheNet.cs
@@ -142,7 +142,7 @@ namespace Jackett.Common.Indexers
                         var link = new Uri(btnResult.DownloadURL);
                         var comments = new Uri($"{SiteLink}torrents.php?id={btnResult.GroupID}&torrentid={btnResult.TorrentID}");
                         var publishDate = DateTimeUtil.UnixTimestampToDateTime(btnResult.Time);
-                        var item = new ReleaseInfo
+                        var release = new ReleaseInfo
                         {
                             Category = MapTrackerCatToNewznab(btnResult.Resolution),
                             Comments = comments,
@@ -163,11 +163,11 @@ namespace Jackett.Common.Indexers
                             Imdb = imdb
                         };
                         if (!string.IsNullOrEmpty(btnResult.SeriesBanner))
-                            item.BannerUrl = new Uri(btnResult.SeriesBanner);
-                        if (!item.Category.Any()) // default to TV
-                            item.Category.Add(TorznabCatType.TV.ID);
+                            release.BannerUrl = new Uri(btnResult.SeriesBanner);
+                        if (!release.Category.Any()) // default to TV
+                            release.Category.Add(TorznabCatType.TV.ID);
 
-                        releases.Add(item);
+                        releases.Add(release);
                     }
                 }
             }

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -52,9 +52,11 @@ namespace Jackett.Common.Indexers
             // Add default data if necessary
             if (Definition.Settings == null)
             {
-                Definition.Settings = new List<settingsField>();
-                Definition.Settings.Add(new settingsField { Name = "username", Label = "Username", Type = "text" });
-                Definition.Settings.Add(new settingsField { Name = "password", Label = "Password", Type = "password" });
+                Definition.Settings = new List<settingsField>
+                {
+                    new settingsField { Name = "username", Label = "Username", Type = "text" },
+                    new settingsField { Name = "password", Label = "Password", Type = "password" }
+                };
             }
 
             if (Definition.Encoding == null)
@@ -71,10 +73,11 @@ namespace Jackett.Common.Indexers
             // convert definitions with a single search Path to a Paths entry
             if (Definition.Search.Path != null)
             {
-                var legacySearchPath = new searchPathBlock();
-                legacySearchPath.Path = Definition.Search.Path;
-                legacySearchPath.Inheritinputs = true;
-                Definition.Search.Paths.Add(legacySearchPath);
+                Definition.Search.Paths.Add(new searchPathBlock
+                {
+                    Path = Definition.Search.Path,
+                    Inheritinputs = true
+                });
             }
 
             // init missing mandatory attributes
@@ -90,9 +93,10 @@ namespace Jackett.Common.Indexers
                 DefaultSiteLink += "/";
             Language = Definition.Language;
             Type = Definition.Type;
-            TorznabCaps = new TorznabCapabilities();
-
-            TorznabCaps.SupportsImdbMovieSearch = Definition.Caps.Modes.Where(c => c.Key == "movie-search" && c.Value.Contains("imdbid")).Any();
+            TorznabCaps = new TorznabCapabilities
+            {
+                SupportsImdbMovieSearch = Definition.Caps.Modes.Any(c => c.Key == "movie-search" && c.Value.Contains("imdbid"))
+            };
             if (Definition.Caps.Modes.ContainsKey("music-search"))
                 TorznabCaps.SupportedMusicSearchParamsList = Definition.Caps.Modes["music-search"];
 
@@ -204,9 +208,10 @@ namespace Jackett.Common.Indexers
 
         protected Dictionary<string, object> getTemplateVariablesFromConfigData()
         {
-            var variables = new Dictionary<string, object>();
-
-            variables[".Config.sitelink"] = SiteLink;
+            var variables = new Dictionary<string, object>
+            {
+                [".Config.sitelink"] = SiteLink
+            };
             foreach (var Setting in Definition.Settings)
             {
                 var item = configData.GetDynamic(Setting.Name);
@@ -509,10 +514,12 @@ namespace Jackett.Common.Indexers
                     var CloudFlareCaptchaChallenge = landingResultDocument.QuerySelector("script[src=\"/cdn-cgi/scripts/cf.challenge.js\"]");
                     if (CloudFlareCaptchaChallenge != null)
                     {
-                        var CloudFlareQueryCollection = new NameValueCollection();
-                        CloudFlareQueryCollection["id"] = CloudFlareCaptchaChallenge.GetAttribute("data-ray");
+                        var CloudFlareQueryCollection = new NameValueCollection
+                        {
+                            ["id"] = CloudFlareCaptchaChallenge.GetAttribute("data-ray"),
 
-                        CloudFlareQueryCollection["g-recaptcha-response"] = CaptchaConfigItem.Value;
+                            ["g-recaptcha-response"] = CaptchaConfigItem.Value
+                        };
                         var ClearanceUrl = resolvePath("/cdn-cgi/l/chk_captcha?" + CloudFlareQueryCollection.GetQueryString());
 
                         var ClearanceResult = await RequestStringWithCookies(ClearanceUrl.ToString(), null, SiteLink);
@@ -890,12 +897,14 @@ namespace Jackett.Common.Indexers
             if (cloudFlareCaptchaScript != null && grecaptcha != null && cloudFlareCaptchaDisplay)
             {
                 hasCaptcha = true;
-                var CaptchaItem = new RecaptchaItem();
-                CaptchaItem.Name = "Captcha";
-                CaptchaItem.Version = "2";
-                CaptchaItem.SiteKey = grecaptcha.GetAttribute("data-sitekey");
-                if (CaptchaItem.SiteKey == null) // some sites don't store the sitekey in the .g-recaptcha div (e.g. cloudflare captcha challenge page)
-                    CaptchaItem.SiteKey = landingResultDocument.QuerySelector("[data-sitekey]").GetAttribute("data-sitekey");
+                var CaptchaItem = new RecaptchaItem
+                {
+                    Name = "Captcha",
+                    Version = "2",
+                    // some sites don't store the sitekey in the .g-recaptcha div (e.g. cloudflare captcha challenge page)
+                    SiteKey = grecaptcha.GetAttribute("data-sitekey") ??
+                              landingResultDocument.QuerySelector("[data-sitekey]").GetAttribute("data-sitekey")
+                };
 
                 configData.AddDynamic("Captcha", CaptchaItem);
             }
@@ -1400,9 +1409,11 @@ namespace Jackett.Common.Indexers
                     {
                         try
                         {
-                            var release = new ReleaseInfo();
-                            release.MinimumRatio = 1;
-                            release.MinimumSeedTime = 172800; // 48 hours
+                            var release = new ReleaseInfo
+                            {
+                                MinimumRatio = 1,
+                                MinimumSeedTime = 172800 // 48 hours
+                            };
 
                             // Parse fields
                             foreach (var Field in Search.Fields)

--- a/src/Jackett.Common/Indexers/DigitalHive.cs
+++ b/src/Jackett.Common/Indexers/DigitalHive.cs
@@ -102,16 +102,15 @@ namespace Jackett.Common.Indexers
                 result.Captcha.Version = "2";
                 return result;
             }
-            else
+
+            return new ConfigurationDataBasicLogin
             {
-                var result = new ConfigurationDataBasicLogin();
-                result.SiteLink.Value = configData.SiteLink.Value;
-                result.Instructions.Value = configData.Instructions.Value;
-                result.Username.Value = configData.Username.Value;
-                result.Password.Value = configData.Password.Value;
-                result.CookieHeader.Value = loginPage.Cookies;
-                return result;
-            }
+                SiteLink = {Value = configData.SiteLink.Value},
+                Instructions = {Value = configData.Instructions.Value},
+                Username = {Value = configData.Username.Value},
+                Password = {Value = configData.Password.Value},
+                CookieHeader = {Value = loginPage.Cookies}
+            };
         }
 
         public override async Task<IndexerConfigurationStatus> ApplyConfiguration(JToken configJson)

--- a/src/Jackett.Common/Indexers/DivxTotal.cs
+++ b/src/Jackett.Common/Indexers/DivxTotal.cs
@@ -294,14 +294,14 @@ namespace Jackett.Common.Indexers
         private void GenerateRelease(ICollection<ReleaseInfo> releases, string title, string commentsLink,
             string downloadLink, string cat, DateTime publishDate, long size)
         {
-            var guid = new Uri(downloadLink);
-
+            var link = new Uri(downloadLink);
+            var comments = new Uri(commentsLink);
             releases.Add(new ReleaseInfo
             {
                 Title = title,
-                Comments = new Uri(commentsLink),
-                Link = guid,
-                Guid = guid,
+                Comments = comments,
+                Link = link,
+                Guid = link,
                 Category = MapTrackerCatToNewznab(cat),
                 PublishDate = publishDate,
                 Size = size,

--- a/src/Jackett.Common/Indexers/DivxTotal.cs
+++ b/src/Jackett.Common/Indexers/DivxTotal.cs
@@ -296,7 +296,7 @@ namespace Jackett.Common.Indexers
         {
             var link = new Uri(downloadLink);
             var comments = new Uri(commentsLink);
-            releases.Add(new ReleaseInfo
+            var release = new ReleaseInfo
             {
                 Title = title,
                 Comments = comments,
@@ -309,10 +309,11 @@ namespace Jackett.Common.Indexers
                 Seeders = 1,
                 Peers = 2,
                 MinimumRatio = 1,
-                MinimumSeedTime = 172800,// 48 hours
+                MinimumSeedTime = 172800, // 48 hours
                 DownloadVolumeFactor = 0,
                 UploadVolumeFactor = 1,
-            });
+            };
+            releases.Add(release);
         }
 
         private static string OnclickToDownloadLink(string onclick)

--- a/src/Jackett.Common/Indexers/DivxTotal.cs
+++ b/src/Jackett.Common/Indexers/DivxTotal.cs
@@ -294,29 +294,25 @@ namespace Jackett.Common.Indexers
         private void GenerateRelease(ICollection<ReleaseInfo> releases, string title, string commentsLink,
             string downloadLink, string cat, DateTime publishDate, long size)
         {
-            // ReSharper disable once UseObjectOrCollectionInitializer
-            var release = new ReleaseInfo();
+            var guid = new Uri(downloadLink);
 
-            release.Title = title;
-            release.Comments = new Uri(commentsLink);
-            release.Link = new Uri(downloadLink);
-            release.Guid = release.Link;
-
-            release.Category = MapTrackerCatToNewznab(cat);
-            release.PublishDate = publishDate;
-            release.Size = size;
-
-            release.Files = 1;
-
-            release.Seeders = 1;
-            release.Peers = 2;
-
-            release.MinimumRatio = 1;
-            release.MinimumSeedTime = 172800; // 48 hours
-            release.DownloadVolumeFactor = 0;
-            release.UploadVolumeFactor = 1;
-
-            releases.Add(release);
+            releases.Add(new ReleaseInfo
+            {
+                Title = title,
+                Comments = new Uri(commentsLink),
+                Link = guid,
+                Guid = guid,
+                Category = MapTrackerCatToNewznab(cat),
+                PublishDate = publishDate,
+                Size = size,
+                Files = 1,
+                Seeders = 1,
+                Peers = 2,
+                MinimumRatio = 1,
+                MinimumSeedTime = 172800,// 48 hours
+                DownloadVolumeFactor = 0,
+                UploadVolumeFactor = 1,
+            });
         }
 
         private static string OnclickToDownloadLink(string onclick)

--- a/src/Jackett.Common/Indexers/EliteTracker.cs
+++ b/src/Jackett.Common/Indexers/EliteTracker.cs
@@ -165,8 +165,8 @@ namespace Jackett.Common.Indexers
             var pairs = new Dictionary<string, string>
             {
                 {"do", "search"},
-                {"search_type", !string.IsNullOrWhiteSpace(query.ImdbID) ? "t_genre" : "t_name"},
-                {"keywords", !string.IsNullOrWhiteSpace(query.ImdbID) ? query.ImdbID : query.GetQueryString()},
+                {"search_type", query.IsImdbQuery ? "t_genre" : "t_name"},
+                {"keywords", query.IsImdbQuery ? query.ImdbID : query.GetQueryString()},
                 {"category", "0"} // multi cat search not supported
             };
 

--- a/src/Jackett.Common/Indexers/EpubLibre.cs
+++ b/src/Jackett.Common/Indexers/EpubLibre.cs
@@ -113,8 +113,7 @@ namespace Jackett.Common.Indexers
 
                         // publish date is not available in the torrent list, but we add a relative date so we can sort
                         lastPublishDate = lastPublishDate.AddMinutes(-1);
-
-                        var release = new ReleaseInfo
+                        releases.Add(new ReleaseInfo
                         {
                             Title = title,
                             Comments = comments,
@@ -131,8 +130,7 @@ namespace Jackett.Common.Indexers
                             MinimumSeedTime = 172800, // 48 hours
                             DownloadVolumeFactor = 0,
                             UploadVolumeFactor = 1
-                        };
-                        releases.Add(release);
+                        });
                     }
 
                     if (rows.Length < MaxItemsPerPage)

--- a/src/Jackett.Common/Indexers/EpubLibre.cs
+++ b/src/Jackett.Common/Indexers/EpubLibre.cs
@@ -113,7 +113,7 @@ namespace Jackett.Common.Indexers
 
                         // publish date is not available in the torrent list, but we add a relative date so we can sort
                         lastPublishDate = lastPublishDate.AddMinutes(-1);
-                        releases.Add(new ReleaseInfo
+                        var release = new ReleaseInfo
                         {
                             Title = title,
                             Comments = comments,
@@ -130,7 +130,8 @@ namespace Jackett.Common.Indexers
                             MinimumSeedTime = 172800, // 48 hours
                             DownloadVolumeFactor = 0,
                             UploadVolumeFactor = 1
-                        });
+                        };
+                        releases.Add(release);
                     }
 
                     if (rows.Length < MaxItemsPerPage)

--- a/src/Jackett.Common/Indexers/GazelleGames.cs
+++ b/src/Jackett.Common/Indexers/GazelleGames.cs
@@ -286,7 +286,7 @@ namespace Jackett.Common.Indexers
                         var qFreeLeech = Row.QuerySelector("strong.freeleech_label");
                         var qNeutralLeech = Row.QuerySelector("strong.neutralleech_label");
                         var Time = qTime.GetAttribute("title");
-                        var guid = new Uri(SiteLink + qDLLink.GetAttribute("href"));
+                        var link = new Uri(SiteLink + qDLLink.GetAttribute("href"));
                         var seeders = ParseUtil.CoerceInt(qSeeders.TextContent);
                         var publishDate = DateTime.SpecifyKind(
                             DateTime.ParseExact(Time, "MMM dd yyyy, HH:mm", CultureInfo.InvariantCulture),
@@ -299,12 +299,11 @@ namespace Jackett.Common.Indexers
                             MinimumRatio = 1,
                             MinimumSeedTime = 288000, //80 hours
                             Category = GroupCategory,
-                            PublishDate =
-                                publishDate,
+                            PublishDate = publishDate,
                             Size = ReleaseInfo.GetBytes(Size),
                             Comments = comments,
-                            Link = guid,
-                            Guid = guid,
+                            Link = link,
+                            Guid = link,
                             Grabs = grabs,
                             Seeders = seeders,
                             Peers = leechers + seeders,

--- a/src/Jackett.Common/Indexers/GazelleGames.cs
+++ b/src/Jackett.Common/Indexers/GazelleGames.cs
@@ -294,13 +294,14 @@ namespace Jackett.Common.Indexers
                         var comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
                         var grabs = ParseUtil.CoerceLong(qGrabs.TextContent);
                         var leechers = ParseUtil.CoerceInt(qLeechers.TextContent);
+                        var bytes = ReleaseInfo.GetBytes(size);
                         var release = new ReleaseInfo
                         {
                             MinimumRatio = 1,
                             MinimumSeedTime = 288000, //80 hours
                             Category = GroupCategory,
                             PublishDate = publishDate,
-                            Size = ReleaseInfo.GetBytes(size),
+                            Size = bytes,
                             Comments = comments,
                             Link = link,
                             Guid = link,

--- a/src/Jackett.Common/Indexers/GazelleGames.cs
+++ b/src/Jackett.Common/Indexers/GazelleGames.cs
@@ -5,6 +5,7 @@ using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using AngleSharp.Dom;
 using AngleSharp.Html.Parser;
 using Jackett.Common.Models;
 using Jackett.Common.Models.IndexerConfig;
@@ -269,9 +270,8 @@ namespace Jackett.Common.Indexers
                             continue;
 
                         // some users have an extra colum (8), we can't use nth-last-child
-                        var qSize = Row.QuerySelector("td:nth-child(4)");
-                        var Size = qSize.TextContent;
-                        if (string.IsNullOrEmpty(Size)) // external links, example BlazBlue: Calamity Trigger Manual - Guide [GameDOX - External Link]
+                        var size = Row.QuerySelector("td:nth-child(4)").TextContent;
+                        if (string.IsNullOrEmpty(size)) // external links, example BlazBlue: Calamity Trigger Manual - Guide [GameDOX - External Link]
                             continue;
                         var qDetailsLink = Row.QuerySelector("a[href^=\"torrents.php?id=\"]");
                         var title = qDetailsLink.TextContent.Replace(", Freeleech!", "").Replace(", Neutral Leech!", "");
@@ -294,13 +294,13 @@ namespace Jackett.Common.Indexers
                         var comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
                         var grabs = ParseUtil.CoerceLong(qGrabs.TextContent);
                         var leechers = ParseUtil.CoerceInt(qLeechers.TextContent);
-                        releases.Add(new ReleaseInfo
+                        var release = new ReleaseInfo
                         {
                             MinimumRatio = 1,
                             MinimumSeedTime = 288000, //80 hours
                             Category = GroupCategory,
                             PublishDate = publishDate,
-                            Size = ReleaseInfo.GetBytes(Size),
+                            Size = ReleaseInfo.GetBytes(size),
                             Comments = comments,
                             Link = link,
                             Guid = link,
@@ -311,7 +311,8 @@ namespace Jackett.Common.Indexers
                             Description = qDescription?.TextContent,
                             UploadVolumeFactor = qNeutralLeech is null ? 1 : 0,
                             DownloadVolumeFactor = qFreeLeech != null || qNeutralLeech != null ? 0 : 1,
-                        });
+                        };
+                        releases.Add(release);
                     }
                 }
             }

--- a/src/Jackett.Common/Indexers/GazelleGames.cs
+++ b/src/Jackett.Common/Indexers/GazelleGames.cs
@@ -288,23 +288,26 @@ namespace Jackett.Common.Indexers
                         var Time = qTime.GetAttribute("title");
                         var guid = new Uri(SiteLink + qDLLink.GetAttribute("href"));
                         var seeders = ParseUtil.CoerceInt(qSeeders.TextContent);
-
+                        var publishDate = DateTime.SpecifyKind(
+                            DateTime.ParseExact(Time, "MMM dd yyyy, HH:mm", CultureInfo.InvariantCulture),
+                            DateTimeKind.Unspecified).ToLocalTime();
+                        var comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
+                        var grabs = ParseUtil.CoerceLong(qGrabs.TextContent);
+                        var leechers = ParseUtil.CoerceInt(qLeechers.TextContent);
                         releases.Add(new ReleaseInfo
                         {
                             MinimumRatio = 1,
-                            MinimumSeedTime = 80 * 3600,
+                            MinimumSeedTime = 288000, //80 hours
                             Category = GroupCategory,
                             PublishDate =
-                                DateTime.SpecifyKind(
-                                    DateTime.ParseExact(Time, "MMM dd yyyy, HH:mm", CultureInfo.InvariantCulture),
-                                    DateTimeKind.Unspecified).ToLocalTime(),
+                                publishDate,
                             Size = ReleaseInfo.GetBytes(Size),
-                            Comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href")),
+                            Comments = comments,
                             Link = guid,
                             Guid = guid,
-                            Grabs = ParseUtil.CoerceLong(qGrabs.TextContent),
+                            Grabs = grabs,
                             Seeders = seeders,
-                            Peers = ParseUtil.CoerceInt(qLeechers.TextContent) + seeders,
+                            Peers = leechers + seeders,
                             Title = title,
                             Description = qDescription?.TextContent,
                             UploadVolumeFactor = qNeutralLeech is null ? 1 : 0,

--- a/src/Jackett.Common/Indexers/GazelleGames.cs
+++ b/src/Jackett.Common/Indexers/GazelleGames.cs
@@ -270,8 +270,8 @@ namespace Jackett.Common.Indexers
                             continue;
 
                         // some users have an extra colum (8), we can't use nth-last-child
-                        var size = Row.QuerySelector("td:nth-child(4)").TextContent;
-                        if (string.IsNullOrEmpty(size)) // external links, example BlazBlue: Calamity Trigger Manual - Guide [GameDOX - External Link]
+                        var sizeString = Row.QuerySelector("td:nth-child(4)").TextContent;
+                        if (string.IsNullOrEmpty(sizeString)) // external links, example BlazBlue: Calamity Trigger Manual - Guide [GameDOX - External Link]
                             continue;
                         var qDetailsLink = Row.QuerySelector("a[href^=\"torrents.php?id=\"]");
                         var title = qDetailsLink.TextContent.Replace(", Freeleech!", "").Replace(", Neutral Leech!", "");
@@ -294,14 +294,14 @@ namespace Jackett.Common.Indexers
                         var comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
                         var grabs = ParseUtil.CoerceLong(qGrabs.TextContent);
                         var leechers = ParseUtil.CoerceInt(qLeechers.TextContent);
-                        var bytes = ReleaseInfo.GetBytes(size);
+                        var size = ReleaseInfo.GetBytes(sizeString);
                         var release = new ReleaseInfo
                         {
                             MinimumRatio = 1,
                             MinimumSeedTime = 288000, //80 hours
                             Category = GroupCategory,
                             PublishDate = publishDate,
-                            Size = bytes,
+                            Size = size,
                             Comments = comments,
                             Link = link,
                             Guid = link,

--- a/src/Jackett.Common/Indexers/HDBitsApi.cs
+++ b/src/Jackett.Common/Indexers/HDBitsApi.cs
@@ -125,25 +125,25 @@ namespace Jackett.Common.Indexers
             var releases = new List<ReleaseInfo>();
             foreach (JObject r in response["data"])
             {
-                var guid = new Uri(
+                var link = new Uri(
                     SiteLink + "download.php/" + (string)r["filename"] + "?id=" + (string)r["id"] + "&passkey=" +
                     configData.Passkey.Value);
                 var seeders = (int)r["seeders"];
-
+                var publishDate = DateTimeUtil.UnixTimestampToDateTime((int)r["utadded"]);
                 var release = new ReleaseInfo
                 {
                     Title = (string)r["name"],
                     Comments = new Uri(SiteLink + "details.php?id=" + (string)r["id"]),
-                    Link = guid,
+                    Link = link,
                     Category = MapTrackerCatToNewznab((string)r["type_category"]),
                     Size = (long)r["size"],
                     Files = (long)r["numfiles"],
                     Grabs = (long)r["times_completed"],
                     Seeders = seeders,
-                    PublishDate = DateTimeUtil.UnixTimestampToDateTime((int)r["utadded"]),
+                    PublishDate = publishDate,
                     UploadVolumeFactor = GetUploadFactor(r),
                     DownloadVolumeFactor = GetDownloadFactor(r),
-                    Guid = guid,
+                    Guid = link,
                     Peers = seeders + (int)r["leechers"]
                 };
 

--- a/src/Jackett.Common/Indexers/HDBitsApi.cs
+++ b/src/Jackett.Common/Indexers/HDBitsApi.cs
@@ -130,10 +130,11 @@ namespace Jackett.Common.Indexers
                     configData.Passkey.Value);
                 var seeders = (int)r["seeders"];
                 var publishDate = DateTimeUtil.UnixTimestampToDateTime((int)r["utadded"]);
+                var comments = new Uri(SiteLink + "details.php?id=" + (string)r["id"]);
                 var release = new ReleaseInfo
                 {
                     Title = (string)r["name"],
-                    Comments = new Uri(SiteLink + "details.php?id=" + (string)r["id"]),
+                    Comments = comments,
                     Link = link,
                     Category = MapTrackerCatToNewznab((string)r["type_category"]),
                     Size = (long)r["size"],

--- a/src/Jackett.Common/Indexers/HDOlimpo.cs
+++ b/src/Jackett.Common/Indexers/HDOlimpo.cs
@@ -168,7 +168,7 @@ namespace Jackett.Common.Indexers
                             continue;
                     }
 
-                    var guid = new Uri(CommentsUrl + (string)torrent["id"]);
+                    var comments = new Uri(CommentsUrl + (string)torrent["id"]);
                     var publishDate = DateTime.Now;
                     if (torrent["created_at"] != null)
                         publishDate = DateTime.Parse((string)torrent["created_at"]);
@@ -193,8 +193,8 @@ namespace Jackett.Common.Indexers
                         MinimumRatio = 1,
                         MinimumSeedTime = 172800, // 48 hours
                         PublishDate = publishDate,
-                        Comments = guid,
-                        Guid = guid,
+                        Comments = comments,
+                        Guid = comments,
                         Seeders = seeders,
                         Peers = seeders + (int)torrent["leechers"],
                         BannerUrl = bannerUrl

--- a/src/Jackett.Common/Indexers/HDOlimpo.cs
+++ b/src/Jackett.Common/Indexers/HDOlimpo.cs
@@ -179,7 +179,7 @@ namespace Jackett.Common.Indexers
                     var seeders = (int)torrent["seeders"];
                     var link = new Uri(DownloadUrl + (string)torrent["id"]);
                     var fileCount = ((JArray)JsonConvert.DeserializeObject<dynamic>((string)torrent["files_list"])).Count;
-                    releases.Add(new ReleaseInfo
+                    var release = new ReleaseInfo
                     {
                         Title = title,
                         Category = MapTrackerCatToNewznab((string)torrent["categoria"]),
@@ -198,7 +198,8 @@ namespace Jackett.Common.Indexers
                         Seeders = seeders,
                         Peers = seeders + (int)torrent["leechers"],
                         BannerUrl = bannerUrl
-                    });
+                    };
+                    releases.Add(release);
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/HDOlimpo.cs
+++ b/src/Jackett.Common/Indexers/HDOlimpo.cs
@@ -172,7 +172,7 @@ namespace Jackett.Common.Indexers
                     var publishDate = DateTime.Now;
                     if (torrent["created_at"] != null)
                         publishDate = DateTime.Parse((string)torrent["created_at"]);
-                    Uri bannerUrl;
+                    Uri bannerUrl = null;
                     if (torrent["portada"] != null)
 	                    bannerUrl = new Uri(BannerUrl + (string)(torrent["portada"]["hash"]) + "." + (string)(torrent["portada"]["ext"]));
 
@@ -195,7 +195,8 @@ namespace Jackett.Common.Indexers
                         Comments = guid,
                         Guid = guid,
                         Seeders = seeders,
-                        Peers = seeders + (int)torrent["leechers"]
+                        Peers = seeders + (int)torrent["leechers"],
+                        BannerUrl = bannerUrl
                     });
                 }
             }

--- a/src/Jackett.Common/Indexers/HDOlimpo.cs
+++ b/src/Jackett.Common/Indexers/HDOlimpo.cs
@@ -94,6 +94,7 @@ namespace Jackett.Common.Indexers
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {
             var includePremium = ((BoolItem)configData.GetDynamic("IncludePremium")).Value;
+            var cats = MapTorznabCapsToTrackers(query);
 
             var pairs = new Dictionary<string, string>
             {
@@ -104,7 +105,7 @@ namespace Jackett.Common.Indexers
                 {"categoria", MapTorznabCapsToTrackers(query).FirstIfSingleOrDefault("0")}
             };
 
-            var boundary = "---------------------------" + (DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds.ToString(CultureInfo.InvariantCulture).Replace(".", "");
+            var boundary = "---------------------------" + DateTimeUtil.DateTimeToUnixTimestamp(DateTime.UtcNow);
             var bodyParts = new List<string>();
 
             foreach (var pair in pairs)
@@ -157,49 +158,45 @@ namespace Jackett.Common.Indexers
             {
                 foreach (var torrent in torrents)
                 {
-                    var release = new ReleaseInfo();
-
-                    release.Title = (string)torrent["titulo"] + " " + (string)torrent["titulo_extra"];
-
+                    var title = (string)torrent["titulo"] + " " + (string)torrent["titulo_extra"];
                     // for downloading "premium" torrents you need special account
                     if ((string)torrent["premium"] == "si")
                     {
                         if (includePremium)
-                            release.Title += " [PREMIUM]";
+                            title += " [PREMIUM]";
                         else
                             continue;
                     }
 
-                    release.Comments = new Uri(CommentsUrl + (string)torrent["id"]);
-                    release.Guid = release.Comments;
-
-                    release.PublishDate = DateTime.Now;
+                    var guid = new Uri(CommentsUrl + (string)torrent["id"]);
+                    var publishDate = DateTime.Now;
                     if (torrent["created_at"] != null)
-                        release.PublishDate = DateTime.Parse((string)torrent["created_at"]);
-
+                        publishDate = DateTime.Parse((string)torrent["created_at"]);
+                    Uri bannerUrl;
                     if (torrent["portada"] != null)
-                        release.BannerUrl = new Uri(BannerUrl + (string)(torrent["portada"]["hash"]) + "." + (string)(torrent["portada"]["ext"]));
+	                    bannerUrl = new Uri(BannerUrl + (string)(torrent["portada"]["hash"]) + "." + (string)(torrent["portada"]["ext"]));
 
-                    release.Category = MapTrackerCatToNewznab((string)torrent["categoria"]);
-                    release.Size = (long)torrent["size"];
+                    var seeders = (int)torrent["seeders"];
 
-                    release.Seeders = (int)torrent["seeders"];
-                    release.Peers = release.Seeders + (int)torrent["leechers"];
-                    release.Grabs = (long)torrent["snatched"];
-
-                    release.InfoHash = (string)torrent["plain_info_hash"];
-                    release.Link = new Uri(DownloadUrl + (string)torrent["id"]);
-
-                    var files = (JArray)JsonConvert.DeserializeObject<dynamic>((string)torrent["files_list"]);
-                    release.Files = files.Count;
-
-                    release.DownloadVolumeFactor = (string)torrent["freetorrent"] == "0" ? 1 : 0;
-                    release.UploadVolumeFactor = (string)torrent["doubletorrent"] == "0" ? 1 : 2;
-
-                    release.MinimumRatio = 1;
-                    release.MinimumSeedTime = 172800; // 48 hours
-
-                    releases.Add(release);
+                    releases.Add(new ReleaseInfo
+                    {
+                        Title = title,
+                        Category = MapTrackerCatToNewznab((string)torrent["categoria"]),
+                        Size = (long)torrent["size"],
+                        Grabs = (long)torrent["snatched"],
+                        InfoHash = (string)torrent["plain_info_hash"],
+                        Link = new Uri(DownloadUrl + (string)torrent["id"]),
+                        Files = ((JArray)JsonConvert.DeserializeObject<dynamic>((string)torrent["files_list"])).Count,
+                        DownloadVolumeFactor = (string)torrent["freetorrent"] == "0" ? 1 : 0,
+                        UploadVolumeFactor = (string)torrent["doubletorrent"] == "0" ? 1 : 2,
+                        MinimumRatio = 1,
+                        MinimumSeedTime = 172800, // 48 hours
+                        PublishDate = publishDate,
+                        Comments = guid,
+                        Guid = guid,
+                        Seeders = seeders,
+                        Peers = seeders + (int)torrent["leechers"]
+                    });
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/HDOlimpo.cs
+++ b/src/Jackett.Common/Indexers/HDOlimpo.cs
@@ -177,7 +177,8 @@ namespace Jackett.Common.Indexers
 	                    bannerUrl = new Uri(BannerUrl + (string)(torrent["portada"]["hash"]) + "." + (string)(torrent["portada"]["ext"]));
 
                     var seeders = (int)torrent["seeders"];
-
+                    var link = new Uri(DownloadUrl + (string)torrent["id"]);
+                    var fileCount = ((JArray)JsonConvert.DeserializeObject<dynamic>((string)torrent["files_list"])).Count;
                     releases.Add(new ReleaseInfo
                     {
                         Title = title,
@@ -185,8 +186,8 @@ namespace Jackett.Common.Indexers
                         Size = (long)torrent["size"],
                         Grabs = (long)torrent["snatched"],
                         InfoHash = (string)torrent["plain_info_hash"],
-                        Link = new Uri(DownloadUrl + (string)torrent["id"]),
-                        Files = ((JArray)JsonConvert.DeserializeObject<dynamic>((string)torrent["files_list"])).Count,
+                        Link = link,
+                        Files = fileCount,
                         DownloadVolumeFactor = (string)torrent["freetorrent"] == "0" ? 1 : 0,
                         UploadVolumeFactor = (string)torrent["doubletorrent"] == "0" ? 1 : 2,
                         MinimumRatio = 1,

--- a/src/Jackett.Common/Indexers/HorribleSubs.cs
+++ b/src/Jackett.Common/Indexers/HorribleSubs.cs
@@ -111,9 +111,10 @@ namespace Jackett.Common.Indexers
             var ResultParser = new HtmlParser();
             var releases = new List<ReleaseInfo>();
             var searchString = query.GetQueryString();
-            var queryCollection = new NameValueCollection();
-
-            queryCollection.Add("method", "getlatest");
+            var queryCollection = new NameValueCollection
+            {
+                { "method", "getlatest" }
+            };
 
             var searchUrl = ApiEndpoint + "?" + queryCollection.GetQueryString();
             var response = await RequestStringWithCookiesAndRetry(searchUrl, string.Empty);

--- a/src/Jackett.Common/Indexers/LostFilm.cs
+++ b/src/Jackett.Common/Indexers/LostFilm.cs
@@ -723,10 +723,7 @@ namespace Jackett.Common.Indexers
                         // TODO this feels sparse compared to other trackers. Expand later
                         var release = new ReleaseInfo
                         {
-                            Category = new[]
-                            {
-                                TorznabCatType.TV.ID
-                            },
+                            Category = new[] {TorznabCatType.TV.ID},
                             Title = string.Join(" - ", titleComponents.Where(s => !string.IsNullOrEmpty(s))),
                             Link = link,
                             Guid = link,

--- a/src/Jackett.Common/Indexers/LostFilm.cs
+++ b/src/Jackett.Common/Indexers/LostFilm.cs
@@ -718,7 +718,7 @@ namespace Jackett.Common.Indexers
                         sizeString = sizeString.Replace("ГБ", "GB");
                         sizeString = sizeString.Replace("МБ", "MB");
                         sizeString = sizeString.Replace("КБ", "KB"); // untested
-                        var guid = new Uri(downloadLink.GetAttribute("href"));
+                        var link = new Uri(downloadLink.GetAttribute("href"));
 
                         // TODO this feels sparse compared to other trackers. Expand later
                         var release = new ReleaseInfo
@@ -728,8 +728,8 @@ namespace Jackett.Common.Indexers
                                 TorznabCatType.TV.ID
                             },
                             Title = string.Join(" - ", titleComponents.Where(s => !string.IsNullOrEmpty(s))),
-                            Link = guid,
-                            Guid = guid,
+                            Link = link,
+                            Guid = link,
                             Size = ReleaseInfo.GetBytes(sizeString),
                             // add missing torznab fields not available from results
                             Seeders = 1,

--- a/src/Jackett.Common/Indexers/LostFilm.cs
+++ b/src/Jackett.Common/Indexers/LostFilm.cs
@@ -608,10 +608,12 @@ namespace Jackett.Common.Indexers
 
         private async Task<List<ReleaseInfo>> FetchTrackerReleases(TrackerUrlDetails details)
         {
-            var queryCollection = new NameValueCollection();
-            queryCollection.Add("c", details.seriesId);
-            queryCollection.Add("s", details.season);
-            queryCollection.Add("e", string.IsNullOrEmpty(details.episode) ? "999" : details.episode); // 999 is a synonym for the whole serie
+            var queryCollection = new NameValueCollection
+            {
+                { "c", details.seriesId },
+                { "s", details.season },
+                { "e", string.IsNullOrEmpty(details.episode) ? "999" : details.episode } // 999 is a synonym for the whole serie
+            };
             var url = ReleaseUrl + "?" + queryCollection.GetQueryString();
 
             logger.Debug("FetchTrackerReleases: " + url);
@@ -671,12 +673,12 @@ namespace Jackett.Common.Indexers
                 {
                     try
                     {
-                        var release = new ReleaseInfo();
-
-                        release.Category = new int[] { TorznabCatType.TV.ID };
 
                         var detailsInfo = row.QuerySelector("div.inner-box--desc").TextContent;
                         var releaseDetails = parseReleaseDetailsRegex.Match(detailsInfo);
+
+                        // ReSharper states "Expression is always false"
+                        // TODO Refactor to get the intended operation
                         if (releaseDetails == null)
                         {
                             throw new FormatException("Failed to map release details string: " + detailsInfo);
@@ -697,8 +699,11 @@ namespace Jackett.Common.Indexers
                         quality = Regex.Replace(quality, "1080 ", "1080p ", RegexOptions.IgnoreCase);
                         quality = Regex.Replace(quality, "720 ", "720p ", RegexOptions.IgnoreCase);
 
-                        var techComponents = new string[] {
-                            "rus", quality, "(LostFilm)"
+                        var techComponents = new[]
+                        {
+                            "rus",
+                            quality,
+                            "(LostFilm)"
                         };
                         var techInfo = string.Join(" ", techComponents.Where(s => !string.IsNullOrEmpty(s)));
 
@@ -707,27 +712,35 @@ namespace Jackett.Common.Indexers
                         var titleComponents = new string[] {
                             serieTitle, details.GetEpisodeString(), episodeName, techInfo
                         };
-                        release.Title = string.Join(" - ", titleComponents.Where(s => !string.IsNullOrEmpty(s)));
-
                         var downloadLink = row.QuerySelector("div.inner-box--link > a");
-                        release.Link = new Uri(downloadLink.GetAttribute("href"));
-                        release.Guid = release.Link;
-
                         var sizeString = releaseDetails.Groups["size"].Value.ToUpper();
                         sizeString = sizeString.Replace("ТБ", "TB"); // untested
                         sizeString = sizeString.Replace("ГБ", "GB");
                         sizeString = sizeString.Replace("МБ", "MB");
                         sizeString = sizeString.Replace("КБ", "KB"); // untested
-                        release.Size = ReleaseInfo.GetBytes(sizeString);
+                        var guid = new Uri(downloadLink.GetAttribute("href"));
 
-                        // add missing torznab fields not available from results
-                        release.Seeders = 1;
-                        release.Peers = 2;
-                        release.DownloadVolumeFactor = 0;
-                        release.UploadVolumeFactor = 1;
-                        release.MinimumRatio = 1;
-                        release.MinimumSeedTime = 172800; // 48 hours
-
+                        // TODO this feels sparse compared to other trackers. Expand later
+                        var release = new ReleaseInfo
+                        {
+                            Category = new[]
+                            {
+                                TorznabCatType.TV.ID
+                            },
+                            Title = string.Join(" - ", titleComponents.Where(s => !string.IsNullOrEmpty(s))),
+                            Link = guid,
+                            Guid = guid,
+                            Size = ReleaseInfo.GetBytes(sizeString),
+                            // add missing torznab fields not available from results
+                            Seeders = 1,
+                            Peers = 2,
+                            DownloadVolumeFactor = 0,
+                            UploadVolumeFactor = 1,
+                            MinimumRatio = 1,
+                            MinimumSeedTime = 172800 // 48 hours
+                        };
+                        
+                        // TODO Other trackers don't have this log line. Remove or add to other trackers?
                         logger.Debug("> Add: " + release.Title);
                         releases.Add(release);
                     }

--- a/src/Jackett.Common/Indexers/MejorTorrent.cs
+++ b/src/Jackett.Common/Indexers/MejorTorrent.cs
@@ -369,10 +369,11 @@ namespace Jackett.Common.Indexers
             string downloadLink, string cat, DateTime publishDate, long size)
         {
             var link = new Uri(downloadLink);
+            var comments = new Uri(commentsLink);
             releases.Add(new ReleaseInfo
             {
                 Title = title,
-                Comments = new Uri(commentsLink),
+                Comments = comments,
                 Link = link,
                 Guid = link,
                 Category = MapTrackerCatToNewznab(cat),

--- a/src/Jackett.Common/Indexers/MejorTorrent.cs
+++ b/src/Jackett.Common/Indexers/MejorTorrent.cs
@@ -19,6 +19,7 @@ using WebClient = Jackett.Common.Utils.Clients.WebClient;
 
 namespace Jackett.Common.Indexers
 {
+    //TODO fix ReSharper notice
     // ReSharper disable once UnusedType.Global
     public class MejorTorrent : BaseWebIndexer
     {
@@ -363,33 +364,28 @@ namespace Jackett.Common.Indexers
 
             GenerateRelease(releases, title, commentsLink, commentsLink, cat, publishDate, size);
         }
-
+        // TODO refactor for IEnumerable
         private void GenerateRelease(ICollection<ReleaseInfo> releases, string title, string commentsLink,
             string downloadLink, string cat, DateTime publishDate, long size)
         {
-            // ReSharper disable once UseObjectOrCollectionInitializer
-            var release = new ReleaseInfo();
-
-            release.Title = title;
-            release.Comments = new Uri(commentsLink);
-            release.Link = new Uri(downloadLink);
-            release.Guid = release.Link;
-
-            release.Category = MapTrackerCatToNewznab(cat);
-            release.PublishDate = publishDate;
-            release.Size = size;
-
-            release.Files = 1;
-
-            release.Seeders = 1;
-            release.Peers = 2;
-
-            release.MinimumRatio = 1;
-            release.MinimumSeedTime = 172800; // 48 hours
-            release.DownloadVolumeFactor = 0;
-            release.UploadVolumeFactor = 1;
-
-            releases.Add(release);
+            var link = new Uri(downloadLink);
+            releases.Add(new ReleaseInfo
+            {
+                Title = title,
+                Comments = new Uri(commentsLink),
+                Link = link,
+                Guid = link,
+                Category = MapTrackerCatToNewznab(cat),
+                PublishDate = publishDate,
+                Size = size,
+                Files = 1,
+                Seeders = 1,
+                Peers = 2,
+                MinimumRatio = 1,
+                MinimumSeedTime = 172800,// 48 hours
+                DownloadVolumeFactor = 0,
+                UploadVolumeFactor = 1
+            });
         }
 
         private static bool CheckTitleMatchWords(string queryStr, string title)

--- a/src/Jackett.Common/Indexers/MejorTorrent.cs
+++ b/src/Jackett.Common/Indexers/MejorTorrent.cs
@@ -370,7 +370,7 @@ namespace Jackett.Common.Indexers
         {
             var link = new Uri(downloadLink);
             var comments = new Uri(commentsLink);
-            releases.Add(new ReleaseInfo
+            var release = new ReleaseInfo
             {
                 Title = title,
                 Comments = comments,
@@ -386,7 +386,8 @@ namespace Jackett.Common.Indexers
                 MinimumSeedTime = 172800,// 48 hours
                 DownloadVolumeFactor = 0,
                 UploadVolumeFactor = 1
-            });
+            };
+            releases.Add(release);
         }
 
         private static bool CheckTitleMatchWords(string queryStr, string title)

--- a/src/Jackett.Common/Indexers/MoreThanTV.cs
+++ b/src/Jackett.Common/Indexers/MoreThanTV.cs
@@ -267,13 +267,13 @@ namespace Jackett.Common.Indexers
             var grabs = int.Parse(torrentData[1].TextContent, NumberStyles.AllowThousands, CultureInfo.InvariantCulture);
             var seeders = int.Parse(torrentData[2].TextContent, NumberStyles.AllowThousands, CultureInfo.InvariantCulture);
             var leechers = int.Parse(torrentData[3].TextContent, NumberStyles.AllowThousands, CultureInfo.InvariantCulture);
-            var guid = new Uri(GuidUrl + torrentId);
-
+            var comments = new Uri(GuidUrl + torrentId);
+            var link = new Uri(DownloadUrl + torrentId);
             return new ReleaseInfo
             {
                 Title = title,
                 Category = new List<int> { category }, // Who seasons movies right
-                Link = new Uri(DownloadUrl + torrentId),
+                Link = link,
                 PublishDate = publishDate,
                 BannerUrl = banner,
                 Description = description,
@@ -282,8 +282,8 @@ namespace Jackett.Common.Indexers
                 Files = files,
                 Size = size,
                 Grabs = grabs,
-                Guid = guid,
-                Comments = guid,
+                Guid = comments,
+                Comments = comments,
                 DownloadVolumeFactor = 0, // ratioless tracker
                 UploadVolumeFactor = 1
             };

--- a/src/Jackett.Common/Indexers/MoreThanTV.cs
+++ b/src/Jackett.Common/Indexers/MoreThanTV.cs
@@ -22,7 +22,7 @@ namespace Jackett.Common.Indexers
         private string LoginUrl => SiteLink + "login.php";
         private string SearchUrl => SiteLink + "ajax.php?action=browse&searchstr=";
         private string DownloadUrl => SiteLink + "torrents.php?action=download&id=";
-        private string GuidUrl => SiteLink + "torrents.php?torrentid=";
+        private string CommentsUrl => SiteLink + "torrents.php?torrentid=";
 
         private ConfigurationDataBasicLogin ConfigData => (ConfigurationDataBasicLogin)configData;
 
@@ -267,7 +267,7 @@ namespace Jackett.Common.Indexers
             var grabs = int.Parse(torrentData[1].TextContent, NumberStyles.AllowThousands, CultureInfo.InvariantCulture);
             var seeders = int.Parse(torrentData[2].TextContent, NumberStyles.AllowThousands, CultureInfo.InvariantCulture);
             var leechers = int.Parse(torrentData[3].TextContent, NumberStyles.AllowThousands, CultureInfo.InvariantCulture);
-            var comments = new Uri(GuidUrl + torrentId);
+            var comments = new Uri(CommentsUrl + torrentId);
             var link = new Uri(DownloadUrl + torrentId);
             return new ReleaseInfo
             {

--- a/src/Jackett.Common/Indexers/MyAnonamouse.cs
+++ b/src/Jackett.Common/Indexers/MyAnonamouse.cs
@@ -170,21 +170,20 @@ namespace Jackett.Common.Indexers
 
             var qParams = new NameValueCollection
             {
-                { "tor[text]", query.GetQueryString() },
-                { "tor[srchIn][title]", "true" },
-                { "tor[srchIn][author]", "true" },
-                { "tor[searchType]", "all" },
-                { "tor[searchIn]", "torrents" },
-                { "tor[hash]", "" },
-                { "tor[sortType]", "default" },
-                { "tor[startNumber]", "0" },
-
-                { "thumbnails", "1" }, // gives links for thumbnail sized versions of their posters
-                                       //qParams.Add("posterLink", "1"); // gives links for a full sized poster
-                                       //qParams.Add("dlLink", "1"); // include the url to download the torrent
-                { "description", "1" } // include the description
+                {"tor[text]", query.GetQueryString()},
+                {"tor[srchIn][title]", "true"},
+                {"tor[srchIn][author]", "true"},
+                {"tor[searchType]", "all"},
+                {"tor[searchIn]", "torrents"},
+                {"tor[hash]", ""},
+                {"tor[sortType]", "default"},
+                {"tor[startNumber]", "0"},
+                {"thumbnails", "1"}, // gives links for thumbnail sized versions of their posters
+                //{ "posterLink", "1"}, // gives links for a full sized poster
+                //{ "dlLink", "1"}, // include the url to download the torrent
+                {"description", "1"}, // include the description
+                //{"bookmarks", "0"} // include if the item is bookmarked or not
             };
-            //qParams.Add("bookmarks", "0"); // include if the item is bookmarked or not
 
             var catList = MapTorznabCapsToTrackers(query);
             if (catList.Any())

--- a/src/Jackett.Common/Indexers/MyAnonamouse.cs
+++ b/src/Jackett.Common/Indexers/MyAnonamouse.cs
@@ -168,20 +168,22 @@ namespace Jackett.Common.Indexers
         {
             var releases = new List<ReleaseInfo>();
 
-            var qParams = new NameValueCollection();
-            qParams.Add("tor[text]", query.GetQueryString());
-            qParams.Add("tor[srchIn][title]", "true");
-            qParams.Add("tor[srchIn][author]", "true");
-            qParams.Add("tor[searchType]", "all");
-            qParams.Add("tor[searchIn]", "torrents");
-            qParams.Add("tor[hash]", "");
-            qParams.Add("tor[sortType]", "default");
-            qParams.Add("tor[startNumber]", "0");
+            var qParams = new NameValueCollection
+            {
+                { "tor[text]", query.GetQueryString() },
+                { "tor[srchIn][title]", "true" },
+                { "tor[srchIn][author]", "true" },
+                { "tor[searchType]", "all" },
+                { "tor[searchIn]", "torrents" },
+                { "tor[hash]", "" },
+                { "tor[sortType]", "default" },
+                { "tor[startNumber]", "0" },
 
-            qParams.Add("thumbnails", "1"); // gives links for thumbnail sized versions of their posters
-            //qParams.Add("posterLink", "1"); // gives links for a full sized poster
-            //qParams.Add("dlLink", "1"); // include the url to download the torrent
-            qParams.Add("description", "1"); // include the description
+                { "thumbnails", "1" }, // gives links for thumbnail sized versions of their posters
+                                       //qParams.Add("posterLink", "1"); // gives links for a full sized poster
+                                       //qParams.Add("dlLink", "1"); // include the url to download the torrent
+                { "description", "1" } // include the description
+            };
             //qParams.Add("bookmarks", "0"); // include if the item is bookmarked or not
 
             var catList = MapTorznabCapsToTrackers(query);
@@ -225,6 +227,7 @@ namespace Jackett.Common.Indexers
 
                 foreach (var item in jsonContent.Value<JArray>("data"))
                 {
+                    //TODO shift to ReleaseInfo object initializer for consistency
                     var release = new ReleaseInfo();
 
                     var id = item.Value<long>("id");

--- a/src/Jackett.Common/Indexers/NewRealWorld.cs
+++ b/src/Jackett.Common/Indexers/NewRealWorld.cs
@@ -165,8 +165,8 @@ namespace Jackett.Common.Indexers
                 {
 
                     var qDetailsLink = row.QuerySelector("a[href^=details.php?id=]");
-
-                    if (!query.MatchQueryStringAND(qDetailsLink.Text()))
+                    var title = qDetailsLink.TextContent;
+                    if (!query.MatchQueryStringAND(title))
                         continue;
 
                     var qCatLink = row.QuerySelector("a[href^=\"browse.php?cat=\"]");
@@ -198,7 +198,7 @@ namespace Jackett.Common.Indexers
                     {
                         MinimumRatio = 0.75,
                         MinimumSeedTime = 0,
-                        Title = qDetailsLink.TextContent,
+                        Title = title,
                         Category = MapTrackerCatToNewznab(catStr),
                         Link = link,
                         Comments = comments,

--- a/src/Jackett.Common/Indexers/NewRealWorld.cs
+++ b/src/Jackett.Common/Indexers/NewRealWorld.cs
@@ -192,7 +192,8 @@ namespace Jackett.Common.Indexers
                     var files = ParseUtil.CoerceInt(row.QuerySelector("td:contains(Datei) > strong ~ strong").TextContent);
                     var comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
                     var leechers = ParseUtil.CoerceInt(qLeechers.Text());
-                    var bytes = ReleaseInfo.GetBytes(qSize.TextContent.Replace(".", "").Replace(",", "."));
+                    var size = ReleaseInfo.GetBytes(qSize.TextContent.Replace(".", "").Replace(",", "."));
+                    var downloadVolumeFactor = row.QuerySelector("img[title=\"OnlyUpload\"]") != null ? 0 : 1;
                     releases.Add(new ReleaseInfo
                     {
                         MinimumRatio = 0.75,
@@ -202,12 +203,12 @@ namespace Jackett.Common.Indexers
                         Link = link,
                         Comments = comments,
                         Guid = link,
-                        Size = bytes,
+                        Size = size,
                         Seeders = seeders,
                         Peers = leechers + seeders,
                         PublishDate = pubDateUtc,
                         Files = files,
-                        DownloadVolumeFactor = row.QuerySelector("img[title=\"OnlyUpload\"]") != null ? 0 : 1,
+                        DownloadVolumeFactor = downloadVolumeFactor,
                         UploadVolumeFactor = 1
                     });
                 }

--- a/src/Jackett.Common/Indexers/NewRealWorld.cs
+++ b/src/Jackett.Common/Indexers/NewRealWorld.cs
@@ -194,7 +194,7 @@ namespace Jackett.Common.Indexers
                     var leechers = ParseUtil.CoerceInt(qLeechers.Text());
                     var size = ReleaseInfo.GetBytes(qSize.TextContent.Replace(".", "").Replace(",", "."));
                     var downloadVolumeFactor = row.QuerySelector("img[title=\"OnlyUpload\"]") != null ? 0 : 1;
-                    releases.Add(new ReleaseInfo
+                    var release = new ReleaseInfo
                     {
                         MinimumRatio = 0.75,
                         MinimumSeedTime = 0,
@@ -210,7 +210,8 @@ namespace Jackett.Common.Indexers
                         Files = files,
                         DownloadVolumeFactor = downloadVolumeFactor,
                         UploadVolumeFactor = 1
-                    });
+                    };
+                    releases.Add(release);
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/NewRealWorld.cs
+++ b/src/Jackett.Common/Indexers/NewRealWorld.cs
@@ -189,8 +189,10 @@ namespace Jackett.Common.Indexers
                     var dateStr = qDateStr.TextContent.Replace('\xA0', ' ');
                     var dateGerman = DateTime.SpecifyKind(DateTime.ParseExact(dateStr, "dd.MM.yyyy HH:mm:ss", CultureInfo.InvariantCulture), DateTimeKind.Unspecified);
                     var pubDateUtc = TimeZoneInfo.ConvertTimeToUtc(dateGerman, germanyTz);
-                    var files = row.QuerySelector("td:contains(Datei) > strong ~ strong").TextContent;
-
+                    var files = ParseUtil.CoerceInt(row.QuerySelector("td:contains(Datei) > strong ~ strong").TextContent);
+                    var comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
+                    var leechers = ParseUtil.CoerceInt(qLeechers.Text());
+                    var bytes = ReleaseInfo.GetBytes(qSize.TextContent.Replace(".", "").Replace(",", "."));
                     releases.Add(new ReleaseInfo
                     {
                         MinimumRatio = 0.75,
@@ -198,13 +200,13 @@ namespace Jackett.Common.Indexers
                         Title = qDetailsLink.TextContent,
                         Category = MapTrackerCatToNewznab(catStr),
                         Link = link,
-                        Comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href")),
+                        Comments = comments,
                         Guid = link,
-                        Size = ReleaseInfo.GetBytes(qSize.TextContent.Replace(".", "").Replace(",", ".")),
+                        Size = bytes,
                         Seeders = seeders,
-                        Peers = ParseUtil.CoerceInt(qLeechers.Text()) + seeders,
+                        Peers = leechers + seeders,
                         PublishDate = pubDateUtc,
-                        Files = ParseUtil.CoerceInt(files),
+                        Files = files,
                         DownloadVolumeFactor = row.QuerySelector("img[title=\"OnlyUpload\"]") != null ? 0 : 1,
                         UploadVolumeFactor = 1
                     });

--- a/src/Jackett.Common/Indexers/PassThePopcorn.cs
+++ b/src/Jackett.Common/Indexers/PassThePopcorn.cs
@@ -128,19 +128,7 @@ namespace Jackett.Common.Indexers
                     var movieGroupId = (string)movie["GroupId"];
                     foreach (var torrent in movie["Torrents"])
                     {
-                        var release = new ReleaseInfo();
                         var releaseName = (string)torrent["ReleaseName"];
-                        release.Title = releaseName;
-                        release.Description = $"Title: {movieTitle}";
-                        release.BannerUrl = coverUri;
-                        release.Imdb = movieImdbId;
-                        release.Comments = new Uri($"{SearchUrl}?id={WebUtility.UrlEncode(movieGroupId)}");
-                        release.Size = long.Parse((string)torrent["Size"]);
-                        release.Grabs = long.Parse((string)torrent["Snatched"]);
-                        release.Seeders = int.Parse((string)torrent["Seeders"]);
-                        release.Peers = release.Seeders + int.Parse((string)torrent["Leechers"]);
-                        release.PublishDate = DateTime.ParseExact((string)torrent["UploadTime"], "yyyy-MM-dd HH:mm:ss",
-                                                CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal).ToLocalTime();
 
                         var releaseLinkQuery = new NameValueCollection
                         {
@@ -149,14 +137,7 @@ namespace Jackett.Common.Indexers
                             {"authkey", AuthKey},
                             {"torrent_pass", configData.Passkey.Value},
                         };
-                        release.Link = new UriBuilder(SearchUrl) {Query = releaseLinkQuery.GetQueryString()}.Uri;
-                        release.Guid = release.Link;
-                        release.MinimumRatio = 1;
-                        release.MinimumSeedTime = 345600;
                         var free = !(torrent["FreeleechType"] is null);
-                        release.DownloadVolumeFactor = free ? 0 : 1;
-                        release.UploadVolumeFactor = 1;
-                        release.Category = new List<int> { 2000 };
 
                         bool.TryParse((string)torrent["GoldenPopcorn"], out var golden);
                         bool.TryParse((string)torrent["Scene"], out var scene);
@@ -170,6 +151,31 @@ namespace Jackett.Common.Indexers
                             continue; //Skip release if user only wants Checked
                         if (configFreeOnly && !free)
                             continue;
+                        var link = new Uri($"{SearchUrl}?{releaseLinkQuery.GetQueryString()}");
+                        var seeders = int.Parse((string)torrent["Seeders"]);
+                        var release = new ReleaseInfo
+                        {
+                            Title = releaseName,
+                            Description = $"Title: {movieTitle}",
+                            BannerUrl = coverUri,
+                            Imdb = movieImdbId,
+                            Comments = new Uri($"{SearchUrl}?id={WebUtility.UrlEncode(movieGroupId)}"),
+                            Size = long.Parse((string)torrent["Size"]),
+                            Grabs = long.Parse((string)torrent["Snatched"]),
+                            Seeders = seeders,
+                            Peers = seeders + int.Parse((string)torrent["Leechers"]),
+                            PublishDate = DateTime.ParseExact((string)torrent["UploadTime"],
+                            "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal)
+                                .ToLocalTime(),
+                            Link = link,
+                            Guid = link,
+                            MinimumRatio = 1,
+                            MinimumSeedTime = 345600,
+                            DownloadVolumeFactor = 1,
+                            UploadVolumeFactor = 1,
+                            Category = new List<int> { 2000 }
+                        };
+
 
                         var titleTags = new List<string>();
                         var quality = (string)torrent["Quality"];

--- a/src/Jackett.Common/Indexers/PassThePopcorn.cs
+++ b/src/Jackett.Common/Indexers/PassThePopcorn.cs
@@ -153,27 +153,32 @@ namespace Jackett.Common.Indexers
                             continue;
                         var link = new Uri($"{SearchUrl}?{releaseLinkQuery.GetQueryString()}");
                         var seeders = int.Parse((string)torrent["Seeders"]);
+                        var comments = new Uri($"{SearchUrl}?id={WebUtility.UrlEncode(movieGroupId)}");
+                        var size = long.Parse((string)torrent["Size"]);
+                        var grabs = long.Parse((string)torrent["Snatched"]);
+                        var publishDate = DateTime.ParseExact((string)torrent["UploadTime"],
+                                                              "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal)
+                                                  .ToLocalTime();
+                        var leechers = int.Parse((string)torrent["Leechers"]);
                         var release = new ReleaseInfo
                         {
                             Title = releaseName,
                             Description = $"Title: {movieTitle}",
                             BannerUrl = coverUri,
                             Imdb = movieImdbId,
-                            Comments = new Uri($"{SearchUrl}?id={WebUtility.UrlEncode(movieGroupId)}"),
-                            Size = long.Parse((string)torrent["Size"]),
-                            Grabs = long.Parse((string)torrent["Snatched"]),
+                            Comments = comments,
+                            Size = size,
+                            Grabs = grabs,
                             Seeders = seeders,
-                            Peers = seeders + int.Parse((string)torrent["Leechers"]),
-                            PublishDate = DateTime.ParseExact((string)torrent["UploadTime"],
-                            "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture, DateTimeStyles.AssumeUniversal)
-                                .ToLocalTime(),
+                            Peers = seeders + leechers,
+                            PublishDate = publishDate,
                             Link = link,
                             Guid = link,
                             MinimumRatio = 1,
                             MinimumSeedTime = 345600,
                             DownloadVolumeFactor = 1,
                             UploadVolumeFactor = 1,
-                            Category = new List<int> { 2000 }
+                            Category = new List<int> { TorznabCatType.Movies.ID }
                         };
 
 

--- a/src/Jackett.Common/Indexers/PiXELHD.cs
+++ b/src/Jackett.Common/Indexers/PiXELHD.cs
@@ -4,6 +4,7 @@ using System.Collections.Specialized;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using AngleSharp.Dom;
 using AngleSharp.Html.Parser;
 using Jackett.Common.Models;
 using Jackett.Common.Models.IndexerConfig;
@@ -162,20 +163,19 @@ namespace Jackett.Common.Indexers
                         IMDBId = ParseUtil.CoerceLong(IMDBMatch.Groups[1].Value);
                     }
 
-                    var GroupTitle = Group.QuerySelector("strong:has(a[title=\"View Torrent\"])").TextContent.Replace(" ]", "]");
+                    var group = Group.QuerySelector("strong:has(a[title=\"View Torrent\"])").TextContent.Replace(" ]", "]");
 
                     var Rows = Group.QuerySelectorAll("tr.group_torrent:has(a[href^=\"torrents.php?id=\"])");
                     foreach (var Row in Rows)
                     {
                         var title = Row.QuerySelector("a[href^=\"torrents.php?id=\"]");
-                        var link = Row.QuerySelector("a[href^=\"torrents.php?action=download\"]");
                         var added = Row.QuerySelector("td:nth-child(3)");
                         var Size = Row.QuerySelector("td:nth-child(4)");
                         var Grabs = Row.QuerySelector("td:nth-child(6)");
                         var Seeders = Row.QuerySelector("td:nth-child(7)");
                         var Leechers = Row.QuerySelector("td:nth-child(8)");
-                        var releaseLink = new Uri(SiteLink + link.GetAttribute("href"));
-                        var releaseSeeders = ParseUtil.CoerceInt(Seeders.TextContent);
+                        var link = new Uri(SiteLink + Row.QuerySelector("a[href^=\"torrents.php?action=download\"]").GetAttribute("href"));
+                        var seeders = ParseUtil.CoerceInt(Seeders.TextContent);
                         var comments = new Uri(SiteLink + title.GetAttribute("href"));
                         var size = ReleaseInfo.GetBytes(Size.TextContent);
                         var leechers = ParseUtil.CoerceInt(Leechers.TextContent);
@@ -185,14 +185,14 @@ namespace Jackett.Common.Indexers
                         {
                             MinimumRatio = 1,
                             MinimumSeedTime = 72 * 60 * 60,
-                            Title = GroupTitle + " " + title.TextContent,
+                            Title = group + " " + title.TextContent,
                             Category = new List<int> {TorznabCatType.MoviesHD.ID},
-                            Link = releaseLink,
+                            Link = link,
                             Comments = comments,
-                            Guid = releaseLink,
+                            Guid = link,
                             Size = size,
-                            Seeders = releaseSeeders,
-                            Peers = leechers + releaseSeeders,
+                            Seeders = seeders,
+                            Peers = leechers + seeders,
                             Grabs = grabs,
                             PublishDate = publishDate,
                             BannerUrl = bannerURL,

--- a/src/Jackett.Common/Indexers/PiXELHD.cs
+++ b/src/Jackett.Common/Indexers/PiXELHD.cs
@@ -181,7 +181,7 @@ namespace Jackett.Common.Indexers
                         var leechers = ParseUtil.CoerceInt(Leechers.TextContent);
                         var grabs = ParseUtil.CoerceLong(Grabs.TextContent);
                         var publishDate = DateTimeUtil.FromTimeAgo(added.TextContent);
-                        releases.Add(new ReleaseInfo
+                        var release = new ReleaseInfo
                         {
                             MinimumRatio = 1,
                             MinimumSeedTime = 72 * 60 * 60,
@@ -197,7 +197,8 @@ namespace Jackett.Common.Indexers
                             PublishDate = publishDate,
                             BannerUrl = bannerURL,
                             Imdb = IMDBId
-                        });
+                        };
+                        releases.Add(release);
                     }
                 }
             }

--- a/src/Jackett.Common/Indexers/PiXELHD.cs
+++ b/src/Jackett.Common/Indexers/PiXELHD.cs
@@ -176,7 +176,11 @@ namespace Jackett.Common.Indexers
                         var Leechers = Row.QuerySelector("td:nth-child(8)");
                         var releaseLink = new Uri(SiteLink + link.GetAttribute("href"));
                         var releaseSeeders = ParseUtil.CoerceInt(Seeders.TextContent);
-
+                        var comments = new Uri(SiteLink + title.GetAttribute("href"));
+                        var size = ReleaseInfo.GetBytes(Size.TextContent);
+                        var leechers = ParseUtil.CoerceInt(Leechers.TextContent);
+                        var grabs = ParseUtil.CoerceLong(Grabs.TextContent);
+                        var publishDate = DateTimeUtil.FromTimeAgo(added.TextContent);
                         releases.Add(new ReleaseInfo
                         {
                             MinimumRatio = 1,
@@ -184,13 +188,13 @@ namespace Jackett.Common.Indexers
                             Title = GroupTitle + " " + title.TextContent,
                             Category = new List<int> {TorznabCatType.MoviesHD.ID},
                             Link = releaseLink,
-                            Comments = new Uri(SiteLink + title.GetAttribute("href")),
+                            Comments = comments,
                             Guid = releaseLink,
-                            Size = ReleaseInfo.GetBytes(Size.TextContent),
+                            Size = size,
                             Seeders = releaseSeeders,
-                            Peers = ParseUtil.CoerceInt(Leechers.TextContent) + releaseSeeders,
-                            Grabs = ParseUtil.CoerceLong(Grabs.TextContent),
-                            PublishDate = DateTimeUtil.FromTimeAgo(added.TextContent),
+                            Peers = leechers + releaseSeeders,
+                            Grabs = grabs,
+                            PublishDate = publishDate,
                             BannerUrl = bannerURL,
                             Imdb = IMDBId
                         });

--- a/src/Jackett.Common/Indexers/PirateTheNet.cs
+++ b/src/Jackett.Common/Indexers/PirateTheNet.cs
@@ -169,11 +169,12 @@ namespace Jackett.Common.Indexers
                     var comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
                     var size = ReleaseInfo.GetBytes(sizeStr);
                     var leechers = ParseUtil.CoerceInt(qLeechers.Text());
+                    var title = qDetailsLink.GetAttribute("alt");
                     releases.Add(new ReleaseInfo
                     {
                         MinimumRatio = 1,
                         MinimumSeedTime = 72 * 60 * 60,
-                        Title = qDetailsLink.GetAttribute("alt"),
+                        Title = title,
                         Category = MapTrackerCatToNewznab(catStr),
                         Link = link,
                         Comments = comments,

--- a/src/Jackett.Common/Indexers/PirateTheNet.cs
+++ b/src/Jackett.Common/Indexers/PirateTheNet.cs
@@ -136,18 +136,13 @@ namespace Jackett.Common.Indexers
                 var rows = dom.QuerySelectorAll("table.main > tbody > tr");
                 foreach (var row in rows.Skip(1))
                 {
-                    var release = new ReleaseInfo();
-                    release.MinimumRatio = 1;
-                    release.MinimumSeedTime = 72 * 60 * 60;
 
                     var qDetailsLink = row.QuerySelector("td:nth-of-type(2) > a:nth-of-type(1)"); // link to the movie, not the actual torrent
-                    release.Title = qDetailsLink.GetAttribute("alt");
 
                     var qCatIcon = row.QuerySelector("td:nth-of-type(1) > a > img");
                     var catStr = qCatIcon != null ?
                         qCatIcon.GetAttribute("src").Split('/').Last().Split('.').First() :
                         "packs";
-                    release.Category = MapTrackerCatToNewznab(catStr);
 
                     var qSeeders = row.QuerySelector("td:nth-of-type(9)");
                     var qLeechers = row.QuerySelector("td:nth-of-type(10)");
@@ -155,10 +150,7 @@ namespace Jackett.Common.Indexers
                     var qPudDate = row.QuerySelector("td:nth-of-type(6) > nobr");
                     var qSize = row.QuerySelector("td:nth-of-type(7)");
 
-                    release.Link = new Uri(SiteLink + qDownloadLink.GetAttribute("href").Substring(1));
-                    release.Title = qDetailsLink.GetAttribute("alt");
-                    release.Comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
-                    release.Guid = release.Link;
+                    var link = new Uri(SiteLink + qDownloadLink.GetAttribute("href").Substring(1));
 
                     var dateStr = qPudDate.Text().Trim();
                     DateTime pubDateUtc;
@@ -170,24 +162,29 @@ namespace Jackett.Common.Indexers
                     else
                         pubDateUtc = DateTime.SpecifyKind(DateTime.ParseExact(dateStr, "MMM d yyyy hh:mm tt", CultureInfo.InvariantCulture), DateTimeKind.Unspecified);
 
-                    release.PublishDate = pubDateUtc.ToLocalTime();
-
                     var sizeStr = qSize.Text();
-                    release.Size = ReleaseInfo.GetBytes(sizeStr);
-
-                    release.Seeders = ParseUtil.CoerceInt(qSeeders.Text());
-                    release.Peers = ParseUtil.CoerceInt(qLeechers.Text()) + release.Seeders;
-
+                    var seeders = ParseUtil.CoerceInt(qSeeders.Text());
                     var files = row.QuerySelector("td:nth-child(4)").TextContent;
-                    release.Files = ParseUtil.CoerceInt(files);
-
                     var grabs = row.QuerySelector("td:nth-child(8)").TextContent;
-                    release.Grabs = ParseUtil.CoerceInt(grabs);
 
-                    release.DownloadVolumeFactor = 0; // ratioless
-                    release.UploadVolumeFactor = 1;
-
-                    releases.Add(release);
+                    releases.Add(new ReleaseInfo
+                    {
+                        MinimumRatio = 1,
+                        MinimumSeedTime = 72 * 60 * 60,
+                        Title = qDetailsLink.GetAttribute("alt"),
+                        Category = MapTrackerCatToNewznab(catStr),
+                        Link = link,
+                        Comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href")),
+                        Guid = link,
+                        PublishDate = pubDateUtc.ToLocalTime(),
+                        Size = ReleaseInfo.GetBytes(sizeStr),
+                        Seeders = seeders,
+                        Peers = ParseUtil.CoerceInt(qLeechers.Text()) + seeders,
+                        Files = ParseUtil.CoerceInt(files),
+                        Grabs = ParseUtil.CoerceInt(grabs),
+                        DownloadVolumeFactor = 0, // ratioless
+                        UploadVolumeFactor = 1
+                    });
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/PirateTheNet.cs
+++ b/src/Jackett.Common/Indexers/PirateTheNet.cs
@@ -170,7 +170,7 @@ namespace Jackett.Common.Indexers
                     var size = ReleaseInfo.GetBytes(sizeStr);
                     var leechers = ParseUtil.CoerceInt(qLeechers.Text());
                     var title = qDetailsLink.GetAttribute("alt");
-                    releases.Add(new ReleaseInfo
+                    var release = new ReleaseInfo
                     {
                         MinimumRatio = 1,
                         MinimumSeedTime = 72 * 60 * 60,
@@ -187,7 +187,8 @@ namespace Jackett.Common.Indexers
                         Grabs = grabs,
                         DownloadVolumeFactor = 0, // ratioless
                         UploadVolumeFactor = 1
-                    });
+                    };
+                    releases.Add(release);
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/PirateTheNet.cs
+++ b/src/Jackett.Common/Indexers/PirateTheNet.cs
@@ -164,9 +164,11 @@ namespace Jackett.Common.Indexers
 
                     var sizeStr = qSize.Text();
                     var seeders = ParseUtil.CoerceInt(qSeeders.Text());
-                    var files = row.QuerySelector("td:nth-child(4)").TextContent;
-                    var grabs = row.QuerySelector("td:nth-child(8)").TextContent;
-
+                    var files = ParseUtil.CoerceInt(row.QuerySelector("td:nth-child(4)").TextContent);
+                    var grabs = ParseUtil.CoerceInt(row.QuerySelector("td:nth-child(8)").TextContent);
+                    var comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
+                    var size = ReleaseInfo.GetBytes(sizeStr);
+                    var leechers = ParseUtil.CoerceInt(qLeechers.Text());
                     releases.Add(new ReleaseInfo
                     {
                         MinimumRatio = 1,
@@ -174,14 +176,14 @@ namespace Jackett.Common.Indexers
                         Title = qDetailsLink.GetAttribute("alt"),
                         Category = MapTrackerCatToNewznab(catStr),
                         Link = link,
-                        Comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href")),
+                        Comments = comments,
                         Guid = link,
                         PublishDate = pubDateUtc.ToLocalTime(),
-                        Size = ReleaseInfo.GetBytes(sizeStr),
+                        Size = size,
                         Seeders = seeders,
-                        Peers = ParseUtil.CoerceInt(qLeechers.Text()) + seeders,
-                        Files = ParseUtil.CoerceInt(files),
-                        Grabs = ParseUtil.CoerceInt(grabs),
+                        Peers = leechers + seeders,
+                        Files = files,
+                        Grabs = grabs,
                         DownloadVolumeFactor = 0, // ratioless
                         UploadVolumeFactor = 1
                     });

--- a/src/Jackett.Common/Indexers/PolishTracker.cs
+++ b/src/Jackett.Common/Indexers/PolishTracker.cs
@@ -85,9 +85,10 @@ namespace Jackett.Common.Indexers
 
             var searchUrl = TorrentApiUrl;
             var searchString = query.GetQueryString();
-            var queryCollection = new List<KeyValuePair<string, string>>();
-
-            queryCollection.Add("tpage", "1");
+            var queryCollection = new List<KeyValuePair<string, string>>
+            {
+                { "tpage", "1" }
+            };
             foreach (var cat in MapTorznabCapsToTrackers(query))
             {
                 queryCollection.Add("cat[]", cat);
@@ -137,6 +138,7 @@ namespace Jackett.Common.Indexers
 
                 foreach (var torrent in torrents)
                 {
+                    // TODO convert to ReleaseInfo Initializer
                     var release = new ReleaseInfo();
                     var descriptions = new List<string>();
                     release.MinimumRatio = 1;

--- a/src/Jackett.Common/Indexers/Pretome.cs
+++ b/src/Jackett.Common/Indexers/Pretome.cs
@@ -285,17 +285,17 @@ namespace Jackett.Common.Indexers
                 foreach (var row in rows)
                 {
                     var qLink = row.Children[1].QuerySelector("a");
-                    var releaseTitle = qLink.GetAttribute("title");
-                    if (qLink.QuerySelectorAll("span").Length == 1 && releaseTitle.StartsWith("NEW! |"))
+                    var title = qLink.GetAttribute("title");
+                    if (qLink.QuerySelectorAll("span").Length == 1 && title.StartsWith("NEW! |"))
                     {
-                        releaseTitle = releaseTitle.Substring(6).Trim();
+                        title = title.Substring(6).Trim();
                     }
 
-                    var releaseComments = new Uri(SiteLink + qLink.GetAttribute("href"));
+                    var comments = new Uri(SiteLink + qLink.GetAttribute("href"));
                     var qDownload = row.Children[2].QuerySelector("a");
                     var dateStr = Regex.Replace(row.Children[5].InnerHtml, @"\<br[\s]{0,1}[\/]{0,1}\>", " ");
                     var sizeStr = row.Children[7].TextContent;
-                    var releaseSeeders = ParseUtil.CoerceInt(row.Children[9].TextContent);
+                    var seeders = ParseUtil.CoerceInt(row.Children[9].TextContent);
                     var files = ParseUtil.CoerceInt(row.QuerySelector("td:nth-child(4)").TextContent);
                     var cat = row.FirstElementChild.FirstElementChild.GetAttribute("href").Replace("browse.php?", string.Empty);
                     var link = new Uri(SiteLink + qDownload.GetAttribute("href"));
@@ -307,14 +307,14 @@ namespace Jackett.Common.Indexers
                     {
                         MinimumRatio = 1,
                         MinimumSeedTime = 172800, // 48 hours
-                        Title = releaseTitle,
-                        Comments = releaseComments,
-                        Guid = releaseComments,
+                        Title = title,
+                        Comments = comments,
+                        Guid = comments,
                         Link = link,
                         PublishDate = publishDate,
                         Size = size,
-                        Seeders = releaseSeeders,
-                        Peers = leechers + releaseSeeders,
+                        Seeders = seeders,
+                        Peers = leechers + seeders,
                         Category = MapTrackerCatToNewznab(cat),
                         Files = files,
                         Grabs = grabs,

--- a/src/Jackett.Common/Indexers/Pretome.cs
+++ b/src/Jackett.Common/Indexers/Pretome.cs
@@ -303,7 +303,7 @@ namespace Jackett.Common.Indexers
                     var size = ReleaseInfo.GetBytes(sizeStr);
                     var leechers = ParseUtil.CoerceInt(row.Children[10].TextContent);
                     var grabs = ParseUtil.CoerceInt(row.QuerySelector("td:nth-child(9)").TextContent);
-                    releases.Add(new ReleaseInfo
+                    var release = new ReleaseInfo
                     {
                         MinimumRatio = 1,
                         MinimumSeedTime = 172800, // 48 hours
@@ -320,8 +320,8 @@ namespace Jackett.Common.Indexers
                         Grabs = grabs,
                         DownloadVolumeFactor = 0, // ratioless
                         UploadVolumeFactor = 1
-                        
-                    });
+                    };
+                    releases.Add(release);
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/Pretome.cs
+++ b/src/Jackett.Common/Indexers/Pretome.cs
@@ -296,10 +296,13 @@ namespace Jackett.Common.Indexers
                     var dateStr = Regex.Replace(row.Children[5].InnerHtml, @"\<br[\s]{0,1}[\/]{0,1}\>", " ");
                     var sizeStr = row.Children[7].TextContent;
                     var releaseSeeders = ParseUtil.CoerceInt(row.Children[9].TextContent);
+                    var files = ParseUtil.CoerceInt(row.QuerySelector("td:nth-child(4)").TextContent);
                     var cat = row.FirstElementChild.FirstElementChild.GetAttribute("href").Replace("browse.php?", string.Empty);
-                    var files = row.QuerySelector("td:nth-child(4)").TextContent;
-                    var grabs = row.QuerySelector("td:nth-child(9)").TextContent;
-
+                    var link = new Uri(SiteLink + qDownload.GetAttribute("href"));
+                    var publishDate = DateTimeUtil.FromTimeAgo(dateStr);
+                    var size = ReleaseInfo.GetBytes(sizeStr);
+                    var leechers = ParseUtil.CoerceInt(row.Children[10].TextContent);
+                    var grabs = ParseUtil.CoerceInt(row.QuerySelector("td:nth-child(9)").TextContent);
                     releases.Add(new ReleaseInfo
                     {
                         MinimumRatio = 1,
@@ -307,14 +310,14 @@ namespace Jackett.Common.Indexers
                         Title = releaseTitle,
                         Comments = releaseComments,
                         Guid = releaseComments,
-                        Link = new Uri(SiteLink + qDownload.GetAttribute("href")),
-                        PublishDate = DateTimeUtil.FromTimeAgo(dateStr),
-                        Size = ReleaseInfo.GetBytes(sizeStr),
+                        Link = link,
+                        PublishDate = publishDate,
+                        Size = size,
                         Seeders = releaseSeeders,
-                        Peers = ParseUtil.CoerceInt(row.Children[10].TextContent) + releaseSeeders,
+                        Peers = leechers + releaseSeeders,
                         Category = MapTrackerCatToNewznab(cat),
-                        Files = ParseUtil.CoerceInt(files),
-                        Grabs = ParseUtil.CoerceInt(grabs),
+                        Files = files,
+                        Grabs = grabs,
                         DownloadVolumeFactor = 0, // ratioless
                         UploadVolumeFactor = 1
                         

--- a/src/Jackett.Common/Indexers/Rarbg.cs
+++ b/src/Jackett.Common/Indexers/Rarbg.cs
@@ -245,7 +245,7 @@ namespace Jackett.Common.Indexers
                     // ex: 2015-08-16 21:25:08 +0000
                     var dateStr = item.Value<string>("pubdate").Replace(" +0000", "");
                     var dateTime = DateTime.ParseExact(dateStr, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
-                    var releaseSeeders = item.Value<int>("seeders");
+                    var seeders = item.Value<int>("seeders");
                     var title = WebUtility.HtmlDecode(item.Value<string>("title"));
                     var infoHash = magnetUri.ToString().Split(':')[3].Split('&')[0];
                     var publishDate = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc).ToLocalTime();
@@ -263,8 +263,8 @@ namespace Jackett.Common.Indexers
                         Link = link,
                         PublishDate = publishDate,
                         Guid = magnetUri,
-                        Seeders = releaseSeeders,
-                        Peers = leechers + releaseSeeders,
+                        Seeders = seeders,
+                        Peers = leechers + seeders,
                         Size = size,
                         MinimumRatio = 1,
                         MinimumSeedTime = 172800, // 48 hours

--- a/src/Jackett.Common/Indexers/Rarbg.cs
+++ b/src/Jackett.Common/Indexers/Rarbg.cs
@@ -245,22 +245,26 @@ namespace Jackett.Common.Indexers
                     var dateStr = item.Value<string>("pubdate").Replace(" +0000", "");
                     var dateTime = DateTime.ParseExact(dateStr, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
                     var releaseSeeders = item.Value<int>("seeders");
-
+                    var title = WebUtility.HtmlDecode(item.Value<string>("title"));
+                    var infoHash = magnetUri.ToString().Split(':')[3].Split('&')[0];
+                    var publishDate = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc).ToLocalTime();
+                    var leechers = item.Value<int>("leechers");
+                    var size = item.Value<long>("size");
                     var release = new ReleaseInfo
                     {
-                        Title = WebUtility.HtmlDecode(item.Value<string>("title")),
+                        Title = title,
                         Category = MapTrackerCatDescToNewznab(item.Value<string>("category")),
                         MagnetUri = magnetUri,
-                        InfoHash = magnetUri.ToString().Split(':')[3].Split('&')[0],
+                        InfoHash = infoHash,
                         // append app_id to prevent api server returning 403 forbidden
                         Comments = comments,
                         // in case of a torrent download we grab the link from the details page in Download()
                         Link = _provideTorrentLink ? comments : default,
-                        PublishDate = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc).ToLocalTime(),
+                        PublishDate = publishDate,
                         Guid = magnetUri,
                         Seeders = releaseSeeders,
-                        Peers = item.Value<int>("leechers") + releaseSeeders,
-                        Size = item.Value<long>("size"),
+                        Peers = leechers + releaseSeeders,
+                        Size = size,
                         MinimumRatio = 1,
                         MinimumSeedTime = 172800, // 48 hours
                         DownloadVolumeFactor = 0,

--- a/src/Jackett.Common/Indexers/Rarbg.cs
+++ b/src/Jackett.Common/Indexers/Rarbg.cs
@@ -123,9 +123,11 @@ namespace Jackett.Common.Indexers
         {
             if (!HasValidToken)
             {
-                var queryCollection = new NameValueCollection();
-                queryCollection.Add("get_token", "get_token");
-                queryCollection.Add("app_id", app_id);
+                var queryCollection = new NameValueCollection
+                {
+                    { "get_token", "get_token" },
+                    { "app_id", app_id }
+                };
 
                 var tokenUrl = ApiEndpoint + "?" + queryCollection.GetQueryString();
 
@@ -155,13 +157,15 @@ namespace Jackett.Common.Indexers
             var releases = new List<ReleaseInfo>();
             var searchString = query.GetQueryString();
 
-            var queryCollection = new NameValueCollection();
-            queryCollection.Add("token", token);
-            queryCollection.Add("format", "json_extended");
-            queryCollection.Add("app_id", app_id);
-            queryCollection.Add("limit", "100");
-            queryCollection.Add("ranked", "0");
-            queryCollection.Add("sort", _sort);
+            var queryCollection = new NameValueCollection
+            {
+                { "token", token },
+                { "format", "json_extended" },
+                { "app_id", app_id },
+                { "limit", "100" },
+                { "ranked", "0" },
+                { "sort", _sort }
+            };
 
             if (query.ImdbID != null)
             {
@@ -235,41 +239,44 @@ namespace Jackett.Common.Indexers
 
                 foreach (var item in jsonContent.Value<JArray>("torrent_results"))
                 {
-                    var release = new ReleaseInfo();
-                    release.Title = WebUtility.HtmlDecode(item.Value<string>("title"));
-                    release.Category = MapTrackerCatDescToNewznab(item.Value<string>("category"));
+                    var magnetUri = new Uri(item.Value<string>("download"));
+                    var comments = new Uri(item.Value<string>("info_page") + "&app_id=" + app_id);
+                    // ex: 2015-08-16 21:25:08 +0000
+                    var dateStr = item.Value<string>("pubdate").Replace(" +0000", "");
+                    var dateTime = DateTime.ParseExact(dateStr, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+                    var releaseSeeders = item.Value<int>("seeders");
 
-                    release.MagnetUri = new Uri(item.Value<string>("download"));
-                    release.InfoHash = release.MagnetUri.ToString().Split(':')[3].Split('&')[0];
-                    // append app_id to prevent api server returning 403 forbidden
-                    release.Comments = new Uri(item.Value<string>("info_page") + "&app_id=" + app_id);
-                    if (_provideTorrentLink)
-                        release.Link = release.Comments; // in case of a torrent download we grab the link from the details page in Download()
-                    release.Guid = release.MagnetUri;
+                    var release = new ReleaseInfo
+                    {
+                        Title = WebUtility.HtmlDecode(item.Value<string>("title")),
+                        Category = MapTrackerCatDescToNewznab(item.Value<string>("category")),
+                        MagnetUri = magnetUri,
+                        InfoHash = magnetUri.ToString().Split(':')[3].Split('&')[0],
+                        // append app_id to prevent api server returning 403 forbidden
+                        Comments = comments,
+                        // in case of a torrent download we grab the link from the details page in Download()
+                        Link = _provideTorrentLink ? comments : default,
+                        PublishDate = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc).ToLocalTime(),
+                        Guid = magnetUri,
+                        Seeders = releaseSeeders,
+                        Peers = item.Value<int>("leechers") + releaseSeeders,
+                        Size = item.Value<long>("size"),
+                        MinimumRatio = 1,
+                        MinimumSeedTime = 172800, // 48 hours
+                        DownloadVolumeFactor = 0,
+                        UploadVolumeFactor = 1
+                    };
 
                     var episodeInfo = item.Value<JToken>("episode_info");
 
                     if (episodeInfo.HasValues)
                     {
-                        var imdb = episodeInfo.Value<string>("imdb");
-                        release.Imdb = ParseUtil.GetImdbID(imdb);
+                        release.Imdb = ParseUtil.GetImdbID(episodeInfo.Value<string>("imdb"));
                         release.TVDBId = episodeInfo.Value<long?>("tvdb");
                         release.RageID = episodeInfo.Value<long?>("tvrage");
                         release.TMDb = episodeInfo.Value<long?>("themoviedb");
                     }
 
-                    // ex: 2015-08-16 21:25:08 +0000
-                    var dateStr = item.Value<string>("pubdate").Replace(" +0000", "");
-                    var dateTime = DateTime.ParseExact(dateStr, "yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
-                    release.PublishDate = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc).ToLocalTime();
-
-                    release.Seeders = item.Value<int>("seeders");
-                    release.Peers = item.Value<int>("leechers") + release.Seeders;
-                    release.Size = item.Value<long>("size");
-                    release.MinimumRatio = 1;
-                    release.MinimumSeedTime = 172800; // 48 hours
-                    release.DownloadVolumeFactor = 0;
-                    release.UploadVolumeFactor = 1;
 
                     releases.Add(release);
                 }

--- a/src/Jackett.Common/Indexers/Rarbg.cs
+++ b/src/Jackett.Common/Indexers/Rarbg.cs
@@ -240,6 +240,7 @@ namespace Jackett.Common.Indexers
                 foreach (var item in jsonContent.Value<JArray>("torrent_results"))
                 {
                     var magnetUri = new Uri(item.Value<string>("download"));
+                    // append app_id to prevent api server returning 403 forbidden
                     var comments = new Uri(item.Value<string>("info_page") + "&app_id=" + app_id);
                     // ex: 2015-08-16 21:25:08 +0000
                     var dateStr = item.Value<string>("pubdate").Replace(" +0000", "");
@@ -250,16 +251,16 @@ namespace Jackett.Common.Indexers
                     var publishDate = DateTime.SpecifyKind(dateTime, DateTimeKind.Utc).ToLocalTime();
                     var leechers = item.Value<int>("leechers");
                     var size = item.Value<long>("size");
+                    // in case of a torrent download we grab the link from the details page in Download()
+                    var link = _provideTorrentLink ? comments : default;
                     var release = new ReleaseInfo
                     {
                         Title = title,
                         Category = MapTrackerCatDescToNewznab(item.Value<string>("category")),
                         MagnetUri = magnetUri,
                         InfoHash = infoHash,
-                        // append app_id to prevent api server returning 403 forbidden
                         Comments = comments,
-                        // in case of a torrent download we grab the link from the details page in Download()
-                        Link = _provideTorrentLink ? comments : default,
+                        Link = link,
                         PublishDate = publishDate,
                         Guid = magnetUri,
                         Seeders = releaseSeeders,

--- a/src/Jackett.Common/Indexers/RevolutionTT.cs
+++ b/src/Jackett.Common/Indexers/RevolutionTT.cs
@@ -334,10 +334,10 @@ namespace Jackett.Common.Indexers
                         release.Title = qLink.QuerySelector("b").TextContent;
                         release.Description = release.Title;
 
-                        var releaseLink = row.QuerySelector("td:nth-child(4) > a");
-                        if (releaseLink != null)
+                        var link = row.QuerySelector("td:nth-child(4) > a");
+                        if (link != null)
                         {
-                            release.Link = new Uri(SiteLink + releaseLink.GetAttribute("href"));
+                            release.Link = new Uri(SiteLink + link.GetAttribute("href"));
 
                             var dateString = row.QuerySelector("td:nth-child(6) nobr").TextContent.Trim();
                             //"2015-04-25 23:38:12"

--- a/src/Jackett.Common/Indexers/SceneHD.cs
+++ b/src/Jackett.Common/Indexers/SceneHD.cs
@@ -93,8 +93,10 @@ namespace Jackett.Common.Indexers
 
             var releases = new List<ReleaseInfo>();
 
-            var qParams = new NameValueCollection();
-            qParams.Add("api", "");
+            var qParams = new NameValueCollection
+            {
+                { "api", "" }
+            };
             if (query.ImdbIDShort != null)
                 qParams.Add("imdb", query.ImdbIDShort);
             else
@@ -119,6 +121,7 @@ namespace Jackett.Common.Indexers
 
                 foreach (var item in jsonContent)
                 {
+                    //TODO convert to initializer
                     var release = new ReleaseInfo();
 
                     var id = item.Value<long>("id");

--- a/src/Jackett.Common/Indexers/SceneTime.cs
+++ b/src/Jackett.Common/Indexers/SceneTime.cs
@@ -223,6 +223,7 @@ namespace Jackett.Common.Indexers
                 var rows = dom.QuerySelectorAll("tr.browse");
                 foreach (var row in rows)
                 {
+                    // TODO convert to initializer
                     var release = new ReleaseInfo();
                     release.MinimumRatio = 1;
                     release.MinimumSeedTime = 172800; // 48 hours

--- a/src/Jackett.Common/Indexers/Shazbat.cs
+++ b/src/Jackett.Common/Indexers/Shazbat.cs
@@ -114,6 +114,7 @@ namespace Jackett.Common.Indexers
                         dom.QuerySelector("span:contains(\"Freeleech until:\"):has(span.datetime)") != null;
                     foreach (var row in rows.Skip(1))
                     {
+                        // TODO switch to initializer
                         var release = new ReleaseInfo();
                         var titleRow = row.QuerySelector("td:nth-of-type(3)");
                         foreach (var child in titleRow.Children)

--- a/src/Jackett.Common/Indexers/ShowRSS.cs
+++ b/src/Jackett.Common/Indexers/ShowRSS.cs
@@ -69,23 +69,24 @@ namespace Jackett.Common.Indexers
                 xmlDoc.LoadXml(result.Content);
                 foreach (XmlNode node in xmlDoc.GetElementsByTagName("item"))
                 {
-                    var serie_title = node.SelectSingleNode(".//*[local-name()='raw_title']").InnerText;
-                    if ((query.ImdbID == null || !TorznabCaps.SupportsImdbMovieSearch) &&
-                        !query.MatchQueryStringAND(serie_title))
+                    var title = node.SelectSingleNode(".//*[local-name()='raw_title']").InnerText;
+                    if ((!query.IsImdbQuery || !TorznabCaps.SupportsImdbMovieSearch) &&
+                        !query.MatchQueryStringAND(title))
                         continue;
 
                     // Try to guess the category... I'm not proud of myself...
-                    var category = serie_title.Contains("720p") ? TorznabCatType.TVHD.ID : TorznabCatType.TVSD.ID;
+                    var category = title.Contains("720p") ? TorznabCatType.TVHD.ID : TorznabCatType.TVSD.ID;
                     var test = node.SelectSingleNode("enclosure");
                     var magnetUri = new Uri(node.SelectSingleNode("link").InnerText);
                     var publishDate = DateTime.Parse(node.SelectSingleNode("pubDate").InnerText, CultureInfo.InvariantCulture);
                     var infoHash = node.SelectSingleNode("description").InnerText;
+                    //TODO Maybe use magnetUri instead? https://github.com/Jackett/Jackett/pull/7342#discussion_r397552678
                     var guid = new Uri(test.Attributes["url"].Value);
                     releases.Add(new ReleaseInfo
                     {
                         MinimumRatio = 1,
                         MinimumSeedTime = 172800, // 48 hours
-                        Title = serie_title,
+                        Title = title,
                         Comments = magnetUri,
                         Category = new List<int> {category},
                         Guid = guid,

--- a/src/Jackett.Common/Indexers/ShowRSS.cs
+++ b/src/Jackett.Common/Indexers/ShowRSS.cs
@@ -83,7 +83,7 @@ namespace Jackett.Common.Indexers
                     var infoHash = node.SelectSingleNode("description").InnerText;
                     //TODO Maybe use magnetUri instead? https://github.com/Jackett/Jackett/pull/7342#discussion_r397552678
                     var guid = new Uri(test.Attributes["url"].Value);
-                    releases.Add(new ReleaseInfo
+                    var release = new ReleaseInfo
                     {
                         MinimumRatio = 1,
                         MinimumSeedTime = 172800, // 48 hours
@@ -101,7 +101,8 @@ namespace Jackett.Common.Indexers
                         DownloadVolumeFactor = 0,
                         UploadVolumeFactor = 1,
                         MagnetUri = magnetUri
-                    });
+                    };
+                    releases.Add(release);
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/ShowRSS.cs
+++ b/src/Jackett.Common/Indexers/ShowRSS.cs
@@ -67,42 +67,36 @@ namespace Jackett.Common.Indexers
             try
             {
                 xmlDoc.LoadXml(result.Content);
-                ReleaseInfo release;
-                string serie_title;
-
                 foreach (XmlNode node in xmlDoc.GetElementsByTagName("item"))
                 {
-                    release = new ReleaseInfo();
-
-                    release.MinimumRatio = 1;
-                    release.MinimumSeedTime = 172800; // 48 hours
-
-                    serie_title = node.SelectSingleNode(".//*[local-name()='raw_title']").InnerText;
-                    release.Title = serie_title;
-
-                    if ((query.ImdbID == null || !TorznabCaps.SupportsImdbMovieSearch) && !query.MatchQueryStringAND(release.Title))
+                    var serie_title = node.SelectSingleNode(".//*[local-name()='raw_title']").InnerText;
+                    if ((query.ImdbID == null || !TorznabCaps.SupportsImdbMovieSearch) &&
+                        !query.MatchQueryStringAND(serie_title))
                         continue;
 
-                    release.Comments = new Uri(node.SelectSingleNode("link").InnerText);
-
                     // Try to guess the category... I'm not proud of myself...
-                    var category = 5030;
-                    if (serie_title.Contains("720p"))
-                        category = 5040;
-                    release.Category = new List<int> { category };
+                    var category = serie_title.Contains("720p") ? 5040 : 5030;
                     var test = node.SelectSingleNode("enclosure");
-                    release.Guid = new Uri(test.Attributes["url"].Value);
-                    release.PublishDate = DateTime.Parse(node.SelectSingleNode("pubDate").InnerText, CultureInfo.InvariantCulture);
-
-                    release.Description = node.SelectSingleNode("description").InnerText;
-                    release.InfoHash = node.SelectSingleNode("description").InnerText;
-                    release.Size = 0;
-                    release.Seeders = 1;
-                    release.Peers = 1;
-                    release.DownloadVolumeFactor = 0;
-                    release.UploadVolumeFactor = 1;
-                    release.MagnetUri = new Uri(node.SelectSingleNode("link").InnerText);
-                    releases.Add(release);
+                    releases.Add(new ReleaseInfo
+                    {
+                        MinimumRatio = 1,
+                        MinimumSeedTime = 172800, // 48 hours
+                        Title = serie_title,
+                        Comments = new Uri(node.SelectSingleNode("link").InnerText),
+                        Category = new List<int> {category},
+                        Guid = new Uri(test.Attributes["url"].Value),
+                        PublishDate =
+                            DateTime.Parse(node.SelectSingleNode("pubDate").InnerText, CultureInfo.InvariantCulture),
+                        Description = node.SelectSingleNode("description").InnerText,
+                        InfoHash = node.SelectSingleNode("description").InnerText,
+                        Size = 0,
+                        //TODO fix seeder/peer counts if available
+                        Seeders = 1,
+                        Peers = 1,
+                        DownloadVolumeFactor = 0,
+                        UploadVolumeFactor = 1,
+                        MagnetUri = new Uri(node.SelectSingleNode("link").InnerText)
+                    });
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/ShowRSS.cs
+++ b/src/Jackett.Common/Indexers/ShowRSS.cs
@@ -75,27 +75,30 @@ namespace Jackett.Common.Indexers
                         continue;
 
                     // Try to guess the category... I'm not proud of myself...
-                    var category = serie_title.Contains("720p") ? 5040 : 5030;
+                    var category = serie_title.Contains("720p") ? TorznabCatType.TVHD.ID : TorznabCatType.TVSD.ID;
                     var test = node.SelectSingleNode("enclosure");
+                    var magnetUri = new Uri(node.SelectSingleNode("link").InnerText);
+                    var publishDate = DateTime.Parse(node.SelectSingleNode("pubDate").InnerText, CultureInfo.InvariantCulture);
+                    var infoHash = node.SelectSingleNode("description").InnerText;
+                    var guid = new Uri(test.Attributes["url"].Value);
                     releases.Add(new ReleaseInfo
                     {
                         MinimumRatio = 1,
                         MinimumSeedTime = 172800, // 48 hours
                         Title = serie_title,
-                        Comments = new Uri(node.SelectSingleNode("link").InnerText),
+                        Comments = magnetUri,
                         Category = new List<int> {category},
-                        Guid = new Uri(test.Attributes["url"].Value),
-                        PublishDate =
-                            DateTime.Parse(node.SelectSingleNode("pubDate").InnerText, CultureInfo.InvariantCulture),
-                        Description = node.SelectSingleNode("description").InnerText,
-                        InfoHash = node.SelectSingleNode("description").InnerText,
+                        Guid = guid,
+                        PublishDate = publishDate,
+                        Description = infoHash,
+                        InfoHash = infoHash,
                         Size = 0,
                         //TODO fix seeder/peer counts if available
                         Seeders = 1,
                         Peers = 1,
                         DownloadVolumeFactor = 0,
                         UploadVolumeFactor = 1,
-                        MagnetUri = new Uri(node.SelectSingleNode("link").InnerText)
+                        MagnetUri = magnetUri
                     });
                 }
             }

--- a/src/Jackett.Common/Indexers/ShowRSS.cs
+++ b/src/Jackett.Common/Indexers/ShowRSS.cs
@@ -69,6 +69,7 @@ namespace Jackett.Common.Indexers
                 xmlDoc.LoadXml(result.Content);
                 foreach (XmlNode node in xmlDoc.GetElementsByTagName("item"))
                 {
+                    //TODO revisit for refactoring
                     var title = node.SelectSingleNode(".//*[local-name()='raw_title']").InnerText;
                     if ((!query.IsImdbQuery || !TorznabCaps.SupportsImdbMovieSearch) &&
                         !query.MatchQueryStringAND(title))

--- a/src/Jackett.Common/Indexers/SolidTorrents.cs
+++ b/src/Jackett.Common/Indexers/SolidTorrents.cs
@@ -138,37 +138,32 @@ namespace Jackett.Common.Indexers
             return releases;
         }
 
+        //TODO inline single use function
         private ReleaseInfo MakeRelease(JToken torrent)
         {
-            var release = new ReleaseInfo();
-
-            release.Title = (string)torrent["title"];
-
-            // https://solidtorrents.net/view/5e10885d651df640a70ee826
-            release.Comments = new Uri(SiteLink + "view/" + (string)torrent["_id"]);
-            release.Guid = release.Comments;
-
-            release.PublishDate = DateTime.Now;
-            if (torrent["imported"] != null)
-                release.PublishDate = DateTime.Parse((string)torrent["imported"]);
-
-            release.Category = MapTrackerCatToNewznab((string)torrent["category"]);
-            release.Size = (long)torrent["size"];
-
+            var comments = new Uri(SiteLink + "view/" + (string)torrent["_id"]);
             var swarm = torrent["swarm"];
-            release.Seeders = (int)swarm["seeders"];
-            release.Peers = release.Seeders + (int)swarm["leechers"];
-            release.Grabs = (long)swarm["downloads"];
+            var seeders = (int)swarm["seeders"];
+            return new ReleaseInfo
+            {
+                Title = (string)torrent["title"],
 
-            release.InfoHash = (string)torrent["infohash"];
-            release.MagnetUri = new Uri((string)torrent["magnet"]);
-
-            release.MinimumRatio = 1;
-            release.MinimumSeedTime = 172800; // 48 hours
-            release.DownloadVolumeFactor = 0;
-            release.UploadVolumeFactor = 1;
-
-            return release;
+                // https://solidtorrents.net/view/5e10885d651df640a70ee826
+                Comments = comments,
+                Guid = comments,
+                PublishDate = torrent["imported"] != null ? DateTime.Parse((string)torrent["imported"]) : DateTime.Now,
+                Category = MapTrackerCatToNewznab((string)torrent["category"]),
+                Size = (long)torrent["size"],
+                Seeders = seeders,
+                Peers = seeders + (int)swarm["leechers"],
+                Grabs = (long)swarm["downloads"],
+                InfoHash = (string)torrent["infohash"],
+                MagnetUri = new Uri((string)torrent["magnet"]),
+                MinimumRatio = 1,
+                MinimumSeedTime = 172800, // 48 hours
+                DownloadVolumeFactor = 0,
+                UploadVolumeFactor = 1
+            };
         }
     }
 }

--- a/src/Jackett.Common/Indexers/SolidTorrents.cs
+++ b/src/Jackett.Common/Indexers/SolidTorrents.cs
@@ -141,24 +141,25 @@ namespace Jackett.Common.Indexers
         //TODO inline single use function
         private ReleaseInfo MakeRelease(JToken torrent)
         {
+            // https://solidtorrents.net/view/5e10885d651df640a70ee826
             var comments = new Uri(SiteLink + "view/" + (string)torrent["_id"]);
             var swarm = torrent["swarm"];
             var seeders = (int)swarm["seeders"];
+            var publishDate = torrent["imported"] != null ? DateTime.Parse((string)torrent["imported"]) : DateTime.Now;
+            var magnetUri = new Uri((string)torrent["magnet"]);
             return new ReleaseInfo
             {
                 Title = (string)torrent["title"],
-
-                // https://solidtorrents.net/view/5e10885d651df640a70ee826
                 Comments = comments,
                 Guid = comments,
-                PublishDate = torrent["imported"] != null ? DateTime.Parse((string)torrent["imported"]) : DateTime.Now,
+                PublishDate = publishDate,
                 Category = MapTrackerCatToNewznab((string)torrent["category"]),
                 Size = (long)torrent["size"],
                 Seeders = seeders,
                 Peers = seeders + (int)swarm["leechers"],
                 Grabs = (long)swarm["downloads"],
                 InfoHash = (string)torrent["infohash"],
-                MagnetUri = new Uri((string)torrent["magnet"]),
+                MagnetUri = magnetUri,
                 MinimumRatio = 1,
                 MinimumSeedTime = 172800, // 48 hours
                 DownloadVolumeFactor = 0,

--- a/src/Jackett.Common/Indexers/SpeedCD.cs
+++ b/src/Jackett.Common/Indexers/SpeedCD.cs
@@ -155,7 +155,6 @@ namespace Jackett.Common.Indexers
 
                     var title = row.QuerySelector("td[class='lft'] > div > a").TextContent.Trim();
                     var link = new Uri(SiteLink + row.QuerySelector("img[title='Download']").ParentElement.GetAttribute("href").Trim());
-                    var guid = link;
                     var comments = new Uri(SiteLink + row.QuerySelector("td[class='lft'] > div > a").GetAttribute("href").Trim().Remove(0, 1));
                     var size = ReleaseInfo.GetBytes(cells[4].TextContent);
                     var grabs = ParseUtil.CoerceInt(cells[5].TextContent);
@@ -171,7 +170,7 @@ namespace Jackett.Common.Indexers
                     releases.Add(new ReleaseInfo
                     {
                         Title = title,
-                        Guid = guid,
+                        Guid = link,
                         Link = link,
                         PublishDate = publishDate,
                         Size = size,

--- a/src/Jackett.Common/Indexers/SpeedCD.cs
+++ b/src/Jackett.Common/Indexers/SpeedCD.cs
@@ -166,7 +166,7 @@ namespace Jackett.Common.Indexers
 
                     var cat = row.QuerySelector("img[class^='Tcat']").ParentElement.GetAttribute("href").Trim().Remove(0, 5);
                     long.TryParse(cat, out var category);
-
+                    var downloadVolumeFactor = row.QuerySelector("span:contains(\"[Freeleech]\")") != null ? 0 : 1;
                     releases.Add(new ReleaseInfo
                     {
                         Title = title,
@@ -181,7 +181,7 @@ namespace Jackett.Common.Indexers
                         MinimumSeedTime = 172800, // 48 hours
                         Category = MapTrackerCatToNewznab(category.ToString()),
                         Comments = comments,
-                        DownloadVolumeFactor = row.QuerySelector("span:contains(\"[Freeleech]\")") != null ? 0 : 1,
+                        DownloadVolumeFactor = downloadVolumeFactor,
                         UploadVolumeFactor = 1
                     });
                 }

--- a/src/Jackett.Common/Indexers/SpeedCD.cs
+++ b/src/Jackett.Common/Indexers/SpeedCD.cs
@@ -168,27 +168,23 @@ namespace Jackett.Common.Indexers
                     var cat = row.QuerySelector("img[class^='Tcat']").ParentElement.GetAttribute("href").Trim().Remove(0, 5);
                     long.TryParse(cat, out var category);
 
-                    // This fixes the mixed initializer issue, so it's just inconsistent in the code base.
-                    // https://github.com/Jackett/Jackett/pull/7166#discussion_r376817517
-                    var release = new ReleaseInfo();
-
-                    release.Title = title;
-                    release.Guid = guid;
-                    release.Link = link;
-                    release.PublishDate = publishDate;
-                    release.Size = size;
-                    release.Grabs = grabs;
-                    release.Seeders = seeders;
-                    release.Peers = seeders + leechers;
-                    release.MinimumRatio = 1;
-                    release.MinimumSeedTime = 172800; // 48 hours
-                    release.Category = MapTrackerCatToNewznab(category.ToString());
-                    release.Comments = comments;
-
-                    release.DownloadVolumeFactor = row.QuerySelector("span:contains(\"[Freeleech]\")") != null ? 0 : 1;
-                    release.UploadVolumeFactor = 1;
-
-                    releases.Add(release);
+                    releases.Add(new ReleaseInfo
+                    {
+                        Title = title,
+                        Guid = guid,
+                        Link = link,
+                        PublishDate = publishDate,
+                        Size = size,
+                        Grabs = grabs,
+                        Seeders = seeders,
+                        Peers = seeders + leechers,
+                        MinimumRatio = 1,
+                        MinimumSeedTime = 172800, // 48 hours
+                        Category = MapTrackerCatToNewznab(category.ToString()),
+                        Comments = comments,
+                        DownloadVolumeFactor = row.QuerySelector("span:contains(\"[Freeleech]\")") != null ? 0 : 1,
+                        UploadVolumeFactor = 1
+                    });
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/SpeedCD.cs
+++ b/src/Jackett.Common/Indexers/SpeedCD.cs
@@ -167,7 +167,7 @@ namespace Jackett.Common.Indexers
                     var cat = row.QuerySelector("img[class^='Tcat']").ParentElement.GetAttribute("href").Trim().Remove(0, 5);
                     long.TryParse(cat, out var category);
                     var downloadVolumeFactor = row.QuerySelector("span:contains(\"[Freeleech]\")") != null ? 0 : 1;
-                    releases.Add(new ReleaseInfo
+                    var release = new ReleaseInfo
                     {
                         Title = title,
                         Guid = link,
@@ -183,7 +183,8 @@ namespace Jackett.Common.Indexers
                         Comments = comments,
                         DownloadVolumeFactor = downloadVolumeFactor,
                         UploadVolumeFactor = 1
-                    });
+                    };
+                    releases.Add(release);
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/TVVault.cs
+++ b/src/Jackett.Common/Indexers/TVVault.cs
@@ -121,7 +121,7 @@ namespace Jackett.Common.Indexers
                     var grabs = ParseUtil.CoerceLong(Grabs.TextContent);
                     var files = ParseUtil.CoerceLong(Files.TextContent);
                     var category = new List<int> {TvCategoryParser.ParseTvShowQuality(description)};
-                    releases.Add(new ReleaseInfo
+                    var release = new ReleaseInfo
                     {
                         MinimumRatio = 1,
                         MinimumSeedTime = 0,
@@ -139,7 +139,8 @@ namespace Jackett.Common.Indexers
                         Files = files,
                         DownloadVolumeFactor = FreeLeech != null ? 0 : 1,
                         UploadVolumeFactor = 1
-                    });
+                    };
+                    releases.Add(release);
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/TVVault.cs
+++ b/src/Jackett.Common/Indexers/TVVault.cs
@@ -111,28 +111,29 @@ namespace Jackett.Common.Indexers
                     var TorrentIdParts = qDetailsLink.GetAttribute("href").Split('=');
                     var TorrentId = TorrentIdParts[TorrentIdParts.Length - 1];
                     var DLLink = "torrents.php?action=download&id=" + TorrentId.ToString();
-                    var releaseLink = new Uri(SiteLink + DLLink);
-                    var releaseSeeders = ParseUtil.CoerceInt(Seeders.TextContent);
-                    var releaseDescription = DescStr.TextContent.Trim();
+                    var link = new Uri(SiteLink + DLLink);
+                    var seeders = ParseUtil.CoerceInt(Seeders.TextContent);
+                    var description = DescStr.TextContent.Trim();
                     var publishDate = DateTimeUtil.FromTimeAgo(Added.TextContent);
                     var comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
                     var leechers = ParseUtil.CoerceInt(Leechers.TextContent);
                     var size = ReleaseInfo.GetBytes(Size.TextContent);
                     var grabs = ParseUtil.CoerceLong(Grabs.TextContent);
                     var files = ParseUtil.CoerceLong(Files.TextContent);
+                    var category = new List<int> {TvCategoryParser.ParseTvShowQuality(description)};
                     releases.Add(new ReleaseInfo
                     {
                         MinimumRatio = 1,
                         MinimumSeedTime = 0,
-                        Description = releaseDescription,
-                        Title = qDetailsLink.TextContent + " " + releaseDescription,
+                        Description = description,
+                        Title = qDetailsLink.TextContent + " " + description,
                         PublishDate = publishDate,
-                        Category = new List<int> {TvCategoryParser.ParseTvShowQuality(releaseDescription)},
-                        Link = releaseLink,
+                        Category = category,
+                        Link = link,
                         Comments = comments,
-                        Guid = releaseLink,
-                        Seeders = releaseSeeders,
-                        Peers = leechers + releaseSeeders,
+                        Guid = link,
+                        Seeders = seeders,
+                        Peers = leechers + seeders,
                         Size = size,
                         Grabs = grabs,
                         Files = files,

--- a/src/Jackett.Common/Indexers/TVVault.cs
+++ b/src/Jackett.Common/Indexers/TVVault.cs
@@ -114,23 +114,28 @@ namespace Jackett.Common.Indexers
                     var releaseLink = new Uri(SiteLink + DLLink);
                     var releaseSeeders = ParseUtil.CoerceInt(Seeders.TextContent);
                     var releaseDescription = DescStr.TextContent.Trim();
-
+                    var publishDate = DateTimeUtil.FromTimeAgo(Added.TextContent);
+                    var comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
+                    var leechers = ParseUtil.CoerceInt(Leechers.TextContent);
+                    var size = ReleaseInfo.GetBytes(Size.TextContent);
+                    var grabs = ParseUtil.CoerceLong(Grabs.TextContent);
+                    var files = ParseUtil.CoerceLong(Files.TextContent);
                     releases.Add(new ReleaseInfo
                     {
                         MinimumRatio = 1,
                         MinimumSeedTime = 0,
                         Description = releaseDescription,
                         Title = qDetailsLink.TextContent + " " + releaseDescription,
-                        PublishDate = DateTimeUtil.FromTimeAgo(Added.TextContent),
+                        PublishDate = publishDate,
                         Category = new List<int> {TvCategoryParser.ParseTvShowQuality(releaseDescription)},
                         Link = releaseLink,
-                        Comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href")),
+                        Comments = comments,
                         Guid = releaseLink,
                         Seeders = releaseSeeders,
-                        Peers = ParseUtil.CoerceInt(Leechers.TextContent) + releaseSeeders,
-                        Size = ReleaseInfo.GetBytes(Size.TextContent),
-                        Grabs = ReleaseInfo.GetBytes(Grabs.TextContent),
-                        Files = ReleaseInfo.GetBytes(Files.TextContent),
+                        Peers = leechers + releaseSeeders,
+                        Size = size,
+                        Grabs = grabs,
+                        Files = files,
                         DownloadVolumeFactor = FreeLeech != null ? 0 : 1,
                         UploadVolumeFactor = 1
                     });

--- a/src/Jackett.Common/Indexers/TVstore.cs
+++ b/src/Jackett.Common/Indexers/TVstore.cs
@@ -220,23 +220,19 @@ namespace Jackett.Common.Indexers
             var parser = new HtmlParser();
             var dom = parser.ParseDocument(result.Content);
             var scripts = dom.QuerySelectorAll("script");
+            //TODO Linq
             foreach (var script in scripts)
             {
                 if (script.TextContent.Contains("catsh=Array"))
                 {
+                    //TODO no regex in pattern, investigate using string.Split instead?
                     var seriesKnowBySite = Regex.Split(script.TextContent, "catl");
+                    //TODO consider converting to foreach
                     for (var i = 1; i < seriesKnowBySite.Length; i++)
                     {
                         var id = seriesKnowBySite[i];
                         var seriesElement = WebUtility.HtmlDecode(id).Split(';');
-                        series.Add(
-                            new SeriesDetail
-                            {
-                                HunName = seriesElement[1].Split('=')[1].Trim('\'').ToLower(),
-                                EngName = seriesElement[2].Split('=')[1].Trim('\'').ToLower(),
-                                id = seriesElement[0].Split('=')[1].Trim('\''),
-                                imdbid = seriesElement[7].Split('=')[1].Trim('\'')
-                            });
+                        series.Add(new SeriesDetail(seriesElement));
                     }
                 }
             }
@@ -370,7 +366,13 @@ namespace Jackett.Common.Indexers
         public string HunName;
         public string EngName;
         public string imdbid;
-
+        public SeriesDetail(string[] seriesElement)
+        {
+            HunName = seriesElement[1].Split('=')[1].Trim('\'').ToLower();
+            EngName = seriesElement[2].Split('=')[1].Trim('\'').ToLower();
+            id = seriesElement[0].Split('=')[1].Trim('\'');
+            imdbid = seriesElement[7].Split('=')[1].Trim('\'');
+        }
     }
 
 }

--- a/src/Jackett.Common/Indexers/TVstore.cs
+++ b/src/Jackett.Common/Indexers/TVstore.cs
@@ -232,7 +232,18 @@ namespace Jackett.Common.Indexers
                     {
                         var id = seriesKnowBySite[i];
                         var seriesElement = WebUtility.HtmlDecode(id).Split(';');
-                        series.Add(new SeriesDetail(seriesElement));
+                        var hungarianName = seriesElement[1].Split('=')[1].Trim('\'').ToLower();
+                        var englishName = seriesElement[2].Split('=')[1].Trim('\'').ToLower();
+                        var seriesId = seriesElement[0].Split('=')[1].Trim('\'');
+                        var imdbId = seriesElement[7].Split('=')[-1].Trim('\'');
+                        var seriesDetail = new SeriesDetail
+                        {
+                            HunName = hungarianName,
+                            EngName = englishName,
+                            id = seriesId,
+                            imdbid = imdbId
+                        };
+                        series.Add(seriesDetail);
                     }
                 }
             }
@@ -366,13 +377,6 @@ namespace Jackett.Common.Indexers
         public string HunName;
         public string EngName;
         public string imdbid;
-        public SeriesDetail(string[] seriesElement)
-        {
-            HunName = seriesElement[1].Split('=')[1].Trim('\'').ToLower();
-            EngName = seriesElement[2].Split('=')[1].Trim('\'').ToLower();
-            id = seriesElement[0].Split('=')[1].Trim('\'');
-            imdbid = seriesElement[7].Split('=')[1].Trim('\'');
-        }
     }
 
 }

--- a/src/Jackett.Common/Indexers/TVstore.cs
+++ b/src/Jackett.Common/Indexers/TVstore.cs
@@ -231,15 +231,18 @@ namespace Jackett.Common.Indexers
                         {
                             var id = seriesknowbysite[i];
                             var serieselement = WebUtility.HtmlDecode(id).Split(';');
-                            var sd = new SeriesDetail();
-                            sd.HunName = serieselement[1].Split('=')[1].Trim('\'').ToLower();
-                            sd.EngName = serieselement[2].Split('=')[1].Trim('\'').ToLower();
-                            sd.id = serieselement[0].Split('=')[1].Trim('\'');
-                            sd.imdbid = serieselement[7].Split('=')[1].Trim('\'');
-                            series.Add(sd);
+                            series.Add(new SeriesDetail
+                            {
+	                            HunName = serieselement[1].Split('=')[1].Trim('\'').ToLower(),
+	                            EngName = serieselement[2].Split('=')[1].Trim('\'').ToLower(),
+	                            id = serieselement[0].Split('=')[1].Trim('\''),
+	                            imdbid = serieselement[7].Split('=')[1].Trim('\'')
+                            });
                         }
+                        // catch and rethrow without doing anything just remove?
                         catch (IndexOutOfRangeException e)
                         {
+                            // resets call stack normally not the intended result
                             throw (e);
                         }
                     }
@@ -250,6 +253,7 @@ namespace Jackett.Common.Indexers
 
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {
+            //TODO convert to initializer
             var releases = new List<ReleaseInfo>();
 
             /* If series from sites are indexed than we dont need to reindex them. */

--- a/src/Jackett.Common/Indexers/TVstore.cs
+++ b/src/Jackett.Common/Indexers/TVstore.cs
@@ -224,27 +224,19 @@ namespace Jackett.Common.Indexers
             {
                 if (script.TextContent.Contains("catsh=Array"))
                 {
-                    var seriesknowbysite = Regex.Split(script.TextContent, "catl");
-                    for (var i = 1; i < seriesknowbysite.Length; i++)
+                    var seriesKnowBySite = Regex.Split(script.TextContent, "catl");
+                    for (var i = 1; i < seriesKnowBySite.Length; i++)
                     {
-                        try
-                        {
-                            var id = seriesknowbysite[i];
-                            var serieselement = WebUtility.HtmlDecode(id).Split(';');
-                            series.Add(new SeriesDetail
+                        var id = seriesKnowBySite[i];
+                        var seriesElement = WebUtility.HtmlDecode(id).Split(';');
+                        series.Add(
+                            new SeriesDetail
                             {
-	                            HunName = serieselement[1].Split('=')[1].Trim('\'').ToLower(),
-	                            EngName = serieselement[2].Split('=')[1].Trim('\'').ToLower(),
-	                            id = serieselement[0].Split('=')[1].Trim('\''),
-	                            imdbid = serieselement[7].Split('=')[1].Trim('\'')
+                                HunName = seriesElement[1].Split('=')[1].Trim('\'').ToLower(),
+                                EngName = seriesElement[2].Split('=')[1].Trim('\'').ToLower(),
+                                id = seriesElement[0].Split('=')[1].Trim('\''),
+                                imdbid = seriesElement[7].Split('=')[1].Trim('\'')
                             });
-                        }
-                        // catch and rethrow without doing anything just remove?
-                        catch (IndexOutOfRangeException e)
-                        {
-                            // resets call stack normally not the intended result
-                            throw (e);
-                        }
                     }
                 }
             }

--- a/src/Jackett.Common/Indexers/TorrentDay.cs
+++ b/src/Jackett.Common/Indexers/TorrentDay.cs
@@ -231,7 +231,7 @@ namespace Jackett.Common.Indexers
                     var link = new Uri(SiteLink + "download.php/" + torrentID + "/" + torrentID + ".torrent");
                     var publishDate = DateTimeUtil.UnixTimestampToDateTime((long)torrent.ctime).ToLocalTime();
                     var imdb = ParseUtil.GetImdbID(imdbId);
-                    releases.Add(new ReleaseInfo
+                    var release = new ReleaseInfo
                     {
                         Title = torrent.name,
                         MinimumRatio = 1,
@@ -249,7 +249,8 @@ namespace Jackett.Common.Indexers
                         Imdb = imdb,
                         DownloadVolumeFactor = downloadMultiplier ?? 1,
                         UploadVolumeFactor = 1
-                    });
+                    };
+                    releases.Add(release);
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/TorrentDay.cs
+++ b/src/Jackett.Common/Indexers/TorrentDay.cs
@@ -221,34 +221,33 @@ namespace Jackett.Common.Indexers
 
                 foreach (var torrent in json)
                 {
-                    var release = new ReleaseInfo();
-
-                    release.Title = torrent.name;
-                    if ((query.ImdbID == null || !TorznabCaps.SupportsImdbMovieSearch) && !query.MatchQueryStringAND(release.Title))
+                    if ((query.ImdbID == null || !TorznabCaps.SupportsImdbMovieSearch) && !query.MatchQueryStringAND(torrent.name))
                         continue;
-
-                    release.MinimumRatio = 1;
-                    release.MinimumSeedTime = 172800; // 48 hours
-                    release.Category = MapTrackerCatToNewznab(torrent.c.ToString());
-
-                    var torrentId = (long)torrent.t;
-                    release.Comments = new Uri(SiteLink + "details.php?id=" + torrentId);
-                    release.Guid = release.Comments;
-                    release.Link = new Uri(SiteLink + "download.php/" + torrentId + "/" + torrentId + ".torrent");
-                    release.PublishDate = DateTimeUtil.UnixTimestampToDateTime((long)torrent.ctime).ToLocalTime();
-
-                    release.Size = (long)torrent.size;
-                    release.Seeders = (int)torrent.seeders;
-                    release.Peers = release.Seeders + (int)torrent.leechers;
-                    release.Files = (long)torrent.files;
-                    release.Grabs = (long)torrent.completed;
+                    var torrentID = (long)torrent.t;
+                    var releaseComments = new Uri(SiteLink + "details.php?id=" + torrentID);
+                    var seeders = (int)torrent.seeders;
                     var imdbId = (string)torrent["imdb-id"];
-                    release.Imdb = ParseUtil.GetImdbID(imdbId);
                     var downloadMultiplier = (double?)torrent["download-multiplier"];
-                    release.DownloadVolumeFactor = downloadMultiplier ?? 1;
-                    release.UploadVolumeFactor = 1;
 
-                    releases.Add(release);
+                    releases.Add(new ReleaseInfo
+                    {
+                        Title = torrent.name,
+                        MinimumRatio = 1,
+                        MinimumSeedTime = 172800, // 48 hours
+                        Category = MapTrackerCatToNewznab(torrent.c.ToString()),
+                        Comments = releaseComments,
+                        Guid = releaseComments,
+                        Link = new Uri(SiteLink + "download.php/" + torrentID + "/" + torrentID + ".torrent"),
+                        PublishDate = DateTimeUtil.UnixTimestampToDateTime((long)torrent.ctime).ToLocalTime(),
+                        Size = (long)torrent.size,
+                        Seeders = seeders,
+                        Peers = seeders + (int)torrent.leechers,
+                        Files = (long)torrent.files,
+                        Grabs = (long)torrent.completed,
+                        Imdb = ParseUtil.GetImdbID(imdbId),
+                        DownloadVolumeFactor = downloadMultiplier ?? 1,
+                        UploadVolumeFactor = 1
+                    });
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/TorrentDay.cs
+++ b/src/Jackett.Common/Indexers/TorrentDay.cs
@@ -221,10 +221,10 @@ namespace Jackett.Common.Indexers
 
                 foreach (var torrent in json)
                 {
-                    if ((query.ImdbID == null || !TorznabCaps.SupportsImdbMovieSearch) && !query.MatchQueryStringAND(torrent.name))
+                    if ((!query.IsImdbQuery || !TorznabCaps.SupportsImdbMovieSearch) && !query.MatchQueryStringAND(torrent.name))
                         continue;
                     var torrentID = (long)torrent.t;
-                    var releaseComments = new Uri(SiteLink + "details.php?id=" + torrentID);
+                    var comments = new Uri(SiteLink + "details.php?id=" + torrentID);
                     var seeders = (int)torrent.seeders;
                     var imdbId = (string)torrent["imdb-id"];
                     var downloadMultiplier = (double?)torrent["download-multiplier"];
@@ -237,8 +237,8 @@ namespace Jackett.Common.Indexers
                         MinimumRatio = 1,
                         MinimumSeedTime = 172800, // 48 hours
                         Category = MapTrackerCatToNewznab(torrent.c.ToString()),
-                        Comments = releaseComments,
-                        Guid = releaseComments,
+                        Comments = comments,
+                        Guid = comments,
                         Link = link,
                         PublishDate = publishDate,
                         Size = (long)torrent.size,

--- a/src/Jackett.Common/Indexers/TorrentDay.cs
+++ b/src/Jackett.Common/Indexers/TorrentDay.cs
@@ -228,7 +228,9 @@ namespace Jackett.Common.Indexers
                     var seeders = (int)torrent.seeders;
                     var imdbId = (string)torrent["imdb-id"];
                     var downloadMultiplier = (double?)torrent["download-multiplier"];
-
+                    var link = new Uri(SiteLink + "download.php/" + torrentID + "/" + torrentID + ".torrent");
+                    var publishDate = DateTimeUtil.UnixTimestampToDateTime((long)torrent.ctime).ToLocalTime();
+                    var imdb = ParseUtil.GetImdbID(imdbId);
                     releases.Add(new ReleaseInfo
                     {
                         Title = torrent.name,
@@ -237,14 +239,14 @@ namespace Jackett.Common.Indexers
                         Category = MapTrackerCatToNewznab(torrent.c.ToString()),
                         Comments = releaseComments,
                         Guid = releaseComments,
-                        Link = new Uri(SiteLink + "download.php/" + torrentID + "/" + torrentID + ".torrent"),
-                        PublishDate = DateTimeUtil.UnixTimestampToDateTime((long)torrent.ctime).ToLocalTime(),
+                        Link = link,
+                        PublishDate = publishDate,
                         Size = (long)torrent.size,
                         Seeders = seeders,
                         Peers = seeders + (int)torrent.leechers,
                         Files = (long)torrent.files,
                         Grabs = (long)torrent.completed,
-                        Imdb = ParseUtil.GetImdbID(imdbId),
+                        Imdb = imdb,
                         DownloadVolumeFactor = downloadMultiplier ?? 1,
                         UploadVolumeFactor = 1
                     });

--- a/src/Jackett.Common/Indexers/TorrentHeaven.cs
+++ b/src/Jackett.Common/Indexers/TorrentHeaven.cs
@@ -220,7 +220,7 @@ namespace Jackett.Common.Indexers
                     var leechers = ParseUtil.CoerceInt(qLeechers.TextContent);
                     var grabs = ParseUtil.CoerceInt(row.QuerySelector("td:nth-child(7)").TextContent);
                     var publishDate = TimeZoneInfo.ConvertTime(dateGerman, germanyTz, TimeZoneInfo.Local);
-                    releases.Add(new ReleaseInfo
+                    var release = new ReleaseInfo
                     {
                         MinimumRatio = 0.8,
                         MinimumSeedTime = 0,
@@ -236,7 +236,8 @@ namespace Jackett.Common.Indexers
                         Grabs = grabs,
                         DownloadVolumeFactor = downloadFactor,
                         UploadVolumeFactor = 1
-                    });
+                    };
+                    releases.Add(release);
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/TorrentHeaven.cs
+++ b/src/Jackett.Common/Indexers/TorrentHeaven.cs
@@ -149,6 +149,7 @@ namespace Jackett.Common.Indexers
 
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {
+            // TODO verify this code is necessary for TZ data or if builtin exist
             var startTransition = TimeZoneInfo.TransitionTime.CreateFloatingDateRule(
                 new DateTime(1, 1, 1, 3, 0, 0), 3, 5, DayOfWeek.Sunday);
             var endTransition = TimeZoneInfo.TransitionTime.CreateFloatingDateRule(
@@ -192,11 +193,7 @@ namespace Jackett.Common.Indexers
                 var rows = dom.QuerySelectorAll("table.torrenttable > tbody > tr");
                 foreach (var row in rows.Skip(1))
                 {
-                    var release = new ReleaseInfo();
-                    release.MinimumRatio = 0.8;
-                    release.MinimumSeedTime = 0;
                     var qDetailsLink = row.QuerySelector("a[href^=\"index.php?strWebValue=torrent&strWebAction=details\"]");
-                    release.Title = titleRegexp.Match(qDetailsLink.GetAttribute("onmouseover")).Groups[1].Value;
                     var qCatLink = row.QuerySelector("a[href^=\"index.php?strWebValue=torrent&strWebAction=search&dir=\"]");
                     var qDlLink = row.QuerySelector("a[href^=\"index.php?strWebValue=torrent&strWebAction=download&id=\"]");
                     var qSeeders = row.QuerySelectorAll("td.column1")[3];
@@ -204,38 +201,39 @@ namespace Jackett.Common.Indexers
                     var qDateStr = row.QuerySelector("font:has(a)");
                     var qSize = row.QuerySelector("td.column2[align=center]");
                     var catStr = qCatLink.GetAttribute("href").Split('=')[3].Split('#')[0];
-                    release.Category = MapTrackerCatToNewznab(catStr);
-                    release.Link = new Uri(SiteLink + qDlLink.GetAttribute("href"));
-                    release.Comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
-                    release.Guid = release.Link;
+                    var link = new Uri(SiteLink + qDlLink.GetAttribute("href"));
                     var sizeStr = qSize.TextContent;
-                    release.Size = ReleaseInfo.GetBytes(sizeStr);
-                    release.Seeders = ParseUtil.CoerceInt(qSeeders.TextContent);
-                    release.Peers = ParseUtil.CoerceInt(qLeechers.TextContent) + release.Seeders;
-                    var dateStr = qDateStr.TextContent.Trim();
-                    var dateStrParts = dateStr.Split();
-                    var dateGerman = dateStrParts[0] switch
-                    {
-                        "Heute" => (DateTime.SpecifyKind(DateTime.UtcNow.Date, DateTimeKind.Unspecified) + TimeSpan.Parse(dateStrParts[1])),
-                        "Gestern" => (DateTime.SpecifyKind(DateTime.UtcNow.Date, DateTimeKind.Unspecified) + TimeSpan.Parse(dateStrParts[1])
-                                      - TimeSpan.FromDays(1)),
-                        _ => DateTime.SpecifyKind(                            DateTime.ParseExact(
-                                dateStrParts[0] + dateStrParts[1], "dd.MM.yyyyHH:mm", CultureInfo.InvariantCulture),
-                            DateTimeKind.Unspecified)
-                    };
+                    var releaseSeeders = ParseUtil.CoerceInt(qSeeders.TextContent);
+                    var dateStr = qDateStr.TextContent.Trim().Replace("Heute", "Today").Replace("Gestern", "Yesterday");
 
-                    release.PublishDate = TimeZoneInfo.ConvertTime(dateGerman, germanyTz, TimeZoneInfo.Local);
+                    var dateGerman = DateTimeUtil.FromUnknown(dateStr);
+
                     var grabs = row.QuerySelector("td:nth-child(7)").TextContent;
-                    release.Grabs = ParseUtil.CoerceInt(grabs);
+                    double downloadFactor;
                     if (row.QuerySelector("img[src=\"themes/images/freeleech.png\"]") != null
                         || row.QuerySelector("img[src=\"themes/images/onlyup.png\"]") != null)
-                        release.DownloadVolumeFactor = 0;
+                        downloadFactor = 0;
                     else if (row.QuerySelector("img[src=\"themes/images/DL50.png\"]") != null)
-                        release.DownloadVolumeFactor = 0.5;
+                        downloadFactor = 0.5;
                     else
-                        release.DownloadVolumeFactor = 1;
-                    release.UploadVolumeFactor = 1;
-                    releases.Add(release);
+                        downloadFactor = 1;
+                    releases.Add(new ReleaseInfo
+                    {
+                        MinimumRatio = 0.8,
+                        MinimumSeedTime = 0,
+                        Title = titleRegexp.Match(qDetailsLink.GetAttribute("onmouseover")).Groups[1].Value,
+                        Category = MapTrackerCatToNewznab(catStr),
+                        Comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href")),
+                        Link = link,
+                        Guid = link,
+                        Size = ReleaseInfo.GetBytes(sizeStr),
+                        Seeders =  releaseSeeders,
+                        Peers = ParseUtil.CoerceInt(qLeechers.TextContent) + releaseSeeders,
+                        PublishDate = TimeZoneInfo.ConvertTime(dateGerman, germanyTz, TimeZoneInfo.Local),
+                        Grabs = ParseUtil.CoerceInt(grabs),
+                        DownloadVolumeFactor = downloadFactor,
+                        UploadVolumeFactor = 1
+                    });
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/TorrentHeaven.cs
+++ b/src/Jackett.Common/Indexers/TorrentHeaven.cs
@@ -203,7 +203,6 @@ namespace Jackett.Common.Indexers
                     var catStr = qCatLink.GetAttribute("href").Split('=')[3].Split('#')[0];
                     var link = new Uri(SiteLink + qDlLink.GetAttribute("href"));
                     var sizeStr = qSize.TextContent;
-                    var releaseSeeders = ParseUtil.CoerceInt(qSeeders.TextContent);
                     var dateStr = qDateStr.TextContent.Trim().Replace("Heute", "Today").Replace("Gestern", "Yesterday");
 
                     var dateGerman = DateTimeUtil.FromUnknown(dateStr);
@@ -217,9 +216,10 @@ namespace Jackett.Common.Indexers
                         downloadFactor = 1;
                     var title = titleRegexp.Match(qDetailsLink.GetAttribute("onmouseover")).Groups[1].Value;
                     var comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
+                    var seeders = ParseUtil.CoerceInt(qSeeders.TextContent);
                     var leechers = ParseUtil.CoerceInt(qLeechers.TextContent);
-                    var publishDate = TimeZoneInfo.ConvertTime(dateGerman, germanyTz, TimeZoneInfo.Local);
                     var grabs = ParseUtil.CoerceInt(row.QuerySelector("td:nth-child(7)").TextContent);
+                    var publishDate = TimeZoneInfo.ConvertTime(dateGerman, germanyTz, TimeZoneInfo.Local);
                     releases.Add(new ReleaseInfo
                     {
                         MinimumRatio = 0.8,
@@ -230,8 +230,8 @@ namespace Jackett.Common.Indexers
                         Link = link,
                         Guid = link,
                         Size = ReleaseInfo.GetBytes(sizeStr),
-                        Seeders =  releaseSeeders,
-                        Peers = leechers + releaseSeeders,
+                        Seeders =  seeders,
+                        Peers = leechers + seeders,
                         PublishDate = publishDate,
                         Grabs = grabs,
                         DownloadVolumeFactor = downloadFactor,

--- a/src/Jackett.Common/Indexers/TorrentHeaven.cs
+++ b/src/Jackett.Common/Indexers/TorrentHeaven.cs
@@ -207,8 +207,6 @@ namespace Jackett.Common.Indexers
                     var dateStr = qDateStr.TextContent.Trim().Replace("Heute", "Today").Replace("Gestern", "Yesterday");
 
                     var dateGerman = DateTimeUtil.FromUnknown(dateStr);
-
-                    var grabs = row.QuerySelector("td:nth-child(7)").TextContent;
                     double downloadFactor;
                     if (row.QuerySelector("img[src=\"themes/images/freeleech.png\"]") != null
                         || row.QuerySelector("img[src=\"themes/images/onlyup.png\"]") != null)
@@ -217,20 +215,25 @@ namespace Jackett.Common.Indexers
                         downloadFactor = 0.5;
                     else
                         downloadFactor = 1;
+                    var title = titleRegexp.Match(qDetailsLink.GetAttribute("onmouseover")).Groups[1].Value;
+                    var comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
+                    var leechers = ParseUtil.CoerceInt(qLeechers.TextContent);
+                    var publishDate = TimeZoneInfo.ConvertTime(dateGerman, germanyTz, TimeZoneInfo.Local);
+                    var grabs = ParseUtil.CoerceInt(row.QuerySelector("td:nth-child(7)").TextContent);
                     releases.Add(new ReleaseInfo
                     {
                         MinimumRatio = 0.8,
                         MinimumSeedTime = 0,
-                        Title = titleRegexp.Match(qDetailsLink.GetAttribute("onmouseover")).Groups[1].Value,
+                        Title = title,
                         Category = MapTrackerCatToNewznab(catStr),
-                        Comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href")),
+                        Comments = comments,
                         Link = link,
                         Guid = link,
                         Size = ReleaseInfo.GetBytes(sizeStr),
                         Seeders =  releaseSeeders,
-                        Peers = ParseUtil.CoerceInt(qLeechers.TextContent) + releaseSeeders,
-                        PublishDate = TimeZoneInfo.ConvertTime(dateGerman, germanyTz, TimeZoneInfo.Local),
-                        Grabs = ParseUtil.CoerceInt(grabs),
+                        Peers = leechers + releaseSeeders,
+                        PublishDate = publishDate,
+                        Grabs = grabs,
                         DownloadVolumeFactor = downloadFactor,
                         UploadVolumeFactor = 1
                     });

--- a/src/Jackett.Common/Indexers/TorrentNetwork.cs
+++ b/src/Jackett.Common/Indexers/TorrentNetwork.cs
@@ -210,7 +210,17 @@ namespace Jackett.Common.Indexers
                     //var row12 = (long)torrent[12];
                     //var row13 = (string)torrent[13];
                     //var row14 = (long)torrent[14];
-
+                    var link = new Uri(SiteLink + "sdownload/" + torrentID + "/" + passkey);
+                    var publishDate = DateTimeUtil.UnixTimestampToDateTime((double)torrent[3]).ToLocalTime();
+                    var downloadVolumeFactor = (long)torrent[10] switch
+                    {
+                        // Only Up
+                        2 => 0,
+                        // 50 % Down
+                        1 => 0.5,
+                        // All others 100% down
+                        _ => 1,
+                    };
                     releases.Add(new ReleaseInfo
                     {
                         MinimumRatio = 0.8,
@@ -219,22 +229,14 @@ namespace Jackett.Common.Indexers
                         Title = torrent[1].ToString(),
                         Comments = comments,
                         Guid = comments,
-                        Link = new Uri(SiteLink + "sdownload/" + torrentID + "/" + passkey),
-                        PublishDate = DateTimeUtil.UnixTimestampToDateTime((double)torrent[3]).ToLocalTime(),
+                        Link = link,
+                        PublishDate = publishDate,
                         Size = (long)torrent[5],
                         Seeders = releaseSeeders,
                         Peers = releaseSeeders + (int)torrent[7],
                         Description = genres,
                         UploadVolumeFactor = 1,
-                        DownloadVolumeFactor = (long)torrent[10] switch
-                        {
-                            // Only Up
-                            2 => 0,
-                            // 50 % Down
-                            1 => 0.5,
-                            // All others 100% down
-                            _ => 1,
-                        },
+                        DownloadVolumeFactor = downloadVolumeFactor,
                         Grabs = (long)torrent[11]
                     });
                 }

--- a/src/Jackett.Common/Indexers/TorrentNetwork.cs
+++ b/src/Jackett.Common/Indexers/TorrentNetwork.cs
@@ -168,11 +168,13 @@ namespace Jackett.Common.Indexers
 
             var searchUrl = "browse";
             var searchString = query.GetQueryString();
-            var queryCollection = new NameValueCollection();
-            queryCollection.Add("orderC", "4");
-            queryCollection.Add("orderD", "desc");
-            queryCollection.Add("start", "0");
-            queryCollection.Add("length", "100");
+            var queryCollection = new NameValueCollection
+            {
+                { "orderC", "4" },
+                { "orderD", "desc" },
+                { "start", "0" },
+                { "length", "100" }
+            };
 
             if (!string.IsNullOrWhiteSpace(searchString))
                 queryCollection.Add("search", searchString);
@@ -196,43 +198,45 @@ namespace Jackett.Common.Indexers
 
                 foreach (JArray torrent in data)
                 {
-                    var release = new ReleaseInfo();
-                    release.MinimumRatio = 0.8;
-                    release.MinimumSeedTime = 172800; // 48 hours
-
-                    release.Category = MapTrackerCatToNewznab(torrent[0].ToString());
-                    release.Title = torrent[1].ToString();
                     var torrentID = (long)torrent[2];
-                    release.Comments = new Uri(SiteLink + "torrent/" + torrentID);
-                    release.Guid = release.Comments;
-                    release.Link = new Uri(SiteLink + "sdownload/" + torrentID + "/" + passkey);
-                    release.PublishDate = DateTimeUtil.UnixTimestampToDateTime((double)torrent[3]).ToLocalTime();
+                    var comments = new Uri(SiteLink + "torrent/" + torrentID);
                     //var preDelaySeconds = (long)torrent[4];
-                    release.Size = (long)torrent[5];
-                    release.Seeders = (int)torrent[6];
-                    release.Peers = release.Seeders + (int)torrent[7];
+                    var releaseSeeders = (int)torrent[6];
                     //var imdbRating = (double)torrent[8] / 10;
                     var genres = (string)torrent[9];
                     if (!string.IsNullOrWhiteSpace(genres))
-                        release.Description = "Genres: " + genres;
-
-                    var DownloadVolumeFlag = (long)torrent[10];
-                    release.UploadVolumeFactor = 1;
-                    if (DownloadVolumeFlag == 2) // Only Up
-                        release.DownloadVolumeFactor = 0;
-                    else if (DownloadVolumeFlag == 1) // 50 % Down
-                        release.DownloadVolumeFactor = 0.5;
-                    else if (DownloadVolumeFlag == 0)
-                        release.DownloadVolumeFactor = 1;
-
-                    release.Grabs = (long)torrent[11];
-
+                        genres = "Genres: " + genres;
                     // 12/13/14 unknown, probably IDs/name of the uploader
                     //var row12 = (long)torrent[12];
                     //var row13 = (string)torrent[13];
                     //var row14 = (long)torrent[14];
 
-                    releases.Add(release);
+                    releases.Add(new ReleaseInfo
+                    {
+                        MinimumRatio = 0.8,
+                        MinimumSeedTime = 172800, // 48 hours
+                        Category = MapTrackerCatToNewznab(torrent[0].ToString()),
+                        Title = torrent[1].ToString(),
+                        Comments = comments,
+                        Guid = comments,
+                        Link = new Uri(SiteLink + "sdownload/" + torrentID + "/" + passkey),
+                        PublishDate = DateTimeUtil.UnixTimestampToDateTime((double)torrent[3]).ToLocalTime(),
+                        Size = (long)torrent[5],
+                        Seeders = releaseSeeders,
+                        Peers = releaseSeeders + (int)torrent[7],
+                        Description = genres,
+                        UploadVolumeFactor = 1,
+                        DownloadVolumeFactor = (long)torrent[10] switch
+                        {
+                            // Only Up
+                            2 => 0,
+                            // 50 % Down
+                            1 => 0.5,
+                            // All others 100% down
+                            _ => 1,
+                        },
+                        Grabs = (long)torrent[11]
+                    });
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/TorrentNetwork.cs
+++ b/src/Jackett.Common/Indexers/TorrentNetwork.cs
@@ -221,7 +221,7 @@ namespace Jackett.Common.Indexers
                         // All others 100% down
                         _ => 1,
                     };
-                    releases.Add(new ReleaseInfo
+                    var release = new ReleaseInfo
                     {
                         MinimumRatio = 0.8,
                         MinimumSeedTime = 172800, // 48 hours
@@ -238,7 +238,8 @@ namespace Jackett.Common.Indexers
                         UploadVolumeFactor = 1,
                         DownloadVolumeFactor = downloadVolumeFactor,
                         Grabs = (long)torrent[11]
-                    });
+                    };
+                    releases.Add(release);
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/TorrentNetwork.cs
+++ b/src/Jackett.Common/Indexers/TorrentNetwork.cs
@@ -201,7 +201,7 @@ namespace Jackett.Common.Indexers
                     var torrentID = (long)torrent[2];
                     var comments = new Uri(SiteLink + "torrent/" + torrentID);
                     //var preDelaySeconds = (long)torrent[4];
-                    var releaseSeeders = (int)torrent[6];
+                    var seeders = (int)torrent[6];
                     //var imdbRating = (double)torrent[8] / 10;
                     var genres = (string)torrent[9];
                     if (!string.IsNullOrWhiteSpace(genres))
@@ -232,8 +232,8 @@ namespace Jackett.Common.Indexers
                         Link = link,
                         PublishDate = publishDate,
                         Size = (long)torrent[5],
-                        Seeders = releaseSeeders,
-                        Peers = releaseSeeders + (int)torrent[7],
+                        Seeders = seeders,
+                        Peers = seeders + (int)torrent[7],
                         Description = genres,
                         UploadVolumeFactor = 1,
                         DownloadVolumeFactor = downloadVolumeFactor,

--- a/src/Jackett.Common/Indexers/TorrentSyndikat.cs
+++ b/src/Jackett.Common/Indexers/TorrentSyndikat.cs
@@ -194,9 +194,9 @@ namespace Jackett.Common.Indexers
                     var descCol = row.Children[1];
                     var torrentTag = descCol.QuerySelectorAll("span.torrent-tag");
                     //Empty list gives string.Empty in string.Join
-                    var releaseDescription = string.Join(", ", torrentTag.Select(x => x.InnerHtml));
+                    var description = string.Join(", ", torrentTag.Select(x => x.InnerHtml));
                     var qCommentLink = descCol.QuerySelector("a[href*=\"details.php\"]");
-                    var releaseComments = new Uri(SiteLink + qCommentLink.GetAttribute("href").Replace("&hit=1", ""));
+                    var comments = new Uri(SiteLink + qCommentLink.GetAttribute("href").Replace("&hit=1", ""));
 
                     var torrentDetails = descCol.QuerySelector(".torrent_details");
                     var rawDateStr = torrentDetails.ChildNodes[1].TextContent;
@@ -207,29 +207,30 @@ namespace Jackett.Common.Indexers
                     var pubDateUtc = TimeZoneInfo.ConvertTimeToUtc(dateGerman, germanyTz);
                     var longFromString = ParseUtil.GetLongFromString(descCol.QuerySelector("a[href*=\"&searchin=imdb\"]")?.GetAttribute("href"));
                     var sizeFileCountRowChilds = row.Children[5].Children;
-                    var releaseSeeders = ParseUtil.CoerceInt(row.Children[7].TextContent);
+                    var seeders = ParseUtil.CoerceInt(row.Children[7].TextContent);
                     var link = new Uri(SiteLink + qLink.GetAttribute("href"));
                     var files = ParseUtil.CoerceInt(sizeFileCountRowChilds[2].TextContent);
                     var leechers = ParseUtil.CoerceInt(row.Children[8].TextContent);
                     var grabs = ParseUtil.CoerceInt(row.QuerySelector("td:nth-child(7)").TextContent);
                     var downloadVolumeFactor = globalFreeleech || row.QuerySelector("span.torrent-tag-free") != null
                         ? 0 : 1;
+                    var size = ReleaseInfo.GetBytes(sizeFileCountRowChilds[0].TextContent);
                     releases.Add(new ReleaseInfo
                     {
                         MinimumRatio = 1,
                         MinimumSeedTime = 345600, //8 days
                         Category = MapTrackerCatToNewznab(catStr),
                         Link = link,
-                        Description = releaseDescription,
+                        Description = description,
                         Title = qCommentLink.GetAttribute("title"),
-                        Comments = releaseComments,
-                        Guid = releaseComments,
+                        Comments = comments,
+                        Guid = comments,
                         PublishDate = pubDateUtc.ToLocalTime(),
                         Imdb = longFromString,
-                        Size = ReleaseInfo.GetBytes(sizeFileCountRowChilds[0].TextContent),
+                        Size = size,
                         Files = files,
-                        Seeders = releaseSeeders,
-                        Peers = leechers + releaseSeeders,
+                        Seeders = seeders,
+                        Peers = leechers + seeders,
                         Grabs = grabs,
                         DownloadVolumeFactor = downloadVolumeFactor,
                         UploadVolumeFactor = 1

--- a/src/Jackett.Common/Indexers/TorrentSyndikat.cs
+++ b/src/Jackett.Common/Indexers/TorrentSyndikat.cs
@@ -215,7 +215,7 @@ namespace Jackett.Common.Indexers
                     var downloadVolumeFactor = globalFreeleech || row.QuerySelector("span.torrent-tag-free") != null
                         ? 0 : 1;
                     var size = ReleaseInfo.GetBytes(sizeFileCountRowChilds[0].TextContent);
-                    releases.Add(new ReleaseInfo
+                    var release = new ReleaseInfo
                     {
                         MinimumRatio = 1,
                         MinimumSeedTime = 345600, //8 days
@@ -234,7 +234,8 @@ namespace Jackett.Common.Indexers
                         Grabs = grabs,
                         DownloadVolumeFactor = downloadVolumeFactor,
                         UploadVolumeFactor = 1
-                    });
+                    };
+                    releases.Add(release);
                 }
             }
             catch (Exception ex)

--- a/src/Jackett.Common/Indexers/Torrentech.cs
+++ b/src/Jackett.Common/Indexers/Torrentech.cs
@@ -74,13 +74,14 @@ namespace Jackett.Common.Indexers
             var searchString = query.GetQueryString();
 
             WebClientStringResult results = null;
-            var queryCollection = new NameValueCollection();
-
-            queryCollection.Add("act", "search");
-            queryCollection.Add("forums", "all");
-            queryCollection.Add("torrents", "1");
-            queryCollection.Add("search_in", "titles");
-            queryCollection.Add("result_type", "topics");
+            var queryCollection = new NameValueCollection
+            {
+                { "act", "search" },
+                { "forums", "all" },
+                { "torrents", "1" },
+                { "search_in", "titles" },
+                { "result_type", "topics" }
+            };
 
             // if the search string is empty use the getnew view
             if (string.IsNullOrWhiteSpace(searchString))
@@ -112,6 +113,7 @@ namespace Jackett.Common.Indexers
                 {
                     try
                     {
+                        //TODO refactor to initializer
                         var release = new ReleaseInfo();
 
                         var StatsElements = Row.QuerySelector("td:nth-child(5)");

--- a/src/Jackett.Common/Indexers/Torrentscsv.cs
+++ b/src/Jackett.Common/Indexers/Torrentscsv.cs
@@ -138,9 +138,8 @@ namespace Jackett.Common.Indexers
                     double createdunix = torrent.Value<long>("created_unix");
                     var dateTime = new System.DateTime(1970, 1, 1, 0, 0, 0, 0);
                     dateTime = dateTime.AddSeconds(createdunix);
-                    var grabs = torrent.Value<string>("completed") ?? "0";
                     var releaseSeeders = torrent.Value<int>("seeders");
-
+                    var grabs = ParseUtil.CoerceInt(torrent.Value<string>("completed") ?? "0");
                     var release = new ReleaseInfo
                     {
                         Title = torrent.Value<string>("name"),
@@ -154,7 +153,7 @@ namespace Jackett.Common.Indexers
                         Seeders = releaseSeeders,
                         Peers = torrent.Value<int>("leechers") + releaseSeeders,
                         Size = torrent.Value<long>("size_bytes"),
-                        Grabs = ParseUtil.CoerceInt(grabs),
+                        Grabs = grabs,
                         MinimumRatio = 1,
                         MinimumSeedTime = 172800, // 48 hours
                         DownloadVolumeFactor = 0,

--- a/src/Jackett.Common/Indexers/Torrentscsv.cs
+++ b/src/Jackett.Common/Indexers/Torrentscsv.cs
@@ -77,11 +77,12 @@ namespace Jackett.Common.Indexers
             if (string.IsNullOrEmpty(searchString))
                 searchString = "2020";
 
-            var queryCollection = new NameValueCollection();
-
-            queryCollection.Add("q", searchString);
-            queryCollection.Add("size", "500");
-            queryCollection.Add("type_", "torrent");
+            var queryCollection = new NameValueCollection
+            {
+                { "q", searchString },
+                { "size", "500" },
+                { "type_", "torrent" }
+            };
 
             var searchUrl = ApiEndpoint + "?" + queryCollection.GetQueryString();
             var response = await RequestStringWithCookiesAndRetry(searchUrl, string.Empty);
@@ -97,11 +98,8 @@ namespace Jackett.Common.Indexers
                     if (torrent == null)
                         throw new Exception("Error: No data returned!");
 
-                    var release = new ReleaseInfo();
-                    release.Title = torrent.Value<string>("name");
-
                     // construct magnet link from infohash with all public trackers known to man
-                    var magnet_uri = "magnet:?xt=urn:btih:" + torrent.Value<JToken>("infohash") +
+                    var magnet_uri = new Uri( "magnet:?xt=urn:btih:" + torrent.Value<JToken>("infohash") +
                         "&tr=udp://tracker.coppersurfer.tk:6969/announce" +
                         "&tr=udp://tracker.leechers-paradise.org:6969/announce" +
                         "&tr=udp://tracker.internetwarriors.net:1337/announce" +
@@ -134,32 +132,36 @@ namespace Jackett.Common.Indexers
                         "&tr=udp://torrentclub.tech:6969/announce" +
                         "&tr=udp://tracker.tvunderground.org.ru:3218/announce" +
                         "&tr=udp://tracker.open-tracker.org:1337/announce" +
-                        "&tr=udp://tracker.justseed.it:1337/announce";
-
-                    release.MagnetUri = new Uri(magnet_uri);
-                    // there is no comments or details link so we point to the web site instead
-                    release.Comments = new Uri(SiteLink);
-                    release.Guid = release.MagnetUri;
-                    release.Link = release.MagnetUri;
-                    release.InfoHash = torrent.Value<JToken>("infohash").ToString();
+                        "&tr=udp://tracker.justseed.it:1337/announce");
 
                     // convert unix timestamp to human readable date
                     double createdunix = torrent.Value<long>("created_unix");
                     var dateTime = new System.DateTime(1970, 1, 1, 0, 0, 0, 0);
                     dateTime = dateTime.AddSeconds(createdunix);
-                    release.PublishDate = dateTime;
-                    release.Seeders = torrent.Value<int>("seeders");
-                    release.Peers = torrent.Value<int>("leechers") + release.Seeders;
-                    release.Size = torrent.Value<long>("size_bytes");
-                    var grabs = torrent.Value<string>("completed");
-                    if (grabs == null)
-                        grabs = "0";
-                    release.Grabs = ParseUtil.CoerceInt(grabs);
-                    release.MinimumRatio = 1;
-                    release.MinimumSeedTime = 172800; // 48 hours
-                    release.DownloadVolumeFactor = 0;
-                    release.UploadVolumeFactor = 1;
+                    var grabs = torrent.Value<string>("completed") ?? "0";
+                    var releaseSeeders = torrent.Value<int>("seeders");
 
+                    var release = new ReleaseInfo
+                    {
+                        Title = torrent.Value<string>("name"),
+                        MagnetUri = magnet_uri,
+                        // there is no comments or details link so we point to the web site instead
+                        Comments = new Uri(SiteLink),
+                        Guid = magnet_uri,
+                        Link = magnet_uri,
+                        InfoHash = torrent.Value<JToken>("infohash").ToString(),
+                        PublishDate = dateTime,
+                        Seeders = releaseSeeders,
+                        Peers = torrent.Value<int>("leechers") + releaseSeeders,
+                        Size = torrent.Value<long>("size_bytes"),
+                        Grabs = ParseUtil.CoerceInt(grabs),
+                        MinimumRatio = 1,
+                        MinimumSeedTime = 172800, // 48 hours
+                        DownloadVolumeFactor = 0,
+                        UploadVolumeFactor = 1
+                    };
+
+                    //TODO isn't there already a function for this?
                     // dummy mappings for sonarr, radarr, etc
                     var categories = string.Join(";", MapTorznabCapsToTrackers(query));
                     if (!string.IsNullOrEmpty(categories))
@@ -198,7 +200,7 @@ namespace Jackett.Common.Indexers
                         }
                     }
                     // for null category
-                    if (string.IsNullOrEmpty(categories))
+                    else
                     {
                         release.Category = new List<int> { TorznabCatType.Other.ID };
                     }

--- a/src/Jackett.Common/Indexers/Torrentscsv.cs
+++ b/src/Jackett.Common/Indexers/Torrentscsv.cs
@@ -99,7 +99,11 @@ namespace Jackett.Common.Indexers
                         throw new Exception("Error: No data returned!");
 
                     // construct magnet link from infohash with all public trackers known to man
-                    var magnet_uri = new Uri( "magnet:?xt=urn:btih:" + torrent.Value<JToken>("infohash") +
+                    // TODO move trackers to List for reuse elsewhere
+                    // TODO dynamically generate list periodically from online tracker repositories like
+                    // https://torrents.io/tracker-list/
+                    // https://github.com/ngosang/trackerslist
+                    var magnet = new Uri( "magnet:?xt=urn:btih:" + torrent.Value<JToken>("infohash") +
                         "&tr=udp://tracker.coppersurfer.tk:6969/announce" +
                         "&tr=udp://tracker.leechers-paradise.org:6969/announce" +
                         "&tr=udp://tracker.internetwarriors.net:1337/announce" +
@@ -138,20 +142,20 @@ namespace Jackett.Common.Indexers
                     double createdunix = torrent.Value<long>("created_unix");
                     var dateTime = new System.DateTime(1970, 1, 1, 0, 0, 0, 0);
                     dateTime = dateTime.AddSeconds(createdunix);
-                    var releaseSeeders = torrent.Value<int>("seeders");
+                    var seeders = torrent.Value<int>("seeders");
                     var grabs = ParseUtil.CoerceInt(torrent.Value<string>("completed") ?? "0");
                     var release = new ReleaseInfo
                     {
                         Title = torrent.Value<string>("name"),
-                        MagnetUri = magnet_uri,
+                        MagnetUri = magnet,
                         // there is no comments or details link so we point to the web site instead
                         Comments = new Uri(SiteLink),
-                        Guid = magnet_uri,
-                        Link = magnet_uri,
+                        Guid = magnet,
+                        Link = magnet,
                         InfoHash = torrent.Value<JToken>("infohash").ToString(),
                         PublishDate = dateTime,
-                        Seeders = releaseSeeders,
-                        Peers = torrent.Value<int>("leechers") + releaseSeeders,
+                        Seeders = seeders,
+                        Peers = torrent.Value<int>("leechers") + seeders,
                         Size = torrent.Value<long>("size_bytes"),
                         Grabs = grabs,
                         MinimumRatio = 1,

--- a/src/Jackett.Common/Indexers/Xthor.cs
+++ b/src/Jackett.Common/Indexers/Xthor.cs
@@ -234,6 +234,10 @@ namespace Jackett.Common.Indexers
                             torrent.name = regex.Replace(torrent.name, "$1" + ReplaceMulti + "$2");
                         }
 
+                        var publishDate = DateTimeUtil.UnixTimestampToDateTime(torrent.added);
+                        var guid = new Uri(TorrentDescriptionUrl.Replace("{id}", torrent.id.ToString()));
+                        var comments = new Uri(TorrentCommentUrl.Replace("{id}", torrent.id.ToString()));
+                        var link = new Uri(torrent.download_link);
                         var release = new ReleaseInfo
                         {
                             // Mapping data
@@ -243,15 +247,15 @@ namespace Jackett.Common.Indexers
                             Peers = torrent.seeders + torrent.leechers,
                             MinimumRatio = 1,
                             MinimumSeedTime = 345600,
-                            PublishDate = DateTimeUtil.UnixTimestampToDateTime(torrent.added),
+                            PublishDate = publishDate,
                             Size = torrent.size,
                             Grabs = torrent.times_completed,
                             Files = torrent.numfiles,
                             UploadVolumeFactor = 1,
                             DownloadVolumeFactor = (torrent.freeleech == 1 ? 0 : 1),
-                            Guid = new Uri(TorrentDescriptionUrl.Replace("{id}", torrent.id.ToString())),
-                            Comments = new Uri(TorrentCommentUrl.Replace("{id}", torrent.id.ToString())),
-                            Link = new Uri(torrent.download_link),
+                            Guid = guid,
+                            Comments = comments,
+                            Link = link,
                             TMDb = torrent.tmdb_id
                         };
 

--- a/src/Jackett.Common/Indexers/Xthor.cs
+++ b/src/Jackett.Common/Indexers/Xthor.cs
@@ -139,7 +139,7 @@ namespace Jackett.Common.Indexers
 
         // Warning 1998 is async method with no await calls inside
         // TODO: Remove pragma by wrapping return in Task.FromResult and removing async
-        
+
 #pragma warning disable 1998
 
         public override async Task<IndexerConfigurationStatus> ApplyConfiguration(JToken configJson)
@@ -255,6 +255,7 @@ namespace Jackett.Common.Indexers
                             TMDb = torrent.tmdb_id
                         };
 
+                        //TODO make consistent with other trackers
                         if (DevMode)
                         {
                             Output(release.ToString());

--- a/src/Jackett.Common/Indexers/Xthor.cs
+++ b/src/Jackett.Common/Indexers/Xthor.cs
@@ -235,6 +235,7 @@ namespace Jackett.Common.Indexers
                         }
 
                         var publishDate = DateTimeUtil.UnixTimestampToDateTime(torrent.added);
+                        //TODO replace with download link?
                         var guid = new Uri(TorrentDescriptionUrl.Replace("{id}", torrent.id.ToString()));
                         var comments = new Uri(TorrentCommentUrl.Replace("{id}", torrent.id.ToString()));
                         var link = new Uri(torrent.download_link);

--- a/src/Jackett.Common/Indexers/pornolab.cs
+++ b/src/Jackett.Common/Indexers/pornolab.cs
@@ -23,6 +23,7 @@ namespace Jackett.Common.Indexers
 
         protected string cap_sid = null;
         protected string cap_code_field = null;
+        private static readonly Regex s_StripRussianRegex = new Regex(@"(\([А-Яа-яЁё\W]+\))|(^[А-Яа-яЁё\W\d]+\/ )|([а-яА-ЯЁё \-]+,+)|([а-яА-ЯЁё]+)");
 
         private new ConfigurationDataPornolab configData
         {
@@ -278,11 +279,6 @@ namespace Jackett.Common.Indexers
                 {
                     try
                     {
-                        var release = new ReleaseInfo();
-
-                        release.MinimumRatio = 1;
-                        release.MinimumSeedTime = 0;
-
                         var qDownloadLink = Row.QuerySelector("a.tr-dl");
                         if (qDownloadLink == null) // Expects moderation
                             continue;
@@ -290,39 +286,35 @@ namespace Jackett.Common.Indexers
                         var qForumLink = Row.QuerySelector("a.f");
                         var qDetailsLink = Row.QuerySelector("a.tLink");
                         var qSize = Row.QuerySelector("td:nth-child(6) u");
-
-                        release.Title = qDetailsLink.TextContent;
-
-                        release.Comments = new Uri(SiteLink + "forum/" + qDetailsLink.GetAttribute("href"));
-                        release.Description = qForumLink.TextContent;
-                        release.Link = release.Comments;
-                        release.Guid = release.Link;
-                        release.Size = ReleaseInfo.GetBytes(qSize.TextContent);
-
-                        var seeders = Row.QuerySelector("td:nth-child(7) b").TextContent;
-                        if (string.IsNullOrWhiteSpace(seeders))
-                            seeders = "0";
-                        release.Seeders = ParseUtil.CoerceInt(seeders);
-                        release.Peers = ParseUtil.CoerceInt(Row.QuerySelector("td:nth-child(8)").TextContent) + release.Seeders;
-                        release.Grabs = ParseUtil.CoerceLong(Row.QuerySelector("td:nth-child(9)").TextContent);
+                        var link = new Uri(SiteLink + "forum/" + qDetailsLink.GetAttribute("href"));
+                        var seederString = Row.QuerySelector("td:nth-child(7) b").TextContent;
+                        var seeders = string.IsNullOrWhiteSpace(seederString) ? 0 : ParseUtil.CoerceInt(seederString);
 
                         var timestr = Row.QuerySelector("td:nth-child(10) u").TextContent;
-                        release.PublishDate = DateTimeUtil.UnixTimestampToDateTime(long.Parse(timestr));
-
                         var forum = qForumLink;
                         var forumid = forum.GetAttribute("href").Split('=')[1];
-                        release.Category = MapTrackerCatToNewznab(forumid);
 
-                        release.DownloadVolumeFactor = 1;
-                        release.UploadVolumeFactor = 1;
-
-                        if (configData.StripRussianLetters.Value)
+                        releases.Add(new ReleaseInfo
                         {
-                            var regex = new Regex(@"(\([А-Яа-яЁё\W]+\))|(^[А-Яа-яЁё\W\d]+\/ )|([а-яА-ЯЁё \-]+,+)|([а-яА-ЯЁё]+)");
-                            release.Title = regex.Replace(release.Title, "");
-                        }
-
-                        releases.Add(release);
+                            MinimumRatio = 1,
+                            MinimumSeedTime = 0,
+                            Title =
+                                configData.StripRussianLetters.Value
+                                    ? s_StripRussianRegex.Replace(qDetailsLink.TextContent, "")
+                                    : qDetailsLink.TextContent,
+                            Comments = link,
+                            Description = qForumLink.TextContent,
+                            Link = link,
+                            Guid = link,
+                            Size = ReleaseInfo.GetBytes(qSize.TextContent),
+                            Seeders = seeders,
+                            Peers = ParseUtil.CoerceInt(Row.QuerySelector("td:nth-child(8)").TextContent) + seeders,
+                            Grabs = ParseUtil.CoerceLong(Row.QuerySelector("td:nth-child(9)").TextContent),
+                            PublishDate = DateTimeUtil.UnixTimestampToDateTime(long.Parse(timestr)),
+                            Category = MapTrackerCatToNewznab(forumid),
+                            DownloadVolumeFactor = 1,
+                            UploadVolumeFactor = 1
+                        });
                     }
                     catch (Exception ex)
                     {

--- a/src/Jackett.Common/Indexers/pornolab.cs
+++ b/src/Jackett.Common/Indexers/pornolab.cs
@@ -293,24 +293,28 @@ namespace Jackett.Common.Indexers
                         var timestr = Row.QuerySelector("td:nth-child(10) u").TextContent;
                         var forum = qForumLink;
                         var forumid = forum.GetAttribute("href").Split('=')[1];
-
+                        var title = configData.StripRussianLetters.Value
+                            ? s_StripRussianRegex.Replace(qDetailsLink.TextContent, "")
+                            : qDetailsLink.TextContent;
+                        var size = ReleaseInfo.GetBytes(qSize.TextContent);
+                        var leechers = ParseUtil.CoerceInt(Row.QuerySelector("td:nth-child(8)").TextContent);
+                        var grabs = ParseUtil.CoerceLong(Row.QuerySelector("td:nth-child(9)").TextContent);
+                        var publishDate = DateTimeUtil.UnixTimestampToDateTime(long.Parse(timestr));
                         releases.Add(new ReleaseInfo
                         {
                             MinimumRatio = 1,
                             MinimumSeedTime = 0,
                             Title =
-                                configData.StripRussianLetters.Value
-                                    ? s_StripRussianRegex.Replace(qDetailsLink.TextContent, "")
-                                    : qDetailsLink.TextContent,
+                                title,
                             Comments = link,
                             Description = qForumLink.TextContent,
                             Link = link,
                             Guid = link,
-                            Size = ReleaseInfo.GetBytes(qSize.TextContent),
+                            Size = size,
                             Seeders = seeders,
-                            Peers = ParseUtil.CoerceInt(Row.QuerySelector("td:nth-child(8)").TextContent) + seeders,
-                            Grabs = ParseUtil.CoerceLong(Row.QuerySelector("td:nth-child(9)").TextContent),
-                            PublishDate = DateTimeUtil.UnixTimestampToDateTime(long.Parse(timestr)),
+                            Peers = leechers + seeders,
+                            Grabs = grabs,
+                            PublishDate = publishDate,
                             Category = MapTrackerCatToNewznab(forumid),
                             DownloadVolumeFactor = 1,
                             UploadVolumeFactor = 1

--- a/src/Jackett.Common/Indexers/pornolab.cs
+++ b/src/Jackett.Common/Indexers/pornolab.cs
@@ -300,12 +300,11 @@ namespace Jackett.Common.Indexers
                         var leechers = ParseUtil.CoerceInt(Row.QuerySelector("td:nth-child(8)").TextContent);
                         var grabs = ParseUtil.CoerceLong(Row.QuerySelector("td:nth-child(9)").TextContent);
                         var publishDate = DateTimeUtil.UnixTimestampToDateTime(long.Parse(timestr));
-                        releases.Add(new ReleaseInfo
+                        var release = new ReleaseInfo
                         {
                             MinimumRatio = 1,
                             MinimumSeedTime = 0,
-                            Title =
-                                title,
+                            Title = title,
                             Comments = link,
                             Description = qForumLink.TextContent,
                             Link = link,
@@ -318,7 +317,8 @@ namespace Jackett.Common.Indexers
                             Category = MapTrackerCatToNewznab(forumid),
                             DownloadVolumeFactor = 1,
                             UploadVolumeFactor = 1
-                        });
+                        };
+                        releases.Add(release);
                     }
                     catch (Exception ex)
                     {

--- a/src/Jackett.Common/Indexers/rutracker.cs
+++ b/src/Jackett.Common/Indexers/rutracker.cs
@@ -1539,42 +1539,42 @@ namespace Jackett.Common.Indexers
                 {
                     try
                     {
-                        var release = new ReleaseInfo();
-
-                        release.MinimumRatio = 1;
-                        release.MinimumSeedTime = 0;
-
                         var qDownloadLink = Row.QuerySelector("td.tor-size > a.tr-dl");
                         if (qDownloadLink == null) // Expects moderation
                             continue;
-
                         var qDetailsLink = Row.QuerySelector("td.t-title > div.t-title > a.tLink");
                         var qSize = Row.QuerySelector("td.tor-size");
-
-                        release.Title = qDetailsLink.TextContent;
-
-                        release.Comments = new Uri(SiteLink + "forum/" + qDetailsLink.GetAttribute("href"));
-                        release.Link = new Uri(SiteLink + "forum/" + qDownloadLink.GetAttribute("href"));
-                        release.Guid = release.Comments;
-                        release.Size = ReleaseInfo.GetBytes(qSize.GetAttribute("data-ts_text"));
-
-                        var seeders = Row.QuerySelector("td:nth-child(7) b").TextContent;
-                        if (string.IsNullOrWhiteSpace(seeders))
-                            seeders = "0";
-                        release.Seeders = ParseUtil.CoerceInt(seeders);
-                        release.Peers = ParseUtil.CoerceInt(Row.QuerySelector("td:nth-child(8)").TextContent) + release.Seeders;
-                        release.Grabs = ParseUtil.CoerceLong(Row.QuerySelector("td:nth-child(9)").TextContent);
-
+                        var releaseComments = new Uri(SiteLink + "forum/" + qDetailsLink.GetAttribute("href"));
+                        var seedersString = Row.QuerySelector("td:nth-child(7) b").TextContent;
+                        var seeders = string.IsNullOrWhiteSpace(seedersString) ? 0 : ParseUtil.CoerceInt(seedersString);
                         var timestr = Row.QuerySelector("td:nth-child(10)").GetAttribute("data-ts_text");
-                        release.PublishDate = DateTimeUtil.UnixTimestampToDateTime(long.Parse(timestr));
-
                         var forum = Row.QuerySelector("td.f-name > div.f-name > a");
                         var forumid = forum.GetAttribute("href").Split('=')[1];
-                        release.Category = MapTrackerCatToNewznab(forumid);
 
-                        release.DownloadVolumeFactor = 1;
-                        release.UploadVolumeFactor = 1;
+                        var release = new ReleaseInfo
+                        {
+                            MinimumRatio = 1,
+                            MinimumSeedTime = 0,
+                            Title = qDetailsLink.TextContent,
+                            Comments = releaseComments,
+                            Link = new Uri(SiteLink + "forum/" + qDownloadLink.GetAttribute("href")),
+                            Guid = releaseComments,
+                            Size = ReleaseInfo.GetBytes(qSize.GetAttribute("data-ts_text")),
+                            Seeders = seeders,
+                            Peers = ParseUtil.CoerceInt(Row.QuerySelector("td:nth-child(8)").TextContent) + seeders,
+                            Grabs = ParseUtil.CoerceLong(Row.QuerySelector("td:nth-child(9)").TextContent),
+                            PublishDate = DateTimeUtil.UnixTimestampToDateTime(long.Parse(timestr)),
+                            Category = MapTrackerCatToNewznab(forumid),
+                            DownloadVolumeFactor = 1,
+                            UploadVolumeFactor = 1
+                        };
 
+
+
+
+
+
+                        // TODO finish extracting release variables to simiplify release initialization
                         if (release.Category.Contains(TorznabCatType.TV.ID))
                         {
                             // extract season and episodes

--- a/src/Jackett.Common/Indexers/rutracker.cs
+++ b/src/Jackett.Common/Indexers/rutracker.cs
@@ -1550,20 +1550,24 @@ namespace Jackett.Common.Indexers
                         var timestr = Row.QuerySelector("td:nth-child(10)").GetAttribute("data-ts_text");
                         var forum = Row.QuerySelector("td.f-name > div.f-name > a");
                         var forumid = forum.GetAttribute("href").Split('=')[1];
-
+                        var link = new Uri(SiteLink + "forum/" + qDownloadLink.GetAttribute("href"));
+                        var size = ReleaseInfo.GetBytes(qSize.GetAttribute("data-ts_text"));
+                        var leechers = ParseUtil.CoerceInt(Row.QuerySelector("td:nth-child(8)").TextContent);
+                        var grabs = ParseUtil.CoerceLong(Row.QuerySelector("td:nth-child(9)").TextContent);
+                        var publishDate = DateTimeUtil.UnixTimestampToDateTime(long.Parse(timestr));
                         var release = new ReleaseInfo
                         {
                             MinimumRatio = 1,
                             MinimumSeedTime = 0,
                             Title = qDetailsLink.TextContent,
                             Comments = releaseComments,
-                            Link = new Uri(SiteLink + "forum/" + qDownloadLink.GetAttribute("href")),
+                            Link = link,
                             Guid = releaseComments,
-                            Size = ReleaseInfo.GetBytes(qSize.GetAttribute("data-ts_text")),
+                            Size = size,
                             Seeders = seeders,
-                            Peers = ParseUtil.CoerceInt(Row.QuerySelector("td:nth-child(8)").TextContent) + seeders,
-                            Grabs = ParseUtil.CoerceLong(Row.QuerySelector("td:nth-child(9)").TextContent),
-                            PublishDate = DateTimeUtil.UnixTimestampToDateTime(long.Parse(timestr)),
+                            Peers = leechers + seeders,
+                            Grabs = grabs,
+                            PublishDate = publishDate,
                             Category = MapTrackerCatToNewznab(forumid),
                             DownloadVolumeFactor = 1,
                             UploadVolumeFactor = 1

--- a/src/Jackett.Common/Indexers/rutracker.cs
+++ b/src/Jackett.Common/Indexers/rutracker.cs
@@ -1544,7 +1544,7 @@ namespace Jackett.Common.Indexers
                             continue;
                         var qDetailsLink = Row.QuerySelector("td.t-title > div.t-title > a.tLink");
                         var qSize = Row.QuerySelector("td.tor-size");
-                        var releaseComments = new Uri(SiteLink + "forum/" + qDetailsLink.GetAttribute("href"));
+                        var comments = new Uri(SiteLink + "forum/" + qDetailsLink.GetAttribute("href"));
                         var seedersString = Row.QuerySelector("td:nth-child(7) b").TextContent;
                         var seeders = string.IsNullOrWhiteSpace(seedersString) ? 0 : ParseUtil.CoerceInt(seedersString);
                         var timestr = Row.QuerySelector("td:nth-child(10)").GetAttribute("data-ts_text");
@@ -1560,9 +1560,9 @@ namespace Jackett.Common.Indexers
                             MinimumRatio = 1,
                             MinimumSeedTime = 0,
                             Title = qDetailsLink.TextContent,
-                            Comments = releaseComments,
+                            Comments = comments,
                             Link = link,
-                            Guid = releaseComments,
+                            Guid = comments,
                             Size = size,
                             Seeders = seeders,
                             Peers = leechers + seeders,

--- a/src/Jackett.Common/Indexers/toloka.cs
+++ b/src/Jackett.Common/Indexers/toloka.cs
@@ -258,7 +258,7 @@ namespace Jackett.Common.Indexers
                         var timestr = Row.QuerySelector("td:nth-child(13)").TextContent;
                         var forum = Row.QuerySelector("td:nth-child(2) > a");
                         var forumid = forum.GetAttribute("href").Split('=')[1];
-                        var releaseComments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
+                        var comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
                         var link = new Uri(SiteLink + qDownloadLink.GetAttribute("href"));
                         var size = ReleaseInfo.GetBytes(qSize.TextContent);
                         var leechers = ParseUtil.CoerceInt(Row.QuerySelector("td:nth-child(11) > b").TextContent);
@@ -268,9 +268,9 @@ namespace Jackett.Common.Indexers
                             MinimumRatio = 1,
                             MinimumSeedTime = 0,
                             Title = qDetailsLink.TextContent,
-                            Comments = releaseComments,
+                            Comments = comments,
                             Link = link,
-                            Guid = releaseComments,
+                            Guid = comments,
                             Size = size,
                             Seeders = seeders,
                             Peers = leechers + seeders,
@@ -286,9 +286,7 @@ namespace Jackett.Common.Indexers
                         {
                             // extract season and episodes
                             var regex = new Regex(".+\\/\\s([^а-яА-я\\/]+)\\s\\/.+Сезон\\s*[:]*\\s+(\\d+).+(?:Серії|Епізод)+\\s*[:]*\\s+(\\d+-*\\d*).+,\\s+(.+)\\]\\s(.+)");
-
-                            string title;
-                            title = regex.Replace(release.Title, "$1 - S$2E$3 - rus $4 $5");
+                            var title = regex.Replace(release.Title, "$1 - S$2E$3 - rus $4 $5");
                             title = Regex.Replace(title, "-Rip", "Rip", RegexOptions.IgnoreCase);
                             title = Regex.Replace(title, "WEB-DLRip", "WEBDL", RegexOptions.IgnoreCase);
                             title = Regex.Replace(title, "WEB-DL", "WEBDL", RegexOptions.IgnoreCase);

--- a/src/Jackett.Common/Indexers/toloka.cs
+++ b/src/Jackett.Common/Indexers/toloka.cs
@@ -259,29 +259,27 @@ namespace Jackett.Common.Indexers
                         var forum = Row.QuerySelector("td:nth-child(2) > a");
                         var forumid = forum.GetAttribute("href").Split('=')[1];
                         var releaseComments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
-
+                        var link = new Uri(SiteLink + qDownloadLink.GetAttribute("href"));
+                        var size = ReleaseInfo.GetBytes(qSize.TextContent);
+                        var leechers = ParseUtil.CoerceInt(Row.QuerySelector("td:nth-child(11) > b").TextContent);
+                        var publishDate = DateTimeUtil.FromFuzzyTime(timestr);
                         var release = new ReleaseInfo
                         {
                             MinimumRatio = 1,
                             MinimumSeedTime = 0,
                             Title = qDetailsLink.TextContent,
                             Comments = releaseComments,
-                            Link = new Uri(SiteLink + qDownloadLink.GetAttribute("href")),
+                            Link = link,
                             Guid = releaseComments,
-                            Size = ReleaseInfo.GetBytes(qSize.TextContent),
+                            Size = size,
                             Seeders = seeders,
-                            Peers = ParseUtil.CoerceInt(Row.QuerySelector("td:nth-child(11) > b").TextContent) + seeders,
+                            Peers = leechers + seeders,
                             Grabs = 0, //ParseUtil.CoerceLong(Row.QuerySelector("td:nth-child(9)").TextContent);
-                            PublishDate = DateTimeUtil.FromFuzzyTime(timestr),
+                            PublishDate = publishDate,
                             Category = MapTrackerCatToNewznab(forumid),
                             DownloadVolumeFactor = 1,
                             UploadVolumeFactor = 1
                         };
-
-
-                        
-
-
 
                         // TODO cleanup
                         if (release.Category.Contains(TorznabCatType.TV.ID))

--- a/src/Jackett.Common/Indexers/toloka.cs
+++ b/src/Jackett.Common/Indexers/toloka.cs
@@ -247,48 +247,50 @@ namespace Jackett.Common.Indexers
                 {
                     try
                     {
-                        var release = new ReleaseInfo();
-
-                        release.MinimumRatio = 1;
-                        release.MinimumSeedTime = 0;
-
                         var qDownloadLink = Row.QuerySelector("td:nth-child(6) > a");
                         if (qDownloadLink == null) // Expects moderation
                             continue;
 
                         var qDetailsLink = Row.QuerySelector("td:nth-child(3) > a");
                         var qSize = Row.QuerySelector("td:nth-child(7)");
-
-                        release.Title = qDetailsLink.TextContent;
-
-                        release.Comments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
-                        release.Link = new Uri(SiteLink + qDownloadLink.GetAttribute("href"));
-                        release.Guid = release.Comments;
-                        release.Size = ReleaseInfo.GetBytes(qSize.TextContent);
-
-                        var seeders = Row.QuerySelector("td:nth-child(10) > b").TextContent;
-                        if (string.IsNullOrWhiteSpace(seeders))
-                            seeders = "0";
-                        release.Seeders = ParseUtil.CoerceInt(seeders);
-                        release.Peers = ParseUtil.CoerceInt(Row.QuerySelector("td:nth-child(11) > b").TextContent) + release.Seeders;
-                        release.Grabs = 0;//ParseUtil.CoerceLong(Row.QuerySelector("td:nth-child(9)").TextContent);
-
+                        var seedersStr = Row.QuerySelector("td:nth-child(10) > b").TextContent;
+                        var seeders = string.IsNullOrWhiteSpace(seedersStr) ? 0 : ParseUtil.CoerceInt(seedersStr);
                         var timestr = Row.QuerySelector("td:nth-child(13)").TextContent;
-                        release.PublishDate = DateTimeUtil.FromFuzzyTime(timestr);
-
                         var forum = Row.QuerySelector("td:nth-child(2) > a");
                         var forumid = forum.GetAttribute("href").Split('=')[1];
-                        release.Category = MapTrackerCatToNewznab(forumid);
+                        var releaseComments = new Uri(SiteLink + qDetailsLink.GetAttribute("href"));
 
-                        release.DownloadVolumeFactor = 1;
-                        release.UploadVolumeFactor = 1;
+                        var release = new ReleaseInfo
+                        {
+                            MinimumRatio = 1,
+                            MinimumSeedTime = 0,
+                            Title = qDetailsLink.TextContent,
+                            Comments = releaseComments,
+                            Link = new Uri(SiteLink + qDownloadLink.GetAttribute("href")),
+                            Guid = releaseComments,
+                            Size = ReleaseInfo.GetBytes(qSize.TextContent),
+                            Seeders = seeders,
+                            Peers = ParseUtil.CoerceInt(Row.QuerySelector("td:nth-child(11) > b").TextContent) + seeders,
+                            Grabs = 0, //ParseUtil.CoerceLong(Row.QuerySelector("td:nth-child(9)").TextContent);
+                            PublishDate = DateTimeUtil.FromFuzzyTime(timestr),
+                            Category = MapTrackerCatToNewznab(forumid),
+                            DownloadVolumeFactor = 1,
+                            UploadVolumeFactor = 1
+                        };
 
+
+                        
+
+
+
+                        // TODO cleanup
                         if (release.Category.Contains(TorznabCatType.TV.ID))
                         {
                             // extract season and episodes
                             var regex = new Regex(".+\\/\\s([^а-яА-я\\/]+)\\s\\/.+Сезон\\s*[:]*\\s+(\\d+).+(?:Серії|Епізод)+\\s*[:]*\\s+(\\d+-*\\d*).+,\\s+(.+)\\]\\s(.+)");
 
-                            var title = regex.Replace(release.Title, "$1 - S$2E$3 - rus $4 $5");
+                            string title;
+                            title = regex.Replace(release.Title, "$1 - S$2E$3 - rus $4 $5");
                             title = Regex.Replace(title, "-Rip", "Rip", RegexOptions.IgnoreCase);
                             title = Regex.Replace(title, "WEB-DLRip", "WEBDL", RegexOptions.IgnoreCase);
                             title = Regex.Replace(title, "WEB-DL", "WEBDL", RegexOptions.IgnoreCase);

--- a/src/Jackett.Common/Indexers/yts.cs
+++ b/src/Jackett.Common/Indexers/yts.cs
@@ -76,11 +76,13 @@ namespace Jackett.Common.Indexers
             var releases = new List<ReleaseInfo>();
             var searchString = query.GetQueryString();
 
-            var queryCollection = new NameValueCollection();
+            var queryCollection = new NameValueCollection
+            {
 
-            // without this the API sometimes returns nothing
-            queryCollection.Add("sort", "date_added");
-            queryCollection.Add("limit", "50");
+                // without this the API sometimes returns nothing
+                { "sort", "date_added" },
+                { "limit", "50" }
+            };
 
             if (query.ImdbID != null)
             {
@@ -127,6 +129,7 @@ namespace Jackett.Common.Indexers
                         continue;
                     foreach (var torrent_info in torrents)
                     {
+                        //TODO change to initializer
                         var release = new ReleaseInfo();
 
                         // append type: BRRip or WEBRip, resolves #3558 via #4577

--- a/src/Jackett.Common/Models/Config/ServerConfig.cs
+++ b/src/Jackett.Common/Models/Config/ServerConfig.cs
@@ -129,6 +129,6 @@ namespace Jackett.Common.Models.Config
         }
 
         public void ConfigChanged() =>
-            observers.ForEach(obs=>obs.OnNext(this));
+            observers.ForEach(obs => obs.OnNext(this));
     }
 }

--- a/src/Jackett.Common/Models/DTO/ApiSearch.cs
+++ b/src/Jackett.Common/Models/DTO/ApiSearch.cs
@@ -11,8 +11,10 @@ namespace Jackett.Common.Models.DTO
 
         public static TorznabQuery ToTorznabQuery(ApiSearch request)
         {
-            var stringQuery = new TorznabQuery();
-            stringQuery.QueryType = "search";
+            var stringQuery = new TorznabQuery
+            {
+                QueryType = "search"
+            };
 
             var queryStr = request.Query;
             if (queryStr != null)
@@ -38,9 +40,7 @@ namespace Jackett.Common.Models.DTO
             }
 
             stringQuery.SearchTerm = queryStr;
-            stringQuery.Categories = request.Category;
-            if (stringQuery.Categories == null)
-                stringQuery.Categories = new int[0];
+            stringQuery.Categories = request.Category ?? new int[0];
             stringQuery.ExpandCatsToSubCats();
 
             // try to build an IMDB Query (tt plus 6 to 8 digits)

--- a/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationHDBitsApi.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationHDBitsApi.cs
@@ -7,7 +7,7 @@ namespace Jackett.Common.Models.IndexerConfig.Bespoke
         public CheckboxItem Codecs { get; private set; }
         public CheckboxItem Mediums { get; private set; }
 
-        public ConfigurationDataHDBitsApi(): base()
+        public ConfigurationDataHDBitsApi() : base()
         {
             Codecs = new CheckboxItem(new Dictionary<string, string>()
                 {
@@ -18,7 +18,7 @@ namespace Jackett.Common.Models.IndexerConfig.Bespoke
                     {"6", "VP9"},
                     {"4", "XviD"}
                 })
-            { Name = "Codec", Values = new string[]{ "1", "5", "2", "3", "6", "4" } };
+            { Name = "Codec", Values = new string[] { "1", "5", "2", "3", "6", "4" } };
 
             Mediums = new CheckboxItem(new Dictionary<string, string>()
                 {
@@ -28,7 +28,7 @@ namespace Jackett.Common.Models.IndexerConfig.Bespoke
                     {"5", "Remux"},
                     {"6", "WEB-DL"}
                 })
-            { Name = "Medium", Values = new string[]{ "1", "4", "3", "5", "6" } };
+            { Name = "Medium", Values = new string[] { "1", "4", "3", "5", "6" } };
         }
     }
 }

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationData.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationData.cs
@@ -105,10 +105,12 @@ namespace Jackett.Common.Models.IndexerConfig
             var jArray = new JArray();
             foreach (var item in items)
             {
-                var jObject = new JObject();
-                jObject["id"] = item.ID;
-                jObject["type"] = item.ItemType.ToString().ToLower();
-                jObject["name"] = item.Name;
+                var jObject = new JObject
+                {
+                    ["id"] = item.ID,
+                    ["type"] = item.ItemType.ToString().ToLower(),
+                    ["name"] = item.Name
+                };
                 switch (item.ItemType)
                 {
                     case ItemType.Recaptcha:

--- a/src/Jackett.Common/Models/ReleaseInfo.cs
+++ b/src/Jackett.Common/Models/ReleaseInfo.cs
@@ -37,7 +37,7 @@ namespace Jackett.Common.Models
         public IIndexer Origin;
 
 
-        private static double? GigabytesFromBytes(double? size) => size / 1024.0 / 1024.0 / 1024.0; 
+        private static double? GigabytesFromBytes(double? size) => size / 1024.0 / 1024.0 / 1024.0;
         public double? Gain => Seeders * GigabytesFromBytes(Size);
 
         public ReleaseInfo()

--- a/src/Jackett.Common/Models/TorznabQuery.cs
+++ b/src/Jackett.Common/Models/TorznabQuery.cs
@@ -105,38 +105,35 @@ namespace Jackett.Common.Models
 
         public TorznabQuery Clone()
         {
-            var ret = new TorznabQuery();
-            ret.QueryType = QueryType;
-            if (Categories != null && Categories.Length > 0)
+            var ret = new TorznabQuery
+            {
+                QueryType = QueryType,
+                Extended = Extended,
+                ApiKey = ApiKey,
+                Limit = Limit,
+                Offset = Offset,
+                Season = Season,
+                Episode = Episode,
+                SearchTerm = SearchTerm,
+                IsTest = IsTest,
+                Album = Album,
+                Artist = Artist,
+                Label = Label,
+                Track = Track,
+                Year = Year,
+                RageID = RageID,
+                ImdbID = ImdbID
+            };
+            if (Categories?.Length > 0)
             {
                 ret.Categories = new int[Categories.Length];
                 Array.Copy(Categories, ret.Categories, Categories.Length);
             }
-            ret.Extended = Extended;
-            ret.ApiKey = ApiKey;
-            ret.Limit = Limit;
-            ret.Offset = Offset;
-            ret.Season = Season;
-            ret.Episode = Episode;
-            ret.SearchTerm = SearchTerm;
-            ret.IsTest = IsTest;
-            ret.Album = Album;
-            ret.Artist = Artist;
-            ret.Label = Label;
-            ret.Track = Track;
-            ret.Year = Year;
-            if (Genre != null)
-            {
-                // Make a copied list and then don't use it?
-                Genre.Select(item => item.Clone()).ToList();
-            }
-            if (QueryStringParts != null && QueryStringParts.Length > 0)
+            if (QueryStringParts?.Length > 0)
             {
                 ret.QueryStringParts = new string[QueryStringParts.Length];
                 Array.Copy(QueryStringParts, ret.QueryStringParts, QueryStringParts.Length);
             }
-            ret.RageID = RageID;
-            ret.ImdbID = ImdbID;
 
             return ret;
         }

--- a/src/Jackett.Common/Services/CacheService.cs
+++ b/src/Jackett.Common/Services/CacheService.cs
@@ -19,24 +19,17 @@ namespace Jackett.Common.Services
         {
             lock (cache)
             {
-                var trackerCache = cache.Where(c => c.TrackerId == indexer.ID).FirstOrDefault();
-                if (trackerCache == null)
-                {
-                    trackerCache = new TrackerCache();
-                    trackerCache.TrackerId = indexer.ID;
-                    trackerCache.TrackerName = indexer.DisplayName;
+                var trackerCache = cache.FirstOrDefault(c => c.TrackerId == indexer.ID) ??
+                                   new TrackerCache {TrackerId = indexer.ID, TrackerName = indexer.DisplayName};
                     cache.Add(trackerCache);
-                }
+                
 
                 foreach (var release in releases.OrderByDescending(i => i.PublishDate))
                 {
-                    var existingItem = trackerCache.Results.Where(i => i.Result.Guid == release.Guid).FirstOrDefault();
-                    if (existingItem == null)
-                    {
-                        existingItem = new CachedResult();
-                        existingItem.Created = DateTime.Now;
+                    var existingItem = trackerCache.Results.FirstOrDefault(i => i.Result.Guid == release.Guid) ??
+                                       new CachedResult {Created = DateTime.Now};
                         trackerCache.Results.Add(existingItem);
-                    }
+                    
 
                     existingItem.Result = release;
                 }
@@ -54,12 +47,12 @@ namespace Jackett.Common.Services
             lock (cache)
             {
                 var newItemCount = 0;
-                var trackerCache = cache.Where(c => c.TrackerId == indexer.ID).FirstOrDefault();
+                var trackerCache = cache.FirstOrDefault(c => c.TrackerId == indexer.ID);
                 if (trackerCache != null)
                 {
                     foreach (var release in releases)
                     {
-                        if (trackerCache.Results.Where(i => i.Result.Guid == release.Guid).Count() == 0)
+                        if (trackerCache.Results.Count(i => i.Result.Guid == release.Guid) == 0)
                         {
                             newItemCount++;
                         }

--- a/src/Jackett.Common/Services/CacheService.cs
+++ b/src/Jackett.Common/Services/CacheService.cs
@@ -19,19 +19,23 @@ namespace Jackett.Common.Services
         {
             lock (cache)
             {
-                var trackerCache = cache.FirstOrDefault(c => c.TrackerId == indexer.ID) ??
-                                   new TrackerCache {TrackerId = indexer.ID, TrackerName = indexer.DisplayName};
+                var trackerCache = cache.FirstOrDefault(c => c.TrackerId == indexer.ID);
+                if (trackerCache == null)
+                {
+                    trackerCache = new TrackerCache
+                    {
+                        TrackerId = indexer.ID,
+                        TrackerName = indexer.DisplayName
+                    };
                     cache.Add(trackerCache);
-                
+                }
 
                 foreach (var release in releases.OrderByDescending(i => i.PublishDate))
                 {
                     var existingItem = trackerCache.Results.FirstOrDefault(i => i.Result.Guid == release.Guid) ??
                                        new CachedResult {Created = DateTime.Now};
                         trackerCache.Results.Add(existingItem);
-                    
-
-                    existingItem.Result = release;
+                        existingItem.Result = release;
                 }
 
                 // Prune cache

--- a/src/Jackett.Common/Services/CacheService.cs
+++ b/src/Jackett.Common/Services/CacheService.cs
@@ -32,10 +32,16 @@ namespace Jackett.Common.Services
 
                 foreach (var release in releases.OrderByDescending(i => i.PublishDate))
                 {
-                    var existingItem = trackerCache.Results.FirstOrDefault(i => i.Result.Guid == release.Guid) ??
-                                       new CachedResult {Created = DateTime.Now};
+                    var existingItem = trackerCache.Results.FirstOrDefault(i => i.Result.Guid == release.Guid);
+                    if (existingItem == null)
+                    {
+                        existingItem = new CachedResult
+                        {
+                            Created = DateTime.Now
+                        };
                         trackerCache.Results.Add(existingItem);
-                        existingItem.Result = release;
+                    }
+
                 }
 
                 // Prune cache

--- a/src/Jackett.Common/Services/ImdbResolver.cs
+++ b/src/Jackett.Common/Services/ImdbResolver.cs
@@ -34,8 +34,10 @@ namespace Jackett.Common.Services
             if (string.IsNullOrWhiteSpace(url))
                 url = "http://omdbapi.com";
 
-            var request = new WebRequest(url + "/?apikey=" + apiKey + "&i=" + imdbId);
-            request.Encoding = Encoding.UTF8;
+            var request = new WebRequest(url + "/?apikey=" + apiKey + "&i=" + imdbId)
+            {
+                Encoding = Encoding.UTF8
+            };
             var result = await WebClient.GetString(request);
             var movie = JsonConvert.DeserializeObject<Movie>(result.Content);
 

--- a/src/Jackett.Common/Services/IndexerManagerService.cs
+++ b/src/Jackett.Common/Services/IndexerManagerService.cs
@@ -172,8 +172,10 @@ namespace Jackett.Common.Services
             }
 
             logger.Info("Adding aggregate indexer");
-            aggregateIndexer = new AggregateIndexer(fallbackStrategyProvider, resultFilterProvider, configService, webClient, logger, protectionService);
-            aggregateIndexer.Indexers = indexers.Values;
+            aggregateIndexer = new AggregateIndexer(fallbackStrategyProvider, resultFilterProvider, configService, webClient, logger, protectionService)
+            {
+                Indexers = indexers.Values
+            };
         }
 
         public IIndexer GetIndexer(string name)
@@ -213,10 +215,12 @@ namespace Jackett.Common.Services
         public async Task TestIndexer(string name)
         {
             var indexer = GetIndexer(name);
-            var browseQuery = new TorznabQuery();
-            browseQuery.QueryType = "search";
-            browseQuery.SearchTerm = "";
-            browseQuery.IsTest = true;
+            var browseQuery = new TorznabQuery
+            {
+                QueryType = "search",
+                SearchTerm = "",
+                IsTest = true
+            };
             var result = await indexer.ResultsForQuery(browseQuery);
             logger.Info(string.Format("Found {0} releases from {1}", result.Releases.Count(), indexer.DisplayName));
             if (result.Releases.Count() == 0)

--- a/src/Jackett.Common/Services/UpdateService.cs
+++ b/src/Jackett.Common/Services/UpdateService.cs
@@ -335,9 +335,11 @@ namespace Jackett.Common.Services
             var exe = Path.GetFileName(ExePath());
             var args = string.Join(" ", Environment.GetCommandLineArgs().Skip(1).Select(a => a.Contains(" ") ? "\"" + a + "\"" : a)).Replace("\"", "\\\"");
 
-            var startInfo = new ProcessStartInfo();
-            startInfo.UseShellExecute = false;
-            startInfo.CreateNoWindow = true;
+            var startInfo = new ProcessStartInfo
+            {
+                UseShellExecute = false,
+                CreateNoWindow = true
+            };
 
             // Note: add a leading space to the --Args argument to avoid parsing as arguments
             if (variant == Variants.JackettVariant.Mono)

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
@@ -118,8 +118,10 @@ namespace Jackett.Common.Utils.Clients
 
         public void CreateClient()
         {
-            clearanceHandlr = new ClearanceHandler(BrowserUtil.ChromeUserAgent);
-            clearanceHandlr.MaxTries = 30;
+            clearanceHandlr = new ClearanceHandler(BrowserUtil.ChromeUserAgent)
+            {
+                MaxTries = 30
+            };
             clientHandlr = new HttpClientHandler
             {
                 CookieContainer = cookies,
@@ -240,8 +242,10 @@ namespace Jackett.Common.Utils.Clients
 
             response = await client.SendAsync(request);
 
-            var result = new WebClientByteResult();
-            result.Content = await response.Content.ReadAsByteArrayAsync();
+            var result = new WebClientByteResult
+            {
+                Content = await response.Content.ReadAsByteArrayAsync()
+            };
 
             foreach (var header in response.Headers)
             {

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2NetCore.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2NetCore.cs
@@ -114,8 +114,10 @@ namespace Jackett.Common.Utils.Clients
 
         public void CreateClient()
         {
-            clearanceHandlr = new ClearanceHandler(BrowserUtil.ChromeUserAgent);
-            clearanceHandlr.MaxTries = 30;
+            clearanceHandlr = new ClearanceHandler(BrowserUtil.ChromeUserAgent)
+            {
+                MaxTries = 30
+            };
             clientHandlr = new HttpClientHandler
             {
                 CookieContainer = cookies,
@@ -236,8 +238,10 @@ namespace Jackett.Common.Utils.Clients
 
             response = await client.SendAsync(request);
 
-            var result = new WebClientByteResult();
-            result.Content = await response.Content.ReadAsByteArrayAsync();
+            var result = new WebClientByteResult
+            {
+                Content = await response.Content.ReadAsByteArrayAsync()
+            };
 
             foreach (var header in response.Headers)
             {

--- a/src/Jackett.Common/Utils/JsonContent.cs
+++ b/src/Jackett.Common/Utils/JsonContent.cs
@@ -13,7 +13,7 @@ namespace Jackett.Common.Utils
         public JsonContent(object value, Encoding encoding)
             : base(
                 JsonConvert.SerializeObject(
-                    value, Formatting.Indented, new JsonSerializerSettings {NullValueHandling = NullValueHandling.Ignore}),
+                    value, Formatting.Indented, new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore }),
                 encoding, "application/json")
         {
         }

--- a/src/Jackett.Common/Utils/LoggingSetup.cs
+++ b/src/Jackett.Common/Utils/LoggingSetup.cs
@@ -21,24 +21,30 @@ namespace Jackett.Common.Utils
 
             var logConfig = new LoggingConfiguration();
 
-            var logFile = new FileTarget();
-            logFile.Layout = "${longdate} ${level} ${message} ${exception:format=ToString}";
-            logFile.FileName = Path.Combine(settings.DataFolder, logFileName);
-            logFile.ArchiveFileName = Path.Combine(settings.DataFolder, logFileName + ".{#####}.txt");
-            logFile.ArchiveAboveSize = 2097152; // 2 MB
-            logFile.MaxArchiveFiles = 5;
-            logFile.KeepFileOpen = false;
-            logFile.ArchiveNumbering = ArchiveNumberingMode.DateAndSequence;
+            var logFile = new FileTarget
+            {
+                Layout = "${longdate} ${level} ${message} ${exception:format=ToString}",
+                FileName = Path.Combine(settings.DataFolder, logFileName),
+                ArchiveFileName = Path.Combine(settings.DataFolder, logFileName + ".{#####}.txt"),
+                ArchiveAboveSize = 2097152, // 2 MB
+                MaxArchiveFiles = 5,
+                KeepFileOpen = false,
+                ArchiveNumbering = ArchiveNumberingMode.DateAndSequence
+            };
             logConfig.AddTarget("file", logFile);
 
-            var microsoftRule = new LoggingRule();
-            microsoftRule.LoggerNamePattern = "Microsoft.*";
+            var microsoftRule = new LoggingRule
+            {
+                LoggerNamePattern = "Microsoft.*",
+                Final = true
+            };
             microsoftRule.SetLoggingLevels(LogLevel.Warn, LogLevel.Fatal);
-            microsoftRule.Final = true;
             microsoftRule.Targets.Add(logFile);
 
-            var microsoftDebugRule = new LoggingRule();
-            microsoftDebugRule.LoggerNamePattern = "Microsoft.*";
+            var microsoftDebugRule = new LoggingRule
+            {
+                LoggerNamePattern = "Microsoft.*"
+            };
             microsoftDebugRule.SetLoggingLevels(LogLevel.Debug, LogLevel.Info);
             microsoftDebugRule.Final = true;
             if (settings.TracingEnabled)
@@ -52,8 +58,10 @@ namespace Jackett.Common.Utils
 
             if (!fileOnly)
             {
-                var logConsole = new ColoredConsoleTarget();
-                logConsole.Layout = "${simpledatetime} ${level} ${message} ${exception:format=ToString}";
+                var logConsole = new ColoredConsoleTarget
+                {
+                    Layout = "${simpledatetime} ${level} ${message} ${exception:format=ToString}"
+                };
                 logConfig.AddTarget("console", logConsole);
 
                 var logConsoleRule = new LoggingRule("*", logLevel, logConsole);


### PR DESCRIPTION
This PR implements the Code Style policy of preferring object initializers. Had to go by hand and move some lines to allow for full initialization instead of partial. Some of them still have 1 or 2 Properties that aren't initialized, but that's due to the complexity of moving the lines out of the way.

Added some TODOs where I found some easy refactoring spots to work with as well.