### PR TITLE
Revert accidentally deleted line. Resolves #7870

### DIFF
--- a/src/Jackett.Common/Services/CacheService.cs
+++ b/src/Jackett.Common/Services/CacheService.cs
@@ -42,6 +42,7 @@ namespace Jackett.Common.Services
                         trackerCache.Results.Add(existingItem);
                     }
 
+                    existingItem.Result = release;
                 }
 
                 // Prune cache


### PR DESCRIPTION
This line got removed from the code and was missed in the review of #7342

I've put it back where it was (raw revert) but I don't know if this is the best place for it, since we've already confirmed that the existing cache item has the same GUID, so should we be replacing it with the new one every time it's fetched?