### PR TITLE
kickasstorrent: proxy fixes

### DIFF
--- a/src/Jackett.Common/Definitions/kickasstorrent-kathow.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrent-kathow.yml
@@ -16,7 +16,9 @@
     - https://thekat.se/
     - https://kat.how/
     - https://kat.li/
-    - https://kickasstorrents.unblockninja.com/ # currently not responding
+    - https://kickasstorrents.unblockninja.com/ # kickasstorrent proxy, not kickasstorrent-kathow
+    - https://katcr.to/ # possible 3rd kickasstorrent site/clone?
+    - https://kickasstorrent.cr/ # possible 3rd kickasstorrent site/clone?
 
   caps:
     categories:

--- a/src/Jackett.Common/Definitions/kickasstorrent.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrent.yml
@@ -8,16 +8,17 @@
   followredirect: true
   links:
     - https://katcr.co/
-    - https://katcr.to/
-    - https://kat.unblockit.pro/
     - https://kat.root.yt/
+    - https://kickasstorrents.unblockninja.com/
     - https://katcr.black-mirror.xyz/
     - https://katcr.unblocked.casa/
     - https://katcr.proxyportal.fun/
     - https://katcr.uk-unblock.xyz/
     - https://katcr.ind-unblock.xyz/
   legacylinks:
-    - https://kickasstorrent.cr/ # https://kickasstorrent.cr/category/latest/page/1 is fake torrent page
+    - https://kickasstorrent.cr/ # possible 3rd kickasstorrent site/clone?
+    - https://katcr.to/ # possible 3rd kickasstorrent site/clone?
+    - https://kat.unblockit.pro/ # kickasstorrent-kathow proxy, not kickasstorrent
 
   caps:
     categorymappings:


### PR DESCRIPTION
Removed **unblockit.pro** proxy from kickasstorrent, had added it there by mistake.

**unblockninja** proxy is working again, but is (now?) for kickasstorrent-kathow, not kickasstorrent. The site itself defaults to using the search string `/usearch/torrents-search.php?q=` however `/katsearch/page/1/` works fine on it as well, so doesn't cause an issue in Jackett.

**kickasstorrent.cr** and **katcr.to** appear to be a different clone altogether (possibly of the original KAT), rather than proxies of either kickasstorrent or kickasstorrent-kathow - different favicon, different layout, different categories, etc.. If anyone wants to make them into a separate indexer, have at it.