### PR TITLE
core: improve date parsing for today/yesterday/tomorrow. resolves #7701

### DIFF
--- a/src/Jackett.Common/Utils/DateTimeUtil.cs
+++ b/src/Jackett.Common/Utils/DateTimeUtil.cs
@@ -287,28 +287,9 @@ namespace Jackett.Common.Utils
             }
         }
 
-        private static TimeSpan ParseTimeSpan(string time)
-        {
-            if (string.IsNullOrWhiteSpace(time))
-                return TimeSpan.Zero;
-
-            var offset = TimeSpan.Zero;
-            if (time.EndsWith("AM"))
-            {
-                time = time.Substring(0, time.Length - 2);
-                if (time.StartsWith("12")) // 12:15 AM becomes 00:15
-                    time = "00" + time.Substring(2);
-            }
-            else if (time.EndsWith("PM"))
-            {
-                time = time.Substring(0, time.Length - 2);
-                offset = TimeSpan.FromHours(12);
-            }
-
-            var ts = TimeSpan.Parse(time);
-            ts += offset;
-            return ts;
-        }
-
+        private static TimeSpan ParseTimeSpan(string time) =>
+            string.IsNullOrWhiteSpace(time)
+                ? TimeSpan.Zero
+                : DateTime.Parse(time).TimeOfDay;
     }
 }

--- a/src/Jackett.Common/Utils/DateTimeUtil.cs
+++ b/src/Jackett.Common/Utils/DateTimeUtil.cs
@@ -9,9 +9,9 @@ namespace Jackett.Common.Utils
         public const string Rfc1123ZPattern = "ddd, dd MMM yyyy HH':'mm':'ss z";
 
         private static readonly Regex _TimeAgoRegexp = new Regex(@"(?i)\bago", RegexOptions.Compiled);
-        private static readonly Regex _TodayRegexp = new Regex(@"(?i)\btoday([\s,]*|$)", RegexOptions.Compiled);
-        private static readonly Regex _TomorrowRegexp = new Regex(@"(?i)\btomorrow([\s,]*|$)", RegexOptions.Compiled);
-        private static readonly Regex _YesterdayRegexp = new Regex(@"(?i)\byesterday([\s,]*|$)", RegexOptions.Compiled);
+        private static readonly Regex _TodayRegexp = new Regex(@"(?i)\btoday(?:[\s,]+(?:at){0,1}\s*|[\s,]*|$)", RegexOptions.Compiled);
+        private static readonly Regex _TomorrowRegexp = new Regex(@"(?i)\btomorrow(?:[\s,]+(?:at){0,1}\s*|[\s,]*|$)", RegexOptions.Compiled);
+        private static readonly Regex _YesterdayRegexp = new Regex(@"(?i)\byesterday(?:[\s,]+(?:at){0,1}\s*|[\s,]*|$)", RegexOptions.Compiled);
         private static readonly Regex _DaysOfWeekRegexp = new Regex(@"(?i)\b(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\s+at\s+", RegexOptions.Compiled);
         private static readonly Regex _MissingYearRegexp = new Regex(@"^(\d{1,2}-\d{1,2})(\s|$)", RegexOptions.Compiled);
         private static readonly Regex _MissingYearRegexp2 = new Regex(@"^(\d{1,2}\s+\w{3})\s+(\d{1,2}\:\d{1,2}.*)$", RegexOptions.Compiled); // 1 Jan 10:30

--- a/src/Jackett.Test/Utils/DateTimeUtilTests.cs
+++ b/src/Jackett.Test/Utils/DateTimeUtilTests.cs
@@ -1,0 +1,30 @@
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+
+namespace Jackett.Common.Utils.Tests
+{
+    [TestFixture]
+    public class DateTimeUtilTests
+    {
+        [Test]
+        public void FromUnknownTest()
+        {
+            var today = DateTime.UtcNow.Date;
+            var yesterday = today.AddDays(-1);
+            var tomorrow = today.AddDays(1);
+            var testCases = new Dictionary<string, DateTime>
+            {
+                {"today, at 1:00 PM", today.AddHours(13)},
+                {"Today", today},
+                {"Today at 20:19:54", today.AddHours(20).AddMinutes(19).AddSeconds(54)},
+                {"Today 22:29", today.AddHours(22).AddMinutes(29)},
+                {"Yesterday\n 19:54:54", yesterday.AddHours(19).AddMinutes(54).AddSeconds(54)},
+                {"Yesterday\n 11:55 PM", yesterday.AddHours(23).AddMinutes(55)}
+            };
+
+            foreach (var testCase in testCases)
+                Assert.AreEqual( testCase.Value, DateTimeUtil.FromUnknown(testCase.Key));
+        }
+    }
+}

--- a/src/Jackett.Test/Utils/DateTimeUtilTests.cs
+++ b/src/Jackett.Test/Utils/DateTimeUtilTests.cs
@@ -16,6 +16,7 @@ namespace Jackett.Common.Utils.Tests
             var testCases = new Dictionary<string, DateTime>
             {
                 {"today, at 1:00 PM", today.AddHours(13)},
+                {"today at 12:00PM", today.AddHours(12)},
                 {"Today", today},
                 {"Today at 20:19:54", today.AddHours(20).AddMinutes(19).AddSeconds(54)},
                 {"Today 22:29", today.AddHours(22).AddMinutes(29)},


### PR DESCRIPTION
This modifies the date match Regex to include more options for matching in the DateTimeUtils when attempting to match "today" "tomorrow" or "yesterday"

This new Regex will match the following examples with any amount of whitespace between today and the other components (minimum 1 space between today and at), case insensitive, and can include an optional [time].

- today
- today at
- today, at
- today,

The `?:` specifies these are non-capturing groups, which helps speed up match times by not attempting to add the inner matches to the `.Groups[x]` property.
