### PR TITLE
core: improve linux install scripts. resolves #5533 #6098 #5407

### DIFF
--- a/install_service_systemd.sh
+++ b/install_service_systemd.sh
@@ -1,39 +1,66 @@
 #!/bin/bash
 
-#Setting up colors
+# If you have problems installing Jackett, please open an issue on
+# https://github.com/Jackett/Jackett/issues
+
+# Setting up colors
 BOLDRED="$(printf '\033[1;31m')"
 BOLDGREEN="$(printf '\033[1;32m')"
 NC="$(printf '\033[0m')" # No Color
 
-# Stop and unload the service if it's running
-jackettservice="jackett.service"
-systemctl stop ${jackettservice}
+# Check if the install script is running as root
+if [ "$EUID" -ne 0 ]; then
+    echo "${BOLDRED}ERROR${NC}: Please run this script as root"
+    exit 1
+fi
+
+# Check if Jackett service is running
+JACKETT_SERVICE="jackett.service"
+echo "Checking if the service '${JACKETT_SERVICE}' is running ..."
+if systemctl is-active --quiet "${JACKETT_SERVICE}"; then
+    echo "Service '${JACKETT_SERVICE}' is running"
+
+    # Stop and unload the service
+    if systemctl stop "${JACKETT_SERVICE}"; then
+        echo "Service '${JACKETT_SERVICE}' stopped"
+    else
+        echo "${BOLDRED}ERROR${NC}: The service '${JACKETT_SERVICE}' Can not be stopped"
+        exit 1
+    fi
+
+else
+    echo "Service '${JACKETT_SERVICE}' is not running"
+fi
 
 # Move working directory to Jackett's
-cd "$(dirname "$0")"
+JACKETT_DIR="$(dirname "$(readlink -f "$0")")"
+echo "Jackett will be installed in '${JACKETT_DIR}'"
+if ! cd "${JACKETT_DIR}"; then
+    echo "${BOLDRED}ERROR${NC}: Can not cd into '${JACKETT_DIR}' folder"
+    exit 1
+fi
 
 # Check if we're running from Jackett's directory
 if [ ! -f ./jackett ]; then
-echo "${BOLDRED}ERROR${NC}: Couldn't locate jackett. Is the script in the right directory?"
+    echo "${BOLDRED}ERROR${NC}: Can not locate 'jackett' file in '${JACKETT_DIR}'."
+    echo "Is the script in the right directory?"
     exit 1
 fi
-jackettdir="$(pwd)"
 
 # Check if Jackett's owner is root
-jackettuser="$(stat -c "%U" ./jackett)"
-if [ "${jackettuser}" == "root" ]; then
-echo "${BOLDRED}ERROR${NC}: Jackett shouldn't run as root. Please, change the owner of the Jackett directory."
+JACKETT_USER="$(stat -c "%U" ./jackett)"
+if [ "${JACKETT_USER}" == "root" ] || [ "${JACKETT_USER}" == "UNKNOWN" ] ; then
+    echo "${BOLDRED}ERROR${NC}: The owner of Jackett directory is '${JACKETT_USER}'."
+    echo "Please, change the owner with the command 'chown <user>:<user> -R \"${JACKETT_DIR}\"'"
+    echo "The user <user> will be used to run Jackett."
     exit 1
 fi
-
-# Check that no other service called Jackett is already running
-if [[ $(systemctl status ${jackettservice} | grep "active (running)") ]]; then
-    echo "${BOLDRED}ERROR${NC}: Jackett already seems to be running as a service. Please stop it before running this script again."
-    exit 1
-fi
+echo "Jackett will be executed with the user '${JACKETT_USER}'"
 
 # Write the systemd service descriptor
-cat >"/etc/systemd/system/${jackettservice}" <<EOL
+JACKETT_SERVICE_PATH="/etc/systemd/system/${JACKETT_SERVICE}"
+echo "Creating Jackett unit file in '${JACKETT_SERVICE_PATH}' ..."
+cat > "${JACKETT_SERVICE_PATH}" <<EOL
 [Unit]
 Description=Jackett Daemon
 After=network.target
@@ -43,35 +70,39 @@ SyslogIdentifier=jackett
 Restart=always
 RestartSec=5
 Type=simple
-User=${jackettuser}
-Group=${jackettuser}
-WorkingDirectory=${jackettdir}
-ExecStart=${jackettdir}/jackett_launcher.sh
-TimeoutStopSec=20
+User=${JACKETT_USER}
+Group=${JACKETT_USER}
+WorkingDirectory=${JACKETT_DIR}
+ExecStart=/bin/sh "${JACKETT_DIR}/jackett_launcher.sh"
+TimeoutStopSec=30
 
 [Install]
 WantedBy=multi-user.target
 
 EOL
+if [ $? -ne 0 ]; then
+    echo "${BOLDRED}ERROR${NC}: Can not create the file '${JACKETT_SERVICE_PATH}'"
+    echo "The UnitPath of systemd changes from one distribution to another. You may have to edit the script and change the path manually."
+    exit 1
+fi
 
+echo "Installing Jackett service ..."
 # Reload systemd daemon
-systemctl daemon-reload
+if ! systemctl daemon-reload; then
+    echo "${BOLDRED}ERROR${NC}: Can not reload systemd daemon"
+    exit 1
+fi
 
 # Enable the service for following restarts
-systemctl enable ${jackettservice}
+if ! systemctl enable "${JACKETT_SERVICE}"; then
+    echo "${BOLDRED}ERROR${NC}: Can not enable the service '${JACKETT_SERVICE}'"
+    exit 1
+fi
 
 # Run the service
-systemctl start ${jackettservice}
-
-# Check that it's running
-if [[ $(systemctl status ${jackettservice} | grep "active (running)") ]]; then
-    echo "${BOLDGREEN}Agent successfully installed and launched!${NC}"
+if systemctl start "${JACKETT_SERVICE}"; then
+    echo "${BOLDGREEN}Service successfully installed and launched!${NC}"
 else
-    cat << EOL
-${BOLDRED}ERROR${NC}: Could not launch service. The installation might have failed.
-Please open an issue on https://github.com/Jackett/Jackett/issues and paste following information:
-Jackett directory: \`${jackettdir}\`
-Jackett user: \`${jackettuser}\`
-
-EOL
+    echo "${BOLDRED}ERROR${NC}: Can not start the service '${JACKETT_SERVICE}'"
+    exit 1
 fi

--- a/install_service_systemd_mono.sh
+++ b/install_service_systemd_mono.sh
@@ -1,43 +1,75 @@
 #!/bin/bash
 
-#Setting up colors
+# If you have problems installing Jackett, please open an issue on
+# https://github.com/Jackett/Jackett/issues
+
+# Setting up colors
 BOLDRED="$(printf '\033[1;31m')"
 BOLDGREEN="$(printf '\033[1;32m')"
 NC="$(printf '\033[0m')" # No Color
 
-# Stop and unload the service if it's running
-jackettservice="jackett.service"
-systemctl stop ${jackettservice}
+# Check if the install script is running as root
+if [ "$EUID" -ne 0 ]; then
+    echo "${BOLDRED}ERROR${NC}: Please run this script as root"
+    exit 1
+fi
+
+# Check if Jackett service is running
+JACKETT_SERVICE="jackett.service"
+echo "Checking if the service '${JACKETT_SERVICE}' is running ..."
+if systemctl is-active --quiet "${JACKETT_SERVICE}"; then
+    echo "Service '${JACKETT_SERVICE}' is running"
+
+    # Stop and unload the service
+    if systemctl stop "${JACKETT_SERVICE}"; then
+        echo "Service '${JACKETT_SERVICE}' stopped"
+    else
+        echo "${BOLDRED}ERROR${NC}: The service '${JACKETT_SERVICE}' Can not be stopped"
+        exit 1
+    fi
+
+else
+    echo "Service '${JACKETT_SERVICE}' is not running"
+fi
 
 # Move working directory to Jackett's
-cd "$(dirname "$0")"
+JACKETT_DIR="$(dirname "$(readlink -f "$0")")"
+echo "Jackett will be installed in '${JACKETT_DIR}'"
+if ! cd "${JACKETT_DIR}"; then
+    echo "${BOLDRED}ERROR${NC}: Can not cd into '${JACKETT_DIR}' folder"
+    exit 1
+fi
 
 # Check if we're running from Jackett's directory
 if [ ! -f ./JackettConsole.exe ]; then
-echo "${BOLDRED}ERROR${NC}: Couldn't locate JackettConsole.exe. Is the script in the right directory?"
+    echo "${BOLDRED}ERROR${NC}: Can not locate 'JackettConsole.exe' file in '${JACKETT_DIR}'."
+    echo "Is the script in the right directory?"
     exit 1
 fi
-jackettdir="$(pwd)"
 
 # Check if Jackett's owner is root
-jackettuser="$(stat -c "%U" ./JackettConsole.exe)"
-if [ "${jackettuser}" == "root" ]; then
-echo "${BOLDRED}ERROR${NC}: Jackett shouldn't run as root. Please, change the owner of the Jackett directory."
+JACKETT_USER="$(stat -c "%U" ./JackettConsole.exe)"
+if [ "${JACKETT_USER}" == "root" ] || [ "${JACKETT_USER}" == "UNKNOWN" ] ; then
+    echo "${BOLDRED}ERROR${NC}: The owner of Jackett directory is '${JACKETT_USER}'."
+    echo "Please, change the owner with the command 'chown <user>:<user> -R \"${JACKETT_DIR}\"'"
+    echo "The user <user> will be used to run Jackett."
     exit 1
 fi
+echo "Jackett will be executed with the user '${JACKETT_USER}'"
 
-# Check if mono is installed
-command -v mono >/dev/null 2>&1 || { echo >&2 "${BOLDRED}ERROR${NC}: Jackett requires Mono but it's not installed. Aborting."; exit 1; }
-monodir="$(dirname $(command -v mono))"
-
-# Check that no other service called Jackett is already running
-if [[ $(systemctl status ${jackettservice} | grep "active (running)") ]]; then
-    echo "${BOLDRED}ERROR${NC}: Jackett already seems to be running as a service. Please stop it before running this script again."
+# Check if Mono is installed
+echo "Checking if Mono is installed ..."
+if ! command -v mono > /dev/null; then
+    echo "${BOLDRED}ERROR${NC}: Jackett requires Mono but it's not installed"
     exit 1
 fi
+MONO_DIR="$(dirname "$(command -v mono)")"
+echo "Mono is installed in '${MONO_DIR}'"
 
 # Write the systemd service descriptor
-cat >"/etc/systemd/system/${jackettservice}" <<EOL
+JACKETT_SERVICE_PATH="/etc/systemd/system/${JACKETT_SERVICE}"
+echo "Creating Jackett unit file in '${JACKETT_SERVICE_PATH}' ..."
+cat > "${JACKETT_SERVICE_PATH}" <<EOL
 [Unit]
 Description=Jackett Daemon
 After=network.target
@@ -47,36 +79,39 @@ SyslogIdentifier=jackett
 Restart=always
 RestartSec=5
 Type=simple
-User=${jackettuser}
-Group=${jackettuser}
-WorkingDirectory=${jackettdir}
-ExecStart=${monodir}/mono --debug ${jackettdir}/JackettConsole.exe --NoRestart
-TimeoutStopSec=20
+User=${JACKETT_USER}
+Group=${JACKETT_USER}
+WorkingDirectory=${JACKETT_DIR}
+ExecStart="${MONO_DIR}/mono" --debug "${JACKETT_DIR}/JackettConsole.exe" --NoRestart
+TimeoutStopSec=30
 
 [Install]
 WantedBy=multi-user.target
 
 EOL
+if [ $? -ne 0 ]; then
+    echo "${BOLDRED}ERROR${NC}: Can not create the file '${JACKETT_SERVICE_PATH}'"
+    echo "The UnitPath of systemd changes from one distribution to another. You may have to edit the script and change the path manually."
+    exit 1
+fi
 
+echo "Installing Jackett service ..."
 # Reload systemd daemon
-systemctl daemon-reload
+if ! systemctl daemon-reload; then
+    echo "${BOLDRED}ERROR${NC}: Can not reload systemd daemon"
+    exit 1
+fi
 
 # Enable the service for following restarts
-systemctl enable ${jackettservice}
+if ! systemctl enable "${JACKETT_SERVICE}"; then
+    echo "${BOLDRED}ERROR${NC}: Can not enable the service '${JACKETT_SERVICE}'"
+    exit 1
+fi
 
 # Run the service
-systemctl start ${jackettservice}
-
-# Check that it's running
-if [[ $(systemctl status ${jackettservice} | grep "active (running)") ]]; then
-    echo "${BOLDGREEN}Agent successfully installed and launched!${NC}"
+if systemctl start "${JACKETT_SERVICE}"; then
+    echo "${BOLDGREEN}Service successfully installed and launched!${NC}"
 else
-    cat << EOL
-${BOLDRED}ERROR${NC}: Could not launch service. The installation might have failed.
-Please open an issue on https://github.com/Jackett/Jackett/issues and paste following information:
-Mono directory: \`${monodir}\`
-Jackett directory: \`${jackettdir}\`
-Jackett user: \`${jackettuser}\`
-
-EOL
+    echo "${BOLDRED}ERROR${NC}: Can not start the service '${JACKETT_SERVICE}'"
+    exit 1
 fi

--- a/jackett_launcher.sh
+++ b/jackett_launcher.sh
@@ -7,12 +7,12 @@
 JACKETT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Launch Jackett
-${JACKETT_DIR}/jackett --NoRestart
+"${JACKETT_DIR}/jackett" --NoRestart
 
 # Get user running the service
 JACKETT_USER=$(whoami)
 
 # Wait until the updater ends
-while pgrep -u ${JACKETT_USER} JackettUpdater > /dev/null; do
+while pgrep -u "${JACKETT_USER}" JackettUpdater > /dev/null; do
      sleep 1
 done


### PR DESCRIPTION
I tested all the scripts carefully.

* Detects if the user is unknown
* Detects if the systemd unit path doesn't exist (fedora/centos users will have to make a little change, but I added the explanation in the output)
* Runs `jackett_launcher.sh` with the default shell
* Works if the folder has whitespaces
* Increase verbosity