### PR TITLE
Update 1337x Proxy

### DIFF
--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -5,6 +5,7 @@
   language: en-us
   type: public
   encoding: UTF-8
+  followredirect: true
   links:
     - https://1337x.to/
     - https://1337x.gd/

--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -13,6 +13,8 @@
     - https://x1337x.ws/
     - https://x1337x.eu/
     - https://x1337x.se/
+    - https://1337x.unblockit.pro/
+  legacylinks:
     - https://1337x.unblocked.earth/
 
   caps:


### PR DESCRIPTION
Update to current proxy link.

This changes regularly (maybe once or twice a month?) and causes redirect errors. Is there any way to allow the redirects? https://github.com/unblocked-pw/unblocked-pw.github.io

Not sure if there are other sites using the same proxy, but they would need updated too.

Currently testing will fail due to an ongoing issue, but the site itself is fine - https://github.com/Jackett/Jackett/issues/7743