### PR TITLE
audiobooktorrents: fix title

### DIFF
--- a/src/Jackett.Common/Definitions/audiobooktorrents.yml
+++ b/src/Jackett.Common/Definitions/audiobooktorrents.yml
@@ -97,6 +97,8 @@
         filters:
           - name: regexp
             args: Tip\('<b>(.*?)</b>
+          - name: replace
+            args: ["\\", ""]
       details:
         selector: a[href^="details.php?id="][onmouseover]
         attribute: href


### PR DESCRIPTION
Remove slash
![image](https://user-images.githubusercontent.com/10577978/78163834-33e06500-7449-11ea-88c6-6d4987c5770b.png)

![image](https://user-images.githubusercontent.com/10577978/78163893-43f84480-7449-11ea-9c94-93b3f458d0dd.png)
