### PR TITLE
core: Remove Autofac mappings for WebResult classes.

### DIFF
--- a/src/Jackett.Common/Utils/Clients/WebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/WebClient.cs
@@ -114,14 +114,9 @@ namespace Jackett.Common.Utils.Clients
             var result = await Run(request);
             lastRequest = DateTime.Now;
             result.Request = request;
-            var stringResult = Mapper.Map<WebClientStringResult>(result);
+            WebClientStringResult stringResult = result;
 
-            string decodedContent = null;
-            if (result.ContentBytes != null)
-                decodedContent = result.Encoding.GetString(result.ContentBytes);
-
-            stringResult.ContentString = decodedContent;
-            logger.Debug(string.Format("WebClient({0}): Returning {1} => {2}", ClientType, result.Status, (result.IsRedirect ? result.RedirectingTo + " " : "") + (decodedContent == null ? "<NULL>" : decodedContent)));
+            logger.Debug(string.Format("WebClient({0}): Returning {1} => {2}", ClientType, result.Status, (result.IsRedirect ? result.RedirectingTo + " " : "") + (stringResult.ContentString ?? "<NULL>")));
 
             if (stringResult.Headers.TryGetValue("server", out var server))
             {

--- a/src/Jackett.Common/Utils/Clients/WebClientResult.cs
+++ b/src/Jackett.Common/Utils/Clients/WebClientResult.cs
@@ -6,7 +6,7 @@ namespace Jackett.Common.Utils.Clients
 
         public static implicit operator WebClientStringResult(WebClientByteResult br) => new WebClientStringResult()
         {
-            ContentString = br.Encoding.GetString(br.ContentBytes),
+            ContentString = br.ContentBytes == null ? null : br.Encoding.GetString(br.ContentBytes),
             Cookies = br.Cookies,
             Encoding = br.Encoding,
             Headers = br.Headers,

--- a/src/Jackett.Server/Helper.cs
+++ b/src/Jackett.Server/Helper.cs
@@ -71,23 +71,6 @@ namespace Jackett.Server
         {
             Mapper.Initialize(cfg =>
             {
-                cfg.CreateMap<WebClientByteResult, WebClientStringResult>().ForMember(x => x.ContentString, opt => opt.Ignore()).AfterMap((be, str) =>
-                {
-                    var encoding = be.Request.Encoding ?? Encoding.UTF8;
-                    str.ContentString = encoding.GetString(be.ContentBytes);
-                });
-
-                cfg.CreateMap<WebClientStringResult, WebClientByteResult>().ForMember(x => x.ContentBytes, opt => opt.Ignore()).AfterMap((str, be) =>
-                {
-                    if (!string.IsNullOrEmpty(str.ContentString))
-                    {
-                        var encoding = str.Request.Encoding ?? Encoding.UTF8;
-                        be.ContentBytes = encoding.GetBytes(str.ContentString);
-                    }
-                });
-
-                cfg.CreateMap<WebClientStringResult, WebClientStringResult>();
-                cfg.CreateMap<WebClientByteResult, WebClientByteResult>();
                 cfg.CreateMap<ReleaseInfo, ReleaseInfo>();
 
                 cfg.CreateMap<ReleaseInfo, TrackerCacheResult>().AfterMap((r, t) =>


### PR DESCRIPTION
The Web Results class grouping is finally ready to be removed from Autofac.Mapper pairings so this PR removes all Autofac code concerning these classes. As I go through this old code, I keep seeing weird things that show that the large scope and different ways of doing things really were confusing people. Example as you can see in the changes, Mapper.Map already converts the ContentBytes to ContentString and assumes Bytes will never be null. But in the webclient function, we convert and assign the string a second time, but we check for null in this case. Since passing null to `Encoding.GetString()` throws a null argument exception, I decided checking for null is better and changed my conversion code to match.

Hopefully as we continue to go through the whole code base, we'll find and correct even more times where we repeat the same code multiple times in a row for no reason other than people didn't already know it was being taken care of. The original code before this feature branch takes 3 separate attempts to find the encoding and uses it for setting the content string, each time in a different way. The variance in all three ways is accounted for in the new code of this feature branch. 


Side note:
Since we've already talked about removing Autofac completely due to updating issues, this only leaves conversion between `ReleaseInfo` -> `TrackerCacheResult` and then we can safely remove this library. That is outside the scope of this feature branch, but doesn't look like it will be that difficult when we get around to doing it.