### PR TITLE
core: update user-agent. resolves #7743 resolves #6099

### DIFF
--- a/src/Jackett.Common/Utils/BrowserUtil.cs
+++ b/src/Jackett.Common/Utils/BrowserUtil.cs
@@ -5,21 +5,10 @@ namespace Jackett.Common.Utils
 {
     public static class BrowserUtil
     {
-        public static string ChromeUserAgent
-        {
-            get
-            {
-                // When updating these make sure they are not detected by the incapsula bot detection engine (e.g. kickasstorrent indexer)
-                if (System.Environment.OSVersion.Platform == PlatformID.Unix)
-                {
-                    return "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.67 Safari/537.36";
-                }
-                else
-                {
-                    return "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.67 Safari/537.36";
-                }
-            }
-        }
+        // When updating these make sure they are not detected by the incapsula bot detection engine (e.g. kickasstorrent indexer)
+        public static string ChromeUserAgent => Environment.OSVersion.Platform == PlatformID.Unix ?
+            "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36" :
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/80.0.3987.132 Safari/537.36";
 
         // This can be used to decode e-mail addresses protected by cloudflare
         public static string DecodeCloudFlareProtectedEmail(string input)


### PR DESCRIPTION
Tested with all public trackers and it's working in almost all of them.
The two only public trackers with the exception `Clearance failed after 30 attempt(s)` are:
* cpasbien
* demonoid

But that is because they have reCAPTCHA with image challenge. I think we should add cookies for both.
![image](https://user-images.githubusercontent.com/10577978/77233099-826a4580-6ba5-11ea-828d-87874c35a2de.png)

Maybe works for #7325 but not tested
Update: Tested badasstorrents and it's working too, but I don't remember having problems with this tracker.