### PR TITLE
torrent9: add /top_torrent/ so proxies can work

### DIFF
--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -8,6 +8,8 @@
   followredirect: true
   links:
     - https://www.oxtorrent.me/
+    - https://ww1.torrent9.is/
+    - https://ww1.torrent9.to/
 
   legacylinks:
     - http://www.torrent9.ec/
@@ -29,10 +31,7 @@
     - https://wvw.t9.pe/
     - https://www4.torrent9.to/
     - https://www.torrent9.cat/
-    - https://ww1.torrent9.is/
-    - https://ww1.torrent9.to/
     - https://www.torrent9.is/
-    - https://www4.torrent9.to/
     - https://www.torrent09.uno/
     - https://torrent9.unblockninja.com/ # this is a proxy for torrent9clone
     - https://www.torrent9.pl/ # this is a proxy for torrent9clone
@@ -65,7 +64,7 @@
 
   search:
     paths:
-      - path: "{{ if .Keywords }}/search_torrent/{{ .Keywords }}{{else}}{{end}}"
+      - path: "{{ if .Keywords }}/search_torrent/{{ .Keywords }}{{else}}/top_torrent/{{end}}"
 
     rows:
       selector: table.table-striped > tbody > tr


### PR DESCRIPTION
Following up on the discussion under this commit - https://github.com/Jackett/Jackett/commit/ea0325a1737558ff16c49cd64694a736a875ef00

The homepages of .is and .to don't contain a list of torrents, so Jackett gives a 'found no results' error. A blank search using /search_torrent/ can't be used as it redirects to their homepages (which are on www. and www4. respectively, rather than ww1.). www. and www4. can't be used either as they then redirect to ww1. to perform a search.

For an empty search or test, /top_torrent/ works for both proxies and oxtorrent.me .

I tested with followredirect removed so as links weren't being replaced without me realising, which I think is what was happening with my earlier attempts. Confirmed they still worked when it was re-enabled.

All other legacylinks redirect to the .pl clone or dead sites.

There was a duplicate https://www4.torrent9.to/ under legacylinks so I removed that as well.