### PR TITLE
core: remove virtual member calls (part 2)

### DIFF
--- a/src/Jackett.Common/Indexers/Abstract/AvistazTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/AvistazTracker.cs
@@ -11,6 +11,7 @@ using Jackett.Common.Models;
 using Jackett.Common.Models.IndexerConfig;
 using Jackett.Common.Services.Interfaces;
 using Jackett.Common.Utils;
+using Jackett.Common.Utils.Clients;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using NLog;
@@ -32,21 +33,20 @@ namespace Jackett.Common.Indexers.Abstract
         // hook to adjust the search term
         protected string GetSearchTerm(TorznabQuery query) => $"{query.SearchTerm} {query.GetEpisodeSearchString()}";
 
-        public AvistazTracker(IIndexerConfigurationService configService, Utils.Clients.WebClient webClient, Logger logger, IProtectionService protectionService, string name, string desc, string link)
-            : base(name: name,
-                description: desc,
-                link: link,
-                caps: TorznabUtil.CreateDefaultTorznabTVCaps(),
-                configService: configService,
-                client: webClient,
-                logger: logger,
-                p: protectionService,
-                configData: new ConfigurationDataBasicLogin())
+        protected AvistazTracker(string name, string link, string description, IIndexerConfigurationService configService,
+                                 WebClient client, Logger logger, IProtectionService p, TorznabCapabilities caps)
+            : base(name,
+                   description: description,
+                   link: link,
+                   caps: caps,
+                   configService: configService,
+                   client: client,
+                   logger: logger,
+                   p: p,
+                   configData: new ConfigurationDataBasicLogin())
         {
             Encoding = Encoding.UTF8;
             Language = "en-us";
-
-            TorznabCaps.SupportsImdbMovieSearch = true;
 
             AddCategoryMapping(1, TorznabCatType.Movies);
             AddCategoryMapping(1, TorznabCatType.MoviesForeign);

--- a/src/Jackett.Common/Indexers/Abstract/CouchPotatoTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/CouchPotatoTracker.cs
@@ -23,20 +23,18 @@ namespace Jackett.Common.Indexers.Abstract
             set => base.configData = value;
         }
 
-        public CouchPotatoTracker(IIndexerConfigurationService configService, WebClient client, Logger logger, IProtectionService p, ConfigurationDataUserPasskey configData, string name, string description, string link, string endpoint)
-            : base(name: name,
-                description: description,
-                link: link,
-                caps: new TorznabCapabilities
-                {
-                    SupportsImdbMovieSearch = true
-                },
-                configService: configService,
-                client: client,
-                logger: logger,
-                p: p,
-                configData: configData
-            )
+        protected CouchPotatoTracker(string name, string link, string description, IIndexerConfigurationService configService,
+                                     WebClient client, Logger logger, IProtectionService p, TorznabCapabilities caps,
+                                     ConfigurationData configData, string endpoint)
+            : base(name,
+                   description: description,
+                   link: link,
+                   caps: caps,
+                   configService: configService,
+                   client: client,
+                   logger: logger,
+                   p: p,
+                   configData: configData)
         {
             this.endpoint = endpoint;
         }

--- a/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
@@ -13,6 +13,7 @@ using Jackett.Common.Services.Interfaces;
 using Jackett.Common.Utils;
 using Newtonsoft.Json.Linq;
 using NLog;
+using WebClient = Jackett.Common.Utils.Clients.WebClient;
 
 namespace Jackett.Common.Indexers.Abstract
 {
@@ -34,15 +35,17 @@ namespace Jackett.Common.Indexers.Abstract
             set => base.configData = value;
         }
 
-        public GazelleTracker(IIndexerConfigurationService configService, Utils.Clients.WebClient webClient, Logger logger, IProtectionService protectionService, string name, string desc, string link, bool supportsFreeleechTokens, bool imdbInTags = false, bool has2Fa = false)
-            : base(name: name,
-                description: desc,
+        protected GazelleTracker(string name, string link, string description, IIndexerConfigurationService configService,
+                                 WebClient client, Logger logger, IProtectionService p, TorznabCapabilities caps,
+                                 bool supportsFreeleechTokens, bool imdbInTags = false, bool has2Fa = false)
+            : base(name,
+                description: description,
                 link: link,
-                caps: new TorznabCapabilities(),
+                caps: caps,
                 configService: configService,
-                client: webClient,
+                client: client,
                 logger: logger,
-                p: protectionService,
+                p: p,
                 configData: new ConfigurationDataBasicLogin())
         {
             Encoding = Encoding.UTF8;

--- a/src/Jackett.Common/Indexers/AlphaRatio.cs
+++ b/src/Jackett.Common/Indexers/AlphaRatio.cs
@@ -1,21 +1,30 @@
 using Jackett.Common.Indexers.Abstract;
 using Jackett.Common.Models;
 using Jackett.Common.Services.Interfaces;
+using Jackett.Common.Utils.Clients;
 using NLog;
 
 namespace Jackett.Common.Indexers
 {
     public class AlphaRatio : GazelleTracker
     {
-        public AlphaRatio(IIndexerConfigurationService configService, Utils.Clients.WebClient webClient, Logger logger,
-                          IProtectionService protectionService) : base(
-            name: "AlphaRatio", desc: "AlphaRatio (AR) is a Private Torrent Tracker for 0DAY / GENERAL",
-            link: "https://alpharatio.cc/", configService: configService, logger: logger,
-            protectionService: protectionService, webClient: webClient, supportsFreeleechTokens: true, imdbInTags: true)
+        public AlphaRatio(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
+            : base("AlphaRatio",
+                   description: "AlphaRatio (AR) is a Private Torrent Tracker for 0DAY / GENERAL",
+                   link: "https://alpharatio.cc/",
+                   caps: new TorznabCapabilities
+                   {
+                       SupportsImdbMovieSearch = true
+                   },
+                   configService: configService,
+                   client: wc,
+                   logger: l,
+                   p: ps,
+                   supportsFreeleechTokens: true,
+                   imdbInTags: true)
         {
             Language = "en-us";
             Type = "private";
-            TorznabCaps.SupportsImdbMovieSearch = true;
 
             AddCategoryMapping(1, TorznabCatType.TVSD, "TvSD");
             AddCategoryMapping(2, TorznabCatType.TVHD, "TvHD");

--- a/src/Jackett.Common/Indexers/Anthelion.cs
+++ b/src/Jackett.Common/Indexers/Anthelion.cs
@@ -12,16 +12,16 @@ namespace Jackett.Common.Indexers
             "https://tehconnection.me/",
         };
 
-        public TehConnectionMe(IIndexerConfigurationService configService, WebClient webClient, Logger logger, IProtectionService protectionService)
-            : base(name: "Anthelion", // old name: TehConnection.me
-                desc: "A movies tracker",
-                link: "https://anthelion.me/",
-                configService: configService,
-                logger: logger,
-                protectionService: protectionService,
-                webClient: webClient,
-                supportsFreeleechTokens: true
-                )
+        public TehConnectionMe(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
+            : base("Anthelion", // old name: TehConnection.me
+                   description: "A movies tracker",
+                   link: "https://anthelion.me/",
+                   caps: new TorznabCapabilities(),
+                   configService: configService,
+                   client: wc,
+                   logger: l,
+                   p: ps,
+                   supportsFreeleechTokens: true)
         {
             Language = "en-us";
             Type = "private";

--- a/src/Jackett.Common/Indexers/Avistaz.cs
+++ b/src/Jackett.Common/Indexers/Avistaz.cs
@@ -1,4 +1,5 @@
 using Jackett.Common.Indexers.Abstract;
+using Jackett.Common.Models;
 using Jackett.Common.Services.Interfaces;
 using Jackett.Common.Utils.Clients;
 using NLog;
@@ -7,14 +8,18 @@ namespace Jackett.Common.Indexers
 {
     public class Avistaz : AvistazTracker
     {
-        public Avistaz(IIndexerConfigurationService configService, WebClient webClient, Logger logger, IProtectionService protectionService)
-            : base(name: "Avistaz",
-                desc: "Aka AsiaTorrents",
-                link: "https://avistaz.to/",
-                configService: configService,
-                logger: logger,
-                protectionService: protectionService,
-                webClient: webClient)
+        public Avistaz(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
+            : base("Avistaz",
+                   description: "Aka AsiaTorrents",
+                   link: "https://avistaz.to/",
+                   caps: new TorznabCapabilities
+                   {
+                       SupportsImdbMovieSearch = true
+                   },
+                   configService: configService,
+                   client: wc,
+                   logger: l,
+                   p: ps)
             => Type = "private";
     }
 }

--- a/src/Jackett.Common/Indexers/BrokenStones.cs
+++ b/src/Jackett.Common/Indexers/BrokenStones.cs
@@ -8,16 +8,16 @@ namespace Jackett.Common.Indexers
 {
     public class BrokenStones : GazelleTracker
     {
-        public BrokenStones(IIndexerConfigurationService configService, WebClient webClient, Logger logger, IProtectionService protectionService)
-            : base(name: "BrokenStones",
-                desc: "Broken Stones is a Private site for MacOS and iOS APPS / GAMES",
-                link: "https://brokenstones.club/",
-                configService: configService,
-                logger: logger,
-                protectionService: protectionService,
-                webClient: webClient,
-                supportsFreeleechTokens: true
-                )
+        public BrokenStones(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
+            : base("BrokenStones",
+                   description: "Broken Stones is a Private site for MacOS and iOS APPS / GAMES",
+                   link: "https://brokenstones.club/",
+                   caps: new TorznabCapabilities(),
+                   configService: configService,
+                   client: wc,
+                   logger: l,
+                   p: ps,
+                   supportsFreeleechTokens: true)
         {
             Language = "en-us";
             Type = "private";

--- a/src/Jackett.Common/Indexers/CinemaZ.cs
+++ b/src/Jackett.Common/Indexers/CinemaZ.cs
@@ -1,4 +1,5 @@
 using Jackett.Common.Indexers.Abstract;
+using Jackett.Common.Models;
 using Jackett.Common.Services.Interfaces;
 using Jackett.Common.Utils.Clients;
 using NLog;
@@ -7,15 +8,18 @@ namespace Jackett.Common.Indexers
 {
     public class CinemaZ : AvistazTracker
     {
-        public CinemaZ(IIndexerConfigurationService configService, WebClient webClient, Logger logger, IProtectionService protectionService)
-            : base(name: "CinemaZ",
-                desc: "Part of the Avistaz network.",
-                link: "https://cinemaz.to/",
-                configService: configService,
-                logger: logger,
-                protectionService: protectionService,
-                webClient: webClient
-                )
+        public CinemaZ(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
+            : base("CinemaZ",
+                   description: "Part of the Avistaz network.",
+                   link: "https://cinemaz.to/",
+                   caps: new TorznabCapabilities
+                   {
+                       SupportsImdbMovieSearch = true
+                   },
+                   configService: configService,
+                   client: wc,
+                   logger: l,
+                   p: ps)
             => Type = "private";
     }
 }

--- a/src/Jackett.Common/Indexers/DanishBits.cs
+++ b/src/Jackett.Common/Indexers/DanishBits.cs
@@ -23,17 +23,23 @@ namespace Jackett.Common.Indexers
             set => base.configData = value;
         }
 
-        public DanishBits(IIndexerConfigurationService configService, WebClient c, Logger l, IProtectionService ps)
-            : base(name: "DanishBits",
-                description: "A danish closed torrent tracker",
-                link: "https://danishbits.org/",
-                endpoint: "couchpotato.php",
-                configService: configService,
-                client: c,
-                logger: l,
-                p: ps,
-                configData: new ConfigurationDataUserPasskey("Note about Passkey: This is not your login Password. Find the Passkey by logging into DanishBits with your Browser, and under your account page you'll see your passkey under the 'Personal' section on the left side.")
-            )
+        public DanishBits(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
+            : base("DanishBits",
+                   description: "A danish closed torrent tracker",
+                   link: "https://danishbits.org/",
+                   caps: new TorznabCapabilities
+                   {
+                       SupportsImdbMovieSearch = true
+                   },
+                   configService: configService,
+                   client: wc,
+                   logger: l,
+                   p: ps,
+                   configData: new ConfigurationDataUserPasskey(
+                       @"Note about Passkey: This is not your login Password. Find the Passkey by logging into
+                       DanishBits with your Browser, and under your account page you'll see your passkey under the 'Personal'
+                       section on the left side."),
+                   endpoint: "couchpotato.php")
         {
             Encoding = Encoding.UTF8;
             Language = "da-dk";

--- a/src/Jackett.Common/Indexers/HDOnly.cs
+++ b/src/Jackett.Common/Indexers/HDOnly.cs
@@ -10,16 +10,16 @@ namespace Jackett.Common.Indexers
 {
     public class HDOnly : GazelleTracker
     {
-        public HDOnly(IIndexerConfigurationService configService, WebClient webClient, Logger logger, IProtectionService protectionService)
-            : base(name: "HD-Only",
-                desc: "HD-Only (HD-O) is a FRENCH Private Torrent Tracker for HD MOVIES / TV",
-                link: "https://hd-only.org/",
-                configService: configService,
-                logger: logger,
-                protectionService: protectionService,
-                webClient: webClient,
-                supportsFreeleechTokens: false // ratiofree
-                )
+        public HDOnly(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
+            : base("HD-Only",
+                   description: "HD-Only (HD-O) is a FRENCH Private Torrent Tracker for HD MOVIES / TV",
+                   link: "https://hd-only.org/",
+                   caps: new TorznabCapabilities(),
+                   configService: configService,
+                   client: wc,
+                   logger: l,
+                   p: ps,
+                   supportsFreeleechTokens: false) // ratiofree
         {
             Language = "fr-fr";
             Type = "private";

--- a/src/Jackett.Common/Indexers/Orpheus.cs
+++ b/src/Jackett.Common/Indexers/Orpheus.cs
@@ -9,21 +9,23 @@ namespace Jackett.Common.Indexers
 {
     public class Orpheus : GazelleTracker
     {
-        public Orpheus(IIndexerConfigurationService configService, WebClient webClient, Logger logger, IProtectionService protectionService)
-            : base(name: "Orpheus",
-                desc: "A music tracker",
-                link: "https://orpheus.network/",
-                configService: configService,
-                logger: logger,
-                protectionService: protectionService,
-                webClient: webClient,
-                supportsFreeleechTokens: true,
-                has2Fa: true
-                )
+        public Orpheus(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
+            : base("Orpheus",
+                   description: "A music tracker",
+                   link: "https://orpheus.network/",
+                   caps: new TorznabCapabilities
+                   {
+                       SupportedMusicSearchParamsList = new List<string> { "q", "album", "artist", "label", "year" }
+                   },
+                   configService: configService,
+                   client: wc,
+                   logger: l,
+                   p: ps,
+                   supportsFreeleechTokens: true,
+                   has2Fa: true)
         {
             Language = "en-us";
             Type = "private";
-            TorznabCaps.SupportedMusicSearchParamsList = new List<string>() { "q", "album", "artist", "label", "year" };
 
             AddCategoryMapping(1, TorznabCatType.Audio, "Music");
             AddCategoryMapping(2, TorznabCatType.PC, "Applications");

--- a/src/Jackett.Common/Indexers/PrivateHD.cs
+++ b/src/Jackett.Common/Indexers/PrivateHD.cs
@@ -1,21 +1,25 @@
 using Jackett.Common.Indexers.Abstract;
+using Jackett.Common.Models;
 using Jackett.Common.Services.Interfaces;
 using Jackett.Common.Utils.Clients;
 using NLog;
 
 namespace Jackett.Common.Indexers
 {
-    public class PrivateHD : AvistazTracker, IIndexer
+    public class PrivateHD : AvistazTracker
     {
-        public PrivateHD(IIndexerConfigurationService configService, WebClient webClient, Logger logger, IProtectionService protectionService)
-            : base(name: "PrivateHD",
-                desc: "BitTorrent site for High Quality, High Definition (HD) movies and TV Shows",
-                link: "https://privatehd.to/",
-                configService: configService,
-                logger: logger,
-                protectionService: protectionService,
-                webClient: webClient
-                )
+        public PrivateHD(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
+            : base("PrivateHD",
+                   description: "BitTorrent site for High Quality, High Definition (HD) movies and TV Shows",
+                   link: "https://privatehd.to/",
+                   caps: new TorznabCapabilities
+                   {
+                       SupportsImdbMovieSearch = true
+                   },
+                   configService: configService,
+                   client: wc,
+                   logger: l,
+                   p: ps)
             => Type = "private";
     }
 }

--- a/src/Jackett.Common/Indexers/Psytorrents.cs
+++ b/src/Jackett.Common/Indexers/Psytorrents.cs
@@ -9,16 +9,16 @@ namespace Jackett.Common.Indexers
 {
     public class Psytorrents : GazelleTracker
     {
-        public Psytorrents(IIndexerConfigurationService configService, WebClient webClient, Logger logger, IProtectionService protectionService)
-            : base(name: "Psytorrents",
-                desc: "Psytorrents (PSY) is a Private Torrent Tracker for ELECTRONIC MUSIC",
-                link: "https://psytorrents.info/",
-                configService: configService,
-                logger: logger,
-                protectionService: protectionService,
-                webClient: webClient,
-                supportsFreeleechTokens: true
-                )
+        public Psytorrents(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
+            : base("Psytorrents",
+                   description: "Psytorrents (PSY) is a Private Torrent Tracker for ELECTRONIC MUSIC",
+                   link: "https://psytorrents.info/",
+                   caps: new TorznabCapabilities(),
+                   configService: configService,
+                   client: wc,
+                   logger: l,
+                   p: ps,
+                   supportsFreeleechTokens: true)
         {
             Language = "en-us";
             Type = "private";

--- a/src/Jackett.Common/Indexers/Redacted.cs
+++ b/src/Jackett.Common/Indexers/Redacted.cs
@@ -9,21 +9,23 @@ namespace Jackett.Common.Indexers
 {
     public class PassTheHeadphones : GazelleTracker
     {
-        public PassTheHeadphones(IIndexerConfigurationService configService, WebClient webClient, Logger logger, IProtectionService protectionService)
-            : base(name: "Redacted",
-                desc: "A music tracker",
-                link: "https://redacted.ch/",
-                configService: configService,
-                logger: logger,
-                protectionService: protectionService,
-                webClient: webClient,
-                supportsFreeleechTokens: true,
-                has2Fa: true
-                )
+        public PassTheHeadphones(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
+            : base("Redacted",
+                   description: "A music tracker",
+                   link: "https://redacted.ch/",
+                   caps: new TorznabCapabilities
+                   {
+                       SupportedMusicSearchParamsList = new List<string> { "q", "album", "artist", "label", "year" }
+                   },
+                   configService: configService,
+                   client: wc,
+                   logger: l,
+                   p: ps,
+                   supportsFreeleechTokens: true,
+                   has2Fa: true)
         {
             Language = "en-us";
             Type = "private";
-            TorznabCaps.SupportedMusicSearchParamsList = new List<string>() { "q", "album", "artist", "label", "year" };
 
             AddCategoryMapping(1, TorznabCatType.Audio, "Music");
             AddCategoryMapping(2, TorznabCatType.PC, "Applications");

--- a/src/Jackett.Common/Indexers/SecretCinema.cs
+++ b/src/Jackett.Common/Indexers/SecretCinema.cs
@@ -10,21 +10,23 @@ namespace Jackett.Common.Indexers
 {
     public class SecretCinema : GazelleTracker
     {
-        public SecretCinema(IIndexerConfigurationService configService, WebClient webClient, Logger logger, IProtectionService protectionService)
-            : base(name: "Secret Cinema",
-                desc: "A tracker for rare movies.",
-                link: "https://secret-cinema.pw/",
-                configService: configService,
-                logger: logger,
-                protectionService: protectionService,
-                webClient: webClient,
-                supportsFreeleechTokens: false // ratio free tracker
-                )
+        public SecretCinema(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
+            : base("Secret Cinema",
+                   description: "A tracker for rare movies.",
+                   link: "https://secret-cinema.pw/",
+                   caps: new TorznabCapabilities
+                   {
+                       SupportsImdbMovieSearch = true,
+                       SupportedMusicSearchParamsList = new List<string> { "q", "album", "artist", "label", "year" }
+                   },
+                   configService: configService,
+                   client: wc,
+                   logger: l,
+                   p: ps,
+                   supportsFreeleechTokens: false) // ratioless tracker
         {
             Language = "en-us";
             Type = "private";
-            TorznabCaps.SupportedMusicSearchParamsList = new List<string>() { "q", "album", "artist", "label", "year" };
-            TorznabCaps.SupportsImdbMovieSearch = true;
 
             AddCategoryMapping(1, TorznabCatType.Movies, "Movies");
             AddCategoryMapping(2, TorznabCatType.Audio, "Music");

--- a/src/Jackett.Common/Indexers/cgpeers.cs
+++ b/src/Jackett.Common/Indexers/cgpeers.cs
@@ -8,16 +8,16 @@ namespace Jackett.Common.Indexers
 {
     public class CGPeers : GazelleTracker
     {
-        public CGPeers(IIndexerConfigurationService configService, WebClient webClient, Logger logger, IProtectionService protectionService)
-            : base(name: "CGPeers",
-                desc: "CGPeers is a Private Torrent Tracker for GRAPHICS SOFTWARE / TUTORIALS / ETC",
-                link: "https://www.cgpeers.com/",
-                configService: configService,
-                logger: logger,
-                protectionService: protectionService,
-                webClient: webClient,
-                supportsFreeleechTokens: true
-                )
+        public CGPeers(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
+            : base("CGPeers",
+                   description: "CGPeers is a Private Torrent Tracker for GRAPHICS SOFTWARE / TUTORIALS / ETC",
+                   link: "https://www.cgpeers.com/",
+                   caps: new TorznabCapabilities(),
+                   configService: configService,
+                   client: wc,
+                   logger: l,
+                   p: ps,
+                   supportsFreeleechTokens: true)
         {
             Language = "en-us";
             Type = "private";

--- a/src/Jackett.Common/Indexers/notwhatcd.cs
+++ b/src/Jackett.Common/Indexers/notwhatcd.cs
@@ -9,20 +9,22 @@ namespace Jackett.Common.Indexers
 {
     public class notwhatcd : GazelleTracker
     {
-        public notwhatcd(IIndexerConfigurationService configService, WebClient webClient, Logger logger, IProtectionService protectionService)
-            : base(name: "notwhat.cd",
-                desc: "A music tracker",
-                link: "https://notwhat.cd/",
-                configService: configService,
-                logger: logger,
-                protectionService: protectionService,
-                webClient: webClient,
-                supportsFreeleechTokens: true
-                )
+        public notwhatcd(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps)
+            : base("notwhat.cd",
+                   description: "A music tracker",
+                   link: "https://notwhat.cd/",
+                   caps: new TorznabCapabilities
+                   {
+                       SupportedMusicSearchParamsList = new List<string> { "q", "album", "artist", "label", "year" }
+                   },
+                   configService: configService,
+                   client: wc,
+                   logger: l,
+                   p: ps,
+                   supportsFreeleechTokens: true)
         {
             Language = "en-us";
             Type = "private";
-            TorznabCaps.SupportedMusicSearchParamsList = new List<string>() { "q", "album", "artist", "label", "year" };
 
             AddCategoryMapping(1, TorznabCatType.Audio, "Music");
             AddCategoryMapping(2, TorznabCatType.PC, "Applications");


### PR DESCRIPTION
* Reorder constructor parameters in abstracts to match BaseWebIndexer
* Make TorznabCapabilities configurable per indexer