### PR TITLE
Update standard clients to X509Certificate2

### DIFF
--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
@@ -33,19 +33,15 @@ namespace Jackett.Common.Utils.Clients
         protected static IWebProxy webProxy;
 
         [DebuggerNonUserCode] // avoid "Exception User-Unhandled" Visual Studio messages
-        public static bool ValidateCertificate(object sender, X509Certificate certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
+        public static bool ValidateCertificate(HttpRequestMessage request, X509Certificate2 certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
         {
-            if (sender.GetType() != typeof(HttpWebRequest))
-                return sslPolicyErrors == SslPolicyErrors.None;
-
-            var request = (HttpWebRequest)sender;
             var hash = certificate.GetCertHashString();
 
 
             trustedCertificates.TryGetValue(hash, out var hosts);
             if (hosts != null)
             {
-                if (hosts.Contains(request.Host))
+                if (hosts.Contains(request.RequestUri.Host))
                     return true;
             }
 
@@ -134,6 +130,9 @@ namespace Jackett.Common.Utils.Clients
                 AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
             };
 
+            // custom certificate validation handler (netcore version)
+            clientHandlr.ServerCertificateCustomValidationCallback = ValidateCertificate;
+
             clearanceHandlr.InnerHandler = clientHandlr;
             client = new HttpClient(clearanceHandlr);
         }
@@ -161,9 +160,6 @@ namespace Jackett.Common.Utils.Clients
             }
 
             ServicePointManager.SecurityProtocol = (SecurityProtocolType)192 | (SecurityProtocolType)768 | (SecurityProtocolType)3072;
-
-            // custom handler for our own internal certificates
-            ServicePointManager.ServerCertificateValidationCallback += ValidateCertificate;
         }
 
         protected override async Task<WebClientByteResult> Run(WebRequest webRequest)


### PR DESCRIPTION
This version updates the regular HttpWebClients to use the same version as the *NetCore versions. It's tested in Mono on FreeBSD and working.