### PR TITLE
torrentdownloads: search string fix

### DIFF
--- a/src/Jackett.Common/Definitions/torrentdownloads.yml
+++ b/src/Jackett.Common/Definitions/torrentdownloads.yml
@@ -49,7 +49,7 @@
     paths:
       - path: "{{if .Keywords}}/search/{{else}}/today/{{end}}"
     inputs:
-      $raw: "new=1&{{range .Categories}}s_cat={{.}}&{{end}}"
+      $raw: "{{range .Categories}}s_cat={{.}}&{{end}}"
       search: "{{ .Keywords }}"
 
     rows:


### PR DESCRIPTION
> I get clearance-failed for https://www.torrentdownloads.me/
> and failed,redirected for https://torrentdownloads.unblockit.pro/

https://github.com/Jackett/Jackett/issues/8085#issuecomment-610718909

`new=1` is the source of the issue for those proxies. Seems to be unneeded though, as removing it doesn't change the order of results for .info on either their site or in Jackett.