### PR TITLE
HDBits API: Add missing filter options

### DIFF
--- a/src/Jackett.Common/Indexers/HDBitsApi.cs
+++ b/src/Jackett.Common/Indexers/HDBitsApi.cs
@@ -90,7 +90,7 @@ namespace Jackett.Common.Indexers
             var categories = MapTorznabCapsToTrackers(query);
 
             if(categories.Any())
-                requestData.Add("category", JToken.FromObject(categories.Select(int.Parse)));
+                requestData.Add("category", JToken.FromObject(categories));
 
             if(configData.Codecs.Values.Any())
                 requestData.Add("codec", JToken.FromObject(configData.Codecs.Values.Select(int.Parse)));
@@ -198,4 +198,3 @@ namespace Jackett.Common.Indexers
         }
     }
 }
-

--- a/src/Jackett.Common/Indexers/HDBitsApi.cs
+++ b/src/Jackett.Common/Indexers/HDBitsApi.cs
@@ -89,45 +89,17 @@ namespace Jackett.Common.Indexers
 
             var categories = MapTorznabCapsToTrackers(query);
 
-            if (categories.Count > 0)
-            {
-                requestData["category"] = new JArray();
+            if(categories.Any())
+                requestData.Add("category", JToken.FromObject(categories.Select(int.Parse)));
 
-                foreach (var cat in categories)
-                {
-                    requestData["category"].Add(new JValue(cat));
-                }
-            }
+            if(configData.Codecs.Values.Any())
+                requestData.Add("codec", JToken.FromObject(configData.Codecs.Values.Select(int.Parse)));
 
-            if (configData.Codecs.Values.Length > 0)
-            {
-                requestData["codec"] = new JArray();
+            if(configData.Mediums.Values.Any())
+                requestData.Add("medium", JToken.FromObject(configData.Mediums.Values.Select(int.Parse)));
 
-                foreach (var codec in configData.Codecs.Values)
-                {
-                    requestData["codec"].Add(new JValue(int.Parse(codec)));
-                }
-            }
-
-            if (configData.Mediums.Values.Length > 0)
-            {
-                requestData["medium"] = new JArray();
-
-                foreach (var medium in configData.Mediums.Values)
-                {
-                    requestData["medium"].Add(new JValue(int.Parse(medium)));
-                }
-            }
-
-            if (configData.Origins.Values.Length > 0)
-            {
-                requestData["origin"] = new JArray();
-
-                foreach (var origin in configData.Origins.Values)
-                {
-                    requestData["origin"].Add(new JValue(int.Parse(origin)));
-                }
-            }
+            if(configData.Origins.Values.Any())
+                requestData.Add("origin", JToken.FromObject(configData.Origins.Values.Select(int.Parse)));
 
             requestData["limit"] = 100;
 

--- a/src/Jackett.Common/Indexers/HDBitsApi.cs
+++ b/src/Jackett.Common/Indexers/HDBitsApi.cs
@@ -73,7 +73,7 @@ namespace Jackett.Common.Indexers
 
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {
-            dynamic requestData = new JObject();
+            var requestData = new JObject();
             var queryString = query.GetQueryString();
             var imdbId = ParseUtil.GetImdbID(query.ImdbID);
 

--- a/src/Jackett.Common/Indexers/HDBitsApi.cs
+++ b/src/Jackett.Common/Indexers/HDBitsApi.cs
@@ -119,6 +119,16 @@ namespace Jackett.Common.Indexers
                 }
             }
 
+            if (configData.Origins.Values.Length > 0)
+            {
+                requestData["origin"] = new JArray();
+
+                foreach (var origin in configData.Origins.Values)
+                {
+                    requestData["origin"].Add(new JValue(int.Parse(origin)));
+                }
+            }
+
             requestData["limit"] = 100;
 
             var response = await MakeApiRequest("torrents", requestData);
@@ -178,6 +188,7 @@ namespace Jackett.Common.Indexers
             // 50% Free Leech: all full discs, remuxes, caps and all internal encodes.
             if (halfLeechMediums.Contains((int)r["type_medium"]) || (int)r["type_origin"] == 1)
                 return 0.5;
+            // 25% Free Leech: all TV content that is not an internal encode.
             if ((int)r["type_category"] == 2 && (int)r["type_origin"] != 1)
                 return 0.75;
             return 1;

--- a/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationHDBitsApi.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationHDBitsApi.cs
@@ -6,11 +6,13 @@ namespace Jackett.Common.Models.IndexerConfig.Bespoke
     {
         public CheckboxItem Codecs { get; private set; }
         public CheckboxItem Mediums { get; private set; }
+        public CheckboxItem Origins { get; private set; }
 
         public ConfigurationDataHDBitsApi() : base()
         {
             Codecs = new CheckboxItem(new Dictionary<string, string>()
                 {
+                    {"0", "Undefined"},
                     {"1", "H.264"},
                     {"5", "HEVC"},
                     {"2", "MPEG-2"},
@@ -18,17 +20,25 @@ namespace Jackett.Common.Models.IndexerConfig.Bespoke
                     {"6", "VP9"},
                     {"4", "XviD"}
                 })
-            { Name = "Codec", Values = new string[] { "1", "5", "2", "3", "6", "4" } };
+            { Name = "Codec", Values = new string[] { "0", "1", "5", "2", "3", "6", "4" } };
 
             Mediums = new CheckboxItem(new Dictionary<string, string>()
                 {
+                    {"0", "Undefined"},
                     {"1", "Blu-ray/HD DVD"},
                     {"4", "Capture"},
                     {"3", "Encode"},
                     {"5", "Remux"},
                     {"6", "WEB-DL"}
                 })
-            { Name = "Medium", Values = new string[] { "1", "4", "3", "5", "6" } };
+            { Name = "Medium", Values = new string[] { "0", "1", "4", "3", "5", "6" } };
+
+            Origins = new CheckboxItem(new Dictionary<string, string>()
+                {
+                    {"0", "Undefined"},
+                    {"1", "Internal"}
+                })
+            { Name = "Origin", Values = new string[] { "0", "1" } };
         }
     }
 }


### PR DESCRIPTION
Adds the filter "Origin" as well as fixing the search issue mentioned [here](https://github.com/Jackett/Jackett/issues/4859#issuecomment-605667831) by also allowing "Undefined" as Codec and Medium.