### PR TITLE
redacted: fix double login in gazelle trackers. resolves #6461

### DIFF
--- a/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
@@ -189,8 +189,7 @@ namespace Jackett.Common.Indexers.Abstract
             searchUrl += "?" + queryCollection.GetQueryString();
 
             var response = await RequestStringWithCookiesAndRetry(searchUrl);
-
-            if (response.IsRedirect || query.IsTest)
+            if (response.IsRedirect)
             {
                 // re-login
                 await ApplyConfiguration(null);


### PR DESCRIPTION
Tested in Redacted and AlphaRatio.
I think this should work for all Gazelle trackers.