### PR TITLE
Remove warning suppression

### DIFF
--- a/src/DateTimeRoutines/DateTimeRoutines.csproj
+++ b/src/DateTimeRoutines/DateTimeRoutines.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <LangVersion>8</LangVersion>
+    <NoWarn />
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
-
 </Project>

--- a/src/Jackett.Common/Jackett.Common.csproj
+++ b/src/Jackett.Common/Jackett.Common.csproj
@@ -3,8 +3,10 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>0.0.0</Version>
-    <NoWarn>NU1605</NoWarn>
     <LangVersion>8</LangVersion>
+    <NoWarn />
+    <WarningsAsErrors />
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Jackett.IntegrationTests/Jackett.IntegrationTests.csproj
+++ b/src/Jackett.IntegrationTests/Jackett.IntegrationTests.csproj
@@ -3,6 +3,9 @@
   <PropertyGroup>
     <TargetFramework>netcoreapp3.1</TargetFramework>
     <IsPackable>false</IsPackable>
+    <NoWarn />
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Jackett.Server/Jackett.Server.csproj
+++ b/src/Jackett.Server/Jackett.Server.csproj
@@ -4,8 +4,18 @@
     <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
     <ApplicationIcon>jackett.ico</ApplicationIcon>
     <OutputType>Exe</OutputType>
-    <NoWarn>NU1605</NoWarn>
+    <NoWarn></NoWarn>
     <ServerGarbageCollection>false</ServerGarbageCollection>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Release|netcoreapp3.1|AnyCPU'">
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningsAsErrors />
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(TargetFramework)|$(Platform)'=='Debug|netcoreapp3.1|AnyCPU'">
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
 
   <Choose>

--- a/src/Jackett.Service/Jackett.Service.csproj
+++ b/src/Jackett.Service/Jackett.Service.csproj
@@ -5,6 +5,9 @@
     <OutputType>WinExe</OutputType>
     <AssemblyName>JackettService</AssemblyName>
     <ApplicationIcon>jackett.ico</ApplicationIcon>
+    <NoWarn />
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Jackett.Test/Jackett.Test.csproj
+++ b/src/Jackett.Test/Jackett.Test.csproj
@@ -2,6 +2,9 @@
 
   <PropertyGroup>
     <TargetFrameworks>netcoreapp3.1;net461</TargetFrameworks>
+    <NoWarn />
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Jackett.Tray/Jackett.Tray.csproj
+++ b/src/Jackett.Tray/Jackett.Tray.csproj
@@ -6,6 +6,9 @@
     <UseWindowsForms>true</UseWindowsForms>
     <AssemblyName>JackettTray</AssemblyName>
     <ApplicationIcon>jackett.ico</ApplicationIcon>
+    <NoWarn />
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Jackett.Updater/Jackett.Updater.csproj
+++ b/src/Jackett.Updater/Jackett.Updater.csproj
@@ -7,6 +7,9 @@
     <OutputType>Exe</OutputType>
     <Version>0.0.0</Version>
     <ServerGarbageCollection>false</ServerGarbageCollection>
+    <NoWarn />
+    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
+    <WarningsAsErrors />
   </PropertyGroup>
 
   <!-- Conditionally obtain references for the .NET461 target -->


### PR DESCRIPTION
No build warnings were found after removing suppression, but in Jackett.Common the specific warning suppressed was concerning NuGet packages not getting the right dependency versions, which is not something we should be ignoring, IMO.