### PR TITLE
core: remove non-null related extension classes.

### DIFF
--- a/src/Jackett.Common/Indexers/Meta/Fallbacks.cs
+++ b/src/Jackett.Common/Indexers/Meta/Fallbacks.cs
@@ -37,9 +37,11 @@ namespace Jackett.Common.Indexers.Meta
 
         public async Task<IEnumerable<TorznabQuery>> FallbackQueries()
         {
-            var title = (await resolver.MovieForId(query.ImdbID.ToNonNull())).Title;
+	        if(string.IsNullOrEmpty(query.ImdbID))
+				return Enumerable.Empty<TorznabQuery>();
+	        var title = (await resolver.MovieForId(query.ImdbID)).Title;
             return title != null ? new[] {query.CreateFallback(title)} : Enumerable.Empty<TorznabQuery>();
-        }
+	    }
 
         private readonly IImdbResolver resolver;
         private readonly TorznabQuery query;

--- a/src/Jackett.Common/Indexers/Meta/ResultFilters.cs
+++ b/src/Jackett.Common/Indexers/Meta/ResultFilters.cs
@@ -56,7 +56,9 @@ namespace Jackett.Common.Indexers.Meta
 
             var remainingResults = results.Except(wrongResults).Except(perfectResults);
 
-            var title = (await resolver.MovieForId(query.ImdbID.ToNonNull())).Title;
+            if (string.IsNullOrEmpty(query.ImdbID))
+                return perfectResults;
+            var title = (await resolver.MovieForId(query.ImdbID)).Title;
             if (title == null)
                 return perfectResults;
 

--- a/src/Jackett.Common/Services/ImdbResolver.cs
+++ b/src/Jackett.Common/Services/ImdbResolver.cs
@@ -17,16 +17,16 @@ namespace Jackett.Common.Services
 
     public class OmdbResolver : IImdbResolver
     {
-        public OmdbResolver(WebClient webClient, NonNull<string> omdbApiKey, string omdbApiUrl)
+        public OmdbResolver(WebClient webClient, string omdbApiKey, string omdbApiUrl)
         {
             WebClient = webClient;
-            apiKey = omdbApiKey;
+            apiKey = omdbApiKey ?? throw new ArgumentNullException($"{nameof(omdbApiKey)} cannot be null");
             url = omdbApiUrl;
         }
 
-        public async Task<Movie> MovieForId(NonNull<string> id)
+        public async Task<Movie> MovieForId(string id)
         {
-            string imdbId = id;
+            var imdbId = id ?? throw new ArgumentNullException($"{nameof(id)} cannot be null");
 
             if (!imdbId.StartsWith("tt", StringComparison.Ordinal))
                 imdbId = "tt" + imdbId;

--- a/src/Jackett.Common/Services/IndexerManagerService.cs
+++ b/src/Jackett.Common/Services/IndexerManagerService.cs
@@ -161,7 +161,7 @@ namespace Jackett.Common.Services
             IResultFilterProvider resultFilterProvider = null;
             if (!string.IsNullOrWhiteSpace(omdbApiKey))
             {
-                var imdbResolver = new OmdbResolver(webClient, omdbApiKey.ToNonNull(), serverConfig.OmdbApiUrl);
+                var imdbResolver = new OmdbResolver(webClient, omdbApiKey, serverConfig.OmdbApiUrl);
                 fallbackStrategyProvider = new ImdbFallbackStrategyProvider(imdbResolver);
                 resultFilterProvider = new ImdbTitleResultFilterProvider(imdbResolver);
             }

--- a/src/Jackett.Common/Services/Interfaces/IImdbResolver.cs
+++ b/src/Jackett.Common/Services/Interfaces/IImdbResolver.cs
@@ -5,6 +5,6 @@ namespace Jackett.Common.Services.Interfaces
 {
     public interface IImdbResolver
     {
-        Task<Movie> MovieForId(NonNull<string> imdbId);
+        Task<Movie> MovieForId(string imdbId);
     }
 }

--- a/src/Jackett.Common/Utils/Extensions.cs
+++ b/src/Jackett.Common/Utils/Extensions.cs
@@ -6,35 +6,6 @@ using System.Xml.Linq;
 
 namespace Jackett.Common.Utils
 {
-    // Prefer built in NullReferenceException || ArgumentNullException || NoNullAllowedException
-    public class NonNullException : Exception
-    {
-        public NonNullException() : base("Parameter cannot be null")
-        {
-        }
-    }
-
-    public class NonNull<T> where T : class
-    {
-        public NonNull(T val)
-        {
-            // doesn't throw Exception?
-            if (val == null)
-                new NonNullException();
-
-            Value = val;
-        }
-
-        public static implicit operator T(NonNull<T> n) => n.Value;
-
-        private readonly T Value;
-    }
-
-    public static class GenericConversionExtensions
-    {
-        public static NonNull<T> ToNonNull<T>(this T obj) where T : class => new NonNull<T>(obj);
-    }
-
     public static class EnumerableExtension
     {
         public static T FirstIfSingleOrDefault<T>(this IEnumerable<T> source, T replace = default)


### PR DESCRIPTION
This PR removes `NonNull<T>` and `NonNullException` from the extension libraries in favor of explicit checking in the few places it was used.

C#8 introduces nullable reference types, and by extension adds static compile time checking for things like this. These can be implemented when the project is able to fully support the features of C#8