### PR TITLE
core: Move WebResult String and Byte properties to base class.

### DIFF
--- a/src/Jackett.Common/Indexers/Abnormal.cs
+++ b/src/Jackett.Common/Indexers/Abnormal.cs
@@ -547,7 +547,7 @@ namespace Jackett.Common.Indexers
         /// <returns>Results from query</returns>
         private async Task<string> queryTracker(string request)
         {
-            WebClientStringResult results = null;
+            BaseWebResult results = null;
 
             // Cache mode not enabled or cached file didn't exist for our query
             output("\nQuerying tracker for results....");

--- a/src/Jackett.Common/Indexers/AniDub.cs
+++ b/src/Jackett.Common/Indexers/AniDub.cs
@@ -507,7 +507,7 @@ namespace Jackett.Common.Indexers
             return domDate.NodeValue.Trim();
         }
 
-        private bool IsAuthorized(WebClientStringResult result) =>
+        private bool IsAuthorized(BaseWebResult result) =>
             result.ContentString.Contains("index.php?action=logout");
 
         private IEnumerable<int> ParseCategories(Uri showUri)

--- a/src/Jackett.Common/Indexers/BaseIndexer.cs
+++ b/src/Jackett.Common/Indexers/BaseIndexer.cs
@@ -401,7 +401,7 @@ namespace Jackett.Common.Indexers
             return response.ContentBytes;
         }
 
-        protected async Task<WebClientByteResult> RequestBytesWithCookiesAndRetry(string url, string cookieOverride = null, RequestType method = RequestType.GET, string referer = null, IEnumerable<KeyValuePair<string, string>> data = null)
+        protected async Task<BaseWebResult> RequestBytesWithCookiesAndRetry(string url, string cookieOverride = null, RequestType method = RequestType.GET, string referer = null, IEnumerable<KeyValuePair<string, string>> data = null)
         {
             Exception lastException = null;
             for (var i = 0; i < 3; i++)
@@ -421,7 +421,7 @@ namespace Jackett.Common.Indexers
             throw lastException;
         }
 
-        protected async Task<WebClientStringResult> RequestStringWithCookies(string url, string cookieOverride = null, string referer = null, Dictionary<string, string> headers = null)
+        protected async Task<BaseWebResult> RequestStringWithCookies(string url, string cookieOverride = null, string referer = null, Dictionary<string, string> headers = null)
         {
             var request = new Utils.Clients.WebRequest()
             {
@@ -441,7 +441,7 @@ namespace Jackett.Common.Indexers
             return result;
         }
 
-        protected async Task<WebClientStringResult> RequestStringWithCookiesAndRetry(string url, string cookieOverride = null, string referer = null, Dictionary<string, string> headers = null)
+        protected async Task<BaseWebResult> RequestStringWithCookiesAndRetry(string url, string cookieOverride = null, string referer = null, Dictionary<string, string> headers = null)
         {
             Exception lastException = null;
             for (var i = 0; i < 3; i++)
@@ -461,7 +461,7 @@ namespace Jackett.Common.Indexers
             throw lastException;
         }
 
-        protected virtual async Task<WebClientByteResult> RequestBytesWithCookies(string url, string cookieOverride = null, RequestType method = RequestType.GET, string referer = null, IEnumerable<KeyValuePair<string, string>> data = null, Dictionary<string, string> headers = null)
+        protected virtual async Task<BaseWebResult> RequestBytesWithCookies(string url, string cookieOverride = null, RequestType method = RequestType.GET, string referer = null, IEnumerable<KeyValuePair<string, string>> data = null, Dictionary<string, string> headers = null)
         {
             var request = new Utils.Clients.WebRequest()
             {
@@ -481,7 +481,7 @@ namespace Jackett.Common.Indexers
             return result;
         }
 
-        protected async Task<WebClientStringResult> PostDataWithCookies(string url, IEnumerable<KeyValuePair<string, string>> data, string cookieOverride = null, string referer = null, Dictionary<string, string> headers = null, string rawbody = null, bool? emulateBrowser = null)
+        protected async Task<BaseWebResult> PostDataWithCookies(string url, IEnumerable<KeyValuePair<string, string>> data, string cookieOverride = null, string referer = null, Dictionary<string, string> headers = null, string rawbody = null, bool? emulateBrowser = null)
         {
             var request = new Utils.Clients.WebRequest()
             {
@@ -503,7 +503,7 @@ namespace Jackett.Common.Indexers
             return result;
         }
 
-        protected async Task<WebClientStringResult> PostDataWithCookiesAndRetry(string url, IEnumerable<KeyValuePair<string, string>> data, string cookieOverride = null, string referer = null, Dictionary<string, string> headers = null, string rawbody = null, bool? emulateBrowser = null)
+        protected async Task<BaseWebResult> PostDataWithCookiesAndRetry(string url, IEnumerable<KeyValuePair<string, string>> data, string cookieOverride = null, string referer = null, Dictionary<string, string> headers = null, string rawbody = null, bool? emulateBrowser = null)
         {
             Exception lastException = null;
             for (var i = 0; i < 3; i++)
@@ -523,7 +523,7 @@ namespace Jackett.Common.Indexers
             throw lastException;
         }
 
-        protected async Task<WebClientStringResult> RequestLoginAndFollowRedirect(string url, IEnumerable<KeyValuePair<string, string>> data, string cookies, bool returnCookiesFromFirstCall, string redirectUrlOverride = null, string referer = null, bool accumulateCookies = false)
+        protected async Task<BaseWebResult> RequestLoginAndFollowRedirect(string url, IEnumerable<KeyValuePair<string, string>> data, string cookies, bool returnCookiesFromFirstCall, string redirectUrlOverride = null, string referer = null, bool accumulateCookies = false)
         {
             var request = new Utils.Clients.WebRequest()
             {
@@ -555,7 +555,7 @@ namespace Jackett.Common.Indexers
             return response;
         }
 
-        protected void CheckTrackerDown(WebClientStringResult response)
+        protected void CheckTrackerDown(BaseWebResult response)
         {
             if (response.Status == System.Net.HttpStatusCode.BadGateway
                 || response.Status == System.Net.HttpStatusCode.GatewayTimeout

--- a/src/Jackett.Common/Indexers/BitHdtv.cs
+++ b/src/Jackett.Common/Indexers/BitHdtv.cs
@@ -121,7 +121,7 @@ namespace Jackett.Common.Indexers
             {
                 {"cat", cats.Count == 1 ? cats[0] : "0"}
             };
-            var results = new List<WebClientStringResult>();
+            var results = new List<BaseWebResult>();
             var search = new UriBuilder(SearchUrl);
             if (query.IsImdbQuery)
             {

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -28,7 +28,7 @@ namespace Jackett.Common.Indexers
         protected IndexerDefinition Definition;
         public override string ID => (Definition != null ? Definition.Site : GetIndexerID(GetType()));
 
-        protected WebClientStringResult landingResult;
+        protected BaseWebResult landingResult;
         protected IHtmlDocument landingResultDocument;
 
         protected List<string> DefaultCategories = new List<string>();
@@ -439,7 +439,7 @@ namespace Jackett.Common.Indexers
             return template;
         }
 
-        protected bool checkForError(WebClientStringResult loginResult, IList<errorBlock> errorBlocks)
+        protected bool checkForError(BaseWebResult loginResult, IList<errorBlock> errorBlocks)
         {
             if (loginResult.Status == HttpStatusCode.Unauthorized) // e.g. used by YGGtorrent
                 throw new ExceptionWithConfigData("401 Unauthorized, check your credentials", configData);
@@ -684,7 +684,7 @@ namespace Jackett.Common.Indexers
                 landingResult = null;
                 landingResultDocument = null;
 
-                WebClientStringResult loginResult = null;
+                BaseWebResult loginResult = null;
                 var enctype = form.GetAttribute("enctype");
                 if (enctype == "multipart/form-data")
                 {
@@ -1304,7 +1304,7 @@ namespace Jackett.Common.Indexers
                 var searchUrlUri = new Uri(searchUrl);
 
                 // send HTTP request
-                WebClientStringResult response = null;
+                BaseWebResult response = null;
                 Dictionary<string, string> headers = null;
                 if (Search.Headers != null)
                 {
@@ -1668,7 +1668,7 @@ namespace Jackett.Common.Indexers
             return releases;
         }
 
-        protected async Task<WebClientByteResult> handleRequest(requestBlock request, Dictionary<string, object> variables = null, string referer = null)
+        protected async Task<BaseWebResult> handleRequest(requestBlock request, Dictionary<string, object> variables = null, string referer = null)
         {
             var requestLinkStr = resolvePath(applyGoTemplateText(request.Path, variables)).ToString();
 

--- a/src/Jackett.Common/Indexers/Corsarored.cs
+++ b/src/Jackett.Common/Indexers/Corsarored.cs
@@ -104,7 +104,7 @@ namespace Jackett.Common.Indexers
             return IndexerConfigurationStatus.Completed;
         }
 
-        private dynamic CheckResponse(WebClientStringResult result)
+        private dynamic CheckResponse(BaseWebResult result)
         {
             try
             {

--- a/src/Jackett.Common/Indexers/DanishBits.cs
+++ b/src/Jackett.Common/Indexers/DanishBits.cs
@@ -56,7 +56,7 @@ namespace Jackett.Common.Indexers
             return searchString;
         }
 
-        protected override async Task<WebClientByteResult> RequestBytesWithCookies(string url, string cookieOverride = null, RequestType method = RequestType.GET, string referer = null, IEnumerable<KeyValuePair<string, string>> data = null, Dictionary<string, string> headers = null)
+        protected override async Task<BaseWebResult> RequestBytesWithCookies(string url, string cookieOverride = null, RequestType method = RequestType.GET, string referer = null, IEnumerable<KeyValuePair<string, string>> data = null, Dictionary<string, string> headers = null)
         {
             CookieHeader = null; // Download fill fail with cookies set
             return await base.RequestBytesWithCookies(url, cookieOverride, method, referer, data, headers);

--- a/src/Jackett.Common/Indexers/HDOlimpo.cs
+++ b/src/Jackett.Common/Indexers/HDOlimpo.cs
@@ -149,7 +149,7 @@ namespace Jackett.Common.Indexers
             headers["X-XSRF-TOKEN"] = xsrfToken;
         }
 
-        private List<ReleaseInfo> ParseResponse(WebClientStringResult response, bool includePremium)
+        private List<ReleaseInfo> ParseResponse(BaseWebResult response, bool includePremium)
         {
             var releases = new List<ReleaseInfo>();
 
@@ -212,7 +212,7 @@ namespace Jackett.Common.Indexers
             return releases;
         }
 
-        private JArray CheckResponse(WebClientStringResult response)
+        private JArray CheckResponse(BaseWebResult response)
         {
             try
             {

--- a/src/Jackett.Common/Indexers/InternetArchive.cs
+++ b/src/Jackett.Common/Indexers/InternetArchive.cs
@@ -148,7 +148,7 @@ namespace Jackett.Common.Indexers
             return releases;
         }
 
-        private JArray ParseResponse(WebClientStringResult result)
+        private JArray ParseResponse(BaseWebResult result)
         {
             try
             {

--- a/src/Jackett.Common/Indexers/LostFilm.cs
+++ b/src/Jackett.Common/Indexers/LostFilm.cs
@@ -205,7 +205,7 @@ namespace Jackett.Common.Indexers
             }
         }
 
-        private async Task<WebClientStringResult> RequestStringAndRelogin(string url)
+        private async Task<BaseWebResult> RequestStringAndRelogin(string url)
         {
             var results = await RequestStringWithCookies(url);
             if (results.ContentString.Contains("503 Service"))

--- a/src/Jackett.Common/Indexers/NCore.cs
+++ b/src/Jackett.Common/Indexers/NCore.cs
@@ -218,7 +218,7 @@ namespace Jackett.Common.Indexers
             return releases;
         }
 
-        private List<ReleaseInfo> parseTorrents(WebClientStringResult results, string seasonep, TorznabQuery query,
+        private List<ReleaseInfo> parseTorrents(BaseWebResult results, string seasonep, TorznabQuery query,
                                                 int alreadyFounded, int limit, int previouslyParsedOnPage)
         {
             var releases = new List<ReleaseInfo>();

--- a/src/Jackett.Common/Indexers/Newpct.cs
+++ b/src/Jackett.Common/Indexers/Newpct.cs
@@ -276,7 +276,7 @@ namespace Jackett.Common.Indexers
                 while (pg <= _maxDailyPages)
                 {
                     IEnumerable<NewpctRelease> items = null;
-                    WebClientStringResult results = null;
+                    BaseWebResult results = null;
 
                     if (validUri != null)
                     {
@@ -601,7 +601,7 @@ namespace Jackett.Common.Indexers
                 queryCollection.Add("s", searchStr);
                 queryCollection.Add("pg", pg.ToString());
 
-                WebClientStringResult results = null;
+                BaseWebResult results = null;
                 IEnumerable<NewpctRelease> items = null;
 
                 if (validUri != null)

--- a/src/Jackett.Common/Indexers/Norbits.cs
+++ b/src/Jackett.Common/Indexers/Norbits.cs
@@ -459,9 +459,9 @@ namespace Jackett.Common.Indexers
         /// </summary>
         /// <param name="request">URL created by Query Builder</param>
         /// <returns>Results from query</returns>
-        private async Task<WebClientStringResult> QueryExec(string request)
+        private async Task<BaseWebResult> QueryExec(string request)
         {
-            WebClientStringResult results;
+            BaseWebResult results;
 
             // Switch in we are in DEV mode with Hard Drive Cache or not
             if (DevMode && CacheMode)
@@ -482,9 +482,9 @@ namespace Jackett.Common.Indexers
         /// </summary>
         /// <param name="request">URL created by Query Builder</param>
         /// <returns>Results from query</returns>
-        private async Task<WebClientStringResult> QueryCache(string request)
+        private async Task<BaseWebResult> QueryCache(string request)
         {
-            WebClientStringResult results;
+            BaseWebResult results;
 
             // Create Directory if not exist
             System.IO.Directory.CreateDirectory(Directory);
@@ -519,7 +519,7 @@ namespace Jackett.Common.Indexers
         /// </summary>
         /// <param name="request">URL created by Query Builder</param>
         /// <returns>Results from query</returns>
-        private async Task<WebClientStringResult> QueryTracker(string request)
+        private async Task<BaseWebResult> QueryTracker(string request)
         {
             // Cache mode not enabled or cached file didn't exist for our query
             Output("\nQuerying tracker for results....");

--- a/src/Jackett.Common/Indexers/Nordicbits.cs
+++ b/src/Jackett.Common/Indexers/Nordicbits.cs
@@ -541,9 +541,9 @@ namespace Jackett.Common.Indexers
         /// </summary>
         /// <param name="request">URL created by Query Builder</param>
         /// <returns>Results from query</returns>
-        private async Task<WebClientStringResult> QueryExec(string request)
+        private async Task<BaseWebResult> QueryExec(string request)
         {
-            WebClientStringResult results;
+            BaseWebResult results;
 
             // Switch in we are in DEV mode with Hard Drive Cache or not
             if (DevMode && CacheMode)
@@ -564,9 +564,9 @@ namespace Jackett.Common.Indexers
         /// </summary>
         /// <param name="request">URL created by Query Builder</param>
         /// <returns>Results from query</returns>
-        private async Task<WebClientStringResult> QueryCache(string request)
+        private async Task<BaseWebResult> QueryCache(string request)
         {
-            WebClientStringResult results;
+            BaseWebResult results;
 
             // Create Directory if not exist
             System.IO.Directory.CreateDirectory(Directory);
@@ -601,7 +601,7 @@ namespace Jackett.Common.Indexers
         /// </summary>
         /// <param name="request">URL created by Query Builder</param>
         /// <returns>Results from query</returns>
-        private async Task<WebClientStringResult> QueryTracker(string request)
+        private async Task<BaseWebResult> QueryTracker(string request)
         {
             // Cache mode not enabled or cached file didn't exist for our query
             Output("\nQuerying tracker for results....");

--- a/src/Jackett.Common/Indexers/Partis.cs
+++ b/src/Jackett.Common/Indexers/Partis.cs
@@ -113,7 +113,7 @@ namespace Jackett.Common.Indexers
             var releases = new List<ReleaseInfo>();     //List of releases initialization
             var searchString = query.GetQueryString();  //get search string from query
 
-            WebClientStringResult results = null;
+            BaseWebResult results = null;
             var queryCollection = new NameValueCollection();
             var catList = MapTorznabCapsToTrackers(query);     // map categories from query to indexer specific
             var categ = string.Join(",", catList);

--- a/src/Jackett.Common/Indexers/Shazbat.cs
+++ b/src/Jackett.Common/Indexers/Shazbat.cs
@@ -78,7 +78,7 @@ namespace Jackett.Common.Indexers
         {
             var releases = new List<ReleaseInfo>();
             var queryString = query.GetQueryString();
-            WebClientStringResult results = null;
+            BaseWebResult results = null;
             var searchUrls = new List<string>();
             if (!string.IsNullOrWhiteSpace(query.SanitizedSearchTerm))
             {
@@ -166,7 +166,7 @@ namespace Jackett.Common.Indexers
             return releases;
         }
 
-        private async Task<WebClientStringResult> ReloginIfNecessary(WebClientStringResult response)
+        private async Task<BaseWebResult> ReloginIfNecessary(BaseWebResult response)
         {
             if (response.ContentString.Contains("onclick=\"document.location='logout'\""))
                 return response;

--- a/src/Jackett.Common/Indexers/SolidTorrents.cs
+++ b/src/Jackett.Common/Indexers/SolidTorrents.cs
@@ -73,7 +73,7 @@ namespace Jackett.Common.Indexers
             return IndexerConfigurationStatus.Completed;
         }
 
-        private JArray CheckResponse(WebClientStringResult result)
+        private JArray CheckResponse(BaseWebResult result)
         {
             try
             {

--- a/src/Jackett.Common/Indexers/TVstore.cs
+++ b/src/Jackett.Common/Indexers/TVstore.cs
@@ -113,7 +113,7 @@ namespace Jackett.Common.Indexers
         /// <param name="query">Query.</param>
         /// <param name="already_found">Number of the already found torrents.(used for limit)</param>
         /// <param name="limit">The limit to the number of torrents to download </param>
-        private async Task<List<ReleaseInfo>> ParseTorrents(WebClientStringResult results, TorznabQuery query, int already_found, int limit, int previously_parsed_on_page)
+        private async Task<List<ReleaseInfo>> ParseTorrents(BaseWebResult results, TorznabQuery query, int already_found, int limit, int previously_parsed_on_page)
         {
             var releases = new List<ReleaseInfo>();
             try
@@ -260,7 +260,7 @@ namespace Jackett.Common.Indexers
 
             var unixTimestamp = (int)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
 
-            WebClientStringResult results;
+            BaseWebResult results;
 
             var searchString = "";
             var exactSearchURL = "";

--- a/src/Jackett.Common/Indexers/Torrentech.cs
+++ b/src/Jackett.Common/Indexers/Torrentech.cs
@@ -73,7 +73,7 @@ namespace Jackett.Common.Indexers
             var releases = new List<ReleaseInfo>();
             var searchString = query.GetQueryString();
 
-            WebClientStringResult results = null;
+            BaseWebResult results = null;
             var queryCollection = new NameValueCollection();
 
             queryCollection.Add("act", "search");

--- a/src/Jackett.Common/Utils/Clients/BaseWebResult.cs
+++ b/src/Jackett.Common/Utils/Clients/BaseWebResult.cs
@@ -8,6 +8,7 @@ namespace Jackett.Common.Utils.Clients
 {
     public abstract class BaseWebResult
     {
+        private string _contentString;
         private Encoding _encoding;
 
         public Encoding Encoding
@@ -20,7 +21,8 @@ namespace Jackett.Common.Utils.Clients
                     _encoding = Request.Encoding;
                 else if (Headers.ContainsKey("content-type"))
                 {
-                    var charsetRegexMatch = Regex.Match(Headers["content-type"][0], @"charset=([\w-]+)", RegexOptions.Compiled);
+                    var charsetRegexMatch = Regex.Match(
+                        Headers["content-type"][0], @"charset=([\w-]+)", RegexOptions.Compiled);
                     if (charsetRegexMatch.Success)
                     {
                         var charset = charsetRegexMatch.Groups[1].Value;
@@ -36,18 +38,33 @@ namespace Jackett.Common.Utils.Clients
                 }
 
                 _encoding ??= Encoding.UTF8;
-
                 return _encoding;
             }
             set => _encoding = value;
         }
 
+        public byte[] ContentBytes { get; set; }
         public HttpStatusCode Status { get; set; }
         public string Cookies { get; set; }
         public string RedirectingTo { get; set; }
         public WebRequest Request { get; set; }
+
         public Dictionary<string, string[]> Headers { get; protected set; } =
             new Dictionary<string, string[]>(StringComparer.OrdinalIgnoreCase);
+
+        public string ContentString
+        {
+            get
+            {
+                if (_contentString != null)
+                    return _contentString;
+                if (ContentBytes == null)
+                    return null;
+                _contentString = Encoding.GetString(ContentBytes);
+                return _contentString;
+            }
+            set => _contentString = value;
+        }
 
         public bool IsRedirect => Status == HttpStatusCode.Redirect ||
                                   Status == HttpStatusCode.RedirectKeepVerb ||

--- a/src/Jackett.Common/Utils/Clients/WebByteResult.cs
+++ b/src/Jackett.Common/Utils/Clients/WebByteResult.cs
@@ -2,6 +2,5 @@ namespace Jackett.Common.Utils.Clients
 {
     public class WebClientByteResult : BaseWebResult
     {
-        public byte[] ContentBytes { get; set; }
     }
 }

--- a/src/Jackett.Common/Utils/Clients/WebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/WebClient.cs
@@ -186,7 +186,7 @@ namespace Jackett.Common.Utils.Clients
             return;
         }
 
-        public virtual async Task<WebClientByteResult> GetBytes(WebRequest request)
+        public virtual async Task<BaseWebResult> GetBytes(WebRequest request)
         {
             logger.Debug(string.Format("WebClient({0}).GetBytes(Url:{1})", ClientType, request.Url));
             PrepareRequest(request);
@@ -198,7 +198,7 @@ namespace Jackett.Common.Utils.Clients
             return result;
         }
 
-        public virtual async Task<WebClientStringResult> GetString(WebRequest request)
+        public virtual async Task<BaseWebResult> GetString(WebRequest request)
         {
             logger.Debug(string.Format("WebClient({0}).GetString(Url:{1})", ClientType, request.Url));
             PrepareRequest(request);
@@ -206,7 +206,7 @@ namespace Jackett.Common.Utils.Clients
             var result = await Run(request);
             lastRequest = DateTime.Now;
             result.Request = request;
-            WebClientStringResult stringResult = result;
+            BaseWebResult stringResult = result;
 
             logger.Debug(string.Format("WebClient({0}): Returning {1} => {2}", ClientType, result.Status, (result.IsRedirect ? result.RedirectingTo + " " : "") + (stringResult.ContentString ?? "<NULL>")));
 

--- a/src/Jackett.Common/Utils/Clients/WebClientResult.cs
+++ b/src/Jackett.Common/Utils/Clients/WebClientResult.cs
@@ -2,11 +2,9 @@ namespace Jackett.Common.Utils.Clients
 {
     public class WebClientStringResult : BaseWebResult
     {
-        public string ContentString { get; set; }
-
         public static implicit operator WebClientStringResult(WebClientByteResult br) => new WebClientStringResult()
         {
-            ContentString = br.ContentBytes == null ? null : br.Encoding.GetString(br.ContentBytes),
+            ContentBytes = br.ContentBytes,
             Cookies = br.Cookies,
             Encoding = br.Encoding,
             Headers = br.Headers,

--- a/src/Jackett.Test/TestWebClient.cs
+++ b/src/Jackett.Test/TestWebClient.cs
@@ -11,8 +11,8 @@ namespace Jackett.Test
 {
     public class TestWebClient : WebClient
     {
-        private readonly Dictionary<WebRequest, Func<WebRequest, WebClientByteResult>> byteCallbacks = new Dictionary<WebRequest, Func<WebRequest, WebClientByteResult>>();
-        private readonly Dictionary<WebRequest, Func<WebRequest, WebClientStringResult>> stringCallbacks = new Dictionary<WebRequest, Func<WebRequest, WebClientStringResult>>();
+        private readonly Dictionary<WebRequest, Func<WebRequest, BaseWebResult>> byteCallbacks = new Dictionary<WebRequest, Func<WebRequest, BaseWebResult>>();
+        private readonly Dictionary<WebRequest, Func<WebRequest, BaseWebResult>> stringCallbacks = new Dictionary<WebRequest, Func<WebRequest, BaseWebResult>>();
 
         public TestWebClient(IProcessService p, Logger l, IConfigurationService c, ServerConfig sc)
             : base(p: p,
@@ -26,9 +26,9 @@ namespace Jackett.Test
 
         public void RegisterStringCall(WebRequest req, Func<WebRequest, WebClientStringResult> f) => stringCallbacks.Add(req, f);
 
-        public override Task<WebClientByteResult> GetBytes(WebRequest request) => Task.FromResult<WebClientByteResult>(byteCallbacks.Where(r => r.Key.Equals(request)).First().Value.Invoke(request));
+        public override Task<BaseWebResult> GetBytes(WebRequest request) => Task.FromResult(byteCallbacks.Where(r => r.Key.Equals(request)).First().Value.Invoke(request));
 
-        public override Task<WebClientStringResult> GetString(WebRequest request) => Task.FromResult<WebClientStringResult>(stringCallbacks.Where(r => r.Key.Equals(request)).First().Value.Invoke(request));
+        public override Task<BaseWebResult> GetString(WebRequest request) => Task.FromResult(stringCallbacks.Where(r => r.Key.Equals(request)).First().Value.Invoke(request));
 
         public override void Init()
         {


### PR DESCRIPTION
Moving up the Content properties in preparation for merge. Next PR will rename class names to base where refactoring the code base isn't necessary.