### PR TITLE
base: Move web-result encoding logic to internal lazy evaluaion.

### DIFF
--- a/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
@@ -301,40 +301,6 @@ namespace Jackett.Common.Utils.Clients
                                     result.Cookies = cookieBuilder.ToString().Trim();
                                 }
                                 ServerUtil.ResureRedirectIsFullyQualified(webRequest, result);
-                                Encoding encoding = null;
-                                if (webRequest.Encoding != null)
-                                {
-                                    encoding = webRequest.Encoding;
-                                }
-                                else if (result.Headers.ContainsKey("content-type"))
-                                {
-                                    var CharsetRegex = new Regex(@"charset=([\w-]+)", RegexOptions.Compiled);
-                                    var CharsetRegexMatch = CharsetRegex.Match(result.Headers["content-type"][0]);
-                                    if (CharsetRegexMatch.Success)
-                                    {
-                                        var charset = CharsetRegexMatch.Groups[1].Value;
-                                        try
-                                        {
-                                            encoding = Encoding.GetEncoding(charset);
-                                        }
-                                        catch (Exception ex)
-                                        {
-                                            logger.Error(string.Format("WebClient({0}).GetString(Url:{1}): Error loading encoding {2} based on header {3}: {4}", ClientType, webRequest.Url, charset, result.Headers["content-type"][0], ex));
-                                        }
-                                    }
-                                    else
-                                    {
-                                        logger.Error(string.Format("WebClient({0}).GetString(Url:{1}): Got header without charset: {2}", ClientType, webRequest.Url, result.Headers["content-type"][0]));
-                                    }
-                                }
-
-                                if (encoding == null)
-                                {
-                                    logger.Error(string.Format("WebClient({0}).GetString(Url:{1}): No encoding detected, defaulting to UTF-8", ClientType, webRequest.Url));
-                                    encoding = Encoding.UTF8;
-                                }
-
-                                result.Encoding = encoding;
                                 return result;
                             }
                         }

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
@@ -320,40 +320,6 @@ namespace Jackett.Common.Utils.Clients
                 result.Cookies = cookieBuilder.ToString().Trim();
             }
             ServerUtil.ResureRedirectIsFullyQualified(webRequest, result);
-            Encoding encoding = null;
-            if (webRequest.Encoding != null)
-            {
-                encoding = webRequest.Encoding;
-            }
-            else if (result.Headers.ContainsKey("content-type"))
-            {
-                var CharsetRegex = new Regex(@"charset=([\w-]+)", RegexOptions.Compiled);
-                var CharsetRegexMatch = CharsetRegex.Match(result.Headers["content-type"][0]);
-                if (CharsetRegexMatch.Success)
-                {
-                    var charset = CharsetRegexMatch.Groups[1].Value;
-                    try
-                    {
-                        encoding = Encoding.GetEncoding(charset);
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.Error(string.Format("WebClient({0}).GetString(Url:{1}): Error loading encoding {2} based on header {3}: {4}", ClientType, webRequest.Url, charset, result.Headers["content-type"][0], ex));
-                    }
-                }
-                else
-                {
-                    logger.Error(string.Format("WebClient({0}).GetString(Url:{1}): Got header without charset: {2}", ClientType, webRequest.Url, result.Headers["content-type"][0]));
-                }
-            }
-
-            if (encoding == null)
-            {
-                logger.Error(string.Format("WebClient({0}).GetString(Url:{1}): No encoding detected, defaulting to UTF-8", ClientType, webRequest.Url));
-                encoding = Encoding.UTF8;
-            }
-
-            result.Encoding = encoding;
             return result;
         }
 

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2NetCore.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2NetCore.cs
@@ -320,40 +320,6 @@ namespace Jackett.Common.Utils.Clients
                 result.Cookies = cookieBuilder.ToString().Trim();
             }
             ServerUtil.ResureRedirectIsFullyQualified(webRequest, result);
-            Encoding encoding = null;
-            if (webRequest.Encoding != null)
-            {
-                encoding = webRequest.Encoding;
-            }
-            else if (result.Headers.ContainsKey("content-type"))
-            {
-                var CharsetRegex = new Regex(@"charset=([\w-]+)", RegexOptions.Compiled);
-                var CharsetRegexMatch = CharsetRegex.Match(result.Headers["content-type"][0]);
-                if (CharsetRegexMatch.Success)
-                {
-                    var charset = CharsetRegexMatch.Groups[1].Value;
-                    try
-                    {
-                        encoding = Encoding.GetEncoding(charset);
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.Error(string.Format("WebClient({0}).GetString(Url:{1}): Error loading encoding {2} based on header {3}: {4}", ClientType, webRequest.Url, charset, result.Headers["content-type"][0], ex));
-                    }
-                }
-                else
-                {
-                    logger.Error(string.Format("WebClient({0}).GetString(Url:{1}): Got header without charset: {2}", ClientType, webRequest.Url, result.Headers["content-type"][0]));
-                }
-            }
-
-            if (encoding == null)
-            {
-                logger.Error(string.Format("WebClient({0}).GetString(Url:{1}): No encoding detected, defaulting to UTF-8", ClientType, webRequest.Url));
-                encoding = Encoding.UTF8;
-            }
-
-            result.Encoding = encoding;
             return result;
         }
 

--- a/src/Jackett.Common/Utils/Clients/HttpWebClientNetCore.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClientNetCore.cs
@@ -304,40 +304,6 @@ namespace Jackett.Common.Utils.Clients
                                     result.Cookies = cookieBuilder.ToString().Trim();
                                 }
                                 ServerUtil.ResureRedirectIsFullyQualified(webRequest, result);
-                                Encoding encoding = null;
-                                if (webRequest.Encoding != null)
-                                {
-                                    encoding = webRequest.Encoding;
-                                }
-                                else if (result.Headers.ContainsKey("content-type"))
-                                {
-                                    var CharsetRegex = new Regex(@"charset=([\w-]+)", RegexOptions.Compiled);
-                                    var CharsetRegexMatch = CharsetRegex.Match(result.Headers["content-type"][0]);
-                                    if (CharsetRegexMatch.Success)
-                                    {
-                                        var charset = CharsetRegexMatch.Groups[1].Value;
-                                        try
-                                        {
-                                            encoding = Encoding.GetEncoding(charset);
-                                        }
-                                        catch (Exception ex)
-                                        {
-                                            logger.Error(string.Format("WebClient({0}).GetString(Url:{1}): Error loading encoding {2} based on header {3}: {4}", ClientType, webRequest.Url, charset, result.Headers["content-type"][0], ex));
-                                        }
-                                    }
-                                    else
-                                    {
-                                        logger.Error(string.Format("WebClient({0}).GetString(Url:{1}): Got header without charset: {2}", ClientType, webRequest.Url, result.Headers["content-type"][0]));
-                                    }
-                                }
-
-                                if (encoding == null)
-                                {
-                                    logger.Error(string.Format("WebClient({0}).GetString(Url:{1}): No encoding detected, defaulting to UTF-8", ClientType, webRequest.Url));
-                                    encoding = Encoding.UTF8;
-                                }
-
-                                result.Encoding = encoding;
                                 return result;
                             }
                         }


### PR DESCRIPTION
This pulls the code determining which Encoder to use into the BaseWebResult class, and implements it in a way that it isn't executed unless it needs to be used at least once and caches the result for future access (standard lazy eval).

We do lose access to adding log entries in the encoding determination code by moving it, but I don't feel like these entries matter too much anyway.