### PR TITLE
Add SiteUri to IIndexer and BaseIndexer class

### DIFF
--- a/src/Jackett.Common/Indexers/BaseIndexer.cs
+++ b/src/Jackett.Common/Indexers/BaseIndexer.cs
@@ -20,7 +20,15 @@ namespace Jackett.Common.Indexers
     {
         public static string GetIndexerID(Type type) => type.Name.ToLowerInvariant().StripNonAlphaNumeric();
 
-        public string SiteLink { get; protected set; }
+        public Uri SiteUri { get; protected set; }
+        // For full backward compatibility while migrating
+        // https://docs.microsoft.com/en-us/dotnet/api/system.uri.originalstring?view=netframework-4.8
+        public string SiteLink
+        {
+            get => SiteUri.OriginalString;
+            protected set => SiteUri = new Uri(value, UriKind.Absolute);
+        }
+
         public virtual string[] LegacySiteLinks { get; protected set; }
         public string DefaultSiteLink { get; protected set; }
         public virtual string[] AlternativeSiteLinks { get; protected set; } = new string[] { };
@@ -141,8 +149,10 @@ namespace Jackett.Common.Indexers
             }
 
             // check whether the site link is well-formatted
-            var siteUri = new Uri(configData.SiteLink.Value);
-            SiteLink = configData.SiteLink.Value;
+            // Avoid throwing exception on improper format?
+            //if (Uri.TryCreate(configData.SiteLink.Value, UriKind.Absolute, out var siteUri))
+            //    SiteUri = siteUri;
+            SiteUri= new Uri(configData.SiteLink.Value);
         }
 
         public void LoadFromSavedConfiguration(JToken jsonConfig)

--- a/src/Jackett.Common/Indexers/BaseIndexer.cs
+++ b/src/Jackett.Common/Indexers/BaseIndexer.cs
@@ -25,8 +25,8 @@ namespace Jackett.Common.Indexers
         // https://docs.microsoft.com/en-us/dotnet/api/system.uri.originalstring?view=netframework-4.8
         public string SiteLink
         {
-            get => SiteUri.OriginalString;
-            protected set => SiteUri = new Uri(value, UriKind.Absolute);
+            get => SiteUri?.OriginalString ?? "/";
+            protected set => SiteUri = value == "/" ? null : new Uri(value, UriKind.Absolute);
         }
 
         public virtual string[] LegacySiteLinks { get; protected set; }

--- a/src/Jackett.Common/Indexers/IIndexer.cs
+++ b/src/Jackett.Common/Indexers/IIndexer.cs
@@ -10,6 +10,8 @@ namespace Jackett.Common.Indexers
 {
     public class IndexerResult
     {
+        // Is never set outside class constructor.
+        // Should be made readonly to prevent changing results source?
         public IIndexer Indexer { get; set; }
         public IEnumerable<ReleaseInfo> Releases { get; set; }
 
@@ -22,6 +24,7 @@ namespace Jackett.Common.Indexers
 
     public interface IIndexer
     {
+        Uri SiteUri { get; }
         string SiteLink { get; }
         string[] AlternativeSiteLinks { get; }
 


### PR DESCRIPTION
This is tested and working as a compatible change for 34 trackers with no logs that indicate anything of note changed. This PR is supposed to be as minimally invasive as possible.

In most places, SiteLink is already treated like a string version of a Uri, and is in general converted to Uri type before being consumed in web requests and several other placces. This PR adds a SiteUri variable to IIndexer, and implements it in BaseIndexer, the only class that implements the IIndexer interface, so that we have the option to call on the Uri directly without needing to convert in the calling code.

This PR is implemented in a way that functionality of SiteLink isn't affected through use of the [OriginalString property](https://docs.microsoft.com/en-us/dotnet/api/system.uri.originalstring?view=netframework-4.8) of the Uri class, which preserves the full original formatting of the string used as a base for the Uri instance.

One thing of note is that we currently check in the base constructor if the SiteLink string ends in "/" and the CardigannIndexer class initializes without specifying a Uri currently, passing instead just "/" to satisfy this check. I've made SiteUri compatible with this by checking for that case specifically, but maybe we should use the `.AbsoluteUri` property which returns a string formatted the way we want, and change the checks to instead reject Uri's that include paths (since this is a base link and I assume that's why the check is in place).