### PR TITLE
FunFile: fix error caused by #7369 Resolves #7451

### DIFF
--- a/src/Jackett.Common/Indexers/FunFile.cs
+++ b/src/Jackett.Common/Indexers/FunFile.cs
@@ -150,8 +150,8 @@ namespace Jackett.Common.Indexers
                     release.Grabs = ParseUtil.CoerceInt(grabs);
 
                     var ka = row.NextElementSibling;
-                    var dlFactor = ka.QuerySelector("table > tbody > tr:nth-child(3) > td:nth-child(2)").TextContent.Replace("X", "");
-                    var ulFactor = ka.QuerySelector("table > tbody > tr:nth-child(3) > td:nth-child(1)").TextContent.Replace("X", "");
+                    var dlFactor = ka.QuerySelector("table > tbody > tr:nth-child(3)").QuerySelector("td:nth-child(2)").TextContent.Replace("X", "");
+                    var ulFactor = ka.QuerySelector("table > tbody > tr:nth-child(3)").QuerySelector("td:nth-child(1)").TextContent.Replace("X", "");
                     release.DownloadVolumeFactor = ParseUtil.CoerceDouble(dlFactor);
                     release.UploadVolumeFactor = ParseUtil.CoerceDouble(ulFactor);
 


### PR DESCRIPTION
Tested with the HTML provided by the user.

@garfield69 In this case if you add the `?` symbol to make the field optional, you are breaking the ratios for all torrents. We have to check case by case.