### PR TITLE
Torrent-Explosiv: Remove [Group Tag] in title

### DIFF
--- a/src/Jackett.Common/Definitions/torrent-explosiv.yml
+++ b/src/Jackett.Common/Definitions/torrent-explosiv.yml
@@ -143,6 +143,11 @@
             args: ["details.php?id=", "download.php?torrent="]
       title:
         selector: a.selection_a
+        filters:
+          - name: re_replace
+            args: ["^\\[[\\w ]*\\]\\s?", ""]
+          - name: re_replace
+            args: ["^\\[[\\w ]*\\]\\s?", ""]
       details:
         selector: a.selection_a
         attribute: href


### PR DESCRIPTION
Remove the [Group tag] at the beginning of the scraped title.
Improve automatic use of Jackett with title matching.