### PR TITLE
core: fix links in rss, torznab and potato feeds

### DIFF
--- a/src/Jackett.Common/Models/ResultPage.cs
+++ b/src/Jackett.Common/Models/ResultPage.cs
@@ -33,6 +33,8 @@ namespace Jackett.Common.Models
 
         public string ToXml(Uri selfAtom)
         {
+            // IMPORTANT: We can't use Uri.ToString(), because it generates URLs without URL encode (links with unicode
+            // characters are broken). We must use Uri.AbsoluteUri instead that handles encoding correctly
             var xdoc = new XDocument(
                 new XDeclaration("1.0", "UTF-8", null),
                 new XElement("rss",
@@ -41,42 +43,42 @@ namespace Jackett.Common.Models
                     new XAttribute(XNamespace.Xmlns + "torznab", torznabNs.NamespaceName),
                     new XElement("channel",
                         new XElement(atomNs + "link",
-                            new XAttribute("href", selfAtom.ToString()),
+                            new XAttribute("href", selfAtom.AbsoluteUri),
                             new XAttribute("rel", "self"),
                             new XAttribute("type", "application/rss+xml")
                         ),
                         new XElement("title", ChannelInfo.Title),
                         new XElement("description", ChannelInfo.Description),
-                        new XElement("link", ChannelInfo.Link),
+                        new XElement("link", ChannelInfo.Link.AbsoluteUri),
                         new XElement("language", ChannelInfo.Language),
                         new XElement("category", ChannelInfo.Category),
                         new XElement("image",
-                            new XElement("url", ChannelInfo.ImageUrl.ToString()),
+                            new XElement("url", ChannelInfo.ImageUrl.AbsoluteUri),
                             new XElement("title", ChannelInfo.ImageTitle),
-                            new XElement("link", ChannelInfo.ImageLink.ToString()),
+                            new XElement("link", ChannelInfo.ImageLink.AbsoluteUri),
                             new XElement("description", ChannelInfo.ImageDescription)
                         ),
                         from r in Releases
                         select new XElement("item",
                             new XElement("title", r.Title),
-                            new XElement("guid", r.Guid),
+                            new XElement("guid", r.Guid.AbsoluteUri),  // GUID and (Link or Magnet) are mandatory
                             new XElement("jackettindexer", new XAttribute("id", r.Origin.ID), r.Origin.DisplayName),
-                            r.Comments == null ? null : new XElement("comments", r.Comments.ToString()),
+                            r.Comments == null ? null : new XElement("comments", r.Comments?.AbsoluteUri),
                             r.PublishDate == DateTime.MinValue ? new XElement("pubDate", xmlDateFormat(DateTime.Now)) : new XElement("pubDate", xmlDateFormat(r.PublishDate)),
                             r.Size == null ? null : new XElement("size", r.Size),
                             r.Files == null ? null : new XElement("files", r.Files),
                             r.Grabs == null ? null : new XElement("grabs", r.Grabs),
                             new XElement("description", r.Description),
-                            new XElement("link", r.Link ?? r.MagnetUri),
+                            new XElement("link", r.Link?.AbsoluteUri ?? r.MagnetUri.AbsoluteUri),
                             r.Category == null ? null : from c in r.Category select new XElement("category", c),
                             new XElement(
                                 "enclosure",
-                                new XAttribute("url", r.Link ?? r.MagnetUri),
+                                new XAttribute("url", r.Link?.AbsoluteUri ?? r.MagnetUri.AbsoluteUri),
                                 r.Size == null ? null : new XAttribute("length", r.Size),
                                 new XAttribute("type", "application/x-bittorrent")
                             ),
                             r.Category == null ? null : from c in r.Category select getTorznabElement("category", c),
-                            getTorznabElement("magneturl", r.MagnetUri),
+                            getTorznabElement("magneturl", r.MagnetUri?.AbsoluteUri),
                             getTorznabElement("rageid", r.RageID),
                             getTorznabElement("thetvdb", r.TVDBId),
                             getTorznabElement("imdb", r.Imdb == null ? null : ((long)r.Imdb).ToString("D7")),

--- a/src/Jackett.Common/Models/ResultPage.cs
+++ b/src/Jackett.Common/Models/ResultPage.cs
@@ -63,7 +63,7 @@ namespace Jackett.Common.Models
                             new XElement("title", r.Title),
                             new XElement("guid", r.Guid.AbsoluteUri),  // GUID and (Link or Magnet) are mandatory
                             new XElement("jackettindexer", new XAttribute("id", r.Origin.ID), r.Origin.DisplayName),
-                            r.Comments == null ? null : new XElement("comments", r.Comments?.AbsoluteUri),
+                            r.Comments == null ? null : new XElement("comments", r.Comments.AbsoluteUri),
                             r.PublishDate == DateTime.MinValue ? new XElement("pubDate", xmlDateFormat(DateTime.Now)) : new XElement("pubDate", xmlDateFormat(r.PublishDate)),
                             r.Size == null ? null : new XElement("size", r.Size),
                             r.Files == null ? null : new XElement("files", r.Files),

--- a/src/Jackett.Server/Controllers/ResultsController.cs
+++ b/src/Jackett.Server/Controllers/ResultsController.cs
@@ -499,12 +499,14 @@ namespace Jackett.Server.Controllers
             {
                 var release = AutoMapper.Mapper.Map<ReleaseInfo>(r);
                 release.Link = serverService.ConvertToProxyLink(release.Link, serverUrl, CurrentIndexer.ID, "dl", release.Title);
+                // IMPORTANT: We can't use Uri.ToString(), because it generates URLs without URL encode (links with unicode
+                // characters are broken). We must use Uri.AbsoluteUri instead that handles encoding correctly
                 var item = new TorrentPotatoResponseItem()
                 {
                     release_name = release.Title + "[" + CurrentIndexer.DisplayName + "]", // Suffix the indexer so we can see which tracker we are using in CPS as it just says torrentpotato >.>
-                    torrent_id = release.Guid.ToString(),
-                    details_url = release.Comments.ToString(),
-                    download_url = (release.Link != null ? release.Link.ToString() : release.MagnetUri.ToString()),
+                    torrent_id = release.Guid.AbsoluteUri, // GUID and (Link or Magnet) are mandatory
+                    details_url = release.Comments?.AbsoluteUri,
+                    download_url = (release.Link != null ? release.Link.AbsoluteUri : release.MagnetUri.AbsoluteUri),
                     imdb_id = release.Imdb.HasValue ? ParseUtil.GetFullImdbID("tt" + release.Imdb) : null,
                     freeleech = (release.DownloadVolumeFactor == 0 ? true : false),
                     type = "movie",


### PR DESCRIPTION
I was debugging qBittorrent when I found the problem was in Jackett.

This PR fix the links (comments, download...) in RSS, Torznab and Potato feeds. Only links with Unicode characters were affected but nowadays are a lot. I hope this fix some of the issues related to RSS/Torznab/Potato download links like: #7869 #5267 #5875
Some of them are related to "magnet redirect" too so this won't fix them.

The internal API used by Jackett UI was not affected by this bug.

Fixes https://github.com/qbittorrent/qBittorrent/issues/11877