### PR TITLE
core: add implicit string result conversion

### DIFF
--- a/src/Jackett.Common/Utils/Clients/WebClientResult.cs
+++ b/src/Jackett.Common/Utils/Clients/WebClientResult.cs
@@ -3,5 +3,17 @@ namespace Jackett.Common.Utils.Clients
     public class WebClientStringResult : BaseWebResult
     {
         public string ContentString { get; set; }
+
+        public static implicit operator WebClientStringResult(WebClientByteResult br) => new WebClientStringResult()
+        {
+            ContentString = br.Encoding.GetString(br.ContentBytes),
+            Cookies = br.Cookies,
+            Encoding = br.Encoding,
+            Headers = br.Headers,
+            RedirectingTo = br.RedirectingTo,
+            Request = br.Request,
+            Status = br.Status
+        };
+
     }
 }


### PR DESCRIPTION
This PR adds the ability to implicitly convert a WebByteResult into a WebStringResult without having to use things like AutoFac Mappers. This is in preparation for removing AutoFac mappers for Byte and String results, and prepares for removing more distinct functions across the two classes so they can be merged easier.