### PR TITLE
avistaz: fix category parsing. resolves #7593

### DIFF
--- a/src/Jackett.Common/Indexers/Abstract/AvistazTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/AvistazTracker.cs
@@ -24,6 +24,7 @@ namespace Jackett.Common.Indexers.Abstract
         private string SearchUrl => SiteLink + "torrents?";
         private string IMDBSearch => SiteLink + "ajax/movies/3?term=";
         private readonly Regex CatRegex = new Regex(@"\s+fa\-([a-z]+)\s+", RegexOptions.IgnoreCase);
+        private readonly HashSet<string> HdResolutions = new HashSet<string> { "1080p", "1080i", "720p" };
 
         private new ConfigurationDataBasicLogin configData
         {
@@ -160,10 +161,8 @@ namespace Jackett.Common.Indexers.Abstract
                                 cats.Add(TorznabCatType.Movies.ID);
                             cats.Add(resolution switch
                             {
+                                var res when HdResolutions.Contains(res) => TorznabCatType.MoviesHD.ID,
                                 "2160p" => TorznabCatType.MoviesUHD.ID,
-                                "1080p" => TorznabCatType.MoviesHD.ID,
-                                "1080i" => TorznabCatType.MoviesHD.ID,
-                                "720p" => TorznabCatType.MoviesHD.ID,
                                 _ => TorznabCatType.MoviesSD.ID
                             });
                             break;
@@ -172,10 +171,8 @@ namespace Jackett.Common.Indexers.Abstract
                                 cats.Add(TorznabCatType.TV.ID);
                             cats.Add(resolution switch
                             {
+                                var res when HdResolutions.Contains(res) => TorznabCatType.TVHD.ID,
                                 "2160p" => TorznabCatType.TVUHD.ID,
-                                "1080p" => TorznabCatType.TVHD.ID,
-                                "1080i" => TorznabCatType.TVHD.ID,
-                                "720p" => TorznabCatType.TVHD.ID,
                                 _ => TorznabCatType.TVSD.ID
                             });
                             break;
@@ -197,10 +194,7 @@ namespace Jackett.Common.Indexers.Abstract
                     else
                         release.DownloadVolumeFactor = 1;
 
-                    if (row.QuerySelectorAll("i.fa-diamond").Any())
-                        release.UploadVolumeFactor = 2;
-                    else
-                        release.UploadVolumeFactor = 1;
+                    release.UploadVolumeFactor = row.QuerySelectorAll("i.fa-diamond").Any() ? 2 : 1;
 
                     releases.Add(release);
                 }

--- a/src/Jackett.Common/Indexers/Avistaz.cs
+++ b/src/Jackett.Common/Indexers/Avistaz.cs
@@ -21,5 +21,11 @@ namespace Jackett.Common.Indexers
                    logger: l,
                    p: ps)
             => Type = "private";
+
+        // Avistaz has episodes without season. eg Running Man E323
+        protected override string GetSearchTerm(TorznabQuery query) =>
+            !string.IsNullOrWhiteSpace(query.Episode) && query.Season == 0 ?
+            $"{query.SearchTerm} E{query.Episode}" :
+            $"{query.SearchTerm} {query.GetEpisodeSearchString()}";
     }
 }


### PR DESCRIPTION
Tested in PirateHD only! Please, test it in AvistaZ & CinemaZ

@garfield69 I can't use the mapping from https://github.com/Jackett/Jackett/issues/7593#issuecomment-597441820 because we can't send cat > 3 to the tracker (just cat= 1, 2 or 3)

To fix #8049 (example 2 / issue 2) I had to add the category Movies in some cases. Eg, if you select MoviesHD only it's fine. If you select Movies you will see 2 categories in the results.