### PR TITLE
append both Spanish and English when it's not VOSE

### DIFF
--- a/src/Jackett.Common/Definitions/hdcity.yml
+++ b/src/Jackett.Common/Definitions/hdcity.yml
@@ -179,7 +179,7 @@
         optional: true
         filters:
           - name: append
-            args: " [Spanish]"
+            args: " [Spanish] [English]"
           - name: re_replace
             args: ["(?i)T[\\s-_]?(\\d{1,2})\\b", " S$1 "]
           - name: re_replace


### PR DESCRIPTION
When they aren't VOSE, hdcity releases are both in Spanish and English . This PR just appends both tags instead of only [Spanish], so custom profiles looking for Dual releases can operate properly.