### PR TITLE
core: fix CloudflareSolverRe library. Resolves #7397

### DIFF
--- a/src/Jackett.Common/Jackett.Common.csproj
+++ b/src/Jackett.Common/Jackett.Common.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Autofac" Version="5.1.2" />
     <PackageReference Include="AutoMapper" Version="8.1.0" />
     <PackageReference Include="BencodeNET" Version="3.1.0" />
-    <PackageReference Include="CloudflareSolverRe" Version="1.0.6" />
+    <PackageReference Include="CloudflareSolverReNgosang" Version="1.0.6.1" />
     <PackageReference Include="CommandLineParser" Version="2.7.82" />
     <PackageReference Include="DotNet4.SocksProxy" Version="1.4.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />


### PR DESCRIPTION
I fixed the CloudflareSolverRe library in https://github.com/RyuzakiH/CloudflareSolverRe/pull/18 but the maintainer seems unavailable.  Meanwhile I published the patched version in Nuget.org until he release a new version.
