### PR TITLE
Add enumerable extension FirstIfSingleOrDefault

### DIFF
--- a/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
@@ -231,11 +231,9 @@ namespace Jackett.Common.Indexers.Abstract
 
                     if (imdbInTags)
                     {
-                        var imdbTags = tags
-                            .Select(tag => ParseUtil.GetImdbID((string)tag))
-                            .Where(tag => tag != null);
-                        if (imdbTags.Count() == 1)
-                            release.Imdb = imdbTags.First();
+                        release.Imdb = tags
+                                       .Select(tag => ParseUtil.GetImdbID((string)tag))
+                                       .Where(tag => tag != null).FirstIfSingleOrDefault();
                     }
 
                     if (r["torrents"] is JArray)

--- a/src/Jackett.Common/Indexers/AnimeTorrents.cs
+++ b/src/Jackett.Common/Indexers/AnimeTorrents.cs
@@ -104,12 +104,7 @@ namespace Jackett.Common.Indexers
 
             queryCollection.Add("total", "146"); // Not sure what this is about but its required!
 
-            var cat = "0";
-            var queryCats = MapTorznabCapsToTrackers(query);
-            if (queryCats.Count == 1)
-            {
-                cat = queryCats.First().ToString();
-            }
+            var cat = MapTorznabCapsToTrackers(query).FirstIfSingleOrDefault("0");
 
             queryCollection.Add("cat", cat);
             queryCollection.Add("searchin", "filename");

--- a/src/Jackett.Common/Indexers/AnimeTorrents.cs
+++ b/src/Jackett.Common/Indexers/AnimeTorrents.cs
@@ -103,10 +103,7 @@ namespace Jackett.Common.Indexers
             var queryCollection = new NameValueCollection();
 
             queryCollection.Add("total", "146"); // Not sure what this is about but its required!
-
-            var cat = MapTorznabCapsToTrackers(query).FirstIfSingleOrDefault("0");
-
-            queryCollection.Add("cat", cat);
+            queryCollection.Add("cat", MapTorznabCapsToTrackers(query).FirstIfSingleOrDefault("0"));
             queryCollection.Add("searchin", "filename");
             queryCollection.Add("search", searchString);
             queryCollection.Add("page", "1");

--- a/src/Jackett.Common/Indexers/BitHdtv.cs
+++ b/src/Jackett.Common/Indexers/BitHdtv.cs
@@ -119,7 +119,7 @@ namespace Jackett.Common.Indexers
             var cats = MapTorznabCapsToTrackers(query, true);
             var qc = new NameValueCollection
             {
-                {"cat", cats.Count == 1 ? cats[0] : "0"}
+                {"cat", cats.FirstIfSingleOrDefault("0")}
             };
             var results = new List<WebClientStringResult>();
             var search = new UriBuilder(SearchUrl);

--- a/src/Jackett.Common/Indexers/BitHdtv.cs
+++ b/src/Jackett.Common/Indexers/BitHdtv.cs
@@ -116,10 +116,9 @@ namespace Jackett.Common.Indexers
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {
             var releases = new List<ReleaseInfo>();
-            var cats = MapTorznabCapsToTrackers(query, true);
             var qc = new NameValueCollection
             {
-                {"cat", cats.FirstIfSingleOrDefault("0")}
+                {"cat", MapTorznabCapsToTrackers(query, true).FirstIfSingleOrDefault("0")}
             };
             var results = new List<WebClientStringResult>();
             var search = new UriBuilder(SearchUrl);

--- a/src/Jackett.Common/Indexers/FileList.cs
+++ b/src/Jackett.Common/Indexers/FileList.cs
@@ -105,11 +105,7 @@ namespace Jackett.Common.Indexers
             var releases = new List<ReleaseInfo>();
             var searchUrl = BrowseUrl;
             var searchString = query.GetQueryString();
-
-            var cats = MapTorznabCapsToTrackers(query);
-            var cat = "0";
-            if (cats.Count == 1)
-                cat = cats[0];
+            var cat = MapTorznabCapsToTrackers(query).FirstIfSingleOrDefault("0");
 
             var queryCollection = new NameValueCollection();
 

--- a/src/Jackett.Common/Indexers/FunFile.cs
+++ b/src/Jackett.Common/Indexers/FunFile.cs
@@ -83,7 +83,7 @@ namespace Jackett.Common.Indexers
             {
                 {"incldead", "1"},
                 {"showspam", "1"},
-                {"cat", cats.Count == 1 ? cats[0] : "0"}
+                {"cat", cats.FirstIfSingleOrDefault("0")}
             };
             if (!string.IsNullOrWhiteSpace(query.GetQueryString()))
                 qc.Add("search", query.GetQueryString());

--- a/src/Jackett.Common/Indexers/FunFile.cs
+++ b/src/Jackett.Common/Indexers/FunFile.cs
@@ -77,13 +77,11 @@ namespace Jackett.Common.Indexers
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {
             var releases = new List<ReleaseInfo>();
-
-            var cats = MapTorznabCapsToTrackers(query);
             var qc = new NameValueCollection
             {
                 {"incldead", "1"},
                 {"showspam", "1"},
-                {"cat", cats.FirstIfSingleOrDefault("0")}
+                {"cat", MapTorznabCapsToTrackers(query).FirstIfSingleOrDefault("0")}
             };
             if (!string.IsNullOrWhiteSpace(query.GetQueryString()))
                 qc.Add("search", query.GetQueryString());

--- a/src/Jackett.Common/Indexers/HDOlimpo.cs
+++ b/src/Jackett.Common/Indexers/HDOlimpo.cs
@@ -100,12 +100,9 @@ namespace Jackett.Common.Indexers
                 {"freetorrent", "false"},
                 {"ordenar_por", "created_at"},
                 {"orden", "desc"},
-                {"titulo", query.GetQueryString()}
+                {"titulo", query.GetQueryString()},
+                {"categoria", MapTorznabCapsToTrackers(query).FirstIfSingleOrDefault("0")}
             };
-
-            var cats = MapTorznabCapsToTrackers(query);
-            var category = cats.FirstIfSingleOrDefault("0");
-            pairs.Add("categoria", category);
 
             var boundary = "---------------------------" + (DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds.ToString(CultureInfo.InvariantCulture).Replace(".", "");
             var bodyParts = new List<string>();

--- a/src/Jackett.Common/Indexers/HDOlimpo.cs
+++ b/src/Jackett.Common/Indexers/HDOlimpo.cs
@@ -9,6 +9,7 @@ using AngleSharp.Html.Parser;
 using Jackett.Common.Models;
 using Jackett.Common.Models.IndexerConfig;
 using Jackett.Common.Services.Interfaces;
+using Jackett.Common.Utils;
 using Jackett.Common.Utils.Clients;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -103,7 +104,7 @@ namespace Jackett.Common.Indexers
             };
 
             var cats = MapTorznabCapsToTrackers(query);
-            var category = cats.Count == 1 ? cats.First() : "0";
+            var category = cats.FirstIfSingleOrDefault("0");
             pairs.Add("categoria", category);
 
             var boundary = "---------------------------" + (DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds.ToString(CultureInfo.InvariantCulture).Replace(".", "");

--- a/src/Jackett.Common/Indexers/NewRealWorld.cs
+++ b/src/Jackett.Common/Indexers/NewRealWorld.cs
@@ -143,11 +143,7 @@ namespace Jackett.Common.Indexers
             }
 
             var cats = MapTorznabCapsToTrackers(query);
-            var cat = "0";
-            if (cats.Count == 1)
-            {
-                cat = cats[0];
-            }
+            var cat = cats.FirstIfSingleOrDefault("0");
             queryCollection.Add("cat", cat);
 
             searchUrl += "?" + queryCollection.GetQueryString();

--- a/src/Jackett.Common/Indexers/NewRealWorld.cs
+++ b/src/Jackett.Common/Indexers/NewRealWorld.cs
@@ -142,9 +142,7 @@ namespace Jackett.Common.Indexers
                 queryCollection.Add("search", searchString);
             }
 
-            var cats = MapTorznabCapsToTrackers(query);
-            var cat = cats.FirstIfSingleOrDefault("0");
-            queryCollection.Add("cat", cat);
+            queryCollection.Add("cat", MapTorznabCapsToTrackers(query).FirstIfSingleOrDefault("0"));
 
             searchUrl += "?" + queryCollection.GetQueryString();
 

--- a/src/Jackett.Common/Utils/Extensions.cs
+++ b/src/Jackett.Common/Utils/Extensions.cs
@@ -41,9 +41,13 @@ namespace Jackett.Common.Utils
     {
         public static string AsString(this IEnumerable<char> chars) => string.Concat(chars);
 
-        // Should be collection.Any()
-        // Remove in favor of existing built in function?
-        public static bool IsEmpty<T>(this IEnumerable<T> collection) => collection.Count() > 0;
+        public static T FirstIfSingleOrDefault<T>(this IEnumerable<T> enumerable, T other = default)
+        {
+            //Avoid enumerating the whole array.
+            //If enumerable.Count() < 2, takes whole array.
+            var test = enumerable.Take(2).ToList();
+            return test.Count == 1 ? test[0] : other;
+        }
 
         public static IEnumerable<T> Flatten<T>(this IEnumerable<IEnumerable<T>> list) => list.SelectMany(x => x);
     }

--- a/src/Jackett.Common/Utils/Extensions.cs
+++ b/src/Jackett.Common/Utils/Extensions.cs
@@ -41,12 +41,12 @@ namespace Jackett.Common.Utils
     {
         public static string AsString(this IEnumerable<char> chars) => string.Concat(chars);
 
-        public static T FirstIfSingleOrDefault<T>(this IEnumerable<T> enumerable, T other = default)
+        public static T FirstIfSingleOrDefault<T>(this IEnumerable<T> enumerable, T replace = default)
         {
             //Avoid enumerating the whole array.
             //If enumerable.Count() < 2, takes whole array.
             var test = enumerable.Take(2).ToList();
-            return test.Count == 1 ? test[0] : other;
+            return test.Count == 1 ? test[0] : replace;
         }
 
         public static IEnumerable<T> Flatten<T>(this IEnumerable<IEnumerable<T>> list) => list.SelectMany(x => x);


### PR DESCRIPTION
This PR removes the unused Enumerable extension `IsEmpty()` (replaced in favor of `.Any()`) and adds a new function `FirstIfSingleOrDefault<T>(T replace = default)`

This gives us an inline way of checking if there's only one element in a collection and returning it or the supplied default value if it's not the only element. I've also replaced all existing implementations with this new function that I could find by searching for `== 1` in the whole solution.