### PR TITLE
Fixed indexer TorrentSyndikat.cs - Adding wildcard to season search string

### DIFF
--- a/src/Jackett.Common/Definitions/fanoin.yml
+++ b/src/Jackett.Common/Definitions/fanoin.yml
@@ -49,10 +49,36 @@
       - {id: 23, cat: TV/Sport, desc: "TV/Sport"}
       - {id: 51, cat: Console, desc: "Games/Misc"}
       - {id: 1, cat: PC/0day, desc: "Appz/PC ISO"}
+      - {id: 55, cat: Movies/UHD, desc: "Movies/4K"}
 
     modes:
-      search: [q]
-      tv-search: [q, season, ep]
+      search: [q, imdbid]
+      tv-search: [q, season, ep, imdbid]
+      movie-search: [q, imdbid]
+
+  settings:
+    - name: username
+      type: text
+      label: Username
+    - name: password
+      type: password
+      label: Password
+    - name: sort
+      type: select
+      label: Sort requested from site
+      default: "4"
+      options:
+        "4": "created"
+        "7": "seeders"
+        "5": "size"
+        "1": "title"
+    - name: type
+      type: select
+      label: Order requested from site
+      default: "desc"
+      options:
+        "desc": "desc"
+        "asc": "asc"
 
   login:
     path: takelogin.php
@@ -64,7 +90,7 @@
       - selector: td.embedded:has(h2:contains("failed"))
     test:
       path: browse_old.php
-      
+
   ratio:
     path: browse_old.php
     selector: img[title="Reitings:"]+font
@@ -73,13 +99,16 @@
     paths:
       - path: browse_old.php
     inputs:
-      $raw: "{{range .Categories}}c{{.}}=1&{{end}}"
-      search: "{{ .Query.Keywords }}"
+      $raw: "{{ range .Categories }}c{{.}}=1&{{end}}"
+      search: "{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{else}}{{ .Keywords }}{{end}}"
+      # 0 active 1 incldead 2 onlydead
       incldead: 1
+      sort: "{{ .Config.sort }}"
+      type: "{{ .Config.type }}"
+
     rows:
       selector: tr.browse_actions
-      filters:
-        - name: andmatch
+
     fields:
       title:
         selector: a[href^="details.php?id="]
@@ -113,7 +142,7 @@
           - name: regexp
             args: (\d+)
       date:
-        selector: td:nth-child(2) > small:nth-last-child(2)
+        selector: td:nth-child(2) > small:nth-last-child(2), td:nth-child(2) > small
         filters:
           - name: replace
             args: ["Šodien", "Today"]
@@ -121,12 +150,13 @@
             args: ["Vakar", "Yesterday"]
       downloadvolumefactor:
         case:
-          img[alt="Free"]: "0"
-          "*": "1"
+          img[alt="Free"]: 0
+          "*": 1
       uploadvolumefactor:
         case:
-          img[alt="x2"]: "2"
-          "*": "1"
+          img[alt="x2"]: 2
+          "*": 1
       description:
         selector: td:nth-child(2) > small:nth-last-child(1)
         remove: a[href^="details.php?id="]
+# engine n/a

--- a/src/Jackett.Common/Indexers/TorrentSyndikat.cs
+++ b/src/Jackett.Common/Indexers/TorrentSyndikat.cs
@@ -129,13 +129,11 @@ namespace Jackett.Common.Indexers
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {
             var releases = new List<ReleaseInfo>();
-
-            var searchString = query.GetQueryString();
-            var searchUrl = SearchUrl;
-            var queryCollection = new NameValueCollection();
-
-            queryCollection.Add("incldead", "1");
-            queryCollection.Add("rel_type", "0"); // Alle
+            var queryCollection = new NameValueCollection
+            {
+                {"incldead", "1"},
+                {"rel_type", "0"} // Alle
+            };
 
             if (query.ImdbID != null)
             {
@@ -146,7 +144,7 @@ namespace Jackett.Common.Indexers
             {
                 queryCollection.Add("searchin", "title");
 
-                if (!string.IsNullOrWhiteSpace(searchString))
+                if (!string.IsNullOrWhiteSpace(query.GetQueryString()))
                 {
                     // use AND+wildcard operator to avoid getting to many useless results
                     var searchStringArray = Regex.Split(
@@ -169,7 +167,7 @@ namespace Jackett.Common.Indexers
             foreach (var cat in MapTorznabCapsToTrackers(query))
                 queryCollection.Add("c" + cat, "1");
 
-            searchUrl += "?" + queryCollection.GetQueryString();
+            var searchUrl = SearchUrl + "?" + queryCollection.GetQueryString();
 
             var results = await RequestStringWithCookiesAndRetry(searchUrl);
 

--- a/src/Jackett.Common/Indexers/TorrentSyndikat.cs
+++ b/src/Jackett.Common/Indexers/TorrentSyndikat.cs
@@ -151,6 +151,20 @@ namespace Jackett.Common.Indexers
                     // use AND+wildcard operator to avoid getting to many useless results
                     var searchStringArray = Regex.Split(searchString.Trim(), "[ _.-]+", RegexOptions.Compiled).ToList();
                     searchStringArray = searchStringArray.Select(x => "+" + x).ToList(); // add AND operators
+
+                    //Check if search string ends with S01/S02/S03 and so on. Adds wildcard to the end of search string in order to find all episodes to a season
+
+                    string combindedString = string.Join(" ", searchStringArray);
+                    Regex regex = new Regex("s[0-9]{2}$");
+                    Match match = regex.Match(combindedString);
+
+                    if (match.Success)
+                    {
+                        var item = searchStringArray[searchStringArray.Count - 1];
+                        searchStringArray[searchStringArray.FindIndex(ind => ind.Equals(item))] = item + "*";
+
+                    }
+
                     var searchStringFinal = string.Join(" ", searchStringArray);
                     queryCollection.Add("search", searchStringFinal);
                 }

--- a/src/Jackett.Common/Indexers/TorrentSyndikat.cs
+++ b/src/Jackett.Common/Indexers/TorrentSyndikat.cs
@@ -154,9 +154,9 @@ namespace Jackett.Common.Indexers
 
                     //Check if search string ends with S01/S02/S03 and so on. Adds wildcard to the end of search string in order to find all episodes to a season
 
-                    string combindedString = string.Join(" ", searchStringArray);
-                    Regex regex = new Regex("s[0-9]{2}$");
-                    Match match = regex.Match(combindedString);
+                    var combindedString = string.Join(" ", searchStringArray);
+                    var regex = new Regex("s[0-9]{2}$");
+                    var match = regex.Match(combindedString);
 
                     if (match.Success)
                     {

--- a/src/Jackett.Common/Indexers/TorrentSyndikat.cs
+++ b/src/Jackett.Common/Indexers/TorrentSyndikat.cs
@@ -155,7 +155,7 @@ namespace Jackett.Common.Indexers
                     //Check if search string ends with S01/S02/S03 and so on. Adds wildcard to the end of search string in order to find all episodes to a season
 
                     var combindedString = string.Join(" ", searchStringArray);
-                    var regex = new Regex("s[0-9]{2}$");
+                    var regex = new Regex("s[0-9]{2}$", RegexOptions.IgnoreCase);
                     var match = regex.Match(combindedString);
 
                     if (match.Success)

--- a/src/Jackett.Common/Indexers/TorrentSyndikat.cs
+++ b/src/Jackett.Common/Indexers/TorrentSyndikat.cs
@@ -153,7 +153,7 @@ namespace Jackett.Common.Indexers
 
                     // If only season search add * wildcard to get all episodes
                     var tvEpisode = query.GetEpisodeSearchString();
-                    if (!string.IsNullOrWhiteSpace(tvEpisode)
+                    if (!string.IsNullOrWhiteSpace(tvEpisode))
                     {
                         if(tvEpisode.StartsWith("S") && !tvEpisode.Contains("E"))
                             tvEpisode += "*";

--- a/src/Jackett.Common/Indexers/TorrentSyndikat.cs
+++ b/src/Jackett.Common/Indexers/TorrentSyndikat.cs
@@ -152,10 +152,10 @@ namespace Jackett.Common.Indexers
                         RegexOptions.Compiled).Select(term => $"+{term}");
 
                     // If only season search add * wildcard to get all episodes
-                    if (query.IsTVSearch)
+                    var tvEpisode = query.GetEpisodeSearchString();
+                    if (!string.IsNullOrWhiteSpace(tvEpisode)
                     {
-                        var tvEpisode = query.GetEpisodeSearchString();
-                        if (!string.IsNullOrWhiteSpace(tvEpisode) && tvEpisode.StartsWith("S") && !tvEpisode.Contains("E"))
+                        if(tvEpisode.StartsWith("S") && !tvEpisode.Contains("E"))
                             tvEpisode += "*";
                         searchStringArray = searchStringArray.Append($"+{tvEpisode}");
                     }


### PR DESCRIPTION
When searching for a season (manual search --> i.e. "**West World S03**") the indexer for TorrentSyndikat adds a "+" to every word. (AND Operator).
The search string then looks like this --> "**+West +World +S03**"
Unfortunately searching for  "+West +World +S03" doesn't yield any results on TS altough West World S03**E01** is available. 
Thats beacause a wildcard operator needs to be added to "S03" so it looks like this "**+West +World +S03***"

The code was revised to add a wildcard operator IF the search string ends with S01 / S02 / S03 and so on. Matching with RegEx "**s[0-9]{2}$**"

Is that an expected behaviour? Sonarr for example only has an automated search for "West World S03". (Without episodes) 

I'm new to to Github (not to coding though), so if something's missing please let me know. 