### PR TITLE
Update GloTorrents Links

### DIFF
--- a/src/Jackett.Common/Definitions/glodls.yml
+++ b/src/Jackett.Common/Definitions/glodls.yml
@@ -6,7 +6,9 @@
   type: public
   encoding: UTF-8
   links:
+    - https://gtdb.to/
     - https://glodls.to/
+  legacylinks:
     - https://glodls.rocks/
 
   caps:


### PR DESCRIPTION
gtdb.to is apparently the new official domain

glodls.to works fine still

glodls.rocks looks to be dead