### PR TITLE
topnow: html fix & magnet option added. Resolves #8199

### DIFF
--- a/src/Jackett.Common/Definitions/topnow.yml
+++ b/src/Jackett.Common/Definitions/topnow.yml
@@ -19,30 +19,40 @@
       tv-search: [q, season, ep]
       movie-search: [q]
 
-  settings: []
+  settings:
+    - name: downloadlink
+      type: select
+      label: Download link
+      default: "/torrent/"
+      options:
+        "/torrent/" : ".torrent"
+        "magnet:?xt=": "magnet"
+    - name: ""
+      type: info
+      default: magnet links are not available for all results.
 
   download:
-    selector: a#torrent
+    selector: a[href*="{{ .Config.downloadlink }}"]
     attribute: href
 
   search:
     paths:
-    # http://topnow.se/search.php?dayq=mandalorian
-      - path: search.php
+    # http://topnow.se/index.php?search=mandalorian
+      - path: index.php
     inputs:
-      dayq: "{{.Keywords}}"
+      search: "{{.Keywords}}"
     rows:
-      selector: table.topic_table
+      selector: table.each_card_table
     fields:
       category:
         text: other
       title:
-        selector: td.topic_head
+        selector: td:nth-child(1)
       details:
-        selector: td.topic_content a
+        selector: td.card_content a
         attribute: href
       download:
-        selector: td.topic_content a
+        selector: td.card_content a
         attribute: href
       banner:
         selector: img


### PR DESCRIPTION
Not all results have their own page, and instead direct you to the stream (if you click on the result's name instead of the .torrent download button). Clicking on the name of those results in Jackett also directs you to the stream. Torrents for all results, including those without their own page, are available from the search results page, but I wasn't able to work out how to get them from there instead. Any advice?

e.g. Better Call Saul S05E08 & 09 - https://topnow.se/index.php?search=better+call+saul

magnets are available for most results, but not all, so I added a note to warn users who want to the option. Although that's only from the episode/season page, not the results page, so this might have to be removed.