### PR TITLE
norbits: fixed no results when the tracker returns one torrent

### DIFF
--- a/src/Jackett.Common/Indexers/Norbits.cs
+++ b/src/Jackett.Common/Indexers/Norbits.cs
@@ -274,7 +274,7 @@ namespace Jackett.Common.Indexers
                     var pageLinkCount = 1;
 
                     // Check if we have a minimum of one result
-                    if (firstPageRows?.Length > 1)
+                    if (firstPageRows?.Length >= 1)
                     {
                         // Retrieve total count on our alone page
                         nbResults = firstPageRows.Count();


### PR DESCRIPTION
As requested in #4859 