### PR TITLE
core: move identical functions up to base WebClient instance.

### DIFF
--- a/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
@@ -1,17 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Security;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using CloudflareSolverRe;
-using com.LandonKey.SocksWebProxy;
-using com.LandonKey.SocksWebProxy.Proxy;
 using Jackett.Common.Helpers;
 using Jackett.Common.Models.Config;
 using Jackett.Common.Services.Interfaces;
@@ -21,106 +16,19 @@ namespace Jackett.Common.Utils.Clients
 {
     public class HttpWebClient : WebClient
     {
-        protected static Dictionary<string, ICollection<string>> trustedCertificates = new Dictionary<string, ICollection<string>>();
-        protected static string webProxyUrl;
-        protected static IWebProxy webProxy;
-
-        [DebuggerNonUserCode] // avoid "Exception User-Unhandled" Visual Studio messages
-        public static bool ValidateCertificate(HttpRequestMessage request, X509Certificate2 certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
-        {
-            var hash = certificate.GetCertHashString();
-
-
-            trustedCertificates.TryGetValue(hash, out var hosts);
-            if (hosts != null)
-            {
-                if (hosts.Contains(request.RequestUri.Host))
-                    return true;
-            }
-
-            if (sslPolicyErrors != SslPolicyErrors.None)
-            {
-                // Throw exception with certificate details, this will cause a "Exception User-Unhandled" when running it in the Visual Studio debugger.
-                // The certificate is only available inside this function, so we can't catch it at the calling method.
-                throw new Exception("certificate validation failed: " + certificate.ToString());
-            }
-
-            return sslPolicyErrors == SslPolicyErrors.None;
-        }
-
-        public static void InitProxy(ServerConfig serverConfig)
-        {
-            // dispose old SocksWebProxy
-            if (webProxy is SocksWebProxy proxy)
-                proxy.Dispose();
-            webProxy = null;
-            webProxyUrl = serverConfig.GetProxyUrl();
-            if (!string.IsNullOrWhiteSpace(webProxyUrl))
-            {
-                if (serverConfig.ProxyType != ProxyType.Http)
-                {
-                    var addresses = Dns.GetHostAddressesAsync(serverConfig.ProxyUrl).Result;
-                    var socksConfig = new ProxyConfig
-                    {
-                        SocksAddress = addresses.FirstOrDefault(),
-                        Username = serverConfig.ProxyUsername,
-                        Password = serverConfig.ProxyPassword,
-                        Version = serverConfig.ProxyType == ProxyType.Socks4 ?
-                        ProxyConfig.SocksVersion.Four :
-                        ProxyConfig.SocksVersion.Five
-                    };
-                    if (serverConfig.ProxyPort.HasValue)
-                    {
-                        socksConfig.SocksPort = serverConfig.ProxyPort.Value;
-                    }
-                    webProxy = new SocksWebProxy(socksConfig, false);
-                }
-                else
-                {
-                    NetworkCredential creds = null;
-                    if (!serverConfig.ProxyIsAnonymous)
-                    {
-                        var username = serverConfig.ProxyUsername;
-                        var password = serverConfig.ProxyPassword;
-                        creds = new NetworkCredential(username, password);
-                    }
-                    webProxy = new WebProxy(webProxyUrl)
-                    {
-                        BypassProxyOnLocal = false,
-                        Credentials = creds
-                    };
-                }
-            }
-        }
-
         public HttpWebClient(IProcessService p, Logger l, IConfigurationService c, ServerConfig sc)
             : base(p: p,
                    l: l,
                    c: c,
                    sc: sc)
         {
-            if (webProxyUrl == null)
-                InitProxy(sc);
-        }
-
-        // Called everytime the ServerConfig changes
-        public override void OnNext(ServerConfig value)
-        {
-            var newProxyUrl = serverConfig.GetProxyUrl();
-            if (webProxyUrl != newProxyUrl) // if proxy URL changed
-                InitProxy(serverConfig);
         }
 
         public override void Init()
         {
             ServicePointManager.DefaultConnectionLimit = 1000;
 
-            if (serverConfig.RuntimeSettings.IgnoreSslErrors == true)
-            {
-                logger.Info(string.Format("HttpWebClient: Disabling certificate validation"));
-                ServicePointManager.ServerCertificateValidationCallback += (sender, certificate, chain, sslPolicyErrors) => { return true; };
-            }
-
+            base.Init();
         }
 
         protected override async Task<WebClientByteResult> Run(WebRequest webRequest)
@@ -341,18 +249,6 @@ namespace Jackett.Common.Utils.Clients
                     }
                 }
             }
-        }
-
-        public override void AddTrustedCertificate(string host, string hash)
-        {
-            hash = hash.ToUpper();
-            trustedCertificates.TryGetValue(hash.ToUpper(), out var hosts);
-            if (hosts == null)
-            {
-                hosts = new HashSet<string>();
-                trustedCertificates[hash] = hosts;
-            }
-            hosts.Add(host);
         }
     }
 }

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
@@ -1,17 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Security;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using CloudflareSolverRe;
-using com.LandonKey.SocksWebProxy;
-using com.LandonKey.SocksWebProxy.Proxy;
 using Jackett.Common.Helpers;
 using Jackett.Common.Models.Config;
 using Jackett.Common.Services.Interfaces;
@@ -27,88 +22,13 @@ namespace Jackett.Common.Utils.Clients
         private ClearanceHandler clearanceHandlr;
         private HttpClientHandler clientHandlr;
         private HttpClient client;
-
-        protected static Dictionary<string, ICollection<string>> trustedCertificates = new Dictionary<string, ICollection<string>>();
-        protected static string webProxyUrl;
-        protected static IWebProxy webProxy;
-
-        [DebuggerNonUserCode] // avoid "Exception User-Unhandled" Visual Studio messages
-        public static bool ValidateCertificate(HttpRequestMessage request, X509Certificate2 certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
-        {
-            var hash = certificate.GetCertHashString();
-
-
-            trustedCertificates.TryGetValue(hash, out var hosts);
-            if (hosts != null)
-            {
-                if (hosts.Contains(request.RequestUri.Host))
-                    return true;
-            }
-
-            if (sslPolicyErrors != SslPolicyErrors.None)
-            {
-                // Throw exception with certificate details, this will cause a "Exception User-Unhandled" when running it in the Visual Studio debugger.
-                // The certificate is only available inside this function, so we can't catch it at the calling method.
-                throw new Exception("certificate validation failed: " + certificate.ToString());
-            }
-
-            return sslPolicyErrors == SslPolicyErrors.None;
-        }
-
-        public static void InitProxy(ServerConfig serverConfig)
-        {
-            // dispose old SocksWebProxy
-            if (webProxy is SocksWebProxy proxy)
-                proxy.Dispose();
-            webProxy = null;
-            webProxyUrl = serverConfig.GetProxyUrl();
-            if (!string.IsNullOrWhiteSpace(webProxyUrl))
-            {
-                if (serverConfig.ProxyType != ProxyType.Http)
-                {
-                    var addresses = Dns.GetHostAddressesAsync(serverConfig.ProxyUrl).Result;
-                    var socksConfig = new ProxyConfig
-                    {
-                        SocksAddress = addresses.FirstOrDefault(),
-                        Username = serverConfig.ProxyUsername,
-                        Password = serverConfig.ProxyPassword,
-                        Version = serverConfig.ProxyType == ProxyType.Socks4 ?
-                        ProxyConfig.SocksVersion.Four :
-                        ProxyConfig.SocksVersion.Five
-                    };
-                    if (serverConfig.ProxyPort.HasValue)
-                    {
-                        socksConfig.SocksPort = serverConfig.ProxyPort.Value;
-                    }
-                    webProxy = new SocksWebProxy(socksConfig, false);
-                }
-                else
-                {
-                    NetworkCredential creds = null;
-                    if (!serverConfig.ProxyIsAnonymous)
-                    {
-                        var username = serverConfig.ProxyUsername;
-                        var password = serverConfig.ProxyPassword;
-                        creds = new NetworkCredential(username, password);
-                    }
-                    webProxy = new WebProxy(webProxyUrl)
-                    {
-                        BypassProxyOnLocal = false,
-                        Credentials = creds
-                    };
-                }
-            }
-        }
-
+        
         public HttpWebClient2(IProcessService p, Logger l, IConfigurationService c, ServerConfig sc)
             : base(p: p,
                    l: l,
                    c: c,
                    sc: sc)
         {
-            if (webProxyUrl == null)
-                InitProxy(sc);
-
             cookies = new CookieContainer();
             CreateClient();
         }
@@ -137,10 +57,7 @@ namespace Jackett.Common.Utils.Clients
         // Called everytime the ServerConfig changes
         public override void OnNext(ServerConfig value)
         {
-            var newProxyUrl = serverConfig.GetProxyUrl();
-            if (webProxyUrl != newProxyUrl) // if proxy URL changed
-                InitProxy(serverConfig);
-
+            base.OnNext(value);
             // recreate client if needed (can't just change the proxy attribute)
             if (!ReferenceEquals(clientHandlr.Proxy, webProxy))
             {
@@ -150,11 +67,7 @@ namespace Jackett.Common.Utils.Clients
 
         public override void Init()
         {
-            if (serverConfig.RuntimeSettings.IgnoreSslErrors == true)
-            {
-                logger.Info(string.Format("HttpWebClient2: Disabling certificate validation"));
-                ServicePointManager.ServerCertificateValidationCallback += (sender, certificate, chain, sslPolicyErrors) => { return true; };
-            }
+            base.Init();
 
             ServicePointManager.SecurityProtocol = (SecurityProtocolType)192 | (SecurityProtocolType)768 | (SecurityProtocolType)3072;
         }
@@ -355,18 +268,6 @@ namespace Jackett.Common.Utils.Clients
 
             result.Encoding = encoding;
             return result;
-        }
-
-        public override void AddTrustedCertificate(string host, string hash)
-        {
-            hash = hash.ToUpper();
-            trustedCertificates.TryGetValue(hash.ToUpper(), out var hosts);
-            if (hosts == null)
-            {
-                hosts = new HashSet<string>();
-                trustedCertificates[hash] = hosts;
-            }
-            hosts.Add(host);
         }
     }
 }

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2NetCore.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2NetCore.cs
@@ -1,17 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Security;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using CloudflareSolverRe;
-using com.LandonKey.SocksWebProxy;
-using com.LandonKey.SocksWebProxy.Proxy;
 using Jackett.Common.Helpers;
 using Jackett.Common.Models.Config;
 using Jackett.Common.Services.Interfaces;
@@ -28,87 +23,12 @@ namespace Jackett.Common.Utils.Clients
         private HttpClientHandler clientHandlr;
         private HttpClient client;
 
-        protected static Dictionary<string, ICollection<string>> trustedCertificates = new Dictionary<string, ICollection<string>>();
-        protected static string webProxyUrl;
-        protected static IWebProxy webProxy;
-
-        [DebuggerNonUserCode] // avoid "Exception User-Unhandled" Visual Studio messages
-        public static bool ValidateCertificate(HttpRequestMessage request, X509Certificate2 certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
-        {
-            var hash = certificate.GetCertHashString();
-
-
-            trustedCertificates.TryGetValue(hash, out var hosts);
-            if (hosts != null)
-            {
-                if (hosts.Contains(request.RequestUri.Host))
-                    return true;
-            }
-
-            if (sslPolicyErrors != SslPolicyErrors.None)
-            {
-                // Throw exception with certificate details, this will cause a "Exception User-Unhandled" when running it in the Visual Studio debugger.
-                // The certificate is only available inside this function, so we can't catch it at the calling method.
-                throw new Exception("certificate validation failed: " + certificate.ToString());
-            }
-
-            return sslPolicyErrors == SslPolicyErrors.None;
-        }
-
-        public static void InitProxy(ServerConfig serverConfig)
-        {
-            // dispose old SocksWebProxy
-            if (webProxy is SocksWebProxy proxy)
-                proxy.Dispose();
-            webProxy = null;
-            webProxyUrl = serverConfig.GetProxyUrl();
-            if (!string.IsNullOrWhiteSpace(webProxyUrl))
-            {
-                if (serverConfig.ProxyType != ProxyType.Http)
-                {
-                    var addresses = Dns.GetHostAddressesAsync(serverConfig.ProxyUrl).Result;
-                    var socksConfig = new ProxyConfig
-                    {
-                        SocksAddress = addresses.FirstOrDefault(),
-                        Username = serverConfig.ProxyUsername,
-                        Password = serverConfig.ProxyPassword,
-                        Version = serverConfig.ProxyType == ProxyType.Socks4 ?
-                        ProxyConfig.SocksVersion.Four :
-                        ProxyConfig.SocksVersion.Five
-                    };
-                    if (serverConfig.ProxyPort.HasValue)
-                    {
-                        socksConfig.SocksPort = serverConfig.ProxyPort.Value;
-                    }
-                    webProxy = new SocksWebProxy(socksConfig, false);
-                }
-                else
-                {
-                    NetworkCredential creds = null;
-                    if (!serverConfig.ProxyIsAnonymous)
-                    {
-                        var username = serverConfig.ProxyUsername;
-                        var password = serverConfig.ProxyPassword;
-                        creds = new NetworkCredential(username, password);
-                    }
-                    webProxy = new WebProxy(webProxyUrl)
-                    {
-                        BypassProxyOnLocal = false,
-                        Credentials = creds
-                    };
-                }
-            }
-        }
-
         public HttpWebClient2NetCore(IProcessService p, Logger l, IConfigurationService c, ServerConfig sc)
             : base(p: p,
                    l: l,
                    c: c,
                    sc: sc)
         {
-            if (webProxyUrl == null)
-                InitProxy(sc);
-
             cookies = new CookieContainer();
             CreateClient();
         }
@@ -137,10 +57,7 @@ namespace Jackett.Common.Utils.Clients
         // Called everytime the ServerConfig changes
         public override void OnNext(ServerConfig value)
         {
-            var newProxyUrl = serverConfig.GetProxyUrl();
-            if (webProxyUrl != newProxyUrl) // if proxy URL changed
-                InitProxy(serverConfig);
-
+            base.OnNext(value);
             // recreate client if needed (can't just change the proxy attribute)
             if (!ReferenceEquals(clientHandlr.Proxy, webProxy))
             {
@@ -152,11 +69,7 @@ namespace Jackett.Common.Utils.Clients
         {
             ServicePointManager.DefaultConnectionLimit = 1000;
 
-            if (serverConfig.RuntimeSettings.IgnoreSslErrors == true)
-            {
-                logger.Info(string.Format("HttpWebClient: Disabling certificate validation"));
-                ServicePointManager.ServerCertificateValidationCallback += (sender, certificate, chain, sslPolicyErrors) => { return true; };
-            }
+            base.Init();
         }
 
         protected override async Task<WebClientByteResult> Run(WebRequest webRequest)
@@ -355,18 +268,6 @@ namespace Jackett.Common.Utils.Clients
 
             result.Encoding = encoding;
             return result;
-        }
-
-        public override void AddTrustedCertificate(string host, string hash)
-        {
-            hash = hash.ToUpper();
-            trustedCertificates.TryGetValue(hash.ToUpper(), out var hosts);
-            if (hosts == null)
-            {
-                hosts = new HashSet<string>();
-                trustedCertificates[hash] = hosts;
-            }
-            hosts.Add(host);
         }
     }
 }

--- a/src/Jackett.Common/Utils/Clients/HttpWebClientNetCore.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClientNetCore.cs
@@ -1,17 +1,12 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using System.Net.Security;
-using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using CloudflareSolverRe;
-using com.LandonKey.SocksWebProxy;
-using com.LandonKey.SocksWebProxy.Proxy;
 using Jackett.Common.Helpers;
 using Jackett.Common.Models.Config;
 using Jackett.Common.Services.Interfaces;
@@ -22,107 +17,18 @@ namespace Jackett.Common.Utils.Clients
     // custom HttpWebClient based WebClient for netcore (due to changed custom certificate validation API)
     public class HttpWebClientNetCore : WebClient
     {
-        protected static Dictionary<string, ICollection<string>> trustedCertificates = new Dictionary<string, ICollection<string>>();
-        protected static string webProxyUrl;
-        protected static IWebProxy webProxy;
-
-        [DebuggerNonUserCode] // avoid "Exception User-Unhandled" Visual Studio messages
-        public static bool ValidateCertificate(HttpRequestMessage request, X509Certificate2 certificate, X509Chain chain, SslPolicyErrors sslPolicyErrors)
-        {
-            {
-                var hash = certificate.GetCertHashString();
-
-
-                trustedCertificates.TryGetValue(hash, out var hosts);
-                if (hosts != null)
-                {
-                    if (hosts.Contains(request.RequestUri.Host))
-                        return true;
-                }
-
-                if (sslPolicyErrors != SslPolicyErrors.None)
-                {
-                    // Throw exception with certificate details, this will cause a "Exception User-Unhandled" when running it in the Visual Studio debugger.
-                    // The certificate is only available inside this function, so we can't catch it at the calling method.
-                    throw new Exception("certificate validation failed: " + certificate.ToString());
-                }
-
-                return sslPolicyErrors == SslPolicyErrors.None;
-            }
-        }
-
-        public static void InitProxy(ServerConfig serverConfig)
-        {
-            // dispose old SocksWebProxy
-            if (webProxy is SocksWebProxy proxy)
-                proxy.Dispose();
-            webProxy = null;
-            webProxyUrl = serverConfig.GetProxyUrl();
-            if (!string.IsNullOrWhiteSpace(webProxyUrl))
-            {
-                if (serverConfig.ProxyType != ProxyType.Http)
-                {
-                    var addresses = Dns.GetHostAddressesAsync(serverConfig.ProxyUrl).Result;
-                    var socksConfig = new ProxyConfig
-                    {
-                        SocksAddress = addresses.FirstOrDefault(),
-                        Username = serverConfig.ProxyUsername,
-                        Password = serverConfig.ProxyPassword,
-                        Version = serverConfig.ProxyType == ProxyType.Socks4 ?
-                        ProxyConfig.SocksVersion.Four :
-                        ProxyConfig.SocksVersion.Five
-                    };
-                    if (serverConfig.ProxyPort.HasValue)
-                    {
-                        socksConfig.SocksPort = serverConfig.ProxyPort.Value;
-                    }
-                    webProxy = new SocksWebProxy(socksConfig, false);
-                }
-                else
-                {
-                    NetworkCredential creds = null;
-                    if (!serverConfig.ProxyIsAnonymous)
-                    {
-                        var username = serverConfig.ProxyUsername;
-                        var password = serverConfig.ProxyPassword;
-                        creds = new NetworkCredential(username, password);
-                    }
-                    webProxy = new WebProxy(webProxyUrl)
-                    {
-                        BypassProxyOnLocal = false,
-                        Credentials = creds
-                    };
-                }
-            }
-        }
-
         public HttpWebClientNetCore(IProcessService p, Logger l, IConfigurationService c, ServerConfig sc)
             : base(p: p,
                    l: l,
                    c: c,
                    sc: sc)
         {
-            if (webProxyUrl == null)
-                InitProxy(sc);
         }
-
-        // Called everytime the ServerConfig changes
-        public override void OnNext(ServerConfig value)
-        {
-            var newProxyUrl = serverConfig.GetProxyUrl();
-            if (webProxyUrl != newProxyUrl) // if proxy URL changed
-                InitProxy(serverConfig);
-        }
-
         public override void Init()
         {
             ServicePointManager.DefaultConnectionLimit = 1000;
 
-            if (serverConfig.RuntimeSettings.IgnoreSslErrors == true)
-            {
-                logger.Info(string.Format("HttpWebClient: Disabling certificate validation"));
-                ServicePointManager.ServerCertificateValidationCallback += (sender, certificate, chain, sslPolicyErrors) => { return true; };
-            }
+            base.Init();
         }
 
         protected override async Task<WebClientByteResult> Run(WebRequest webRequest)
@@ -344,18 +250,6 @@ namespace Jackett.Common.Utils.Clients
                     }
                 }
             }
-        }
-
-        public override void AddTrustedCertificate(string host, string hash)
-        {
-            hash = hash.ToUpper();
-            trustedCertificates.TryGetValue(hash.ToUpper(), out var hosts);
-            if (hosts == null)
-            {
-                hosts = new HashSet<string>();
-                trustedCertificates[hash] = hosts;
-            }
-            hosts.Add(host);
         }
     }
 }

--- a/src/Jackett.Common/Utils/Clients/WebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/WebClient.cs
@@ -231,7 +231,7 @@ namespace Jackett.Common.Utils.Clients
         {
             if (serverConfig.RuntimeSettings.IgnoreSslErrors == true)
             {
-                logger.Info(string.Format("HttpWebClient2: Disabling certificate validation"));
+                logger.Info($"WebClient({ClientType}): Disabling certificate validation");
                 ServicePointManager.ServerCertificateValidationCallback += (sender, certificate, chain, sslPolicyErrors) => { return true; };
             }
         }


### PR DESCRIPTION
This PR moves all code that is identical in the 4 implementations of the WebClient class into the base WebClient where possible. If a full function isn't identical, and the ability to call `base.Func()` is an option for the function, then this method is used to remove as much code as possible from the base classes.