### PR TITLE
core: rename WebClientByteResult.Content to WebClientByteResult.ContentBytes

### DIFF
--- a/src/Jackett.Common/Indexers/BakaBT.cs
+++ b/src/Jackett.Common/Indexers/BakaBT.cs
@@ -205,7 +205,7 @@ namespace Jackett.Common.Indexers
                 throw new Exception("Unable to find download link.");
 
             var response = await RequestBytesWithCookies(SiteLink + downloadLink);
-            return response.Content;
+            return response.ContentBytes;
         }
     }
 }

--- a/src/Jackett.Common/Indexers/BaseIndexer.cs
+++ b/src/Jackett.Common/Indexers/BaseIndexer.cs
@@ -393,12 +393,12 @@ namespace Jackett.Common.Indexers
             if (response.Status != System.Net.HttpStatusCode.OK && response.Status != System.Net.HttpStatusCode.Continue && response.Status != System.Net.HttpStatusCode.PartialContent)
             {
                 logger.Error("Failed download cookies: " + CookieHeader);
-                if (response.Content != null)
-                    logger.Error("Failed download response:\n" + Encoding.UTF8.GetString(response.Content));
+                if (response.ContentBytes != null)
+                    logger.Error("Failed download response:\n" + Encoding.UTF8.GetString(response.ContentBytes));
                 throw new Exception($"Remote server returned {response.Status.ToString()}" + (response.IsRedirect ? " => " + response.RedirectingTo : ""));
             }
 
-            return response.Content;
+            return response.ContentBytes;
         }
 
         protected async Task<WebClientByteResult> RequestBytesWithCookiesAndRetry(string url, string cookieOverride = null, RequestType method = RequestType.GET, string referer = null, IEnumerable<KeyValuePair<string, string>> data = null)

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -913,7 +913,7 @@ namespace Jackett.Common.Indexers
                         var CaptchaImage = new ImageItem { Name = "Captcha Image" };
                         var CaptchaText = new StringItem { Name = "Captcha Text" };
 
-                        CaptchaImage.Value = captchaImageData.Content;
+                        CaptchaImage.Value = captchaImageData.ContentBytes;
 
                         configData.AddDynamic("CaptchaImage", CaptchaImage);
                         configData.AddDynamic("CaptchaText", CaptchaText);

--- a/src/Jackett.Common/Indexers/LostFilm.cs
+++ b/src/Jackett.Common/Indexers/LostFilm.cs
@@ -114,7 +114,7 @@ namespace Jackett.Common.Indexers
             {
                 var captchaUrl = SiteLink + qCaptchaImg.GetAttribute("src");
                 var captchaImage = await RequestBytesWithCookies(captchaUrl, loginPage.Cookies);
-                configData.CaptchaImage.Value = captchaImage.Content;
+                configData.CaptchaImage.Value = captchaImage.ContentBytes;
             }
             else
             {

--- a/src/Jackett.Common/Indexers/PiXELHD.cs
+++ b/src/Jackett.Common/Indexers/PiXELHD.cs
@@ -66,7 +66,7 @@ namespace Jackett.Common.Indexers
                 input_captcha = catchaInput.GetAttribute("name");
 
                 var captchaImage = await RequestBytesWithCookies(SiteLink + catchaImg.GetAttribute("src"), loginPage.Cookies, RequestType.GET, LoginUrl);
-                configData.CaptchaImage.Value = captchaImage.Content;
+                configData.CaptchaImage.Value = captchaImage.ContentBytes;
             }
             else
             {

--- a/src/Jackett.Common/Indexers/TorrentHeaven.cs
+++ b/src/Jackett.Common/Indexers/TorrentHeaven.cs
@@ -106,7 +106,7 @@ namespace Jackett.Common.Indexers
             {
                 var captchaUrl = SiteLink + qCaptchaImg.GetAttribute("src");
                 var captchaImage = await RequestBytesWithCookies(captchaUrl, loginPage.Cookies);
-                configData.CaptchaImage.Value = captchaImage.Content;
+                configData.CaptchaImage.Value = captchaImage.ContentBytes;
             }
             else
                 configData.CaptchaImage.Value = Array.Empty<byte>();

--- a/src/Jackett.Common/Indexers/XSpeeds.cs
+++ b/src/Jackett.Common/Indexers/XSpeeds.cs
@@ -147,7 +147,7 @@ namespace Jackett.Common.Indexers
                 var CaptchaImage = new ImageItem { Name = "Captcha Image" };
                 var CaptchaText = new StringItem { Name = "Captcha Text" };
 
-                CaptchaImage.Value = captchaImage.Content;
+                CaptchaImage.Value = captchaImage.ContentBytes;
 
                 configData.AddDynamic("CaptchaImage", CaptchaImage);
                 configData.AddDynamic("CaptchaText", CaptchaText);

--- a/src/Jackett.Common/Indexers/pornolab.cs
+++ b/src/Jackett.Common/Indexers/pornolab.cs
@@ -190,7 +190,7 @@ namespace Jackett.Common.Indexers
             if (captchaimg != null)
             {
                 var captchaImage = await RequestBytesWithCookies("https:" + captchaimg.GetAttribute("src"));
-                configData.CaptchaImage.Value = captchaImage.Content;
+                configData.CaptchaImage.Value = captchaImage.ContentBytes;
 
                 var codefield = LoginResultDocument.QuerySelector("input[name^=\"cap_code_\"]");
                 cap_code_field = codefield.GetAttribute("name");

--- a/src/Jackett.Common/Indexers/rutracker.cs
+++ b/src/Jackett.Common/Indexers/rutracker.cs
@@ -1447,7 +1447,7 @@ namespace Jackett.Common.Indexers
             if (captchaimg != null)
             {
                 var captchaImage = await RequestBytesWithCookies(captchaimg.GetAttribute("src"));
-                configData.CaptchaImage.Value = captchaImage.Content;
+                configData.CaptchaImage.Value = captchaImage.ContentBytes;
 
                 var codefield = LoginResultDocument.QuerySelector("input[name^=\"cap_code_\"]");
                 cap_code_field = codefield.GetAttribute("name");

--- a/src/Jackett.Common/Services/UpdateService.cs
+++ b/src/Jackett.Common/Services/UpdateService.cs
@@ -267,14 +267,14 @@ namespace Jackett.Common.Services
             if (isWindows)
             {
                 var zipPath = Path.Combine(tempDir, "Update.zip");
-                File.WriteAllBytes(zipPath, data.Content);
+                File.WriteAllBytes(zipPath, data.ContentBytes);
                 var fastZip = new FastZip();
                 fastZip.ExtractZip(zipPath, tempDir, null);
             }
             else
             {
                 var gzPath = Path.Combine(tempDir, "Update.tar.gz");
-                File.WriteAllBytes(gzPath, data.Content);
+                File.WriteAllBytes(gzPath, data.ContentBytes);
                 Stream inStream = File.OpenRead(gzPath);
                 Stream gzipStream = new GZipInputStream(inStream);
 

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
@@ -226,7 +226,7 @@ namespace Jackett.Common.Utils.Clients
                             {
                                 var result = new WebClientByteResult
                                 {
-                                    Content = await response.Content.ReadAsByteArrayAsync()
+                                    ContentBytes = await response.Content.ReadAsByteArrayAsync()
                                 };
 
                                 foreach (var header in response.Headers)

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
@@ -245,7 +245,7 @@ namespace Jackett.Common.Utils.Clients
             response = await client.SendAsync(request);
 
             var result = new WebClientByteResult();
-            result.Content = await response.Content.ReadAsByteArrayAsync();
+            result.ContentBytes = await response.Content.ReadAsByteArrayAsync();
 
             foreach (var header in response.Headers)
             {

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2NetCore.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2NetCore.cs
@@ -241,7 +241,7 @@ namespace Jackett.Common.Utils.Clients
             response = await client.SendAsync(request);
 
             var result = new WebClientByteResult();
-            result.Content = await response.Content.ReadAsByteArrayAsync();
+            result.ContentBytes = await response.Content.ReadAsByteArrayAsync();
 
             foreach (var header in response.Headers)
             {

--- a/src/Jackett.Common/Utils/Clients/HttpWebClientNetCore.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClientNetCore.cs
@@ -225,7 +225,7 @@ namespace Jackett.Common.Utils.Clients
                             {
                                 var result = new WebClientByteResult
                                 {
-                                    Content = await response.Content.ReadAsByteArrayAsync()
+                                    ContentBytes = await response.Content.ReadAsByteArrayAsync()
                                 };
 
                                 foreach (var header in response.Headers)

--- a/src/Jackett.Common/Utils/Clients/WebByteResult.cs
+++ b/src/Jackett.Common/Utils/Clients/WebByteResult.cs
@@ -2,6 +2,6 @@ namespace Jackett.Common.Utils.Clients
 {
     public class WebClientByteResult : BaseWebResult
     {
-        public byte[] Content { get; set; }
+        public byte[] ContentBytes { get; set; }
     }
 }

--- a/src/Jackett.Common/Utils/Clients/WebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/WebClient.cs
@@ -102,7 +102,7 @@ namespace Jackett.Common.Utils.Clients
             var result = await Run(request);
             lastRequest = DateTime.Now;
             result.Request = request;
-            logger.Debug(string.Format("WebClient({0}): Returning {1} => {2} bytes", ClientType, result.Status, (result.IsRedirect ? result.RedirectingTo + " " : "") + (result.Content == null ? "<NULL>" : result.Content.Length.ToString())));
+            logger.Debug(string.Format("WebClient({0}): Returning {1} => {2} bytes", ClientType, result.Status, (result.IsRedirect ? result.RedirectingTo + " " : "") + (result.ContentBytes == null ? "<NULL>" : result.ContentBytes.Length.ToString())));
             return result;
         }
 
@@ -117,8 +117,8 @@ namespace Jackett.Common.Utils.Clients
             var stringResult = Mapper.Map<WebClientStringResult>(result);
 
             string decodedContent = null;
-            if (result.Content != null)
-                decodedContent = result.Encoding.GetString(result.Content);
+            if (result.ContentBytes != null)
+                decodedContent = result.Encoding.GetString(result.ContentBytes);
 
             stringResult.ContentString = decodedContent;
             logger.Debug(string.Format("WebClient({0}): Returning {1} => {2}", ClientType, result.Status, (result.IsRedirect ? result.RedirectingTo + " " : "") + (decodedContent == null ? "<NULL>" : decodedContent)));

--- a/src/Jackett.Server/Helper.cs
+++ b/src/Jackett.Server/Helper.cs
@@ -74,15 +74,15 @@ namespace Jackett.Server
                 cfg.CreateMap<WebClientByteResult, WebClientStringResult>().ForMember(x => x.ContentString, opt => opt.Ignore()).AfterMap((be, str) =>
                 {
                     var encoding = be.Request.Encoding ?? Encoding.UTF8;
-                    str.ContentString = encoding.GetString(be.Content);
+                    str.ContentString = encoding.GetString(be.ContentBytes);
                 });
 
-                cfg.CreateMap<WebClientStringResult, WebClientByteResult>().ForMember(x => x.Content, opt => opt.Ignore()).AfterMap((str, be) =>
+                cfg.CreateMap<WebClientStringResult, WebClientByteResult>().ForMember(x => x.ContentBytes, opt => opt.Ignore()).AfterMap((str, be) =>
                 {
                     if (!string.IsNullOrEmpty(str.ContentString))
                     {
                         var encoding = str.Request.Encoding ?? Encoding.UTF8;
-                        be.Content = encoding.GetBytes(str.ContentString);
+                        be.ContentBytes = encoding.GetBytes(str.ContentString);
                     }
                 });
 


### PR DESCRIPTION
This PR changes `WebClientByteResult.Content` into `WebClientByteResult.ContentBytes` in preparation for merging the two classes.