### PR TITLE
Assorted proxies for assorted indexers

### DIFF
--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -15,6 +15,8 @@
     - https://x1337x.eu/
     - https://x1337x.se/
     - https://1337x.unblockit.pro/
+    - https://1337.root.yt/
+    - https://1337x.unblockninja.com/
   legacylinks:
     - https://1337x.unblocked.earth/
 

--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -17,6 +17,11 @@
     - https://1337x.unblockit.pro/
     - https://1337.root.yt/
     - https://1337x.unblockninja.com/
+    - https://1337x.black-mirror.xyz/
+    - https://1337x.unblocked.casa/
+    - https://1337x.proxyportal.fun/
+    - https://1337x.uk-unblock.xyz/
+    - https://1337x.ind-unblock.xyz/
   legacylinks:
     - https://1337x.unblocked.earth/
 

--- a/src/Jackett.Common/Definitions/btdb.yml
+++ b/src/Jackett.Common/Definitions/btdb.yml
@@ -9,11 +9,11 @@
   links:
     - https://btdb.io/
     - https://btdb.unblockit.pro/
-    - https://btdb.black-mirror.xyz
-    - https://btdb.unblocked.casa
-    - https://btdb.proxyportal.fun
-    - https://btdb.uk-unblock.xyz
-    - https://btdb.ind-unblock.xyz
+    - https://btdb.black-mirror.xyz/
+    - https://btdb.unblocked.casa/
+    - https://btdb.proxyportal.fun/
+    - https://btdb.uk-unblock.xyz/
+    - https://btdb.ind-unblock.xyz/
   legacylinks:
     - https://btdb.to/
     - https://btdb.unblocked.app/

--- a/src/Jackett.Common/Definitions/btdb.yml
+++ b/src/Jackett.Common/Definitions/btdb.yml
@@ -9,11 +9,11 @@
   links:
     - https://btdb.io/
     - https://btdb.unblockit.pro/
-    - btdb.black-mirror.xyz
-    - btdb.unblocked.casa
-    - btdb.proxyportal.fun
-    - btdb.uk-unblock.xyz
-    - btdb.ind-unblock.xyz
+    - https://btdb.black-mirror.xyz
+    - https://btdb.unblocked.casa
+    - https://btdb.proxyportal.fun
+    - https://btdb.uk-unblock.xyz
+    - https://btdb.ind-unblock.xyz
   legacylinks:
     - https://btdb.to/
     - https://btdb.unblocked.app/

--- a/src/Jackett.Common/Definitions/btdb.yml
+++ b/src/Jackett.Common/Definitions/btdb.yml
@@ -9,6 +9,11 @@
   links:
     - https://btdb.io/
     - https://btdb.unblockit.pro/
+    - btdb.black-mirror.xyz
+    - btdb.unblocked.casa
+    - btdb.proxyportal.fun
+    - btdb.uk-unblock.xyz
+    - btdb.ind-unblock.xyz
   legacylinks:
     - https://btdb.to/
     - https://btdb.unblocked.app/

--- a/src/Jackett.Common/Definitions/cpasbienclone.yml
+++ b/src/Jackett.Common/Definitions/cpasbienclone.yml
@@ -8,6 +8,12 @@
   followredirect: true
   links:
     - https://www1.cpasbiens.cm/
+    - https://cpasbien.to/
+    - https://cpasbiens.black-mirror.xyz/
+    - https://cpasbiens.unblocked.casa/
+    - https://cpasbiens.proxyportal.fun/
+    - https://cpasbiens.uk-unblock.xyz/
+    - https://cpasbiens.ind-unblock.xyz/
   legacylinks:
     - https://www1.cpasbiens.ws/
     - https://www2.cpasbiens.ws/

--- a/src/Jackett.Common/Definitions/demonoid.yml
+++ b/src/Jackett.Common/Definitions/demonoid.yml
@@ -9,6 +9,11 @@
   links:
     - https://www.demonoid.is/
     - https://demonoid.unblockit.pro/
+    - https://dnoid.black-mirror.xyz/
+    - https://dnoid.unblocked.casa/
+    - https://dnoid.proxyportal.fun/
+    - https://dnoid.uk-unblock.xyz/
+    - https://dnoid.ind-unblock.xyz/
   legacylinks:
     - https://www.dnoid.to/
 

--- a/src/Jackett.Common/Definitions/ettv.yml
+++ b/src/Jackett.Common/Definitions/ettv.yml
@@ -9,6 +9,8 @@
   links:
     - https://www.ettv.to/
     - https://ettv.unblockit.pro/
+    - https://ettv.root.yt/
+    - https://ettv.unblockninja.com/
   legacylinks:
     - https://www.ettv.tv/
 

--- a/src/Jackett.Common/Definitions/ettv.yml
+++ b/src/Jackett.Common/Definitions/ettv.yml
@@ -11,6 +11,11 @@
     - https://ettv.unblockit.pro/
     - https://ettv.root.yt/
     - https://ettv.unblockninja.com/
+    - https://ettv.black-mirror.xyz/
+    - https://ettv.unblocked.casa/
+    - https://ettv.proxyportal.fun/
+    - https://ettv.uk-unblock.xyz/
+    - https://ettv.ind-unblock.xyz/
   legacylinks:
     - https://www.ettv.tv/
 

--- a/src/Jackett.Common/Definitions/extratorrent-cd.yml
+++ b/src/Jackett.Common/Definitions/extratorrent-cd.yml
@@ -5,8 +5,10 @@
   language: en-us
   type: public
   encoding: UTF-8
+  followredirect: true
   links:
     - https://extratorrent.si/
+    - https://extratorrent.unblockit.pro/
 
   caps:
     categorymappings:

--- a/src/Jackett.Common/Definitions/exttorrents.yml
+++ b/src/Jackett.Common/Definitions/exttorrents.yml
@@ -7,6 +7,8 @@
   encoding: UTF-8
   links:
     - https://ext.to/
+  legacylinks:
+    - https://kickasstorrents.unblockninja.com/ # currently redirects to https://ext.to/
 
   caps:
     categories:

--- a/src/Jackett.Common/Definitions/exttorrents.yml
+++ b/src/Jackett.Common/Definitions/exttorrents.yml
@@ -8,7 +8,7 @@
   links:
     - https://ext.to/
   legacylinks:
-    - https://kickasstorrents.unblockninja.com/ # currently redirects to https://ext.to/
+    - https://ext.unblockninja.com/ # currently redirects to https://ext.to/
 
   caps:
     categories:

--- a/src/Jackett.Common/Definitions/eztv.yml
+++ b/src/Jackett.Common/Definitions/eztv.yml
@@ -9,6 +9,8 @@
   links:
     - https://eztv.io/
     - https://eztv.unblockit.pro/
+    - https://eztv.root.yt/
+    - https://eztv.unblockninja.com/
   legacylinks:
     - https://eztv.ag/ # redirects to .io
     - https://eztv.re/ # redirects to .io

--- a/src/Jackett.Common/Definitions/eztv.yml
+++ b/src/Jackett.Common/Definitions/eztv.yml
@@ -11,6 +11,11 @@
     - https://eztv.unblockit.pro/
     - https://eztv.root.yt/
     - https://eztv.unblockninja.com/
+    - https://eztv.black-mirror.xyz/
+    - https://eztv.unblocked.casa/
+    - https://eztv.proxyportal.fun/
+    - https://eztv.uk-unblock.xyz/
+    - https://eztv.ind-unblock.xyz/
   legacylinks:
     - https://eztv.ag/ # redirects to .io
     - https://eztv.re/ # redirects to .io

--- a/src/Jackett.Common/Definitions/glodls.yml
+++ b/src/Jackett.Common/Definitions/glodls.yml
@@ -5,9 +5,11 @@
   language: en-us
   type: public
   encoding: UTF-8
+  followredirect: true
   links:
     - https://gtdb.to/
     - https://glodls.to/
+    - https://glotorrents.unblockit.pro/
   legacylinks:
     - https://glodls.rocks/
 

--- a/src/Jackett.Common/Definitions/glodls.yml
+++ b/src/Jackett.Common/Definitions/glodls.yml
@@ -10,6 +10,11 @@
     - https://gtdb.to/
     - https://glodls.to/
     - https://glotorrents.unblockit.pro/
+    - https://glodls.black-mirror.xyz/
+    - https://glodls.unblocked.casa/
+    - https://glodls.proxyportal.fun/
+    - https://glodls.uk-unblock.xyz/
+    - https://glodls.ind-unblock.xyz/
   legacylinks:
     - https://glodls.rocks/
 

--- a/src/Jackett.Common/Definitions/idope.yml
+++ b/src/Jackett.Common/Definitions/idope.yml
@@ -7,6 +7,11 @@
   encoding: UTF-8
   links:
     - https://idope.se/
+    - https://idope.black-mirror.xyz/
+    - https://idope.unblocked.casa/
+    - https://idope.proxyportal.fun/
+    - https://idope.uk-unblock.xyz/
+    - https://idope.ind-unblock.xyz/
 
   caps:
     categorymappings:

--- a/src/Jackett.Common/Definitions/ilcorsaronero.yml
+++ b/src/Jackett.Common/Definitions/ilcorsaronero.yml
@@ -5,10 +5,13 @@
   language: it-it
   type: public
   encoding: Windows-1252
+  followredirect: true
   links:
     - https://ilcorsaronero.pw/
     - https://ilcorsaronero.fun/
     - https://ilcorsaronero.pro/
+    - https://ilcorsaronero.unblockit.pro/
+    - https://ww1-torrent9.root.yt/
   legacylinks:
     - https://ilcorsaronero.live/
     - https://ilcorsaronero.vip/

--- a/src/Jackett.Common/Definitions/isohunt2.yml
+++ b/src/Jackett.Common/Definitions/isohunt2.yml
@@ -7,6 +7,7 @@
   encoding: UTF-8
   links:
     - https://isohunt2.net/
+    - https://isohunt.nz/
 
   caps:
     categorymappings:

--- a/src/Jackett.Common/Definitions/itorrent.yml
+++ b/src/Jackett.Common/Definitions/itorrent.yml
@@ -5,8 +5,10 @@
   language: hu
   type: public
   encoding: UTF-8
+  followredirect: true
   links:
     - https://itorrent.ws/
+    - https://itorrent.unblockit.pro/
 
   caps:
     categories:

--- a/src/Jackett.Common/Definitions/kickasstorrent-kathow.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrent-kathow.yml
@@ -5,8 +5,10 @@
   language: en-us
   type: public
   encoding: UTF-8
+  followredirect: true
   links:
     - https://kickass.ws/
+    - https://kickass.unblockit.pro/
   legacylinks:
     - https://kickass.gg/
     - https://katcr.io/
@@ -14,6 +16,7 @@
     - https://thekat.se/
     - https://kat.how/
     - https://kat.li/
+    - https://kickasstorrents.unblockninja.com/ # currently not responding
 
   caps:
     categories:

--- a/src/Jackett.Common/Definitions/kickasstorrent.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrent.yml
@@ -11,11 +11,11 @@
     - https://katcr.to/
     - https://kat.unblockit.pro/
     - https://kat.root.yt/
-    - https://katcr.black-mirror.xyz
-    - https://katcr.unblocked.casa
-    - https://katcr.proxyportal.fun
-    - https://katcr.uk-unblock.xyz
-    - https://katcr.ind-unblock.xyz
+    - https://katcr.black-mirror.xyz/
+    - https://katcr.unblocked.casa/
+    - https://katcr.proxyportal.fun/
+    - https://katcr.uk-unblock.xyz/
+    - https://katcr.ind-unblock.xyz/
   legacylinks:
     - https://kickasstorrent.cr/ # https://kickasstorrent.cr/category/latest/page/1 is fake torrent page
 

--- a/src/Jackett.Common/Definitions/kickasstorrent.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrent.yml
@@ -11,7 +11,6 @@
     - https://katcr.to/
     - https://kat.unblockit.pro/
     - https://kat.root.yt/
-    - https://katcr.black-mirror.xyz/
   legacylinks:
     - https://kickasstorrent.cr/ # https://kickasstorrent.cr/category/latest/page/1 is fake torrent page
 

--- a/src/Jackett.Common/Definitions/kickasstorrent.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrent.yml
@@ -12,6 +12,8 @@
     - https://kat.unblockit.pro/
     - https://kat.root.yt/
     - https://katcr.black-mirror.xyz/
+  legacylinks:
+    - https://kickasstorrent.cr/ # https://kickasstorrent.cr/category/latest/page/1 is fake torrent page
 
   caps:
     categorymappings:

--- a/src/Jackett.Common/Definitions/kickasstorrent.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrent.yml
@@ -8,7 +8,10 @@
   followredirect: true
   links:
     - https://katcr.co/
+    - https://katcr.to/
     - https://kat.unblockit.pro/
+    - https://kat.root.yt/
+    - https://katcr.black-mirror.xyz/
 
   caps:
     categorymappings:

--- a/src/Jackett.Common/Definitions/kickasstorrent.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrent.yml
@@ -11,6 +11,11 @@
     - https://katcr.to/
     - https://kat.unblockit.pro/
     - https://kat.root.yt/
+    - https://katcr.black-mirror.xyz
+    - https://katcr.unblocked.casa
+    - https://katcr.proxyportal.fun
+    - https://katcr.uk-unblock.xyz
+    - https://katcr.ind-unblock.xyz
   legacylinks:
     - https://kickasstorrent.cr/ # https://kickasstorrent.cr/category/latest/page/1 is fake torrent page
 

--- a/src/Jackett.Common/Definitions/limetorrents.yml
+++ b/src/Jackett.Common/Definitions/limetorrents.yml
@@ -13,6 +13,7 @@
     - https://limetor.com/
     - https://www.limetor.pro/
     - https://limetorrents.unblockit.pro/
+    - https://limetorrents.unblockninja.com/
   legacylinks:
     - https://www.limetorrents.io/
     - https://www.limetorrents.cc/

--- a/src/Jackett.Common/Definitions/limetorrents.yml
+++ b/src/Jackett.Common/Definitions/limetorrents.yml
@@ -14,6 +14,11 @@
     - https://www.limetor.pro/
     - https://limetorrents.unblockit.pro/
     - https://limetorrents.unblockninja.com/
+    - https://limetorrents.black-mirror.xyz/
+    - https://limetorrents.unblocked.casa/
+    - https://limetorrents.proxyportal.fun/
+    - https://limetorrents.uk-unblock.xyz/
+    - https://limetorrents.ind-unblock.xyz/
   legacylinks:
     - https://www.limetorrents.io/
     - https://www.limetorrents.cc/

--- a/src/Jackett.Common/Definitions/magnet4you.yml
+++ b/src/Jackett.Common/Definitions/magnet4you.yml
@@ -7,6 +7,11 @@
   encoding: UTF-8
   links:
     - https://magnet4you.me/
+    - https://magnet4you.black-mirror.xyz/
+    - https://magnet4you.unblocked.casa/
+    - https://magnet4you.proxyportal.fun/
+    - https://magnet4you.uk-unblock.xyz/
+    - https://magnet4you.ind-unblock.xyz/
   legacylinks:
     - http://magnet4you.me/
 

--- a/src/Jackett.Common/Definitions/monova.yml
+++ b/src/Jackett.Common/Definitions/monova.yml
@@ -10,6 +10,8 @@
     - https://monova.org/
     - https://monova.to/
     - https://monova.unblockit.pro/
+  legacylinks:
+    - https://monova.unblockninja.com/ # currently redirects to https://monova.org/
 
   caps:
     categories:

--- a/src/Jackett.Common/Definitions/monova.yml
+++ b/src/Jackett.Common/Definitions/monova.yml
@@ -10,6 +10,11 @@
     - https://monova.org/
     - https://monova.to/
     - https://monova.unblockit.pro/
+    - https://monova.black-mirror.xyz/
+    - https://monova.unblocked.casa/
+    - https://monova.proxyportal.fun/
+    - https://monova.uk-unblock.xyz/
+    - https://monova.ind-unblock.xyz/
   legacylinks:
     - https://monova.unblockninja.com/ # currently redirects to https://monova.org/
 

--- a/src/Jackett.Common/Definitions/movcr.yml
+++ b/src/Jackett.Common/Definitions/movcr.yml
@@ -7,6 +7,11 @@
   encoding: UTF-8
   links:
     - https://movcr.to/
+    - https://movcr.black-mirror.xyz/
+    - https://movcr.unblocked.casa/
+    - https://movcr.proxyportal.fun/
+    - https://movcr.uk-unblock.xyz/
+    - https://movcr.ind-unblock.xyz/
   legacylinks:
     - https://movcr.tv/
 

--- a/src/Jackett.Common/Definitions/nntt.yml
+++ b/src/Jackett.Common/Definitions/nntt.yml
@@ -7,6 +7,11 @@
   encoding: UTF-8
   links:
     - http://www.nntt.org/ # site does not support https ERR_CONNECTION_REFUSED
+    - https://nntt.black-mirror.xyz/
+    - https://nntt.unblocked.casa/
+    - https://nntt.proxyportal.fun/
+    - https://nntt.uk-unblock.xyz/
+    - https://nntt.ind-unblock.xyz/
 
   caps:
     categorymappings:

--- a/src/Jackett.Common/Definitions/nyaasi.yml
+++ b/src/Jackett.Common/Definitions/nyaasi.yml
@@ -7,6 +7,7 @@
   encoding: UTF-8
   links:
     - https://nyaa.si/
+    - https://nyaa.root.yt/
 
   settings:
     - name: cat-id

--- a/src/Jackett.Common/Definitions/nyaasi.yml
+++ b/src/Jackett.Common/Definitions/nyaasi.yml
@@ -8,6 +8,11 @@
   links:
     - https://nyaa.si/
     - https://nyaa.root.yt/
+    - https://nyaa.black-mirror.xyz/
+    - https://nyaa.unblocked.casa/
+    - https://nyaa.proxyportal.fun/
+    - https://nyaa.uk-unblock.xyz/
+    - https://nyaa.ind-unblock.xyz/
 
   settings:
     - name: cat-id

--- a/src/Jackett.Common/Definitions/oxtorrent.yml
+++ b/src/Jackett.Common/Definitions/oxtorrent.yml
@@ -8,6 +8,11 @@
   followredirect: true
   links:
     - https://www.oxtorrent.com/
+    - https://oxtorrent.black-mirror.xyz/
+    - https://oxtorrent.unblocked.casa/
+    - https://oxtrorrent.proxyportal.fun/
+    - https://oxtorrent.uk-unblock.xyz/
+    - https://oxtorrent.ind-unblock.xyz/
   legacylinks:
     - https://wwv.oxtorrent.com/
     - https://www.smartorrent.tv/

--- a/src/Jackett.Common/Definitions/oxtorrent.yml
+++ b/src/Jackett.Common/Definitions/oxtorrent.yml
@@ -8,6 +8,7 @@
   followredirect: true
   links:
     - https://www.oxtorrent.com/
+    - https://www.oxtorrent.co/
     - https://oxtorrent.black-mirror.xyz/
     - https://oxtorrent.unblocked.casa/
     - https://oxtrorrent.proxyportal.fun/

--- a/src/Jackett.Common/Definitions/prostylex.yml
+++ b/src/Jackett.Common/Definitions/prostylex.yml
@@ -7,6 +7,11 @@
   encoding: UTF-8
   links:
     - https://prostylex.org/
+    - https://prostylex.black-mirror.xyz/
+    - https://prostylex.unblocked.casa/
+    - https://prostylex.proxyportal.fun/
+    - https://prostylex.uk-unblock.xyz/
+    - https://prostylex.ind-unblock.xyz/
   legacylinks:
     - http://prostylex.com/
 

--- a/src/Jackett.Common/Definitions/rutor.yml
+++ b/src/Jackett.Common/Definitions/rutor.yml
@@ -8,6 +8,7 @@
   links:
     - http://rutor.info/ # site does not support https ERR_CONNECTION_REFUSED
     - http://new-rutor.org/
+    - https://rutor.root.yt/
   legacylinks:
     - http://live-rutor.org/ # domain expired 9 Feb 2020
 

--- a/src/Jackett.Common/Definitions/rutor.yml
+++ b/src/Jackett.Common/Definitions/rutor.yml
@@ -9,6 +9,11 @@
     - http://rutor.info/ # site does not support https ERR_CONNECTION_REFUSED
     - http://new-rutor.org/
     - https://rutor.root.yt/
+    - https://rutor.black-mirror.xyz/
+    - https://rutor.unblocked.casa/
+    - https://rutor.proxyportal.fun/
+    - https://rutor.uk-unblock.xyz/
+    - https://rutor.ind-unblock.xyz/
   legacylinks:
     - http://live-rutor.org/ # domain expired 9 Feb 2020
 

--- a/src/Jackett.Common/Definitions/skytorrentsclone.yml
+++ b/src/Jackett.Common/Definitions/skytorrentsclone.yml
@@ -7,6 +7,11 @@
   encoding: UTF-8
   links:
     - https://www.skytorrents.lol/
+    - https://skytorrents.black-mirror.xyz/
+    - https://skytorrents.unblocked.casa/
+    - https://skytorrents.proxyportal.fun/
+    - https://skytorrents.uk-unblock.xyz/
+    - https://skytorrents.ind-unblock.xyz/
   legacylinks:
     - https://www.skytorrents.to/
 

--- a/src/Jackett.Common/Definitions/tokyotosho.yml
+++ b/src/Jackett.Common/Definitions/tokyotosho.yml
@@ -7,6 +7,11 @@
   encoding: UTF-8
   links:
     - https://www.tokyotosho.info/
+    - https://tokyotosho.black-mirror.xyz/
+    - https://tokyotosho.unblocked.casa/
+    - https://tokyotosho.proxyportal.fun/
+    - https://tokyotosho.uk-unblock.xyz/
+    - https://tokyotosho.ind-unblock.xyz/
 
   settings:
     - name: type-id

--- a/src/Jackett.Common/Definitions/torlock.yml
+++ b/src/Jackett.Common/Definitions/torlock.yml
@@ -9,6 +9,7 @@
   links:
     - https://www.torlock.com/
     - https://www.torlock2.com/
+    https://www.torlock.icu/
     - https://torlock.unblockit.pro/
   legacylinks:
     - https://torlock.com/

--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -8,6 +8,7 @@
   followredirect: true
   links:
     - https://www.oxtorrent.me/
+    - https://www.torrent9.pl/
 
   legacylinks:
     - http://www.torrent9.ec/
@@ -34,6 +35,7 @@
     - https://www.torrent9.is/
     - https://www4.torrent9.to/
     - https://www.torrent09.uno/
+    - https://torrent9.unblockninja.com/ # .torrent file download currently broken
 
   caps:
     categorymappings:

--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -9,6 +9,11 @@
   links:
     - https://www.oxtorrent.me/
     - https://www.torrent9.pl/
+    - https://oxtorrent.black-mirror.xyz/
+    - https://oxtorrent.unblocked.casa/
+    - https://oxtrorrent.proxyportal.fun/
+    - https://oxtorrent.uk-unblock.xyz/
+    - https://oxtorrent.ind-unblock.xyz/
 
   legacylinks:
     - http://www.torrent9.ec/

--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -9,11 +9,11 @@
   links:
     - https://www.oxtorrent.me/
     - https://www.torrent9.pl/
-    - https://oxtorrent.black-mirror.xyz/
-    - https://oxtorrent.unblocked.casa/
-    - https://oxtrorrent.proxyportal.fun/
-    - https://oxtorrent.uk-unblock.xyz/
-    - https://oxtorrent.ind-unblock.xyz/
+    - https://torrent9.black-mirror.xyz/
+    - https://torrent9.unblocked.casa/
+    - https://torrent9.proxyportal.fun/
+    - https://torrent9.uk-unblock.xyz/
+    - https://torrent9.ind-unblock.xyz/
 
   legacylinks:
     - http://www.torrent9.ec/

--- a/src/Jackett.Common/Definitions/torrentdownload.yml
+++ b/src/Jackett.Common/Definitions/torrentdownload.yml
@@ -36,6 +36,13 @@
       movie-search: [q]
 
   settings:
+    - name: cookie
+      type: text
+      label: Cookie
+    - name: info
+      type: info
+      label: How to get the Cookie
+      default: "<ol><li>Access this tracker with your browser<li>Open the <b>DevTools</b> panel by pressing <b>F12</b><li>Select the <b>Network</b> tab<li>Click on the <b>Doc</b> button<li>Refresh the page by pressing <b>F5</b><li>Select the <b>Headers</b> tab<li>Find <b>'cookie:'</b> in the <b>Request Headers</b> section<li><b>Select</b> and <b>Copy</b> the whole cookie string <i>(everything after 'cookie: ')</i> and <b>Paste</b> here.</ol>"
     - name: sort
       type: select
       label: Sort requested from site (Applies only to Search with Keywords)
@@ -49,9 +56,14 @@
     selector: a[href^="magnet:?xt="]
     attribute: href
 
+  login:
+    method: cookie
+    test:
+      path: /
+
   search:
     paths:
-      - path: "{{ if .Keywords }}search{{ re_replace .Config.sort \"_\" \"\" }}?q={{ .Keywords }}{{else}}latest{{end}}"
+      - path: "{{ if .Keywords }}search{{ re_replace .Config.sort \"_\" \"\" }}?q={{ .Keywords }}{{else}}{{end}}"
 
     rows:
       selector: table.table2 > tbody > tr:has(span.smallish)
@@ -59,7 +71,6 @@
     fields:
       category:
         selector: div.tt-name > span.smallish
-        optional: true
         filters:
           - name: re_replace
             args: ["[^A-Za-z]+", ""] # strip everything but letters

--- a/src/Jackett.Common/Definitions/torrentdownload.yml
+++ b/src/Jackett.Common/Definitions/torrentdownload.yml
@@ -36,13 +36,6 @@
       movie-search: [q]
 
   settings:
-    - name: cookie
-      type: text
-      label: Cookie
-    - name: info
-      type: info
-      label: How to get the Cookie
-      default: "<ol><li>Access this tracker with your browser<li>Open the <b>DevTools</b> panel by pressing <b>F12</b><li>Select the <b>Network</b> tab<li>Click on the <b>Doc</b> button<li>Refresh the page by pressing <b>F5</b><li>Select the <b>Headers</b> tab<li>Find <b>'cookie:'</b> in the <b>Request Headers</b> section<li><b>Select</b> and <b>Copy</b> the whole cookie string <i>(everything after 'cookie: ')</i> and <b>Paste</b> here.</ol>"
     - name: sort
       type: select
       label: Sort requested from site (Applies only to Search with Keywords)
@@ -56,14 +49,9 @@
     selector: a[href^="magnet:?xt="]
     attribute: href
 
-  login:
-    method: cookie
-    test:
-      path: /
-
   search:
     paths:
-      - path: "{{ if .Keywords }}search{{ re_replace .Config.sort \"_\" \"\" }}?q={{ .Keywords }}{{else}}{{end}}"
+      - path: "{{ if .Keywords }}search{{ re_replace .Config.sort \"_\" \"\" }}?q={{ .Keywords }}{{else}}latest{{end}}"
 
     rows:
       selector: table.table2 > tbody > tr:has(span.smallish)
@@ -71,6 +59,7 @@
     fields:
       category:
         selector: div.tt-name > span.smallish
+        optional: true
         filters:
           - name: re_replace
             args: ["[^A-Za-z]+", ""] # strip everything but letters

--- a/src/Jackett.Common/Definitions/torrentdownload.yml
+++ b/src/Jackett.Common/Definitions/torrentdownload.yml
@@ -9,6 +9,11 @@
   links:
     - https://www.torrentdownload.info/
     - https://torrentdownload.unblockit.pro/
+    - https://torrentdownload.black-mirror.xyz/
+    - https://torrentdownload.unblocked.casa/
+    - https://torrentdownload.proxyportal.fun/
+    - https://torrentdownload.uk-unblock.xyz/
+    - https://torrentdownload.ind-unblock.xyz/
 
   caps:
     categories:

--- a/src/Jackett.Common/Definitions/torrentdownloads.yml
+++ b/src/Jackett.Common/Definitions/torrentdownloads.yml
@@ -10,6 +10,11 @@
     - https://www.torrentdownloads.info/
     - https://www.torrentdownloads.me/
     - https://torrentdownloads.unblockit.pro/
+    - https://torrentdownloads.black-mirror.xyz/
+    - https://torrentdownloads.unblocked.casa/
+    - https://torrentdownloads.proxyportal.fun/
+    - https://torrentdownloads.uk-unblock.xyz/
+    - https://torrentdownloads.ind-unblock.xyz/
 
   caps:
     categorymappings:

--- a/src/Jackett.Common/Definitions/torrentdownloads.yml
+++ b/src/Jackett.Common/Definitions/torrentdownloads.yml
@@ -5,10 +5,11 @@
   language: en-us
   type: public
   encoding: UTF-8
+  followredirect: true
   links:
     - https://www.torrentdownloads.info/
-  legacylinks:
-    - https://www.torrentdownloads.me/ # ERR_NAME_RESOLUTION_FAILED
+    - https://www.torrentdownloads.me/
+    - https://torrentdownloads.unblockit.pro/
 
   caps:
     categorymappings:

--- a/src/Jackett.Common/Definitions/torrentgalaxyorg.yml
+++ b/src/Jackett.Common/Definitions/torrentgalaxyorg.yml
@@ -9,6 +9,7 @@
   links:
     - https://torrentgalaxy.to/
     - https://torrentgalaxy.unblockit.pro/
+    - https://torrentgalaxy.unblockninja.com/
   legacylinks:
     - https://torrentgalaxy.org/
     - https://torrentgalaxy.pw/

--- a/src/Jackett.Common/Definitions/torrentgalaxyorg.yml
+++ b/src/Jackett.Common/Definitions/torrentgalaxyorg.yml
@@ -10,6 +10,11 @@
     - https://torrentgalaxy.to/
     - https://torrentgalaxy.unblockit.pro/
     - https://torrentgalaxy.unblockninja.com/
+    - https://tgx.black-mirror.xyz/
+    - https://tgx.unblocked.casa/
+    - https://tgx.proxyportal.fun/
+    - https://tgx.uk-unblock.xyz/
+    - https://tgx.ind-unblock.xyz/
   legacylinks:
     - https://torrentgalaxy.org/
     - https://torrentgalaxy.pw/

--- a/src/Jackett.Common/Definitions/torrentproject2.yml
+++ b/src/Jackett.Common/Definitions/torrentproject2.yml
@@ -7,6 +7,7 @@
   encoding: UTF-8
   links:
     - https://torrentproject.cc/
+    - https://torrentproject2.org/
   legacylinks:
     - https://torrentproject2.se/
 

--- a/src/Jackett.Common/Definitions/torrentz2.yml
+++ b/src/Jackett.Common/Definitions/torrentz2.yml
@@ -9,6 +9,8 @@
   links:
     - https://torrentz2.eu/
     - https://torrentz.unblockit.pro/
+  legacylinks:
+    - https://torrentz2.unblockninja.com/ # proxy fails at DDoS protection
 
   caps:
     categories:

--- a/src/Jackett.Common/Definitions/torrentz2.yml
+++ b/src/Jackett.Common/Definitions/torrentz2.yml
@@ -9,11 +9,11 @@
   links:
     - https://torrentz2.eu/
     - https://torrentz.unblockit.pro/
-    - https://torrentz2.black-mirror.xyz
-    - https://torrentz2.unblocked.casa
-    - https://torrentz2.proxyportal.fun
-    - https://torrentz2.uk-unblock.xyz
-    - https://torrentz2.ind-unblock.xyz
+    - https://torrentz2.black-mirror.xyz/
+    - https://torrentz2.unblocked.casa/
+    - https://torrentz2.proxyportal.fun/
+    - https://torrentz2.uk-unblock.xyz/
+    - https://torrentz2.ind-unblock.xyz/
   legacylinks:
     - https://torrentz2.unblockninja.com/ # proxy fails at DDoS protection
 

--- a/src/Jackett.Common/Definitions/torrentz2.yml
+++ b/src/Jackett.Common/Definitions/torrentz2.yml
@@ -9,6 +9,11 @@
   links:
     - https://torrentz2.eu/
     - https://torrentz.unblockit.pro/
+    - https://torrentz2.black-mirror.xyz
+    - https://torrentz2.unblocked.casa
+    - https://torrentz2.proxyportal.fun
+    - https://torrentz2.uk-unblock.xyz
+    - https://torrentz2.ind-unblock.xyz
   legacylinks:
     - https://torrentz2.unblockninja.com/ # proxy fails at DDoS protection
 

--- a/src/Jackett.Common/Definitions/yourbittorrent.yml
+++ b/src/Jackett.Common/Definitions/yourbittorrent.yml
@@ -8,7 +8,6 @@
   links:
     - https://yourbittorrent.com/
     - https://yourbittorrent2.com/
-  legacylinks:
     - https://yourbittorrent.host/
 
   caps:

--- a/src/Jackett.Common/Definitions/zooqle.yml
+++ b/src/Jackett.Common/Definitions/zooqle.yml
@@ -9,6 +9,11 @@
   links:
     - https://zooqle.com/
     - https://zooqle.unblockit.pro/
+    - https://zooqle.black-mirror.xyz/
+    - https://zooqle.unblocked.casa/
+    - https://zooqle.proxyportal.fun/
+    - https://zooqle.uk-unblock.xyz/
+    - https://zooqle.ind-unblock.xyz/
 
   caps:
     categories:


### PR DESCRIPTION
Sourced from:
- https://unblocked-pw.github.io/ (a couple had been missed)
- https://root.yt/
- https://unblockninja.com/
- https://black-mirror.xyz/

A few legacylinks were found either to work again or redirect to a new working link, so those were added as well.

`followredirect` was enabled for those indexers with unblocked.pro links added.

All links were tested as working in Jackett at time of writing (don't think I missed any at least).

Several potential proxy links did not work in Jackett and so were added to legacylinks with explanations, in case they either work at a later date, or someone thinks they have been missed and adds them without testing. Feel free to check them in case I missed something obvious.

Apologies for the multiple commits on some files, I had way too many tabs open lol