### PR TITLE
Remove enumerable related extensions

### DIFF
--- a/src/Jackett.Common/Indexers/BaseIndexer.cs
+++ b/src/Jackett.Common/Indexers/BaseIndexer.cs
@@ -265,7 +265,7 @@ namespace Jackett.Common.Indexers
                 return results;
 
             var filteredResults = results.Where(
-                result => result.Category.IsEmptyOrNull() || query.Categories.Intersect(result.Category).Any() ||
+                result => result.Category?.Any() != true || query.Categories.Intersect(result.Category).Any() ||
                           TorznabCatType.QueryContainsParentCategory(query.Categories, result.Category));
 
             return filteredResults;

--- a/src/Jackett.Common/Indexers/Meta/BaseMetaIndexer.cs
+++ b/src/Jackett.Common/Indexers/Meta/BaseMetaIndexer.cs
@@ -85,7 +85,7 @@ namespace Jackett.Common.Indexers.Meta
                 logger.Error(aggregateTask.Exception, "Error during request in metaindexer " + ID);
             }
 
-            var unorderedResult = aggregateTask.Result.Select(r => r.Releases).Flatten();
+            var unorderedResult = aggregateTask.Result.SelectMany(r => r.Releases);
             var resultFilters = resultFilterProvider.FiltersForQuery(query);
             var filteredResults = resultFilters.Select(async f => await f.FilterResults(unorderedResult)).SelectMany(t => t.Result);
             var uniqueFilteredResults = filteredResults.Distinct();

--- a/src/Jackett.Common/Indexers/Meta/Fallbacks.cs
+++ b/src/Jackett.Common/Indexers/Meta/Fallbacks.cs
@@ -24,7 +24,7 @@ namespace Jackett.Common.Indexers.Meta
 
     public class NoFallbackStrategyProvider : IFallbackStrategyProvider
     {
-        public IEnumerable<IFallbackStrategy> FallbackStrategiesForQuery(TorznabQuery query) => (new NoFallbackStrategy()).ToEnumerable();
+        public IEnumerable<IFallbackStrategy> FallbackStrategiesForQuery(TorznabQuery query) { yield return new NoFallbackStrategy(); }
     }
 
     public class ImdbFallbackStrategy : IFallbackStrategy
@@ -32,18 +32,16 @@ namespace Jackett.Common.Indexers.Meta
         public ImdbFallbackStrategy(IImdbResolver resolver, TorznabQuery query)
         {
             this.resolver = resolver;
-            titles = null;
             this.query = query;
         }
 
         public async Task<IEnumerable<TorznabQuery>> FallbackQueries()
         {
-            titles ??= (await resolver.MovieForId(query.ImdbID.ToNonNull())).Title?.ToEnumerable() ?? Enumerable.Empty<string>();
-            return titles.Select(query.CreateFallback);
+            var title = (await resolver.MovieForId(query.ImdbID.ToNonNull())).Title;
+            return title != null ? new[] {query.CreateFallback(title)} : Enumerable.Empty<TorznabQuery>();
         }
 
         private readonly IImdbResolver resolver;
-        private IEnumerable<string> titles;
         private readonly TorznabQuery query;
     }
 

--- a/src/Jackett.Common/Indexers/TVstore.cs
+++ b/src/Jackett.Common/Indexers/TVstore.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Globalization;
+using System.Linq;
 using System.Net;
 using System.Text;
 using System.Text.RegularExpressions;
@@ -255,12 +256,9 @@ namespace Jackett.Common.Indexers
             //TODO convert to initializer
             var releases = new List<ReleaseInfo>();
 
-            /* If series from sites are indexed than we dont need to reindex them. */
-            if (series == null || series.IsEmpty())
-            {
+            // If series from sites are indexed then we don't need to reindex them.
+            if (series?.Any() != true)
                 await GetSeriesInfo();
-            }
-
             var unixTimestamp = (int)(DateTime.UtcNow.Subtract(new DateTime(1970, 1, 1))).TotalSeconds;
 
             WebClientStringResult results;

--- a/src/Jackett.Common/Models/TorznabQuery.cs
+++ b/src/Jackett.Common/Models/TorznabQuery.cs
@@ -56,7 +56,7 @@ namespace Jackett.Common.Models
                 var term = SearchTerm;
                 if (SearchTerm == null)
                     term = "";
-                var safetitle = term.Where(c => (char.IsLetterOrDigit(c)
+                var safeTitle = term.Where(c => (char.IsLetterOrDigit(c)
                                                  || char.IsWhiteSpace(c)
                                                  || c == '-'
                                                  || c == '.'
@@ -70,8 +70,8 @@ namespace Jackett.Common.Models
                                                  || c == ']'
                                                  || c == '+'
                                                  || c == '%'
-                                               )).AsString();
-                return safetitle;
+                                               ));
+                return string.Concat(safeTitle);
             }
         }
 

--- a/src/Jackett.Common/Utils/Extensions.cs
+++ b/src/Jackett.Common/Utils/Extensions.cs
@@ -32,36 +32,18 @@ namespace Jackett.Common.Utils
 
     public static class GenericConversionExtensions
     {
-        public static IEnumerable<T> ToEnumerable<T>(this T obj) => new T[] { obj };
-
         public static NonNull<T> ToNonNull<T>(this T obj) where T : class => new NonNull<T>(obj);
     }
 
     public static class EnumerableExtension
     {
-        public static string AsString(this IEnumerable<char> chars) => string.Concat(chars);
-
-        public static T FirstIfSingleOrDefault<T>(this IEnumerable<T> enumerable, T replace = default)
+        public static T FirstIfSingleOrDefault<T>(this IEnumerable<T> source, T replace = default)
         {
-            //Avoid enumerating the whole array.
-            //If enumerable.Count() < 2, takes whole array.
-            var test = enumerable.Take(2).ToList();
+            if (source is ICollection<T> collection)
+                return collection.Count == 1 ? collection.First() : replace;
+            var test = source.Take(2).ToList();
             return test.Count == 1 ? test[0] : replace;
         }
-
-        public static IEnumerable<T> Flatten<T>(this IEnumerable<IEnumerable<T>> list) => list.SelectMany(x => x);
-    }
-
-    public static class CollectionExtension
-    {
-        // IEnumerable class above already does this. All ICollection are IEnumerable, so favor IEnumerable?
-        public static bool IsEmpty<T>(this ICollection<T> obj) => obj.Count == 0;
-
-        // obj == null || obj.IsEmpty() causes VS to suggest merging sequential checks
-        // the result is obj?.IsEmpty() == true which returns false when null
-        // Other options are obj?.IsEmpty() == true || obj == null Or (obj?.IsEmpty()).GetValueOrDefault(true)
-        // All three options remove the suggestion and give the intended result of this function
-        public static bool IsEmptyOrNull<T>(this ICollection<T> obj) => obj?.IsEmpty() ?? true;
     }
 
     public static class XElementExtension
@@ -69,11 +51,6 @@ namespace Jackett.Common.Utils
         public static XElement First(this XElement element, string name) => element.Descendants(name).First();
 
         public static string FirstValue(this XElement element, string name) => element.First(name).Value;
-    }
-
-    public static class KeyValuePairsExtension
-    {
-        public static IDictionary<Key, Value> ToDictionary<Key, Value>(this IEnumerable<KeyValuePair<Key, Value>> pairs) => pairs.ToDictionary(x => x.Key, x => x.Value);
     }
 
     public static class TaskExtensions


### PR DESCRIPTION
All of the IEnumerable and ICollection extension methods in Extensions.cs could either be inlined, weren't used, or were hiding better implementations at the calling method. This PR removes them all in favor of their alternatives.

This means that the only Enumerable extension remaining would be the one in #7837 if it's accepted and merged.