### PR TITLE
Readme: Full framework now no longer needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Developer note: The software implements the [Torznab](https://github.com/Sonarr/
 
 
 #### Supported Systems
-* Windows 7SP1 or greater using .NET 4.6.1 or above [Download here](https://dotnet.microsoft.com/download/dotnet-framework/net461)
+* Windows 7SP1 or greater
 * Linux [supported operating systems here](https://github.com/dotnet/core/blob/master/release-notes/2.1/2.1-supported-os.md#linux)
 * macOS 10.13 or greater
 


### PR DESCRIPTION
Since we are now running self contained .NET Core, no .NET is required on the host system