### PR TITLE
core: rename WebClientStringResult.Content to WebClientStringResult.ContentString

### DIFF
--- a/src/Jackett.Common/Indexers/720pier.cs
+++ b/src/Jackett.Common/Indexers/720pier.cs
@@ -120,15 +120,15 @@ namespace Jackett.Common.Indexers
                 {"autologin", "on"}
             };
             var htmlParser = new HtmlParser();
-            var loginDocument = htmlParser.ParseDocument((await RequestStringWithCookies(LoginUrl)).Content);
+            var loginDocument = htmlParser.ParseDocument((await RequestStringWithCookies(LoginUrl)).ContentString);
             pairs["creation_time"] = loginDocument.GetElementsByName("creation_time")[0].GetAttribute("value");
             pairs["form_token"] = loginDocument.GetElementsByName("form_token")[0].GetAttribute("value");
             pairs["sid"] = loginDocument.GetElementsByName("sid")[0].GetAttribute("value");
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, LoginUrl, true);
-            await ConfigureIfOK(result.Cookies, result.Content?.Contains("ucp.php?mode=logout&") == true, () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString?.Contains("ucp.php?mode=logout&") == true, () =>
             {
-                var errorMessage = result.Content;
+                var errorMessage = result.ContentString;
                 throw new ExceptionWithConfigData(errorMessage, configData);
             });
             return IndexerConfigurationStatus.RequiresTesting;
@@ -170,7 +170,7 @@ namespace Jackett.Common.Indexers
 
             var searchUrl = SearchUrl + "?" + queryCollection.GetQueryString();
             var results = await RequestStringWithCookies(searchUrl);
-            if (!results.Content.Contains("ucp.php?mode=logout"))
+            if (!results.ContentString.Contains("ucp.php?mode=logout"))
             {
                 await ApplyConfiguration(null);
                 results = await RequestStringWithCookies(searchUrl);
@@ -180,7 +180,7 @@ namespace Jackett.Common.Indexers
                 const string rowsSelector = "ul.topics > li.row";
 
                 var resultParser = new HtmlParser();
-                var searchResultDocument = resultParser.ParseDocument(results.Content);
+                var searchResultDocument = resultParser.ParseDocument(results.ContentString);
                 var rows = searchResultDocument.QuerySelectorAll(rowsSelector);
                 foreach (var row in rows)
                 {
@@ -204,7 +204,7 @@ namespace Jackett.Common.Indexers
                         release.Guid = release.Comments;
 
                         var detailsResult = await RequestStringWithCookies(SiteLink + qDetailsLink.GetAttribute("href"));
-                        var detailsResultDocument = resultParser.ParseDocument(detailsResult.Content);
+                        var detailsResultDocument = resultParser.ParseDocument(detailsResult.ContentString);
                         var qDownloadLink = detailsResultDocument.QuerySelector("table.table2 > tbody > tr > td > a[href^=\"/download/torrent\"]");
 
                         release.Link = new Uri(SiteLink + qDownloadLink.GetAttribute("href").TrimStart('/'));
@@ -244,7 +244,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/Abnormal.cs
+++ b/src/Jackett.Common/Indexers/Abnormal.cs
@@ -172,7 +172,7 @@ namespace Jackett.Common.Indexers
             {
                 // Parse error page
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(response.Content);
+                var dom = parser.ParseDocument(response.ContentString);
                 var message = dom.QuerySelector(".warning").TextContent.Split('.').Reverse().Skip(1).First();
 
                 // Try left
@@ -557,7 +557,7 @@ namespace Jackett.Common.Indexers
             results = await RequestStringWithCookiesAndRetry(request, null, null, emulatedBrowserHeaders);
 
             // Return results from tracker
-            return results.Content;
+            return results.ContentString;
         }
 
         /// <summary>

--- a/src/Jackett.Common/Indexers/Abstract/AvistazTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/AvistazTracker.cs
@@ -60,7 +60,7 @@ namespace Jackett.Common.Indexers.Abstract
         {
             LoadValuesFromJson(configJson);
             var loginPage = await RequestStringWithCookies(LoginUrl, string.Empty);
-            var token = new Regex("<meta name=\"_token\" content=\"(.*?)\">").Match(loginPage.Content).Groups[1].ToString();
+            var token = new Regex("<meta name=\"_token\" content=\"(.*?)\">").Match(loginPage.ContentString).Groups[1].ToString();
             var pairs = new Dictionary<string, string> {
                 { "_token", token },
                 { "email_username", configData.Username.Value },
@@ -69,10 +69,10 @@ namespace Jackett.Common.Indexers.Abstract
             };
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, loginPage.Cookies, true, null, LoginUrl);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("auth/logout"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("auth/logout"), () =>
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(result.Content);
+                var dom = parser.ParseDocument(result.ContentString);
                 var messageEl = dom.QuerySelector(".form-error");
                 var errorMessage = messageEl.Text().Trim();
                 throw new ExceptionWithConfigData(errorMessage, configData);
@@ -115,7 +115,7 @@ namespace Jackett.Common.Indexers.Abstract
             try
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(response.Content);
+                var dom = parser.ParseDocument(response.ContentString);
                 var rows = dom.QuerySelectorAll("table:has(thead) > tbody > tr");
                 foreach (var row in rows)
                 {
@@ -175,7 +175,7 @@ namespace Jackett.Common.Indexers.Abstract
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
             return releases;
         }
@@ -193,7 +193,7 @@ namespace Jackett.Common.Indexers.Abstract
                     await ApplyConfiguration(null);
                     imdbResponse = await RequestStringWithCookiesAndRetry(imdbUrl, null, null, imdbHeaders);
                 }
-                var json = JsonConvert.DeserializeObject<dynamic>(imdbResponse.Content);
+                var json = JsonConvert.DeserializeObject<dynamic>(imdbResponse.ContentString);
                 return (string)((JArray)json["data"])[0]["id"];
             }
             catch (Exception)

--- a/src/Jackett.Common/Indexers/Abstract/CouchPotatoTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/CouchPotatoTracker.cs
@@ -76,11 +76,11 @@ namespace Jackett.Common.Indexers.Abstract
             JObject json = null;
             try
             {
-                json = JObject.Parse(response.Content);
+                json = JObject.Parse(response.ContentString);
             }
             catch (Exception ex)
             {
-                throw new Exception("Error while parsing json: " + response.Content, ex);
+                throw new Exception("Error while parsing json: " + response.ContentString, ex);
             }
             var error = (string)json["error"];
             if (error != null)
@@ -118,7 +118,7 @@ namespace Jackett.Common.Indexers.Abstract
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
@@ -122,13 +122,13 @@ namespace Jackett.Common.Indexers.Abstract
             }
 
             var response = await RequestLoginAndFollowRedirect(LoginUrl, pairs, string.Empty, true, SiteLink);
-            await ConfigureIfOK(response.Cookies, response.Content != null && response.Content.Contains("logout.php"), () =>
+            await ConfigureIfOK(response.Cookies, response.ContentString != null && response.ContentString.Contains("logout.php"), () =>
             {
                 var loginResultParser = new HtmlParser();
-                var loginResultDocument = loginResultParser.ParseDocument(response.Content);
+                var loginResultDocument = loginResultParser.ParseDocument(response.ContentString);
                 var loginform = loginResultDocument.QuerySelector("#loginform");
                 if (loginform == null)
-                    throw new ExceptionWithConfigData(response.Content, configData);
+                    throw new ExceptionWithConfigData(response.ContentString, configData);
 
                 loginform.QuerySelector("table").Remove();
                 var errorMessage = loginform.TextContent.Replace("\n\t", " ").Trim();
@@ -199,7 +199,7 @@ namespace Jackett.Common.Indexers.Abstract
 
             try
             {
-                var json = JObject.Parse(response.Content);
+                var json = JObject.Parse(response.ContentString);
                 foreach (JObject r in json["response"]["results"])
                 {
                     var groupTime = DateTimeUtil.UnixTimestampToDateTime(long.Parse((string)r["groupTime"]));
@@ -259,7 +259,7 @@ namespace Jackett.Common.Indexers.Abstract
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/AniDub.cs
+++ b/src/Jackett.Common/Indexers/AniDub.cs
@@ -116,7 +116,7 @@ namespace Jackett.Common.Indexers
             );
 
             var parser = new HtmlParser();
-            var document = await parser.ParseDocumentAsync(result.Content);
+            var document = await parser.ParseDocumentAsync(result.ContentString);
 
             await ConfigureIfOK(result.Cookies, IsAuthorized(result), () =>
             {
@@ -160,7 +160,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var document = await parser.ParseDocumentAsync(result.Content);
+                var document = await parser.ParseDocumentAsync(result.ContentString);
 
                 foreach (var linkNode in document.QuerySelectorAll(ReleaseLinksSelector))
                 {
@@ -170,7 +170,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(result.Content, ex);
+                OnParseError(result.ContentString, ex);
             }
 
             return releases;
@@ -197,7 +197,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var document = await parser.ParseDocumentAsync(result.Content);
+                var document = await parser.ParseDocumentAsync(result.ContentString);
                 var content = document.GetElementById(ContentId);
 
                 var date = GetDateFromShowPage(url, content);
@@ -245,7 +245,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(result.Content, ex);
+                OnParseError(result.ContentString, ex);
             }
 
             return releases;
@@ -508,7 +508,7 @@ namespace Jackett.Common.Indexers
         }
 
         private bool IsAuthorized(WebClientStringResult result) =>
-            result.Content.Contains("index.php?action=logout");
+            result.ContentString.Contains("index.php?action=logout");
 
         private IEnumerable<int> ParseCategories(Uri showUri)
         {
@@ -533,7 +533,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var document = await parser.ParseDocumentAsync(response.Content);
+                var document = await parser.ParseDocumentAsync(response.ContentString);
 
                 foreach (var linkNode in document.QuerySelectorAll(searchLinkSelector))
                 {
@@ -543,7 +543,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/Anidex.cs
+++ b/src/Jackett.Common/Indexers/Anidex.cs
@@ -167,7 +167,7 @@ namespace Jackett.Common.Indexers
                 throw new IOException($"Anidex search returned unexpected result. Expected 200 OK but got {response.Status.ToString()}.");
 
             // Search seems to have been a success so parse it
-            return ParseResult(response.Content);
+            return ParseResult(response.ContentString);
         }
 
         private IEnumerable<ReleaseInfo> ParseResult(string response)
@@ -244,13 +244,13 @@ namespace Jackett.Common.Indexers
 
                 if (!result.IsRedirect)
                     // Success returns a redirect. For anything else, assume a failure.
-                    throw new IOException($"Unexpected result from DDOS Guard while attempting to bypass: {result.Content}");
+                    throw new IOException($"Unexpected result from DDOS Guard while attempting to bypass: {result.ContentString}");
 
                 // Call the redirect URL to retrieve the cookie
                 result = await RequestStringWithCookiesAndRetry(result.RedirectingTo);
                 if (!result.IsRedirect)
                     // Success is another redirect. For anything else, assume a failure.
-                    throw new IOException($"Unexpected result when returning from DDOS Guard bypass: {result.Content}");
+                    throw new IOException($"Unexpected result when returning from DDOS Guard bypass: {result.ContentString}");
 
                 // If we got to this point, the bypass should have succeeded and we have stored the necessary cookies to access the site normally.
             }

--- a/src/Jackett.Common/Indexers/AnimeBytes.cs
+++ b/src/Jackett.Common/Indexers/AnimeBytes.cs
@@ -176,9 +176,9 @@ namespace Jackett.Common.Indexers
 
             // Get the content from the tracker
             var response = await RequestStringWithCookiesAndRetry(queryUrl);
-            if (!response.Content.StartsWith("{")) // not JSON => error
+            if (!response.ContentString.StartsWith("{")) // not JSON => error
                 throw new ExceptionWithConfigData("unexcepted response (not JSON)", configData);
-            dynamic json = JsonConvert.DeserializeObject<dynamic>(response.Content);
+            dynamic json = JsonConvert.DeserializeObject<dynamic>(response.ContentString);
 
             // Parse
             try
@@ -392,7 +392,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
 
             // Add to the cache

--- a/src/Jackett.Common/Indexers/AnimeTorrents.cs
+++ b/src/Jackett.Common/Indexers/AnimeTorrents.cs
@@ -79,10 +79,10 @@ namespace Jackett.Common.Indexers
             var loginPage = await RequestStringWithCookiesAndRetry(LoginUrl, "", LoginUrl);
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, loginPage.Cookies, true);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("logout.php"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("logout.php"), () =>
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(result.Content);
+                var dom = parser.ParseDocument(result.ContentString);
                 var errorMessage = dom.QuerySelector(".ui-state-error").Text().Trim();
                 throw new ExceptionWithConfigData(errorMessage, configData);
             });
@@ -124,7 +124,7 @@ namespace Jackett.Common.Indexers
 
             var response = await RequestStringWithCookiesAndRetry(searchUrl, null, SearchUrlReferer, extraHeaders);
 
-            var results = response.Content;
+            var results = response.ContentString;
             try
             {
                 var parser = new HtmlParser();

--- a/src/Jackett.Common/Indexers/BB.cs
+++ b/src/Jackett.Common/Indexers/BB.cs
@@ -73,10 +73,10 @@ namespace Jackett.Common.Indexers
             };
 
             var response = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, SiteLink);
-            await ConfigureIfOK(response.Cookies, response.Content != null && response.Content.Contains("logout.php"), () =>
+            await ConfigureIfOK(response.Cookies, response.ContentString != null && response.ContentString.Contains("logout.php"), () =>
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(response.Content);
+                var dom = parser.ParseDocument(response.ContentString);
                 var messageEl = dom.QuerySelectorAll("#loginform");
                 var messages = new List<string>();
                 for (var i = 0; i < 13; i++)
@@ -137,7 +137,7 @@ namespace Jackett.Common.Indexers
                 try
                 {
                     var parser = new HtmlParser();
-                    var dom = parser.ParseDocument(results.Content);
+                    var dom = parser.ParseDocument(results.ContentString);
                     var rows = dom.QuerySelectorAll("#torrent_table > tbody > tr.torrent");
                     foreach (var row in rows)
                     {
@@ -193,7 +193,7 @@ namespace Jackett.Common.Indexers
                 }
                 catch (Exception ex)
                 {
-                    OnParseError(results.Content, ex);
+                    OnParseError(results.ContentString, ex);
                 }
             }
             return releases;

--- a/src/Jackett.Common/Indexers/BJShare.cs
+++ b/src/Jackett.Common/Indexers/BJShare.cs
@@ -107,9 +107,9 @@ namespace Jackett.Common.Indexers
             };
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, LoginUrl, true);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("logout.php"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("logout.php"), () =>
             {
-                var errorMessage = result.Content;
+                var errorMessage = result.ContentString;
                 throw new ExceptionWithConfigData(errorMessage, ConfigData);
             });
             return IndexerConfigurationStatus.RequiresTesting;
@@ -196,7 +196,7 @@ namespace Jackett.Common.Indexers
                     const string rowsSelector = "table.torrent_table > tbody > tr:not(tr.colhead)";
 
                     var searchResultParser = new HtmlParser();
-                    var searchResultDocument = searchResultParser.ParseDocument(results.Content);
+                    var searchResultDocument = searchResultParser.ParseDocument(results.ContentString);
                     var rows = searchResultDocument.QuerySelectorAll(rowsSelector);
                     foreach (var row in rows)
                     {
@@ -317,7 +317,7 @@ namespace Jackett.Common.Indexers
                 }
                 catch (Exception ex)
                 {
-                    OnParseError(results.Content, ex);
+                    OnParseError(results.ContentString, ex);
                 }
             }
             else // use search
@@ -368,7 +368,7 @@ namespace Jackett.Common.Indexers
                     const string rowsSelector = "table.torrent_table > tbody > tr:not(tr.colhead)";
 
                     var searchResultParser = new HtmlParser();
-                    var searchResultDocument = searchResultParser.ParseDocument(results.Content);
+                    var searchResultDocument = searchResultParser.ParseDocument(results.ContentString);
                     var rows = searchResultDocument.QuerySelectorAll(rowsSelector);
 
                     ICollection<int> groupCategory = null;
@@ -550,7 +550,7 @@ namespace Jackett.Common.Indexers
                 }
                 catch (Exception ex)
                 {
-                    OnParseError(results.Content, ex);
+                    OnParseError(results.ContentString, ex);
                 }
             }
 

--- a/src/Jackett.Common/Indexers/BakaBT.cs
+++ b/src/Jackett.Common/Indexers/BakaBT.cs
@@ -66,7 +66,7 @@ namespace Jackett.Common.Indexers
             };
 
             var response = await RequestLoginAndFollowRedirect(LoginUrl, pairs, loginForm.Cookies, true, null, SiteLink);
-            var responseContent = response.Content;
+            var responseContent = response.ContentString;
             await ConfigureIfOK(response.Cookies, responseContent.Contains(LogoutStr), () =>
             {
                 var parser = new HtmlParser();
@@ -91,7 +91,7 @@ namespace Jackett.Common.Indexers
             var searchString = query.SanitizedSearchTerm;
             var episodeSearchUrl = SearchUrl + WebUtility.UrlEncode(searchString);
             var response = await RequestStringWithCookiesAndRetry(episodeSearchUrl);
-            if (!response.Content.Contains(LogoutStr))
+            if (!response.ContentString.Contains(LogoutStr))
             {
                 //Cookie appears to expire after a period of time or logging in to the site via browser
                 await DoLogin();
@@ -101,7 +101,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(response.Content);
+                var dom = parser.ParseDocument(response.ContentString);
                 var rows = dom.QuerySelectorAll(".torrents tr.torrent, .torrents tr.torrent_alt");
 
                 foreach (var row in rows)
@@ -188,7 +188,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
 
             return releases;
@@ -198,7 +198,7 @@ namespace Jackett.Common.Indexers
         {
             var downloadPage = await RequestStringWithCookies(link.ToString());
             var parser = new HtmlParser();
-            var dom = parser.ParseDocument(downloadPage.Content);
+            var dom = parser.ParseDocument(downloadPage.ContentString);
             var downloadLink = dom.QuerySelectorAll(".download_link").First().GetAttribute("href");
 
             if (string.IsNullOrWhiteSpace(downloadLink))

--- a/src/Jackett.Common/Indexers/BaseIndexer.cs
+++ b/src/Jackett.Common/Indexers/BaseIndexer.cs
@@ -567,7 +567,7 @@ namespace Jackett.Common.Indexers
                 throw new Exception("Request to " + response.Request.Url + " failed (Error " + response.Status + ") - The tracker seems to be down.");
             }
 
-            if (response.Status == System.Net.HttpStatusCode.Forbidden && response.Content.Contains("<span data-translate=\"complete_sec_check\">Please complete the security check to access</span>"))
+            if (response.Status == System.Net.HttpStatusCode.Forbidden && response.ContentString.Contains("<span data-translate=\"complete_sec_check\">Please complete the security check to access</span>"))
             {
                 throw new Exception("Request to " + response.Request.Url + " failed (Error " + response.Status + ") - The page is protected by an Cloudflare reCaptcha. The page is in aggressive DDoS mitigation mode or your IP might be blacklisted (e.g. in case of shared VPN IPs). There's no easy way of making it usable with Jackett.");
             }

--- a/src/Jackett.Common/Indexers/BitCityReloaded.cs
+++ b/src/Jackett.Common/Indexers/BitCityReloaded.cs
@@ -94,10 +94,10 @@ namespace Jackett.Common.Indexers
             };
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, LoginUrl);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("logout.php"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("logout.php"), () =>
                 {
                     var parser = new HtmlParser();
-                    var dom = parser.ParseDocument(result.Content);
+                    var dom = parser.ParseDocument(result.ContentString);
                     var errorMessage = dom.QuerySelector("#login_error").Text().Trim();
                     throw new ExceptionWithConfigData(errorMessage, configData);
                 });
@@ -127,7 +127,7 @@ namespace Jackett.Common.Indexers
             searchUrl += "?" + queryCollection.GetQueryString();
 
             var response = await RequestStringWithCookiesAndRetry(searchUrl, null, BrowseUrl);
-            var results = response.Content;
+            var results = response.ContentString;
             try
             {
                 var parser = new HtmlParser();

--- a/src/Jackett.Common/Indexers/BitHdtv.cs
+++ b/src/Jackett.Common/Indexers/BitHdtv.cs
@@ -65,7 +65,7 @@ namespace Jackett.Common.Indexers
             if (loginPage.IsRedirect)
                 return result; // already logged in
             var parser = new HtmlParser();
-            var cq = parser.ParseDocument(loginPage.Content);
+            var cq = parser.ParseDocument(loginPage.ContentString);
             var recaptchaSiteKey = cq.QuerySelector(".g-recaptcha")?.GetAttribute("data-sitekey");
             result.CookieHeader.Value = loginPage.Cookies;
             result.Captcha.SiteKey = recaptchaSiteKey;
@@ -105,10 +105,10 @@ namespace Jackett.Common.Indexers
             }
 
             var response = await RequestLoginAndFollowRedirect(TakeLoginUrl, pairs, null, true, null, SiteLink);
-            await ConfigureIfOK(response.Cookies, response.Content != null && response.Content.Contains("logout.php"), () =>
+            await ConfigureIfOK(response.Cookies, response.ContentString != null && response.ContentString.Contains("logout.php"), () =>
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(response.Content);
+                var dom = parser.ParseDocument(response.ContentString);
                 var messageEl = dom.QuerySelectorAll("table.detail td.text").Last();
                 foreach (var child in messageEl.QuerySelectorAll("a"))
                     child.Remove();
@@ -143,7 +143,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(results.Content);
+                var dom = parser.ParseDocument(results.ContentString);
                 foreach (var child in dom.QuerySelectorAll("#needseed"))
                     child.Remove();
                 foreach (var table in dom.QuerySelectorAll("table[align=center] + br + table > tbody"))
@@ -210,7 +210,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/BroadcastTheNet.cs
+++ b/src/Jackett.Common/Indexers/BroadcastTheNet.cs
@@ -112,7 +112,7 @@ namespace Jackett.Common.Indexers
 
             try
             {
-                var btnResponse = JsonConvert.DeserializeObject<BTNRPCResponse>(response.Content);
+                var btnResponse = JsonConvert.DeserializeObject<BTNRPCResponse>(response.ContentString);
 
                 if (btnResponse != null && btnResponse.Result != null && btnResponse.Result.Torrents != null)
                 {
@@ -168,7 +168,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
             return releases;
         }

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -448,7 +448,7 @@ namespace Jackett.Common.Indexers
                 return true; // no error
 
             var ResultParser = new HtmlParser();
-            var ResultDocument = ResultParser.ParseDocument(loginResult.Content);
+            var ResultDocument = ResultParser.ParseDocument(loginResult.ContentString);
             foreach (var error in errorBlocks)
             {
                 var selection = ResultDocument.QuerySelector(error.Selector);
@@ -522,11 +522,11 @@ namespace Jackett.Common.Indexers
                             // request real login page again
                             landingResult = await RequestStringWithCookies(LoginUrl, null, SiteLink);
                             var htmlParser = new HtmlParser();
-                            landingResultDocument = htmlParser.ParseDocument(landingResult.Content);
+                            landingResultDocument = htmlParser.ParseDocument(landingResult.ContentString);
                         }
                         else
                         {
-                            throw new ExceptionWithConfigData(string.Format("Login failed: Cloudflare clearance failed using cookies {0}: {1}", CookieHeader, ClearanceResult.Content), configData);
+                            throw new ExceptionWithConfigData(string.Format("Login failed: Cloudflare clearance failed using cookies {0}: {1}", CookieHeader, ClearanceResult.ContentString), configData);
                         }
                     }
                     else
@@ -637,7 +637,7 @@ namespace Jackett.Common.Indexers
                 {
                     var captchaUrl = resolvePath("simpleCaptcha.php?numImages=1");
                     var simpleCaptchaResult = await RequestStringWithCookies(captchaUrl.ToString(), null, LoginUrl);
-                    var simpleCaptchaJSON = JObject.Parse(simpleCaptchaResult.Content);
+                    var simpleCaptchaJSON = JObject.Parse(simpleCaptchaResult.ContentString);
                     var captchaSelection = simpleCaptchaJSON["images"][0]["hash"].ToString();
                     pairs["captchaSelection"] = captchaSelection;
                     pairs["submitme"] = "X";
@@ -800,7 +800,7 @@ namespace Jackett.Common.Indexers
             if (Login.Test.Selector != null)
             {
                 var testResultParser = new HtmlParser();
-                var testResultDocument = testResultParser.ParseDocument(testResult.Content);
+                var testResultDocument = testResultParser.ParseDocument(testResult.ContentString);
                 var selection = testResultDocument.QuerySelectorAll(Login.Test.Selector);
                 if (selection.Length == 0)
                 {
@@ -873,7 +873,7 @@ namespace Jackett.Common.Indexers
             landingResult = await RequestStringWithCookies(LoginUrl.AbsoluteUri, null, SiteLink);
 
             var htmlParser = new HtmlParser();
-            landingResultDocument = htmlParser.ParseDocument(landingResult.Content);
+            landingResultDocument = htmlParser.ParseDocument(landingResult.ContentString);
 
             var hasCaptcha = false;
 
@@ -1323,7 +1323,7 @@ namespace Jackett.Common.Indexers
                 if (response.IsRedirect && SearchPath.Followredirect)
                     await FollowIfRedirect(response);
 
-                var results = response.Content;
+                var results = response.ContentString;
 
 
                 try
@@ -1348,7 +1348,7 @@ namespace Jackett.Common.Indexers
                         if (response.IsRedirect && SearchPath.Followredirect)
                             await FollowIfRedirect(response);
 
-                        results = response.Content;
+                        results = response.ContentString;
                         SearchResultDocument = SearchResultParser.ParseDocument(results);
                     }
 
@@ -1747,7 +1747,7 @@ namespace Jackett.Common.Indexers
                     var response = await RequestStringWithCookies(link.ToString());
                     if (response.IsRedirect)
                         response = await RequestStringWithCookies(response.RedirectingTo);
-                    var results = response.Content;
+                    var results = response.ContentString;
                     var searchResultParser = new HtmlParser();
                     var searchResultDocument = searchResultParser.ParseDocument(results);
                     var downloadElement = searchResultDocument.QuerySelector(selector);

--- a/src/Jackett.Common/Indexers/Corsarored.cs
+++ b/src/Jackett.Common/Indexers/Corsarored.cs
@@ -108,7 +108,7 @@ namespace Jackett.Common.Indexers
         {
             try
             {
-                var json = JsonConvert.DeserializeObject<dynamic>(result.Content);
+                var json = JsonConvert.DeserializeObject<dynamic>(result.ContentString);
 
                 switch (json)
                 {
@@ -121,7 +121,7 @@ namespace Jackett.Common.Indexers
             catch (Exception e)
             {
                 logger.Error("checkResponse() Error: ", e.Message);
-                throw new ExceptionWithConfigData(result.Content, configData);
+                throw new ExceptionWithConfigData(result.ContentString, configData);
             }
         }
 

--- a/src/Jackett.Common/Indexers/DigitalHive.cs
+++ b/src/Jackett.Common/Indexers/DigitalHive.cs
@@ -92,7 +92,7 @@ namespace Jackett.Common.Indexers
         {
             var loginPage = await RequestStringWithCookies(LoginUrl, configData.CookieHeader.Value);
             var parser = new HtmlParser();
-            var cq = parser.ParseDocument(loginPage.Content);
+            var cq = parser.ParseDocument(loginPage.ContentString);
             var recaptchaSiteKey = cq.QuerySelector(".g-recaptcha").GetAttribute("data-sitekey");
             if (recaptchaSiteKey != null)
             {
@@ -149,10 +149,10 @@ namespace Jackett.Common.Indexers
 
             var result = await RequestLoginAndFollowRedirect(AjaxLoginUrl, pairs, configData.CookieHeader.Value, true, SiteLink, LoginUrl);
 
-            await ConfigureIfOK(result.Cookies, result.Content.Contains("logout.php"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString.Contains("logout.php"), () =>
             {
                 var parser = new HtmlParser();
-                var errorMessage = parser.ParseDocument(result.Content);
+                var errorMessage = parser.ParseDocument(result.ContentString);
                 throw new ExceptionWithConfigData(errorMessage.Text(), configData);
             });
 
@@ -188,11 +188,11 @@ namespace Jackett.Common.Indexers
             }
             try
             {
-                releases.AddRange(contentToReleaseInfos(query, results.Content));
+                releases.AddRange(contentToReleaseInfos(query, results.ContentString));
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/DivxTotal.cs
+++ b/src/Jackett.Common/Indexers/DivxTotal.cs
@@ -100,12 +100,12 @@ namespace Jackett.Common.Indexers
                 var result = await RequestStringWithCookies(url);
 
                 if (result.Status != HttpStatusCode.OK)
-                    throw new ExceptionWithConfigData(result.Content, configData);
+                    throw new ExceptionWithConfigData(result.ContentString, configData);
 
                 try
                 {
                     var searchResultParser = new HtmlParser();
-                    var doc = searchResultParser.ParseDocument(result.Content);
+                    var doc = searchResultParser.ParseDocument(result.ContentString);
 
                     var table = doc.QuerySelector("table.table");
                     if (table == null)
@@ -133,7 +133,7 @@ namespace Jackett.Common.Indexers
                 }
                 catch (Exception ex)
                 {
-                    OnParseError(result.Content, ex);
+                    OnParseError(result.ContentString, ex);
                 }
 
                 page++; // update page number
@@ -153,10 +153,10 @@ namespace Jackett.Common.Indexers
                 var result = await RequestStringWithCookies(downloadUrl);
 
                 if (result.Status != HttpStatusCode.OK)
-                    throw new ExceptionWithConfigData(result.Content, configData);
+                    throw new ExceptionWithConfigData(result.ContentString, configData);
 
                 var searchResultParser = new HtmlParser();
-                var doc = searchResultParser.ParseDocument(result.Content);
+                var doc = searchResultParser.ParseDocument(result.ContentString);
 
                 var onclick = doc.QuerySelector("a[onclick*=\"/download/torrent\"]")
                     .GetAttribute("onclick");
@@ -212,10 +212,10 @@ namespace Jackett.Common.Indexers
             var result = await RequestStringWithCookies(commentsLink);
 
             if (result.Status != HttpStatusCode.OK)
-                throw new ExceptionWithConfigData(result.Content, configData);
+                throw new ExceptionWithConfigData(result.ContentString, configData);
 
             var searchResultParser = new HtmlParser();
-            var doc = searchResultParser.ParseDocument(result.Content);
+            var doc = searchResultParser.ParseDocument(result.ContentString);
 
             var tables = doc.QuerySelectorAll("table.table");
             foreach (var table in tables)

--- a/src/Jackett.Common/Indexers/EliteTracker.cs
+++ b/src/Jackett.Common/Indexers/EliteTracker.cs
@@ -154,7 +154,7 @@ namespace Jackett.Common.Indexers
 
             await ConfigureIfOK(result.Cookies, result.Cookies != null, () =>
            {
-               var errorMessage = result.Content;
+               var errorMessage = result.ContentString;
                throw new ExceptionWithConfigData(errorMessage, configData);
            });
 
@@ -184,7 +184,7 @@ namespace Jackett.Common.Indexers
             {
                 var RowsSelector = "table[id='sortabletable'] > tbody > tr";
                 var SearchResultParser = new HtmlParser();
-                var SearchResultDocument = SearchResultParser.ParseDocument(results.Content);
+                var SearchResultDocument = SearchResultParser.ParseDocument(results.ContentString);
                 var Rows = SearchResultDocument.QuerySelectorAll(RowsSelector);
                 var lastDate = DateTime.Now;
 
@@ -292,7 +292,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/Feeds/BaseFeedIndexer.cs
+++ b/src/Jackett.Common/Indexers/Feeds/BaseFeedIndexer.cs
@@ -42,7 +42,7 @@ namespace Jackett.Common.Indexers.Feeds
             };
             var result = await webclient.GetString(request);
 
-            var results = ParseFeedForResults(result.Content);
+            var results = ParseFeedForResults(result.ContentString);
 
             return results;
         }

--- a/src/Jackett.Common/Indexers/FileList.cs
+++ b/src/Jackett.Common/Indexers/FileList.cs
@@ -82,7 +82,7 @@ namespace Jackett.Common.Indexers
             LoadValuesFromJson(configJson);
             var responseFirstPage = await RequestStringWithCookiesAndRetry(SiteLink + "login.php?returnto=%2F", "");
             var parser = new HtmlParser();
-            var domFirstPage = parser.ParseDocument(responseFirstPage.Content);
+            var domFirstPage = parser.ParseDocument(responseFirstPage.ContentString);
             var validator = domFirstPage.QuerySelector("input[name =\"validator\"]").GetAttribute("value");
             var pairs = new Dictionary<string, string> {
                 { "validator", validator},
@@ -91,9 +91,9 @@ namespace Jackett.Common.Indexers
             };
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, responseFirstPage.Cookies, true, null, LoginUrl);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("logout.php"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("logout.php"), () =>
             {
-                var dom = parser.ParseDocument(result.Content);
+                var dom = parser.ParseDocument(result.ContentString);
                 var errorMessage = dom.QuerySelector(".main").TextContent.Trim();
                 throw new ExceptionWithConfigData(errorMessage, configData);
             });
@@ -133,7 +133,7 @@ namespace Jackett.Common.Indexers
                 response = await RequestStringWithCookiesAndRetry(searchUrl, null, BrowseUrl);
             }
 
-            var results = response.Content;
+            var results = response.ContentString;
             try
             {
                 var parser = new HtmlParser();

--- a/src/Jackett.Common/Indexers/FunFile.cs
+++ b/src/Jackett.Common/Indexers/FunFile.cs
@@ -64,10 +64,10 @@ namespace Jackett.Common.Indexers
             };
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, LoginUrl);
-            await ConfigureIfOK(result.Cookies, result.Content.Contains("logout.php"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString.Contains("logout.php"), () =>
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(result.Content);
+                var dom = parser.ParseDocument(result.ContentString);
                 var errorMessage = dom.QuerySelector("td.mf_content").InnerHtml;
                 throw new ExceptionWithConfigData(errorMessage, configData);
             });
@@ -101,7 +101,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(results.Content);
+                var dom = parser.ParseDocument(results.ContentString);
                 var rows = dom.QuerySelectorAll("table[cellpadding=2] > tbody > tr:has(td.row3)");
                 foreach (var row in rows)
                 {
@@ -154,7 +154,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/Fuzer.cs
+++ b/src/Jackett.Common/Indexers/Fuzer.cs
@@ -104,7 +104,7 @@ namespace Jackett.Common.Indexers
         {
             var loginPage = await RequestStringWithCookies(LoginUrl, string.Empty);
             var parser = new HtmlParser();
-            var cq = parser.ParseDocument(loginPage.Content);
+            var cq = parser.ParseDocument(loginPage.ContentString);
             var captcha = cq.QuerySelector(".g-recaptcha"); // invisible recaptcha
             if (captcha != null)
             {
@@ -160,7 +160,7 @@ namespace Jackett.Common.Indexers
                 {"cookieuser", "1"}
             };
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, loginPage.Cookies, true, null, LoginUrl);
-            await ConfigureIfOK(result.Cookies, result.Content?.Contains("images/loading.gif") == true,
+            await ConfigureIfOK(result.Cookies, result.ContentString?.Contains("images/loading.gif") == true,
                                 () => throw new ExceptionWithConfigData("Couldn't login", configData));
             Thread.Sleep(2);
             return IndexerConfigurationStatus.RequiresTesting;
@@ -203,7 +203,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(data.Content);
+                var dom = parser.ParseDocument(data.ContentString);
                 var rows = dom.QuerySelectorAll("tr.box_torrent");
                 foreach (var row in rows)
                 {
@@ -249,7 +249,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(data.Content, ex);
+                OnParseError(data.ContentString, ex);
             }
 
             return releases;
@@ -273,7 +273,7 @@ namespace Jackett.Common.Indexers
             };
             var results = await RequestStringWithCookies(site.ToString());
             var parser = new HtmlParser();
-            var dom = parser.ParseDocument(results.Content);
+            var dom = parser.ParseDocument(results.ContentString);
             var rows = dom.QuerySelectorAll("#listtable > tbody > tr");
             foreach (var row in rows.Skip(1))
             {
@@ -283,7 +283,7 @@ namespace Jackett.Common.Indexers
                     var address = link.GetAttribute("href");
                     if (string.IsNullOrEmpty(address))
                         continue;
-                    var realDom = parser.ParseDocument(results.Content);
+                    var realDom = parser.ParseDocument(results.ContentString);
                     return realDom.QuerySelector("#content:nth-child(1) > h1").TextContent;
                 }
             }

--- a/src/Jackett.Common/Indexers/GazelleGames.cs
+++ b/src/Jackett.Common/Indexers/GazelleGames.cs
@@ -233,7 +233,7 @@ namespace Jackett.Common.Indexers
                 var RowsSelector = ".torrent_table > tbody > tr";
 
                 var SearchResultParser = new HtmlParser();
-                var SearchResultDocument = SearchResultParser.ParseDocument(results.Content);
+                var SearchResultDocument = SearchResultParser.ParseDocument(results.ContentString);
                 var Rows = SearchResultDocument.QuerySelectorAll(RowsSelector);
 
                 var stickyGroup = false;
@@ -336,7 +336,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/GimmePeers.cs
+++ b/src/Jackett.Common/Indexers/GimmePeers.cs
@@ -89,10 +89,10 @@ namespace Jackett.Common.Indexers
             var loginPage = await RequestStringWithCookies(SiteLink, string.Empty);
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, loginPage.Cookies, true, SiteLink, SiteLink);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("logout.php"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("logout.php"), () =>
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(result.Content);
+                var dom = parser.ParseDocument(result.ContentString);
                 var messageEl = dom.QuerySelector("body > div");
                 var errorMessage = messageEl.TextContent.Trim();
                 throw new ExceptionWithConfigData(errorMessage, configData);
@@ -140,7 +140,7 @@ namespace Jackett.Common.Indexers
                 response = await RequestStringWithCookiesAndRetry(searchUrl, null, BrowseUrl);
             }
 
-            var results = response.Content;
+            var results = response.ContentString;
             try
             {
                 var parser = new HtmlParser();

--- a/src/Jackett.Common/Indexers/HDBitsApi.cs
+++ b/src/Jackett.Common/Indexers/HDBitsApi.cs
@@ -201,11 +201,11 @@ namespace Jackett.Common.Indexers
 
             try
             {
-                json = JObject.Parse(response.Content);
+                json = JObject.Parse(response.ContentString);
             }
             catch (Exception ex)
             {
-                throw new Exception("Error while parsing json: " + response.Content, ex);
+                throw new Exception("Error while parsing json: " + response.ContentString, ex);
             }
 
             if ((int)json["status"] != 0)

--- a/src/Jackett.Common/Indexers/HDSpace.cs
+++ b/src/Jackett.Common/Indexers/HDSpace.cs
@@ -81,11 +81,11 @@ namespace Jackett.Common.Indexers
             // Send Post
             var response = await RequestLoginAndFollowRedirect(LoginUrl, pairs, loginPage.Cookies, true, null, LoginUrl);
 
-            await ConfigureIfOK(response.Cookies, response.Content?.Contains("logout.php") == true, () =>
+            await ConfigureIfOK(response.Cookies, response.ContentString?.Contains("logout.php") == true, () =>
             {
                 var errorStr = "You have {0} remaining login attempts";
                 var remainingAttemptSpan = new Regex(string.Format(errorStr, "(.*?)"))
-                                           .Match(loginPage.Content).Groups[1].ToString();
+                                           .Match(loginPage.ContentString).Groups[1].ToString();
                 var attempts = Regex.Replace(remainingAttemptSpan, "<.*?>", string.Empty);
                 var errorMessage = string.Format(errorStr, attempts);
                 throw new ExceptionWithConfigData(errorMessage, configData);
@@ -112,7 +112,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var resultParser = new HtmlParser();
-                var searchResultDocument = resultParser.ParseDocument(response.Content);
+                var searchResultDocument = resultParser.ParseDocument(response.ContentString);
                 var rows = searchResultDocument.QuerySelectorAll("table.lista > tbody > tr");
 
                 foreach (var row in rows)
@@ -161,7 +161,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/HDTorrents.cs
+++ b/src/Jackett.Common/Indexers/HDTorrents.cs
@@ -99,7 +99,7 @@ namespace Jackett.Common.Indexers
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, loginPage.Cookies, true, null, LoginUrl);
 
             await ConfigureIfOK(
-                result.Cookies, result.Content?.Contains("If your browser doesn't have javascript enabled") == true,
+                result.Cookies, result.ContentString?.Contains("If your browser doesn't have javascript enabled") == true,
                 () => throw new ExceptionWithConfigData("Couldn't login", configData));
             return IndexerConfigurationStatus.RequiresTesting;
         }
@@ -128,7 +128,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(results.Content);
+                var dom = parser.ParseDocument(results.ContentString);
 
                 var userInfo = dom.QuerySelector(".mainmenu > table > tbody > tr:has(td[title=\"Active-Torrents\"])");
                 var rank = userInfo.QuerySelector("td:nth-child(2)").TextContent.Substring(6);
@@ -215,7 +215,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/Hebits.cs
+++ b/src/Jackett.Common/Indexers/Hebits.cs
@@ -66,10 +66,10 @@ namespace Jackett.Common.Indexers
             CookieHeader = string.Empty;
             var result = await RequestLoginAndFollowRedirect(LoginPostUrl, pairs, CookieHeader, true, null, SiteLink);
             await ConfigureIfOK(
-                result.Cookies, result.Content?.Contains("OK") == true, () =>
+                result.Cookies, result.ContentString?.Contains("OK") == true, () =>
                 {
                     var parser = new HtmlParser();
-                    var dom = parser.ParseDocument(result.Content);
+                    var dom = parser.ParseDocument(result.ContentString);
                     var errorMessage = dom.TextContent.Trim();
                     errorMessage += " attempts left. Please check your credentials.";
                     throw new ExceptionWithConfigData(errorMessage, configData);
@@ -91,7 +91,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(response.Content);
+                var dom = parser.ParseDocument(response.ContentString);
                 var rows = dom.QuerySelectorAll(".browse > div > div");
                 foreach (var row in rows)
                 {
@@ -129,7 +129,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/HorribleSubs.cs
+++ b/src/Jackett.Common/Indexers/HorribleSubs.cs
@@ -79,11 +79,11 @@ namespace Jackett.Common.Indexers
 
             try
             {
-                if (response.Content.Contains("Nothing was found"))
+                if (response.ContentString.Contains("Nothing was found"))
                 {
                     return releases.ToArray();
                 }
-                var dom = ResultParser.ParseDocument(response.Content);
+                var dom = ResultParser.ParseDocument(response.ContentString);
                 var resultLinks = dom.QuerySelectorAll("ul > li > a");
                 var uniqueShowLinks = new HashSet<string>();
                 foreach (var resultLink in resultLinks)
@@ -100,7 +100,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
 
             return releases;
@@ -120,12 +120,12 @@ namespace Jackett.Common.Indexers
 
             try
             {
-                if (response.Content.Contains("Nothing was found"))
+                if (response.ContentString.Contains("Nothing was found"))
                 {
                     return releases.ToArray();
                 }
 
-                var dom = ResultParser.ParseDocument(response.Content);
+                var dom = ResultParser.ParseDocument(response.ContentString);
                 var latestresults = dom.QuerySelectorAll("ul > li > a");
                 foreach (var resultLink in latestresults)
                 {
@@ -138,7 +138,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
 
             return releases;
@@ -153,7 +153,7 @@ namespace Jackett.Common.Indexers
                 var showPageResponse = await RequestStringWithCookiesAndRetry(ResultURL, string.Empty);
                 await FollowIfRedirect(showPageResponse);
 
-                var match = Regex.Match(showPageResponse.Content, "(var hs_showid = )([0-9]*)(;)", RegexOptions.IgnoreCase);
+                var match = Regex.Match(showPageResponse.ContentString, "(var hs_showid = )([0-9]*)(;)", RegexOptions.IgnoreCase);
                 if (match.Success == false)
                 {
                     return releases;
@@ -173,7 +173,7 @@ namespace Jackett.Common.Indexers
                     while (true)
                     {
                         var showAPIResponse = await RequestStringWithCookiesAndRetry(apiUrl + "&nextid=" + nextId, string.Empty);
-                        var showAPIdom = ResultParser.ParseDocument(showAPIResponse.Content);
+                        var showAPIdom = ResultParser.ParseDocument(showAPIResponse.ContentString);
                         var releaseRowResults = showAPIdom.QuerySelectorAll("div.rls-info-container");
                         releaserows.AddRange(releaseRowResults);
                         nextId++;

--- a/src/Jackett.Common/Indexers/IPTorrents.cs
+++ b/src/Jackett.Common/Indexers/IPTorrents.cs
@@ -180,7 +180,7 @@ namespace Jackett.Common.Indexers
                 searchUrl += "?" + queryCollection.GetQueryString();
 
             var response = await RequestStringWithCookiesAndRetry(searchUrl, null, BrowseUrl);
-            var results = response.Content;
+            var results = response.ContentString;
 
             if (results == null || !results.Contains("/lout.php"))
                 throw new Exception("The user is not logged in. It is possible that the cookie has expired or you made a mistake when copying it. Please check the settings.");

--- a/src/Jackett.Common/Indexers/ImmortalSeed.cs
+++ b/src/Jackett.Common/Indexers/ImmortalSeed.cs
@@ -102,9 +102,9 @@ namespace Jackett.Common.Indexers
 
             var response = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, LoginUrl);
 
-            await ConfigureIfOK(response.Cookies, response.Content.Contains("You have successfully logged in"), () =>
+            await ConfigureIfOK(response.Cookies, response.ContentString.Contains("You have successfully logged in"), () =>
             {
-                var errorMessage = response.Content;
+                var errorMessage = response.ContentString;
                 throw new ExceptionWithConfigData(errorMessage, configData);
             });
 
@@ -122,7 +122,7 @@ namespace Jackett.Common.Indexers
             var results = await RequestStringWithCookiesAndRetry(searchUrl);
 
             // Occasionally the cookies become invalid, login again if that happens
-            if (results.Content.Contains("You do not have permission to access this page."))
+            if (results.ContentString.Contains("You do not have permission to access this page."))
             {
                 await ApplyConfiguration(null);
                 results = await RequestStringWithCookiesAndRetry(searchUrl);
@@ -131,7 +131,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(results.Content);
+                var dom = parser.ParseDocument(results.ContentString);
 
                 var rows = dom.QuerySelectorAll("#sortabletable tr:has(a[href*=\"details.php?id=\"])");
                 foreach (var row in rows)
@@ -190,7 +190,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/InternetArchive.cs
+++ b/src/Jackett.Common/Indexers/InternetArchive.cs
@@ -154,7 +154,7 @@ namespace Jackett.Common.Indexers
             {
                 if (result.Status != HttpStatusCode.OK)
                     throw new Exception("Response code error. HTTP code: " + result.Status);
-                var json = JsonConvert.DeserializeObject<dynamic>(result.Content);
+                var json = JsonConvert.DeserializeObject<dynamic>(result.ContentString);
                 if (!(json is JObject) || !(json["response"] is JObject) || !(json["response"]["docs"] is JArray))
                     throw new Exception("Response format error");
                 return (JArray)json["response"]["docs"];
@@ -162,7 +162,7 @@ namespace Jackett.Common.Indexers
             catch (Exception e)
             {
                 logger.Error("ParseResponse Error: ", e.Message);
-                throw new ExceptionWithConfigData(result.Content, ConfigData);
+                throw new ExceptionWithConfigData(result.ContentString, ConfigData);
             }
         }
 

--- a/src/Jackett.Common/Indexers/MejorTorrent.cs
+++ b/src/Jackett.Common/Indexers/MejorTorrent.cs
@@ -98,17 +98,17 @@ namespace Jackett.Common.Indexers
             // Eg http://www.mejortorrentt.org/peli-descargar-torrent-11995-Harry-Potter-y-la-piedra-filosofal.html
             var result = await RequestStringWithCookies(downloadUrl);
             if (result.Status != HttpStatusCode.OK)
-                throw new ExceptionWithConfigData(result.Content, configData);
+                throw new ExceptionWithConfigData(result.ContentString, configData);
             var searchResultParser = new HtmlParser();
-            var html = searchResultParser.ParseDocument(result.Content);
+            var html = searchResultParser.ParseDocument(result.ContentString);
             downloadUrl = SiteLink + html.QuerySelector("a[href*=\"sec=descargas\"]").GetAttribute("href");
 
             // Eg http://www.mejortorrentt.org/secciones.php?sec=descargas&ap=contar&tabla=peliculas&id=11995&link_bajar=1
             result = await RequestStringWithCookies(downloadUrl);
             if (result.Status != HttpStatusCode.OK)
-                throw new ExceptionWithConfigData(result.Content, configData);
+                throw new ExceptionWithConfigData(result.ContentString, configData);
             searchResultParser = new HtmlParser();
-            html = searchResultParser.ParseDocument(result.Content);
+            html = searchResultParser.ParseDocument(result.ContentString);
             var onclick = html.QuerySelector("a[onclick*=\"/uploads/\"]").GetAttribute("onclick");
             var table = onclick.Split(new[] { "table: '" }, StringSplitOptions.None)[1].Split(new[] { "'" }, StringSplitOptions.None)[0];
             var name = onclick.Split(new[] { "name: '" }, StringSplitOptions.None)[1].Split(new[] { "'" }, StringSplitOptions.None)[0];
@@ -125,11 +125,11 @@ namespace Jackett.Common.Indexers
             var url = SiteLink + NewTorrentsUrl;
             var result = await RequestStringWithCookies(url);
             if (result.Status != HttpStatusCode.OK)
-                throw new ExceptionWithConfigData(result.Content, configData);
+                throw new ExceptionWithConfigData(result.ContentString, configData);
             try
             {
                 var searchResultParser = new HtmlParser();
-                var doc = searchResultParser.ParseDocument(result.Content);
+                var doc = searchResultParser.ParseDocument(result.ContentString);
 
                 var container = doc.QuerySelector("#main_table_center_center1 table div");
                 var parsedCommentsLink = new List<string>();
@@ -174,7 +174,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(result.Content, ex);
+                OnParseError(result.ContentString, ex);
             }
 
             return releases;
@@ -189,12 +189,12 @@ namespace Jackett.Common.Indexers
             var url = SiteLink + SearchUrl + "?" + qc.GetQueryString();
             var result = await RequestStringWithCookies(url);
             if (result.Status != HttpStatusCode.OK)
-                throw new ExceptionWithConfigData(result.Content, configData);
+                throw new ExceptionWithConfigData(result.ContentString, configData);
 
             try
             {
                 var searchResultParser = new HtmlParser();
-                var doc = searchResultParser.ParseDocument(result.Content);
+                var doc = searchResultParser.ParseDocument(result.ContentString);
 
                 var table = doc.QuerySelector("#main_table_center_center2 table table");
                 // check the search term is valid
@@ -223,7 +223,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(result.Content, ex);
+                OnParseError(result.ContentString, ex);
             }
 
             return releases;
@@ -271,10 +271,10 @@ namespace Jackett.Common.Indexers
         {
             var result = await RequestStringWithCookies(commentsLink);
             if (result.Status != HttpStatusCode.OK)
-                throw new ExceptionWithConfigData(result.Content, configData);
+                throw new ExceptionWithConfigData(result.ContentString, configData);
 
             var searchResultParser = new HtmlParser();
-            var doc = searchResultParser.ParseDocument(result.Content);
+            var doc = searchResultParser.ParseDocument(result.ContentString);
 
             var rows = doc.QuerySelectorAll("#main_table_center_center1 table table table tr");
             foreach (var row in rows)

--- a/src/Jackett.Common/Indexers/MoreThanTV.cs
+++ b/src/Jackett.Common/Indexers/MoreThanTV.cs
@@ -60,13 +60,13 @@ namespace Jackett.Common.Indexers
             var preRequest = await RequestStringWithCookiesAndRetry(LoginUrl, string.Empty);
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, preRequest.Cookies, true, SearchUrl, SiteLink);
 
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("status\":\"success\""), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("status\":\"success\""), () =>
             {
-                if (result.Content.Contains("Your IP address has been banned."))
+                if (result.ContentString.Contains("Your IP address has been banned."))
                     throw new ExceptionWithConfigData("Your IP address has been banned.", ConfigData);
 
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(result.Content);
+                var dom = parser.ParseDocument(result.ContentString);
                 foreach (var element in dom.QuerySelectorAll("#loginform > table"))
                     element.Remove();
                 var errorMessage = dom.QuerySelector("#loginform").TextContent.Trim().Replace("\n\t", " ");
@@ -142,7 +142,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var document = parser.ParseDocument(response.Content);
+                var document = parser.ParseDocument(response.ContentString);
                 var groups = document.QuerySelectorAll(".torrent_table > tbody > tr.group");
                 var torrents = document.QuerySelectorAll(".torrent_table > tbody > tr.torrent");
 
@@ -240,7 +240,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
         }
 

--- a/src/Jackett.Common/Indexers/MyAnonamouse.cs
+++ b/src/Jackett.Common/Indexers/MyAnonamouse.cs
@@ -206,14 +206,14 @@ namespace Jackett.Common.Indexers
             }
 
             var response = await RequestStringWithCookiesAndRetry(urlSearch);
-            if (response.Content.StartsWith("Error"))
+            if (response.ContentString.StartsWith("Error"))
             {
-                throw new Exception(response.Content);
+                throw new Exception(response.ContentString);
             }
 
             try
             {
-                var jsonContent = JObject.Parse(response.Content);
+                var jsonContent = JObject.Parse(response.ContentString);
                 var sitelink = new Uri(SiteLink);
 
                 var error = jsonContent.Value<string>("error");
@@ -286,7 +286,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/NCore.cs
+++ b/src/Jackett.Common/Indexers/NCore.cs
@@ -103,10 +103,10 @@ namespace Jackett.Common.Indexers
                 pairs.Add("2factor", configData.TwoFactor.Value);
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, loginPage.Cookies, true, referer: SiteLink);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("profile.php"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("profile.php"), () =>
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(result.Content);
+                var dom = parser.ParseDocument(result.ContentString);
                 var messageEl = dom.QuerySelector("#hibauzenet table tbody tr");
                 var msgContainer = messageEl.Children[1];
                 var errorMessage = msgContainer != null ? msgContainer.TextContent : "Error while trying to login.";
@@ -163,7 +163,7 @@ namespace Jackett.Common.Indexers
 
 
             var parser = new HtmlParser();
-            var dom = parser.ParseDocument(results.Content);
+            var dom = parser.ParseDocument(results.ContentString);
             var numVal = 0;
 
             // find number of torrents / page
@@ -225,7 +225,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(results.Content);
+                var dom = parser.ParseDocument(results.ContentString);
 
                 var rows = dom.QuerySelector(".box_torrent_all").QuerySelectorAll(".box_torrent");
 
@@ -328,7 +328,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/NewRealWorld.cs
+++ b/src/Jackett.Common/Indexers/NewRealWorld.cs
@@ -108,10 +108,10 @@ namespace Jackett.Common.Indexers
             };
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, LoginUrl, true);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("logout.php"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("logout.php"), () =>
                 {
                     var parser = new HtmlParser();
-                    var dom = parser.ParseDocument(result.Content);
+                    var dom = parser.ParseDocument(result.ContentString);
                     var errorMessage = dom.QuerySelector("table.tableinborder").InnerHtml;
                     throw new ExceptionWithConfigData(errorMessage, configData);
                 });
@@ -163,7 +163,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(response.Content);
+                var dom = parser.ParseDocument(response.ContentString);
                 var rows = dom.QuerySelectorAll("table.testtable> tbody > tr:has(td.tableb)");
 
                 foreach (var row in rows)
@@ -221,7 +221,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/Newpct.cs
+++ b/src/Jackett.Common/Indexers/Newpct.cs
@@ -190,7 +190,7 @@ namespace Jackett.Common.Indexers
                 {
                     var results = await RequestStringWithCookiesAndRetry(uri.AbsoluteUri);
                     await FollowIfRedirect(results);
-                    var content = results.Content;
+                    var content = results.ContentString;
 
                     if (content != null)
                     {
@@ -282,20 +282,20 @@ namespace Jackett.Common.Indexers
                     {
                         var uri = new Uri(validUri, string.Format(_dailyUrl, pg));
                         results = await RequestStringWithCookiesAndRetry(uri.AbsoluteUri);
-                        if (results == null || string.IsNullOrEmpty(results.Content))
+                        if (results == null || string.IsNullOrEmpty(results.ContentString))
                             break;
                         await FollowIfRedirect(results);
-                        items = ParseDailyContent(results.Content);
+                        items = ParseDailyContent(results.ContentString);
                     }
                     else
                     {
                         foreach (var uri in GetLinkUris(new Uri(siteLink, string.Format(_dailyUrl, pg))))
                         {
                             results = await RequestStringWithCookiesAndRetry(uri.AbsoluteUri);
-                            if (results != null && !string.IsNullOrEmpty(results.Content))
+                            if (results != null && !string.IsNullOrEmpty(results.ContentString))
                             {
                                 await FollowIfRedirect(results);
-                                items = ParseDailyContent(results.Content);
+                                items = ParseDailyContent(results.ContentString);
                                 if (items != null && items.Any())
                                 {
                                     validUri = uri;
@@ -431,7 +431,7 @@ namespace Jackett.Common.Indexers
             await FollowIfRedirect(results);
 
             //Episodes list
-            var seriesEpisodesUrl = ParseSeriesListContent(results.Content, seriesName);
+            var seriesEpisodesUrl = ParseSeriesListContent(results.ContentString, seriesName);
             if (!string.IsNullOrEmpty(seriesEpisodesUrl))
             {
                 var pg = 1;
@@ -441,7 +441,7 @@ namespace Jackett.Common.Indexers
                     results = await RequestStringWithCookiesAndRetry(episodesListUrl.AbsoluteUri);
                     await FollowIfRedirect(results);
 
-                    var items = ParseEpisodesListContent(results.Content);
+                    var items = ParseEpisodesListContent(results.ContentString);
                     if (items == null || !items.Any())
                         break;
 
@@ -610,17 +610,17 @@ namespace Jackett.Common.Indexers
                     {
                         var uri = new Uri(validUri, _searchJsonUrl);
                         results = await PostDataWithCookies(uri.AbsoluteUri, queryCollection);
-                        if (results == null || string.IsNullOrEmpty(results.Content))
+                        if (results == null || string.IsNullOrEmpty(results.ContentString))
                             break;
-                        items = ParseSearchJsonContent(uri, results.Content);
+                        items = ParseSearchJsonContent(uri, results.ContentString);
                     }
                     else
                     {
                         var uri = new Uri(validUri, _searchUrl);
                         results = await PostDataWithCookies(uri.AbsoluteUri, queryCollection);
-                        if (results == null || string.IsNullOrEmpty(results.Content))
+                        if (results == null || string.IsNullOrEmpty(results.ContentString))
                             break;
-                        items = ParseSearchContent(results.Content);
+                        items = ParseSearchContent(results.ContentString);
                     }
                 }
                 else
@@ -651,12 +651,12 @@ namespace Jackett.Common.Indexers
                                         results = null;
                                     }
 
-                                    if (results != null && !string.IsNullOrEmpty(results.Content))
+                                    if (results != null && !string.IsNullOrEmpty(results.ContentString))
                                     {
                                         if (usingJson)
-                                            items = ParseSearchJsonContent(uri, results.Content);
+                                            items = ParseSearchJsonContent(uri, results.ContentString);
                                         else
-                                            items = ParseSearchContent(results.Content);
+                                            items = ParseSearchContent(results.ContentString);
 
                                         if (items != null)
                                         {

--- a/src/Jackett.Common/Indexers/Norbits.cs
+++ b/src/Jackett.Common/Indexers/Norbits.cs
@@ -205,7 +205,7 @@ namespace Jackett.Common.Indexers
             // Checking ...
             Output("\n-> Checking logged-in state....");
             var loggedInCheck = await RequestStringWithCookies(SearchUrl);
-            if (!loggedInCheck.Content.Contains("logout.php"))
+            if (!loggedInCheck.ContentString.Contains("logout.php"))
             {
                 // Cookie expired, renew session on provider
                 Output("-> Not logged, login now...\n");
@@ -263,7 +263,7 @@ namespace Jackett.Common.Indexers
                 // Getting results & Store content
                 var response = await RequestStringWithCookiesAndRetry(request, ConfigData.CookieHeader.Value);
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(response.Content);
+                var dom = parser.ParseDocument(response.ContentString);
 
                 try
                 {

--- a/src/Jackett.Common/Indexers/Nordicbits.cs
+++ b/src/Jackett.Common/Indexers/Nordicbits.cs
@@ -260,7 +260,7 @@ namespace Jackett.Common.Indexers
             // Checking ...
             Output("\n-> Checking logged-in state....");
             var loggedInCheck = await RequestStringWithCookies(SearchUrl);
-            if (!loggedInCheck.Content.Contains("logout.php"))
+            if (!loggedInCheck.ContentString.Contains("logout.php"))
             {
                 // Cookie expired, renew session on provider
                 Output("-> Not logged, login now...\n");
@@ -318,7 +318,7 @@ namespace Jackett.Common.Indexers
                 // Getting results & Store content
                 var response = await RequestStringWithCookiesAndRetry(request, ConfigData.CookieHeader.Value);
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(response.Content);
+                var dom = parser.ParseDocument(response.ContentString);
 
                 try
                 {

--- a/src/Jackett.Common/Indexers/Partis.cs
+++ b/src/Jackett.Common/Indexers/Partis.cs
@@ -98,10 +98,10 @@ namespace Jackett.Common.Indexers
             };
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, string.Empty, false, null, null, true);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("/odjava"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("/odjava"), () =>
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(result.Content);
+                var dom = parser.ParseDocument(result.ContentString);
                 var errorMessage = dom.QuerySelector("div.obvet > span.najvecji").TextContent.Trim(); // Prijava ni uspela! obvestilo
                 throw new ExceptionWithConfigData(errorMessage, configData);
             });
@@ -142,7 +142,7 @@ namespace Jackett.Common.Indexers
             await FollowIfRedirect(results, null, null, null, true);
 
             // are we logged in?
-            if (!results.Content.Contains("/odjava"))
+            if (!results.ContentString.Contains("/odjava"))
             {
                 await ApplyConfiguration(null);
             }
@@ -156,7 +156,7 @@ namespace Jackett.Common.Indexers
                 var RowsSelector = "div.list > div[name=\"torrrow\"]";
 
                 var ResultParser = new HtmlParser();
-                var SearchResultDocument = ResultParser.ParseDocument(results.Content);
+                var SearchResultDocument = ResultParser.ParseDocument(results.ContentString);
                 var Rows = SearchResultDocument.QuerySelectorAll(RowsSelector);
                 foreach (var Row in Rows)
                 {
@@ -217,7 +217,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/PassThePopcorn.cs
+++ b/src/Jackett.Common/Indexers/PassThePopcorn.cs
@@ -116,7 +116,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 //Iterate over the releases for each movie
-                var jsResults = JObject.Parse(results.Content);
+                var jsResults = JObject.Parse(results.ContentString);
                 foreach (var movie in jsResults["Movies"])
                 {
                     var movieTitle = (string)movie["Title"];
@@ -227,7 +227,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/PiXELHD.cs
+++ b/src/Jackett.Common/Indexers/PiXELHD.cs
@@ -55,7 +55,7 @@ namespace Jackett.Common.Indexers
         {
             var loginPage = await RequestStringWithCookies(LoginUrl, string.Empty);
             var LoginParser = new HtmlParser();
-            var LoginDocument = LoginParser.ParseDocument(loginPage.Content);
+            var LoginDocument = LoginParser.ParseDocument(loginPage.ContentString);
 
             configData.CaptchaCookie.Value = loginPage.Cookies;
 
@@ -99,10 +99,10 @@ namespace Jackett.Common.Indexers
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, configData.CaptchaCookie.Value, true);
 
-            await ConfigureIfOK(result.Cookies, result.Content.Contains("logout.php"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString.Contains("logout.php"), () =>
            {
                var LoginParser = new HtmlParser();
-               var LoginDocument = LoginParser.ParseDocument(result.Content);
+               var LoginDocument = LoginParser.ParseDocument(result.ContentString);
                var errorMessage = LoginDocument.QuerySelector("span.warning[id!=\"no-cookies\"]:has(br)").TextContent;
                throw new ExceptionWithConfigData(errorMessage, configData);
            });
@@ -142,7 +142,7 @@ namespace Jackett.Common.Indexers
 
             var IMDBRegEx = new Regex(@"tt(\d+)", RegexOptions.Compiled);
             var hParser = new HtmlParser();
-            var ResultDocument = hParser.ParseDocument(results.Content);
+            var ResultDocument = hParser.ParseDocument(results.ContentString);
             try
             {
                 var Groups = ResultDocument.QuerySelectorAll("div.browsePoster");
@@ -196,7 +196,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/PirateTheNet.cs
+++ b/src/Jackett.Common/Indexers/PirateTheNet.cs
@@ -73,7 +73,7 @@ namespace Jackett.Common.Indexers
             CookieHeader = ""; // clear old cookies
 
             var result1 = await RequestStringWithCookies(CaptchaUrl);
-            var json1 = JObject.Parse(result1.Content);
+            var json1 = JObject.Parse(result1.ContentString);
             var captchaSelection = json1["images"][0]["hash"];
 
             var pairs = new Dictionary<string, string> {
@@ -84,7 +84,7 @@ namespace Jackett.Common.Indexers
 
             var result2 = await RequestLoginAndFollowRedirect(LoginUrl, pairs, result1.Cookies, true, null, null, true);
 
-            await ConfigureIfOK(result2.Cookies, result2.Content.Contains("logout.php"), () =>
+            await ConfigureIfOK(result2.Cookies, result2.ContentString.Contains("logout.php"), () =>
                                     throw new ExceptionWithConfigData("Login Failed", configData));
             return IndexerConfigurationStatus.RequiresTesting;
         }
@@ -132,7 +132,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(results.Content);
+                var dom = parser.ParseDocument(results.ContentString);
                 var rows = dom.QuerySelectorAll("table.main > tbody > tr");
                 foreach (var row in rows.Skip(1))
                 {
@@ -192,7 +192,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/PolishTracker.cs
+++ b/src/Jackett.Common/Indexers/PolishTracker.cs
@@ -71,7 +71,7 @@ namespace Jackett.Common.Indexers
 
             await ConfigureIfOK(result.Cookies, result.Cookies != null && result.Cookies.Contains("id="), () =>
             {
-                var errorMessage = result.Content;
+                var errorMessage = result.ContentString;
                 if (errorMessage.Contains("Error!"))
                     errorMessage = "E-mail or password is incorrect";
                 throw new ExceptionWithConfigData(errorMessage, configData);
@@ -106,9 +106,9 @@ namespace Jackett.Common.Indexers
                 result = await RequestStringWithCookiesAndRetry(searchUrl, null, TorrentApiUrl);
             }
 
-            if (!result.Content.StartsWith("{")) // not JSON => error
-                throw new ExceptionWithConfigData(result.Content, configData);
-            dynamic json = JsonConvert.DeserializeObject<dynamic>(result.Content);
+            if (!result.ContentString.StartsWith("{")) // not JSON => error
+                throw new ExceptionWithConfigData(result.ContentString, configData);
+            dynamic json = JsonConvert.DeserializeObject<dynamic>(result.ContentString);
             try
             {
                 dynamic torrents = json["torrents"]; // latest torrents

--- a/src/Jackett.Common/Indexers/Pretome.cs
+++ b/src/Jackett.Common/Indexers/Pretome.cs
@@ -195,7 +195,7 @@ namespace Jackett.Common.Indexers
             // Get result from redirect
             await FollowIfRedirect(result, LoginUrl, null, loginCookies);
 
-            await ConfigureIfOK(loginCookies, result.Content != null && result.Content.Contains("logout.php"), () =>
+            await ConfigureIfOK(loginCookies, result.ContentString != null && result.ContentString.Contains("logout.php"), () =>
             {
                 CookieHeader = string.Empty;
                 throw new ExceptionWithConfigData("Failed", configData);
@@ -280,7 +280,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(response.Content);
+                var dom = parser.ParseDocument(response.ContentString);
                 var rows = dom.QuerySelectorAll("table > tbody > tr.browse");
                 foreach (var row in rows)
                 {
@@ -328,7 +328,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
             return releases;
         }

--- a/src/Jackett.Common/Indexers/Rarbg.cs
+++ b/src/Jackett.Common/Indexers/Rarbg.cs
@@ -128,7 +128,7 @@ namespace Jackett.Common.Indexers
                 var tokenUrl = ApiEndpoint + "?" + queryCollection.GetQueryString();
 
                 var result = await RequestStringWithCookiesAndRetry(tokenUrl);
-                var json = JObject.Parse(result.Content);
+                var json = JObject.Parse(result.ContentString);
                 token = json.Value<string>("token");
                 lastTokenFetch = DateTime.Now;
             }
@@ -199,7 +199,7 @@ namespace Jackett.Common.Indexers
 
             try
             {
-                var jsonContent = JObject.Parse(response.Content);
+                var jsonContent = JObject.Parse(response.ContentString);
 
                 var errorCode = jsonContent.Value<int>("error_code");
                 if (errorCode == 20) // no results found
@@ -274,7 +274,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
 
             return releases;
@@ -285,7 +285,7 @@ namespace Jackett.Common.Indexers
             // build download link from info redirect link
             var slink = link.ToString();
             var response = await RequestStringWithCookies(slink);
-            if (!response.IsRedirect && response.Content.Contains("Invalid token."))
+            if (!response.IsRedirect && response.ContentString.Contains("Invalid token."))
             {
                 // get new token
                 token = null;

--- a/src/Jackett.Common/Indexers/RevolutionTT.cs
+++ b/src/Jackett.Common/Indexers/RevolutionTT.cs
@@ -195,10 +195,10 @@ namespace Jackett.Common.Indexers
             var homePageLoad = await RequestLoginAndFollowRedirect(LandingPageURL, new Dictionary<string, string> { }, null, true, null, SiteLink);
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, homePageLoad.Cookies, true, null, LandingPageURL);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("/logout.php"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("/logout.php"), () =>
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(result.Content);
+                var dom = parser.ParseDocument(result.ContentString);
                 var errorMessage = dom.QuerySelector(".error").TextContent.Trim();
                 throw new ExceptionWithConfigData(errorMessage, configData);
             });
@@ -210,7 +210,7 @@ namespace Jackett.Common.Indexers
                 { "feed", "dl" }
             };
                 var rssPage = await PostDataWithCookies(GetRSSKeyUrl, rssParams, result.Cookies);
-                var match = Regex.Match(rssPage.Content, "(?<=passkey\\=)([a-zA-z0-9]*)");
+                var match = Regex.Match(rssPage.ContentString, "(?<=passkey\\=)([a-zA-z0-9]*)");
                 configData.RSSKey.Value = match.Success ? match.Value : string.Empty;
                 if (string.IsNullOrWhiteSpace(configData.RSSKey.Value))
                     throw new Exception("Failed to get RSS Key");
@@ -235,7 +235,7 @@ namespace Jackett.Common.Indexers
             if (string.IsNullOrWhiteSpace(searchString))
             {
                 var rssPage = await RequestStringWithCookiesAndRetry(RSSUrl + configData.RSSKey.Value);
-                var rssDoc = XDocument.Parse(rssPage.Content);
+                var rssDoc = XDocument.Parse(rssPage.ContentString);
 
                 foreach (var item in rssDoc.Descendants("item"))
                 {
@@ -318,7 +318,7 @@ namespace Jackett.Common.Indexers
                 try
                 {
                     var parser = new HtmlParser();
-                    var dom = parser.ParseDocument(results.Content);
+                    var dom = parser.ParseDocument(results.ContentString);
                     var rows = dom.QuerySelectorAll("#torrents-table > tbody > tr");
 
                     foreach (var row in rows.Skip(1))
@@ -365,7 +365,7 @@ namespace Jackett.Common.Indexers
                 }
                 catch (Exception ex)
                 {
-                    OnParseError(results.Content, ex);
+                    OnParseError(results.ContentString, ex);
                 }
             }
 

--- a/src/Jackett.Common/Indexers/SceneHD.cs
+++ b/src/Jackett.Common/Indexers/SceneHD.cs
@@ -114,7 +114,7 @@ namespace Jackett.Common.Indexers
 
             try
             {
-                var jsonContent = JArray.Parse(response.Content);
+                var jsonContent = JArray.Parse(response.ContentString);
                 var sitelink = new Uri(SiteLink);
 
                 foreach (var item in jsonContent)
@@ -159,7 +159,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/SceneTime.cs
+++ b/src/Jackett.Common/Indexers/SceneTime.cs
@@ -108,7 +108,7 @@ namespace Jackett.Common.Indexers
         {
             var loginPage = await RequestStringWithCookies(StartPageUrl, string.Empty);
             var parser = new HtmlParser();
-            var dom = parser.ParseDocument(loginPage.Content);
+            var dom = parser.ParseDocument(loginPage.ContentString);
             var recaptcha = dom.QuerySelector(".g-recaptcha");
             if (recaptcha != null)
             {
@@ -161,10 +161,10 @@ namespace Jackett.Common.Indexers
             }
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, LoginUrl);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("logout.php"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("logout.php"), () =>
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(result.Content);
+                var dom = parser.ParseDocument(result.ContentString);
                 var errorMessage = dom.QuerySelector("td.text").TextContent.Trim();
                 throw new ExceptionWithConfigData(errorMessage, configData);
             });
@@ -194,7 +194,7 @@ namespace Jackett.Common.Indexers
             var searchUrl = SearchUrl + "?" + qParams.GetQueryString();
 
             var results = await RequestStringWithCookies(searchUrl);
-            var releases = ParseResponse(query, results.Content);
+            var releases = ParseResponse(query, results.ContentString);
 
             return releases;
         }

--- a/src/Jackett.Common/Indexers/Shazbat.cs
+++ b/src/Jackett.Common/Indexers/Shazbat.cs
@@ -62,11 +62,11 @@ namespace Jackett.Common.Indexers
 
             // Get cookie
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, LoginUrl);
-            await ConfigureIfOK(result.Cookies, result.Content?.Contains("glyphicon-log-out") == true,
+            await ConfigureIfOK(result.Cookies, result.ContentString?.Contains("glyphicon-log-out") == true,
                                 () => throw new ExceptionWithConfigData("The username and password entered do not match.", configData));
             var rssProfile = await RequestStringWithCookiesAndRetry(RSSProfile);
             var parser = new HtmlParser();
-            var rssDom = parser.ParseDocument(rssProfile.Content);
+            var rssDom = parser.ParseDocument(rssProfile.ContentString);
             configData.RSSKey.Value = rssDom.QuerySelector(".col-sm-9:nth-of-type(1)").TextContent.Trim();
             if (string.IsNullOrWhiteSpace(configData.RSSKey.Value))
                 throw new ExceptionWithConfigData("Failed to find RSS key.", configData);
@@ -89,7 +89,7 @@ namespace Jackett.Common.Indexers
                 results = await PostDataWithCookiesAndRetry(SearchUrl, pairs, null, TorrentsUrl);
                 results = await ReloginIfNecessary(results);
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(results.Content);
+                var dom = parser.ParseDocument(results.ContentString);
                 var shows = dom.QuerySelectorAll("div.show[data-id]");
                 foreach (var show in shows)
                 {
@@ -107,7 +107,7 @@ namespace Jackett.Common.Indexers
                     results = await RequestStringWithCookies(searchUrl);
                     results = await ReloginIfNecessary(results);
                     var parser = new HtmlParser();
-                    var dom = parser.ParseDocument(results.Content);
+                    var dom = parser.ParseDocument(results.ContentString);
                     var rows = dom.QuerySelectorAll(
                         string.IsNullOrWhiteSpace(queryString) ? "#torrent-table tr" : "table tr");
                     var globalFreeleech =
@@ -157,7 +157,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
             foreach (var release in releases)
                 release.Category = release.Title.Contains("1080p") || release.Title.Contains("720p")
@@ -168,7 +168,7 @@ namespace Jackett.Common.Indexers
 
         private async Task<WebClientStringResult> ReloginIfNecessary(WebClientStringResult response)
         {
-            if (response.Content.Contains("onclick=\"document.location='logout'\""))
+            if (response.ContentString.Contains("onclick=\"document.location='logout'\""))
                 return response;
 
             await ApplyConfiguration(null);

--- a/src/Jackett.Common/Indexers/ShowRSS.cs
+++ b/src/Jackett.Common/Indexers/ShowRSS.cs
@@ -66,7 +66,7 @@ namespace Jackett.Common.Indexers
 
             try
             {
-                xmlDoc.LoadXml(result.Content);
+                xmlDoc.LoadXml(result.ContentString);
                 ReleaseInfo release;
                 string serie_title;
 
@@ -107,7 +107,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(result.Content, ex);
+                OnParseError(result.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/SolidTorrents.cs
+++ b/src/Jackett.Common/Indexers/SolidTorrents.cs
@@ -77,7 +77,7 @@ namespace Jackett.Common.Indexers
         {
             try
             {
-                var json = JsonConvert.DeserializeObject<dynamic>(result.Content);
+                var json = JsonConvert.DeserializeObject<dynamic>(result.ContentString);
                 if (!(json is JObject) || !(json["results"] is JArray) || json["results"] == null)
                     throw new Exception("Server error");
                 return (JArray)json["results"];
@@ -85,7 +85,7 @@ namespace Jackett.Common.Indexers
             catch (Exception e)
             {
                 logger.Error("CheckResponse() Error: ", e.Message);
-                throw new ExceptionWithConfigData(result.Content, ConfigData);
+                throw new ExceptionWithConfigData(result.ContentString, ConfigData);
             }
         }
 

--- a/src/Jackett.Common/Indexers/SpeedCD.cs
+++ b/src/Jackett.Common/Indexers/SpeedCD.cs
@@ -96,10 +96,10 @@ namespace Jackett.Common.Indexers
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, SiteLink);
 
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("/browse.php"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("/browse.php"), () =>
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(result.Content);
+                var dom = parser.ParseDocument(result.ContentString);
                 var errorMessage = dom.Text();
                 if (errorMessage.Contains("Wrong Captcha!"))
                     errorMessage = "Captcha requiered due to a failed login attempt. Login via a browser to whitelist your IP and then reconfigure jackett.";
@@ -136,7 +136,7 @@ namespace Jackett.Common.Indexers
             }
 
             var response = await RequestStringWithCookiesAndRetry(urlSearch);
-            if (!response.Content.Contains("/logout.php"))
+            if (!response.ContentString.Contains("/logout.php"))
             {
                 //Cookie appears to expire after a period of time or logging in to the site via browser
                 await DoLogin();
@@ -146,7 +146,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(response.Content);
+                var dom = parser.ParseDocument(response.ContentString);
                 var rows = dom.QuerySelectorAll("div[id='torrentTable'] > div[class^='box torrentBox'] > div[class='boxContent'] > table > tbody > tr");
 
                 foreach (var row in rows)
@@ -193,7 +193,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
             return releases;
         }

--- a/src/Jackett.Common/Indexers/Superbits.cs
+++ b/src/Jackett.Common/Indexers/Superbits.cs
@@ -128,8 +128,8 @@ namespace Jackett.Common.Indexers
 
             try
             {
-                //var json = JArray.Parse(results.Content);
-                dynamic json = JsonConvert.DeserializeObject<dynamic>(results.Content);
+                //var json = JArray.Parse(results.ContentString);
+                dynamic json = JsonConvert.DeserializeObject<dynamic>(results.ContentString);
                 foreach (var row in json ?? System.Linq.Enumerable.Empty<dynamic>())
                 {
                     var release = new ReleaseInfo();
@@ -201,7 +201,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/TVVault.cs
+++ b/src/Jackett.Common/Indexers/TVVault.cs
@@ -58,8 +58,8 @@ namespace Jackett.Common.Indexers
             };
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, LoginUrl, true);
-            await ConfigureIfOK(result.Cookies, result.Content?.Contains("logout.php") == true,
-                                () => throw new ExceptionWithConfigData(result.Content, configData));
+            await ConfigureIfOK(result.Cookies, result.ContentString?.Contains("logout.php") == true,
+                                () => throw new ExceptionWithConfigData(result.ContentString, configData));
             return IndexerConfigurationStatus.RequiresTesting;
         }
 
@@ -92,7 +92,7 @@ namespace Jackett.Common.Indexers
                 var RowsSelector = "table.torrent_table > tbody > tr.torrent";
 
                 var SearchResultParser = new HtmlParser();
-                var SearchResultDocument = SearchResultParser.ParseDocument(results.Content);
+                var SearchResultDocument = SearchResultParser.ParseDocument(results.ContentString);
                 var Rows = SearchResultDocument.QuerySelectorAll(RowsSelector);
                 foreach (var Row in Rows)
                 {
@@ -142,7 +142,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/TVstore.cs
+++ b/src/Jackett.Common/Indexers/TVstore.cs
@@ -68,7 +68,7 @@ namespace Jackett.Common.Indexers
             };
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, loginPage.Cookies, true, referer: SiteLink);
-            await ConfigureIfOK(result.Cookies, result.Content?.Contains("Főoldal") == true, () => throw new ExceptionWithConfigData(
+            await ConfigureIfOK(result.Cookies, result.ContentString?.Contains("Főoldal") == true, () => throw new ExceptionWithConfigData(
                 $"Error while trying to login with: Username: {configData.Username.Value} Password: {configData.Password.Value}", configData));
 
             return IndexerConfigurationStatus.RequiresTesting;
@@ -118,7 +118,7 @@ namespace Jackett.Common.Indexers
             var releases = new List<ReleaseInfo>();
             try
             {
-                var content = results.Content;
+                var content = results.ContentString;
                 /* Content Looks like this
                  * 2\15\2\1\1727\207244\1x08 \[WebDL-720p - Eng - AJP69]\gb\2018-03-09 08:11:53\akció, kaland, sci-fi \0\0\1\191170047\1\0\Anonymous\50\0\0\\0\4\0\174\0\
                  * 1\ 0\0\1\1727\207243\1x08 \[WebDL-1080p - Eng - AJP69]\gb\2018-03-09 08:11:49\akció, kaland, sci-fi \0\0\1\305729738\1\0\Anonymous\50\0\0\\0\8\0\102\0\0\0\0\1\\\
@@ -155,7 +155,7 @@ namespace Jackett.Common.Indexers
                     var unixTimestamp = (int)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
 
                     var fileinfoURL = SearchUrl + "?func=getToggle&id=" + parameters[torrent_id] + "&w=F&pg=0&now=" + unixTimestamp;
-                    var fileinfo = (await RequestStringWithCookiesAndRetry(fileinfoURL)).Content;
+                    var fileinfo = (await RequestStringWithCookiesAndRetry(fileinfoURL)).ContentString;
                     release.Link = new Uri(DownloadUrl + "?id=" + parameters[torrent_id]);
                     release.Guid = release.Link;
                     release.Comments = release.Link;
@@ -194,7 +194,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;
@@ -218,7 +218,7 @@ namespace Jackett.Common.Indexers
             var result = await RequestStringWithCookiesAndRetry(BrowseUrl);
 
             var parser = new HtmlParser();
-            var dom = parser.ParseDocument(result.Content);
+            var dom = parser.ParseDocument(result.ContentString);
             var scripts = dom.QuerySelectorAll("script");
             foreach (var script in scripts)
             {
@@ -329,7 +329,7 @@ namespace Jackett.Common.Indexers
             results = await RequestStringWithCookiesAndRetry(exactSearchURL);
 
             /* Parse page Information from result */
-            var content = results.Content;
+            var content = results.ContentString;
             var splits = content.Split('\\');
             var max_found = int.Parse(splits[0]);
             var torrent_per_page = int.Parse(splits[1]);

--- a/src/Jackett.Common/Indexers/TorrentBytes.cs
+++ b/src/Jackett.Common/Indexers/TorrentBytes.cs
@@ -89,12 +89,12 @@ namespace Jackett.Common.Indexers
             var loginPage = await RequestStringWithCookies(SiteLink, string.Empty);
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, loginPage.Cookies, true, SiteLink, SiteLink);
             await ConfigureIfOK(
-                result.Cookies, result.Content?.Contains("my.php") == true, () =>
+                result.Cookies, result.ContentString?.Contains("my.php") == true, () =>
                 {
                     var parser = new HtmlParser();
-                    var dom = parser.ParseDocument(result.Content);
+                    var dom = parser.ParseDocument(result.ContentString);
                     var messageEl = dom.QuerySelector("td.embedded");
-                    var errorMessage = messageEl != null ? messageEl.TextContent : result.Content;
+                    var errorMessage = messageEl != null ? messageEl.TextContent : result.ContentString;
                     throw new ExceptionWithConfigData(errorMessage, configData);
                 });
             return IndexerConfigurationStatus.RequiresTesting;
@@ -133,7 +133,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(response.Content);
+                var dom = parser.ParseDocument(response.ContentString);
                 var rows = dom.QuerySelectorAll("table > tbody:has(tr > td.colhead) > tr:not(:has(td.colhead))");
                 foreach (var row in rows)
                 {
@@ -182,7 +182,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/TorrentDay.cs
+++ b/src/Jackett.Common/Indexers/TorrentDay.cs
@@ -127,7 +127,7 @@ namespace Jackett.Common.Indexers
                 loginPage = await RequestStringWithCookies(loginPage.RedirectingTo, string.Empty);
 
             var parser = new HtmlParser();
-            var dom = parser.ParseDocument(loginPage.Content);
+            var dom = parser.ParseDocument(loginPage.ContentString);
             var result = configData;
 
             //result.CookieHeader.Value = loginPage.Cookies;
@@ -168,10 +168,10 @@ namespace Jackett.Common.Indexers
             }
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, configData.CookieHeader.Value, true, null, LoginUrl);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("logout.php"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("logout.php"), () =>
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(result.Content);
+                var dom = parser.ParseDocument(result.ContentString);
                 var messageEl = dom.QuerySelector("#login");
                 foreach (var child in messageEl.QuerySelectorAll("form"))
                     child.Remove();
@@ -217,7 +217,7 @@ namespace Jackett.Common.Indexers
 
             try
             {
-                var json = JsonConvert.DeserializeObject<dynamic>(results.Content);
+                var json = JsonConvert.DeserializeObject<dynamic>(results.ContentString);
 
                 foreach (var torrent in json)
                 {
@@ -253,7 +253,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
             return releases;
         }

--- a/src/Jackett.Common/Indexers/TorrentHeaven.cs
+++ b/src/Jackett.Common/Indexers/TorrentHeaven.cs
@@ -100,7 +100,7 @@ namespace Jackett.Common.Indexers
         {
             var loginPage = await RequestStringWithCookies(IndexUrl, string.Empty);
             var parser = new HtmlParser();
-            var dom = parser.ParseDocument(loginPage.Content);
+            var dom = parser.ParseDocument(loginPage.ContentString);
             var qCaptchaImg = dom.QuerySelector("td.tablea > img");
             if (qCaptchaImg != null)
             {
@@ -130,13 +130,13 @@ namespace Jackett.Common.Indexers
             if (!string.IsNullOrWhiteSpace(configData.CaptchaText.Value))
                 pairs.Add("proofcode", configData.CaptchaText.Value);
             var result = await RequestLoginAndFollowRedirect(IndexUrl, pairs, configData.CaptchaCookie.Value, true, referer: IndexUrl, accumulateCookies: true);
-            if (result.Content == null || (!result.Content.Contains("login_complete") &&
-                                           !result.Content.Contains("index.php?strWebValue=account&strWebAction=logout")))
+            if (result.ContentString == null || (!result.ContentString.Contains("login_complete") &&
+                                           !result.ContentString.Contains("index.php?strWebValue=account&strWebAction=logout")))
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(result.Content);
+                var dom = parser.ParseDocument(result.ContentString);
                 var errorMessageEl = dom.QuerySelector("table > tbody > tr > td[valign=top][width=100%]");
-                var errorMessage = errorMessageEl != null ? errorMessageEl.InnerHtml : result.Content;
+                var errorMessage = errorMessageEl != null ? errorMessageEl.InnerHtml : result.ContentString;
                 throw new ExceptionWithConfigData(errorMessage, configData);
             }
 
@@ -188,7 +188,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(response.Content);
+                var dom = parser.ParseDocument(response.ContentString);
                 var rows = dom.QuerySelectorAll("table.torrenttable > tbody > tr");
                 foreach (var row in rows.Skip(1))
                 {
@@ -240,7 +240,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/TorrentLeech.cs
+++ b/src/Jackett.Common/Indexers/TorrentLeech.cs
@@ -101,7 +101,7 @@ namespace Jackett.Common.Indexers
         {
             var loginPage = await RequestStringWithCookies(LoginUrl, string.Empty);
             var parser = new HtmlParser();
-            var dom = parser.ParseDocument(loginPage.Content);
+            var dom = parser.ParseDocument(loginPage.ContentString);
             var captcha = dom.QuerySelector(".g-recaptcha");
             if (captcha != null)
             {
@@ -159,10 +159,10 @@ namespace Jackett.Common.Indexers
             };
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, LoginUrl);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("/user/account/logout"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("/user/account/logout"), () =>
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(result.Content);
+                var dom = parser.ParseDocument(result.ContentString);
                 var errorMessage = dom.QuerySelector("p.text-danger:contains(\"Error:\")").TextContent.Trim();
                 throw new ExceptionWithConfigData(errorMessage, configData);
             });
@@ -204,7 +204,7 @@ namespace Jackett.Common.Indexers
 
             var results = await RequestStringWithCookiesAndRetry(searchUrl);
 
-            if (results.Content.Contains("/user/account/login"))
+            if (results.ContentString.Contains("/user/account/login"))
             {
                 //Cookie appears to expire after a period of time or logging in to the site via browser
                 await DoLogin();
@@ -213,7 +213,7 @@ namespace Jackett.Common.Indexers
 
             try
             {
-                dynamic jsonObj = JsonConvert.DeserializeObject(results.Content);
+                dynamic jsonObj = JsonConvert.DeserializeObject(results.ContentString);
 
                 foreach (var torrent in jsonObj.torrentList)
                 {
@@ -256,7 +256,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/TorrentNetwork.cs
+++ b/src/Jackett.Common/Indexers/TorrentNetwork.cs
@@ -122,9 +122,9 @@ namespace Jackett.Common.Indexers
         {
             var jsonData = JsonConvert.SerializeObject(data);
             var result = await PostDataWithCookies(APIUrl + endpoint, null, null, SiteLink, APIHeaders, jsonData);
-            if (!result.Content.StartsWith("{")) // not JSON => error
-                throw new ExceptionWithConfigData(result.Content, configData);
-            dynamic json = JsonConvert.DeserializeObject<dynamic>(result.Content);
+            if (!result.ContentString.StartsWith("{")) // not JSON => error
+                throw new ExceptionWithConfigData(result.ContentString, configData);
+            dynamic json = JsonConvert.DeserializeObject<dynamic>(result.ContentString);
             return json;
         }
 

--- a/src/Jackett.Common/Indexers/TorrentSyndikat.cs
+++ b/src/Jackett.Common/Indexers/TorrentSyndikat.cs
@@ -109,7 +109,7 @@ namespace Jackett.Common.Indexers
             CookieHeader = "";
 
             var result1 = await RequestStringWithCookies(CaptchaUrl);
-            var json1 = JObject.Parse(result1.Content);
+            var json1 = JObject.Parse(result1.ContentString);
             var captchaSelection = json1["images"][0]["hash"];
 
             var pairs = new Dictionary<string, string> {
@@ -121,8 +121,8 @@ namespace Jackett.Common.Indexers
 
             var result2 = await RequestLoginAndFollowRedirect(LoginUrl, pairs, result1.Cookies, true, null, null, true);
 
-            await ConfigureIfOK(result2.Cookies, result2.Content.Contains("/logout.php"),
-                () => throw new ExceptionWithConfigData(result2.Content, configData));
+            await ConfigureIfOK(result2.Cookies, result2.ContentString.Contains("/logout.php"),
+                () => throw new ExceptionWithConfigData(result2.ContentString, configData));
             return IndexerConfigurationStatus.RequiresTesting;
         }
 
@@ -172,7 +172,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(results.Content);
+                var dom = parser.ParseDocument(results.ContentString);
                 var rows = dom.QuerySelectorAll("table.torrent_table > tbody > tr");
                 var globalFreeleech = dom.QuerySelector("legend:contains(\"Freeleech\")+ul > li > b:contains(\"Freeleech\")") != null;
                 foreach (var row in rows.Skip(1))
@@ -239,7 +239,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/Torrentech.cs
+++ b/src/Jackett.Common/Indexers/Torrentech.cs
@@ -60,9 +60,9 @@ namespace Jackett.Common.Indexers
             };
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, LoginUrl, true);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("Logged in as: "), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("Logged in as: "), () =>
             {
-                var errorMessage = result.Content;
+                var errorMessage = result.ContentString;
                 throw new ExceptionWithConfigData(errorMessage, configData);
             });
             return IndexerConfigurationStatus.RequiresTesting;
@@ -106,7 +106,7 @@ namespace Jackett.Common.Indexers
                 var RowsSelector = "div.borderwrap:has(div.maintitle) > table > tbody > tr:has(a[href*=\"index.php?showtopic=\"])";
 
                 var SearchResultParser = new HtmlParser();
-                var SearchResultDocument = SearchResultParser.ParseDocument(results.Content);
+                var SearchResultDocument = SearchResultParser.ParseDocument(results.ContentString);
                 var Rows = SearchResultDocument.QuerySelectorAll(RowsSelector);
                 foreach (var Row in Rows)
                 {
@@ -190,7 +190,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;
@@ -199,7 +199,7 @@ namespace Jackett.Common.Indexers
         public override async Task<byte[]> Download(Uri link)
         {
             var response = await RequestStringWithCookies(link.ToString());
-            var results = response.Content;
+            var results = response.ContentString;
             var SearchResultParser = new HtmlParser();
             var SearchResultDocument = SearchResultParser.ParseDocument(results);
             var downloadSelector = "a[title=\"Download attachment\"]";

--- a/src/Jackett.Common/Indexers/Torrentscsv.cs
+++ b/src/Jackett.Common/Indexers/Torrentscsv.cs
@@ -88,7 +88,7 @@ namespace Jackett.Common.Indexers
 
             try
             {
-                var jsonStart = response.Content;
+                var jsonStart = response.ContentString;
                 var jsonContent = JArray.Parse(jsonStart);
 
                 foreach (var torrent in jsonContent)
@@ -207,7 +207,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
             return releases;
         }

--- a/src/Jackett.Common/Indexers/Torrentseeds.cs
+++ b/src/Jackett.Common/Indexers/Torrentseeds.cs
@@ -104,7 +104,7 @@ namespace Jackett.Common.Indexers
             LoadValuesFromJson(configJson);
             var loginPage = await RequestStringWithCookies(TokenUrl);
             var parser = new HtmlParser();
-            var dom = parser.ParseDocument(loginPage.Content);
+            var dom = parser.ParseDocument(loginPage.ContentString);
             var token = dom.QuerySelector("form.form-horizontal > span");
             var csrf = token.Children[1].GetAttribute("value");
             var pairs = new Dictionary<string, string>
@@ -117,10 +117,10 @@ namespace Jackett.Common.Indexers
             };
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, loginPage.Cookies, true, accumulateCookies: true);
             await ConfigureIfOK(
-                result.Cookies, result.Content.Contains("/logout.php?"),
+                result.Cookies, result.ContentString.Contains("/logout.php?"),
                 () =>
                 {
-                    var errorDom = parser.ParseDocument(result.Content);
+                    var errorDom = parser.ParseDocument(result.ContentString);
                     var errorMessage = errorDom.QuerySelector("td.colhead2").InnerHtml;
                     throw new ExceptionWithConfigData(errorMessage, configData);
                 });
@@ -146,7 +146,7 @@ namespace Jackett.Common.Indexers
                 queryCollection.Add("cat[" + cat + "]", "1");
             searchUrl += "?" + queryCollection.GetQueryString();
             var response = await RequestStringWithCookiesAndRetry(searchUrl);
-            var results = response.Content;
+            var results = response.ContentString;
             if (!results.Contains("/logout.php?"))
             {
                 await ApplyConfiguration(null);
@@ -158,7 +158,7 @@ namespace Jackett.Common.Indexers
                 // handle single entries
                 var qCommentLink = new Uri(response.RedirectingTo);
                 await FollowIfRedirect(response, accumulateCookies: true);
-                results = response.Content;
+                results = response.ContentString;
                 try
                 {
                     var parser = new HtmlParser();

--- a/src/Jackett.Common/Indexers/TransmitheNet.cs
+++ b/src/Jackett.Common/Indexers/TransmitheNet.cs
@@ -61,12 +61,12 @@ namespace Jackett.Common.Indexers
             CookieHeader = string.Empty;
             var response = await RequestLoginAndFollowRedirect(LoginUrl, pairs, CookieHeader, true, null, LoginUrl);
 
-            await ConfigureIfOK(response.Cookies, response.Content != null && response.Content.Contains("logout.php"), () =>
+            await ConfigureIfOK(response.Cookies, response.ContentString != null && response.ContentString.Contains("logout.php"), () =>
             {
                 var parser = new HtmlParser();
-                var document = parser.ParseDocument(response.Content);
+                var document = parser.ParseDocument(response.ContentString);
                 var messageEl = document.QuerySelector("form > span[class='warning']");
-                var errorMessage = response.Content;
+                var errorMessage = response.ContentString;
                 if (messageEl != null)
                     errorMessage = messageEl.TextContent.Trim();
                 throw new ExceptionWithConfigData(errorMessage, configData);
@@ -76,7 +76,7 @@ namespace Jackett.Common.Indexers
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {
             var loggedInCheck = await RequestStringWithCookies(SearchUrl);
-            if (!loggedInCheck.Content.Contains("logout.php"))
+            if (!loggedInCheck.ContentString.Contains("logout.php"))
             {
                 //Cookie appears to expire after a period of time or logging in to the site via browser
                 await DoLogin();
@@ -92,7 +92,7 @@ namespace Jackett.Common.Indexers
             //}
 
             var response = await RequestStringWithCookiesAndRetry(Url);
-            var releases = ParseResponse(response.Content);
+            var releases = ParseResponse(response.ContentString);
 
             return releases;
         }

--- a/src/Jackett.Common/Indexers/XSpeeds.cs
+++ b/src/Jackett.Common/Indexers/XSpeeds.cs
@@ -137,7 +137,7 @@ namespace Jackett.Common.Indexers
         {
             var loginPage = await RequestStringWithCookies(LandingUrl);
             var parser = new HtmlParser();
-            var dom = parser.ParseDocument(loginPage.Content);
+            var dom = parser.ParseDocument(loginPage.ContentString);
             var qCaptchaImg = dom.QuerySelector("img#regimage");
             if (qCaptchaImg != null)
             {
@@ -178,11 +178,11 @@ namespace Jackett.Common.Indexers
 
             //var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, SiteLink, true);
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, SearchUrl, LandingUrl, true);
-            await ConfigureIfOK(result.Cookies, result.Content?.Contains("logout.php") == true,
+            await ConfigureIfOK(result.Cookies, result.ContentString?.Contains("logout.php") == true,
                 () =>
                 {
                     var parser = new HtmlParser();
-                    var dom = parser.ParseDocument(result.Content);
+                    var dom = parser.ParseDocument(result.ContentString);
                     var errorMessage = dom.QuerySelector(".left_side table:nth-of-type(1) tr:nth-of-type(2)")?.TextContent.Trim().Replace("\n\t", " ");
                     if (string.IsNullOrWhiteSpace(errorMessage))
                         errorMessage = dom.QuerySelector("div.notification-body").TextContent.Trim().Replace("\n\t", " ");
@@ -199,7 +199,7 @@ namespace Jackett.Common.Indexers
                                     {"showrows", "50"}
                                 };
                 var rssPage = await PostDataWithCookies(GetRSSKeyUrl, rssParams, result.Cookies);
-                var match = Regex.Match(rssPage.Content, "(?<=secret_key\\=)([a-zA-z0-9]*)");
+                var match = Regex.Match(rssPage.ContentString, "(?<=secret_key\\=)([a-zA-z0-9]*)");
                 configData.RSSKey.Value = match.Success ? match.Value : string.Empty;
                 if (string.IsNullOrWhiteSpace(configData.RSSKey.Value))
                     throw new Exception("Failed to get RSS Key");
@@ -229,12 +229,12 @@ namespace Jackett.Common.Indexers
                 var rssPage = await RequestStringWithCookiesAndRetry(string.Format(RSSUrl, configData.RSSKey.Value));
                 try
                 {
-                    if (rssPage.Content.EndsWith("\0"))
+                    if (rssPage.ContentString.EndsWith("\0"))
                     {
-                        rssPage.Content = rssPage.Content.Substring(0, rssPage.Content.Length - 1);
+                        rssPage.ContentString = rssPage.ContentString.Substring(0, rssPage.ContentString.Length - 1);
                     }
-                    rssPage.Content = RemoveInvalidXmlChars(rssPage.Content);
-                    var rssDoc = XDocument.Parse(rssPage.Content);
+                    rssPage.ContentString = RemoveInvalidXmlChars(rssPage.ContentString);
+                    var rssDoc = XDocument.Parse(rssPage.ContentString);
 
                     foreach (var item in rssDoc.Descendants("item"))
                     {
@@ -274,7 +274,7 @@ namespace Jackett.Common.Indexers
                 catch (Exception ex)
                 {
                     logger.Error("XSpeeds: Error while parsing the RSS feed:");
-                    logger.Error(rssPage.Content);
+                    logger.Error(rssPage.ContentString);
                     throw ex;
                 }
             }
@@ -318,7 +318,7 @@ namespace Jackett.Common.Indexers
             try
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(searchPage.Content);
+                var dom = parser.ParseDocument(searchPage.ContentString);
                 var rows = dom.QuerySelectorAll("table#sortabletable > tbody > tr:has(div > a[href*=\"details.php?id=\"])");
                 foreach (var row in rows)
                 {
@@ -372,7 +372,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(searchPage.Content, ex);
+                OnParseError(searchPage.ContentString, ex);
             }
             if (!CookieHeader.Trim().Equals(prevCook.Trim()))
             {

--- a/src/Jackett.Common/Indexers/Xthor.cs
+++ b/src/Jackett.Common/Indexers/Xthor.cs
@@ -485,10 +485,10 @@ namespace Jackett.Common.Indexers
             // Request our first page
             var results = await webclient.GetString(myIndexRequest);
             if (results.Status == HttpStatusCode.InternalServerError) // See issue #2110
-                throw new Exception("Internal Server Error (" + results.Content + "), probably you reached the API limits, please reduce the number of queries");
+                throw new Exception("Internal Server Error (" + results.ContentString + "), probably you reached the API limits, please reduce the number of queries");
 
             // Return results from tracker
-            return results.Content;
+            return results.ContentString;
         }
 
         /// <summary>

--- a/src/Jackett.Common/Indexers/digitalcore.cs
+++ b/src/Jackett.Common/Indexers/digitalcore.cs
@@ -136,8 +136,8 @@ namespace Jackett.Common.Indexers
 
             try
             {
-                //var json = JArray.Parse(results.Content);
-                dynamic json = JsonConvert.DeserializeObject<dynamic>(results.Content);
+                //var json = JArray.Parse(results.ContentString);
+                dynamic json = JsonConvert.DeserializeObject<dynamic>(results.ContentString);
                 foreach (var row in json ?? System.Linq.Enumerable.Empty<dynamic>())
                 {
                     var release = new ReleaseInfo();
@@ -211,7 +211,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/myAmity.cs
+++ b/src/Jackett.Common/Indexers/myAmity.cs
@@ -77,10 +77,10 @@ namespace Jackett.Common.Indexers
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, null, true, null, LoginUrl, true);
 
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Cookies.Contains("pass=") && !result.Cookies.Contains("deleted"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.Cookies.Contains("pass=") && !result.Cookies.Contains("deleted"), () =>
             {
                 var parser = new HtmlParser();
-                var dom = parser.ParseDocument(result.Content);
+                var dom = parser.ParseDocument(result.ContentString);
                 var errorMessage = dom.QuerySelector("div.myFrame-content").InnerHtml;
                 throw new ExceptionWithConfigData(errorMessage, configData);
             });
@@ -125,7 +125,7 @@ namespace Jackett.Common.Indexers
                 response = await RequestStringWithCookies(searchUrl);
             }
 
-            var results = response.Content;
+            var results = response.ContentString;
             try
             {
                 var parser = new HtmlParser();

--- a/src/Jackett.Common/Indexers/pornolab.cs
+++ b/src/Jackett.Common/Indexers/pornolab.cs
@@ -185,7 +185,7 @@ namespace Jackett.Common.Indexers
             configData.CookieHeader.Value = null;
             var response = await RequestStringWithCookies(LoginUrl);
             var LoginResultParser = new HtmlParser();
-            var LoginResultDocument = LoginResultParser.ParseDocument(response.Content);
+            var LoginResultDocument = LoginResultParser.ParseDocument(response.ContentString);
             var captchaimg = LoginResultDocument.QuerySelector("img[src*=\"/captcha/\"]");
             if (captchaimg != null)
             {
@@ -226,12 +226,12 @@ namespace Jackett.Common.Indexers
             }
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, CookieHeader, true, null, LoginUrl, true);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("Вы зашли как:"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("Вы зашли как:"), () =>
             {
-                logger.Debug(result.Content);
+                logger.Debug(result.ContentString);
                 var errorMessage = "Unknown error message, please report";
                 var LoginResultParser = new HtmlParser();
-                var LoginResultDocument = LoginResultParser.ParseDocument(result.Content);
+                var LoginResultDocument = LoginResultParser.ParseDocument(result.ContentString);
                 var errormsg = LoginResultDocument.QuerySelector("h4[class=\"warnColor1 tCenter mrg_16\"]");
                 if (errormsg != null)
                     errorMessage = errormsg.TextContent;
@@ -261,7 +261,7 @@ namespace Jackett.Common.Indexers
 
             var searchUrl = SearchUrl + "?" + queryCollection.GetQueryString();
             var results = await RequestStringWithCookies(searchUrl);
-            if (!results.Content.Contains("Вы зашли как:"))
+            if (!results.ContentString.Contains("Вы зашли как:"))
             {
                 // re login
                 await ApplyConfiguration(null);
@@ -272,7 +272,7 @@ namespace Jackett.Common.Indexers
                 var RowsSelector = "table#tor-tbl > tbody > tr";
 
                 var SearchResultParser = new HtmlParser();
-                var SearchResultDocument = SearchResultParser.ParseDocument(results.Content);
+                var SearchResultDocument = SearchResultParser.ParseDocument(results.ContentString);
                 var Rows = SearchResultDocument.QuerySelectorAll(RowsSelector);
                 foreach (var Row in Rows)
                 {
@@ -332,7 +332,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;
@@ -343,7 +343,7 @@ namespace Jackett.Common.Indexers
         {
             var downloadlink = link;
             var response = await RequestStringWithCookies(link.ToString());
-            var results = response.Content;
+            var results = response.ContentString;
             var SearchResultParser = new HtmlParser();
             var SearchResultDocument = SearchResultParser.ParseDocument(results);
             var downloadSelector = "a[class=\"dl-stub dl-link\"]";

--- a/src/Jackett.Common/Indexers/rutracker.cs
+++ b/src/Jackett.Common/Indexers/rutracker.cs
@@ -1442,7 +1442,7 @@ namespace Jackett.Common.Indexers
             configData.CookieHeader.Value = null;
             var response = await RequestStringWithCookies(LoginUrl);
             var LoginResultParser = new HtmlParser();
-            var LoginResultDocument = LoginResultParser.ParseDocument(response.Content);
+            var LoginResultDocument = LoginResultParser.ParseDocument(response.ContentString);
             var captchaimg = LoginResultDocument.QuerySelector("img[src^=\"https://static.t-ru.org/captcha/\"]");
             if (captchaimg != null)
             {
@@ -1483,12 +1483,12 @@ namespace Jackett.Common.Indexers
             }
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, CookieHeader, true, null, LoginUrl, true);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("id=\"logged-in-username\""), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("id=\"logged-in-username\""), () =>
             {
-                logger.Debug(result.Content);
+                logger.Debug(result.ContentString);
                 var errorMessage = "Unknown error message, please report";
                 var LoginResultParser = new HtmlParser();
-                var LoginResultDocument = LoginResultParser.ParseDocument(result.Content);
+                var LoginResultDocument = LoginResultParser.ParseDocument(result.ContentString);
                 var errormsg = LoginResultDocument.QuerySelector("h4[class=\"warnColor1 tCenter mrg_16\"]");
                 if (errormsg != null)
                     errorMessage = errormsg.TextContent;
@@ -1522,7 +1522,7 @@ namespace Jackett.Common.Indexers
 
             var searchUrl = SearchUrl + "?" + queryCollection.GetQueryString();
             var results = await RequestStringWithCookies(searchUrl);
-            if (!results.Content.Contains("id=\"logged-in-username\""))
+            if (!results.ContentString.Contains("id=\"logged-in-username\""))
             {
                 // re login
                 await ApplyConfiguration(null);
@@ -1533,7 +1533,7 @@ namespace Jackett.Common.Indexers
                 var RowsSelector = "table#tor-tbl > tbody > tr";
 
                 var SearchResultParser = new HtmlParser();
-                var SearchResultDocument = SearchResultParser.ParseDocument(results.Content);
+                var SearchResultDocument = SearchResultParser.ParseDocument(results.ContentString);
                 var Rows = SearchResultDocument.QuerySelectorAll(RowsSelector);
                 foreach (var Row in Rows)
                 {
@@ -1625,7 +1625,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/toloka.cs
+++ b/src/Jackett.Common/Indexers/toloka.cs
@@ -191,12 +191,12 @@ namespace Jackett.Common.Indexers
             };
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, CookieHeader, true, null, LoginUrl, true);
-            await ConfigureIfOK(result.Cookies, result.Content != null && result.Content.Contains("logout=true"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("logout=true"), () =>
             {
-                logger.Debug(result.Content);
+                logger.Debug(result.ContentString);
                 var errorMessage = "Unknown error message, please report";
                 var LoginResultParser = new HtmlParser();
-                var LoginResultDocument = LoginResultParser.ParseDocument(result.Content);
+                var LoginResultDocument = LoginResultParser.ParseDocument(result.ContentString);
                 var errormsg = LoginResultDocument.QuerySelector("h4[class=\"warnColor1 tCenter mrg_16\"]");
                 if (errormsg != null)
                     errorMessage = errormsg.TextContent;
@@ -230,7 +230,7 @@ namespace Jackett.Common.Indexers
 
             var searchUrl = SearchUrl + "?" + queryCollection.GetQueryString();
             var results = await RequestStringWithCookies(searchUrl);
-            if (!results.Content.Contains("logout=true"))
+            if (!results.ContentString.Contains("logout=true"))
             {
                 // re login
                 await ApplyConfiguration(null);
@@ -241,7 +241,7 @@ namespace Jackett.Common.Indexers
                 var RowsSelector = "table.forumline > tbody > tr[class*=prow]";
 
                 var SearchResultParser = new HtmlParser();
-                var SearchResultDocument = SearchResultParser.ParseDocument(results.Content);
+                var SearchResultDocument = SearchResultParser.ParseDocument(results.ContentString);
                 var Rows = SearchResultDocument.QuerySelectorAll(RowsSelector);
                 foreach (var Row in Rows)
                 {
@@ -312,7 +312,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(results.Content, ex);
+                OnParseError(results.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Indexers/yts.cs
+++ b/src/Jackett.Common/Indexers/yts.cs
@@ -98,8 +98,8 @@ namespace Jackett.Common.Indexers
             try
             {
                 // returned content might start with an html error message, remove it first
-                var jsonStart = response.Content.IndexOf('{');
-                var jsonContentStr = response.Content.Remove(0, jsonStart);
+                var jsonStart = response.ContentString.IndexOf('{');
+                var jsonContentStr = response.ContentString.Remove(0, jsonStart);
 
                 var jsonContent = JObject.Parse(jsonContentStr);
 
@@ -202,7 +202,7 @@ namespace Jackett.Common.Indexers
             }
             catch (Exception ex)
             {
-                OnParseError(response.Content, ex);
+                OnParseError(response.ContentString, ex);
             }
 
             return releases;

--- a/src/Jackett.Common/Services/ImdbResolver.cs
+++ b/src/Jackett.Common/Services/ImdbResolver.cs
@@ -37,7 +37,7 @@ namespace Jackett.Common.Services
             var request = new WebRequest(url + "/?apikey=" + apiKey + "&i=" + imdbId);
             request.Encoding = Encoding.UTF8;
             var result = await WebClient.GetString(request);
-            var movie = JsonConvert.DeserializeObject<Movie>(result.Content);
+            var movie = JsonConvert.DeserializeObject<Movie>(result.ContentString);
 
             return movie;
         }

--- a/src/Jackett.Common/Services/UpdateService.cs
+++ b/src/Jackett.Common/Services/UpdateService.cs
@@ -126,7 +126,7 @@ namespace Jackett.Common.Services
                     logger.Error("Failed to get the release list: " + response.Status);
                 }
 
-                var releases = JsonConvert.DeserializeObject<List<Release>>(response.Content);
+                var releases = JsonConvert.DeserializeObject<List<Release>>(response.ContentString);
 
                 if (!serverConfig.UpdatePrerelease)
                 {

--- a/src/Jackett.Common/Utils/Clients/WebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/WebClient.cs
@@ -152,13 +152,13 @@ namespace Jackett.Common.Utils.Clients
             if (result.Content != null)
                 decodedContent = encoding.GetString(result.Content);
 
-            stringResult.Content = decodedContent;
+            stringResult.ContentString = decodedContent;
             logger.Debug(string.Format("WebClient({0}): Returning {1} => {2}", ClientType, result.Status, (result.IsRedirect ? result.RedirectingTo + " " : "") + (decodedContent == null ? "<NULL>" : decodedContent)));
 
             if (stringResult.Headers.TryGetValue("server", out var server))
             {
                 if (server[0] == "cloudflare-nginx")
-                    stringResult.Content = BrowserUtil.DecodeCloudFlareProtectedEmailFromHTML(stringResult.Content);
+                    stringResult.ContentString = BrowserUtil.DecodeCloudFlareProtectedEmailFromHTML(stringResult.ContentString);
             }
             return stringResult;
         }

--- a/src/Jackett.Common/Utils/Clients/WebClientResult.cs
+++ b/src/Jackett.Common/Utils/Clients/WebClientResult.cs
@@ -2,6 +2,6 @@ namespace Jackett.Common.Utils.Clients
 {
     public class WebClientStringResult : BaseWebResult
     {
-        public string Content { get; set; }
+        public string ContentString { get; set; }
     }
 }

--- a/src/Jackett.Server/Helper.cs
+++ b/src/Jackett.Server/Helper.cs
@@ -71,18 +71,18 @@ namespace Jackett.Server
         {
             Mapper.Initialize(cfg =>
             {
-                cfg.CreateMap<WebClientByteResult, WebClientStringResult>().ForMember(x => x.Content, opt => opt.Ignore()).AfterMap((be, str) =>
+                cfg.CreateMap<WebClientByteResult, WebClientStringResult>().ForMember(x => x.ContentString, opt => opt.Ignore()).AfterMap((be, str) =>
                 {
                     var encoding = be.Request.Encoding ?? Encoding.UTF8;
-                    str.Content = encoding.GetString(be.Content);
+                    str.ContentString = encoding.GetString(be.Content);
                 });
 
                 cfg.CreateMap<WebClientStringResult, WebClientByteResult>().ForMember(x => x.Content, opt => opt.Ignore()).AfterMap((str, be) =>
                 {
-                    if (!string.IsNullOrEmpty(str.Content))
+                    if (!string.IsNullOrEmpty(str.ContentString))
                     {
                         var encoding = str.Request.Encoding ?? Encoding.UTF8;
-                        be.Content = encoding.GetBytes(str.Content);
+                        be.Content = encoding.GetBytes(str.ContentString);
                     }
                 });
 


### PR DESCRIPTION
This PR renames `WebClientStringResult.Content` to `WebClientStringResult.ContentString` for preparation of merging the WebResult classes into a single class.