### PR TITLE
Remove reflection in Nullable TryParse extension

### DIFF
--- a/src/Jackett.Common/Indexers/Feeds/BaseNewznabIndexer.cs
+++ b/src/Jackett.Common/Indexers/Feeds/BaseNewznabIndexer.cs
@@ -28,6 +28,10 @@ namespace Jackett.Common.Indexers.Feeds
         protected virtual ReleaseInfo ResultFromFeedItem(XElement item)
         {
             var attributes = item.Descendants().Where(e => e.Name.LocalName == "attr");
+            var size = long.TryParse(ReadAttribute(attributes, "size"), out var longVal ) ? (long?)longVal : null;
+            var files = long.TryParse(ReadAttribute(attributes, "files"), out longVal) ? (long?)longVal : null;
+            var seeders = int.TryParse(ReadAttribute(attributes, "seeders"), out var intVal) ? (int?)intVal : null;
+            var peers = int.TryParse(ReadAttribute(attributes, "peers"), out intVal) ? (int?)intVal : null;
             var release = new ReleaseInfo
             {
                 Title = item.FirstValue("title"),
@@ -36,11 +40,11 @@ namespace Jackett.Common.Indexers.Feeds
                 Comments = item.FirstValue("comments").ToUri(),
                 PublishDate = item.FirstValue("pubDate").ToDateTime(),
                 Category = new List<int> { int.Parse(attributes.First(e => e.Attribute("name").Value == "category").Attribute("value").Value) },
-                Size = ReadAttribute(attributes, "size").TryParse<long>(),
-                Files = ReadAttribute(attributes, "files").TryParse<long>(),
+                Size = size,
+                Files = files,
                 Description = item.FirstValue("description"),
-                Seeders = ReadAttribute(attributes, "seeders").TryParse<int>(),
-                Peers = ReadAttribute(attributes, "peers").TryParse<int>(),
+                Seeders = seeders,
+                Peers = peers,
                 InfoHash = attributes.First(e => e.Attribute("name").Value == "infohash").Attribute("value").Value,
                 MagnetUri = attributes.First(e => e.Attribute("name").Value == "magneturl").Attribute("value").Value.ToUri(),
             };

--- a/src/Jackett.Common/Utils/Extensions.cs
+++ b/src/Jackett.Common/Utils/Extensions.cs
@@ -83,29 +83,6 @@ namespace Jackett.Common.Utils
         public static IDictionary<Key, Value> ToDictionary<Key, Value>(this IEnumerable<KeyValuePair<Key, Value>> pairs) => pairs.ToDictionary(x => x.Key, x => x.Value);
     }
 
-    public static class ParseExtension
-    {
-        public static T? TryParse<T>(this string value) where T : struct, IConvertible
-        {
-            if (string.IsNullOrWhiteSpace(value))
-                return null;
-            try
-            {
-                var val = Convert.ChangeType(value, typeof(T));
-                return (T)val;
-            }
-            catch(Exception e) when
-                (e is InvalidCastException // Conversion not supported
-                 || e is FormatException) // Conversion failed
-            {
-                return null;
-            }
-            //Other exceptions include
-            //OverflowException value > T.MaxValue
-            //ArgumentNullException when typeof(T) == null
-        }
-    }
-
     public static class TaskExtensions
     {
         public static Task<IEnumerable<TResult>> Until<TResult>(this IEnumerable<Task<TResult>> tasks, TimeSpan timeout)


### PR DESCRIPTION
This refactors the in house `T? TryParse<T>(string)` extension method to be faster by avoiding using reflection. It narrows the compatible types by doing so, but is currently only used for long and int, which are still compatible, as well as all other built in ValueTypes