### PR TITLE
test: add unit test to validate all cardigann definitions

### DIFF
--- a/src/Jackett.Common/Definitions/4thd.yml
+++ b/src/Jackett.Common/Definitions/4thd.yml
@@ -10,7 +10,7 @@
 
   caps:
     categorymappings:
-      - {id: 38, cat: Movies, desc: "Movie Pack"}
+      - {id: 38, cat: Movies, dec: "Movie Pack"}
       - {id: 36, cat: Movies, desc: "Movies/Classic Films"}
       - {id: 13, cat: Movies, desc: "Movies/Documentary"}
       - {id: 21, cat: Movies/Foreign, desc: "Movies/Foreign"}

--- a/src/Jackett.Common/Definitions/4thd.yml
+++ b/src/Jackett.Common/Definitions/4thd.yml
@@ -10,7 +10,7 @@
 
   caps:
     categorymappings:
-      - {id: 38, cat: Movies, dec: "Movie Pack"}
+      - {id: 38, cat: Movies, desc: "Movie Pack"}
       - {id: 36, cat: Movies, desc: "Movies/Classic Films"}
       - {id: 13, cat: Movies, desc: "Movies/Documentary"}
       - {id: 21, cat: Movies/Foreign, desc: "Movies/Foreign"}

--- a/src/Jackett.Common/Services/ConfigurationService.cs
+++ b/src/Jackett.Common/Services/ConfigurationService.cs
@@ -69,7 +69,9 @@ namespace Jackett.Common.Services
                         {
                             try
                             {
-                                processService.StartProcessAndLog(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath, "--MigrateSettings", true);
+                                // Use EscapedCodeBase to avoid Uri reserved characters from causing bugs
+                                // https://stackoverflow.com/questions/896572
+                                processService.StartProcessAndLog(new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath, "--MigrateSettings", true);
                             }
                             catch
                             {
@@ -164,7 +166,9 @@ namespace Jackett.Common.Services
             }
         }
 
-        public string ApplicationFolder() => Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
+        // Use EscapedCodeBase to avoid Uri reserved characters from causing bugs
+        // https://stackoverflow.com/questions/896572
+        public string ApplicationFolder() => Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath);
 
         public string GetContentFolder()
         {
@@ -232,7 +236,7 @@ namespace Jackett.Common.Services
             }
             else
             {
-                //We don't load these out of the config files as it could get confusing to users who accidently save. 
+                //We don't load these out of the config files as it could get confusing to users who accidently save.
                 //In future we could flatten the serverconfig, and use command line parameters to override any configuration.
                 config.RuntimeSettings = runtimeSettings;
             }

--- a/src/Jackett.Common/Services/WindowsServiceConfigService.cs
+++ b/src/Jackett.Common/Services/WindowsServiceConfigService.cs
@@ -51,7 +51,9 @@ namespace Jackett.Common.Services
             }
             else
             {
-                var applicationFolder = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
+                // Use EscapedCodeBase to avoid Uri reserved characters from causing bugs
+                // https://stackoverflow.com/questions/896572
+                var applicationFolder = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath);
 
                 var exePath = Path.Combine(applicationFolder, SERVICEEXE);
                 if (!File.Exists(exePath) && Debugger.IsAttached)

--- a/src/Jackett.Server/Services/ServiceConfigService.cs
+++ b/src/Jackett.Server/Services/ServiceConfigService.cs
@@ -47,7 +47,9 @@ namespace Jackett.Server.Services
             }
             else
             {
-                var applicationFolder = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
+                // Use EscapedCodeBase to avoid Uri reserved characters from causing bugs
+                // https://stackoverflow.com/questions/896572
+                var applicationFolder = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath);
 
                 var exePath = Path.Combine(applicationFolder, SERVICEEXE);
                 if (!File.Exists(exePath) && Debugger.IsAttached)

--- a/src/Jackett.Service/Service.cs
+++ b/src/Jackett.Service/Service.cs
@@ -51,7 +51,9 @@ namespace Jackett.Service
 
         private void StartConsoleApplication()
         {
-            var applicationFolder = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
+            // Use EscapedCodeBase to avoid Uri reserved characters from causing bugs
+            // https://stackoverflow.com/questions/896572
+            var applicationFolder = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath);
 
             var exePath = Path.Combine(applicationFolder, "JackettConsole.exe");
 

--- a/src/Jackett.Test/Definitions/DefinitionsParserTests.cs
+++ b/src/Jackett.Test/Definitions/DefinitionsParserTests.cs
@@ -1,0 +1,36 @@
+using System;
+using System.IO;
+using System.Reflection;
+using Jackett.Common.Models;
+using NUnit.Framework;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+using Assert = NUnit.Framework.Assert;
+
+namespace Jackett.Test.Definitions
+{
+    [TestFixture]
+    public class DefinitionsParserTests
+    {
+        [Test]
+        public void LoadAndParseAllCardigannDefinitions()
+        {
+            var applicationFolder = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
+            var definitionsFolder = Path.GetFullPath(Path.Combine(applicationFolder, "Definitions"));
+            var deserializer = new DeserializerBuilder()
+                               .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                               .Build();
+            var files = new DirectoryInfo(definitionsFolder).GetFiles("*.yml");
+            foreach (var file in files)
+                try
+                {
+                    var definitionString = File.ReadAllText(file.FullName);
+                    deserializer.Deserialize<IndexerDefinition>(definitionString);
+                }
+                catch (Exception ex)
+                {
+                    Assert.Fail($"Error while parsing Cardigann definition {file.Name}\n{ex}");
+                }
+        }
+    }
+}

--- a/src/Jackett.Test/Definitions/DefinitionsParserTests.cs
+++ b/src/Jackett.Test/Definitions/DefinitionsParserTests.cs
@@ -15,7 +15,9 @@ namespace Jackett.Test.Definitions
         [Test]
         public void LoadAndParseAllCardigannDefinitions()
         {
-            var applicationFolder = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().CodeBase).LocalPath);
+            // Use EscapedCodeBase to avoid Uri reserved characters from causing bugs
+            // https://stackoverflow.com/questions/896572
+            var applicationFolder = Path.GetDirectoryName(new Uri(Assembly.GetExecutingAssembly().EscapedCodeBase).LocalPath);
             var definitionsFolder = Path.GetFullPath(Path.Combine(applicationFolder, "Definitions"));
             var deserializer = new DeserializerBuilder()
                                .WithNamingConvention(CamelCaseNamingConvention.Instance)


### PR DESCRIPTION
This test will validate all cardigann definitions. The Azure Pipeline will fail if something is wrong. The error contains the indexer, the line and the field.

```
Error while parsing Cardigann definition 4thd.yml
YamlDotNet.Core.YamlException: (Line: 13, Col: 9, Idx: 240) - (Line: 13, Col: 9, Idx: 240): Exception during deserialization
 ---> System.Runtime.Serialization.SerializationException: Property 'dec' not found on type 'Jackett.Common.Models.CategorymappingBlock'.
```