### PR TITLE
Add language flags taking VOSE into account

### DIFF
--- a/src/Jackett.Common/Definitions/divteam.yml
+++ b/src/Jackett.Common/Definitions/divteam.yml
@@ -116,7 +116,17 @@
         selector: a[href^="download.php?id="]
         attribute: href
       title:
-        selector: a[href^="index.php?page=torrent-details"]
+        selector: a[href^="index.php?page=torrent-details"]:contains("VOSE")
+        optional: true
+        filters:
+          - name: append
+            args: " [English]"
+      title:
+        selector: a[href^="index.php?page=torrent-details"]:not(:contains("VOSE"))
+        optional: true
+        filters:
+          - name: append
+            args: " [Spanish] [English]"
       banner:
         selector: a[onmouseover][href^="index.php?page=torrent-details"]
         attribute: onmouseover

--- a/src/Jackett.Common/Definitions/divteam.yml
+++ b/src/Jackett.Common/Definitions/divteam.yml
@@ -116,7 +116,7 @@
         selector: a[href^="download.php?id="]
         attribute: href
       title:
-        selector: a[href^="index.php?page=torrent-details"]:contains("VOSE")
+        selector: a[href^="index.php?page=torrent-details"][onmouseover]:contains("VOSE")
         optional: true
         filters:
           - name: append

--- a/src/Jackett.Common/Definitions/divteam.yml
+++ b/src/Jackett.Common/Definitions/divteam.yml
@@ -157,6 +157,7 @@
         selector: td:nth-last-child(2)
       downloadvolumefactor:
         case:
+          img[src="images/freeleech.gif"]: 0
           img[src="images/gold.png"]: 0
           img[src="images/silver.png"]: 0.5
           "*": 1

--- a/src/Jackett.Common/Definitions/divteam.yml
+++ b/src/Jackett.Common/Definitions/divteam.yml
@@ -122,7 +122,7 @@
           - name: append
             args: " [English]"
       title:
-        selector: a[href^="index.php?page=torrent-details"]:not(:contains("VOSE"))
+        selector: a[href^="index.php?page=torrent-details"][onmouseover]:not(:contains("VOSE"))
         optional: true
         filters:
           - name: append


### PR DESCRIPTION
Same as with hdcity, content is Dual (Spanish and English) by default, unless VOSE specified. 
There's also Spanish content which might or might not be flagged as VOSE (it seems it usually doesn't, unless original language is something like Galician, which is a very edge case).

In case of false positives when flagged as Dual but only Spanish, Radarr/Sonarr will still find Spanish and download, so just by handling MediaInfo properly nothing happens.

In case of the ones flagged as VOSE, there's no much we can do so I think it's a nice tradeoff