### PR TITLE
ETTV: update primary URL and proxies

### DIFF
--- a/src/Jackett.Common/Definitions/ettv.yml
+++ b/src/Jackett.Common/Definitions/ettv.yml
@@ -7,7 +7,7 @@
   encoding: UTF-8
   followredirect: true
   links:
-    - https://www.ettv.to/
+    - https://www.ettvdl.com/
     - https://ettv.unblockit.pro/
     - https://ettv.root.yt/
     - https://ettv.unblockninja.com/
@@ -18,6 +18,7 @@
     - https://ettv.ind-unblock.xyz/
   legacylinks:
     - https://www.ettv.tv/
+    - https://www.ettv.to/
 
   caps:
     categorymappings:

--- a/src/Jackett.Common/Definitions/ettv.yml
+++ b/src/Jackett.Common/Definitions/ettv.yml
@@ -9,16 +9,16 @@
   links:
     - https://www.ettvdl.com/
     - https://ettv.unblockit.pro/
-    - https://ettv.root.yt/
     - https://ettv.unblockninja.com/
-    - https://ettv.black-mirror.xyz/
-    - https://ettv.unblocked.casa/
-    - https://ettv.proxyportal.fun/
-    - https://ettv.uk-unblock.xyz/
-    - https://ettv.ind-unblock.xyz/
   legacylinks:
     - https://www.ettv.tv/
     - https://www.ettv.to/
+    - https://ettv.root.yt/ # currently redirects to ettvdl.com
+    - https://ettv.black-mirror.xyz/ # currently redirects to ettvdl.com
+    - https://ettv.unblocked.casa/ # currently redirects to ettvdl.com
+    - https://ettv.proxyportal.fun/ # currently redirects to ettvdl.com
+    - https://ettv.uk-unblock.xyz/ # currently redirects to ettvdl.com
+    - https://ettv.ind-unblock.xyz/ # currently redirects to ettvdl.com
 
   caps:
     categorymappings:


### PR DESCRIPTION
ettv.to now redirects to ettvdl.com

Most proxies are broken by this and so have been moved to legacylinks for now