### PR TITLE
core: add more binary formats in .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,13 +2,12 @@
 * text=auto
 * text eol=lf
 
-# Explicitly declare text files you want to always be normalized and converted
-# to native line endings on checkout.
-
-# Declare files that will always have LF line endings on checkout.
-
-# Declare files that will always have CRLF line endings on checkout.
-
 # Denote all files that are truly binary and should not be modified.
-*.png binary
+*.eot binary
+*.ico binary
 *.jpg binary
+*.otf binary
+*.png binary
+*.ttf binary
+*.woff binary
+*.woff2 binary


### PR DESCRIPTION
Git is breaking some files after 6afaf39d5a48ef6ece3b5cb22f81c13c82f74664