### PR TITLE
XtremeZone: add imdb search support

### DIFF
--- a/src/Jackett.Common/Definitions/xtremezone.yml
+++ b/src/Jackett.Common/Definitions/xtremezone.yml
@@ -57,8 +57,8 @@
       - {id: 51, cat: XXX, desc: "XXX-SD"}
 
     modes:
-      search: [q]
-      tv-search: [q, season, ep]
+      search: [q, imdbid]
+      tv-search: [q, season, ep, imdbid]
       movie-search: [q, imdbid]
 
   settings:

--- a/src/Jackett.Common/Definitions/xtremezone.yml
+++ b/src/Jackett.Common/Definitions/xtremezone.yml
@@ -59,7 +59,7 @@
     modes:
       search: [q]
       tv-search: [q, season, ep]
-      movie-search: [q]
+      movie-search: [q, imdbid]
 
   settings:
     - name: username


### PR DESCRIPTION
`movie-search` mode wasn't saying it supported imdb, so it was skipping the searches and returning 0 results from an "unsupported" search.

fixes #7520

can check off XtremeZone in #4859