### PR TITLE
Cardigann: Add template functions eq/ne

### DIFF
--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -210,7 +210,9 @@ namespace Jackett.Common.Indexers
         {
             var variables = new Dictionary<string, object>
             {
-                [".Config.sitelink"] = SiteLink
+                [".Config.sitelink"] = SiteLink,
+                [".True"] = "True",
+                [".False"] = null
             };
             foreach (var Setting in Definition.Settings)
             {
@@ -296,63 +298,81 @@ namespace Jackett.Common.Indexers
                 JoinMatches = JoinMatches.NextMatch();
             }
 
-            // handle or, and functions
-            var AndOrRegex = new Regex(@"(and|or)\s+\((\..+?)\)\s+\((\..+?)\)(\s+\((\..+?)\)){0,1}");
-            var AndOrRegexMatches = AndOrRegex.Match(template);
 
-            while (AndOrRegexMatches.Success)
+            var supportedLogicFunctions = new[]
             {
+                "and",
+                "or",
+                "eq",
+                "ne"
+            };
+            var acceptsStringLiterals = new[]
+            {
+                "eq",
+                "ne"
+            };
+            var logicStr = string.Join("|", supportedLogicFunctions.Select(Regex.Escape));
+
+            // Matches a logic function above and 2 or more of (.varname) or .varname or "string literal" in any combination
+            var logicRegex = new Regex(@$"\b({logicStr})(?:\s+(\(?\.[^\)\s]+\)?|""[^""]+"")){{2,}}");
+            var logicMatch = logicRegex.Match(template);
+
+            while (logicMatch.Success)
+            {
+                var functionStartIndex = logicMatch.Groups[0].Index;
+                var functionLength = logicMatch.Groups[0].Length;
+                var functionName = logicMatch.Groups[1].Value;
+                // Use Group.Captures to get each matching string in a repeating Match.Group
+                // Strip () around variable names here, as they are optional. Use quotes to differentiate variables and literals
+                var parameters = logicMatch.Groups[2].Captures.Cast<Capture>().Select(c => c.Value.Trim('(', ')')).ToList();
                 var functionResult = "";
-                var all = AndOrRegexMatches.Groups[0].Value;
-                var op = AndOrRegexMatches.Groups[1].Value;
-                var first = AndOrRegexMatches.Groups[2].Value;
-                var second = AndOrRegexMatches.Groups[3].Value;
-                var third = "";
-                if (AndOrRegexMatches.Groups.Count > 5)
+
+                // If the function can't use string literals, fail silently by removing the literals.
+                if (!acceptsStringLiterals.Contains(functionName))
+                    parameters.RemoveAll(param => param.StartsWith("\""));
+
+                switch (functionName)
                 {
-                    third = AndOrRegexMatches.Groups[5].Value;
+                    case "and": // returns first null or empty, else last variable
+                    case "or": // returns first not null or empty, else last variable
+                        var isAnd = functionName == "and";
+                        foreach (var parameter in parameters)
+                        {
+                            functionResult = parameter;
+                            // (null as string) == null
+                            // (if null or empty) break if and, continue if or
+                            // (if neither null nor empty) continue if and, break if or
+                            if (string.IsNullOrWhiteSpace(variables[parameter] as string) == isAnd)
+                                break;
+                        }
+                        break;
+                    case "eq": // Returns .True if equal
+                    case "ne": // Returns .False if equal
+                    {
+                        var wantEqual = functionName == "eq";
+                        // eq/ne take exactly 2 params. Update the length to match
+                        // This removes the whitespace between params 2 and 3.
+                        // It shouldn't matter because we add spaces back in around the result
+                        if (parameters.Count > 2)
+                            functionLength = logicMatch.Groups[2].Captures[2].Index - functionStartIndex;
+
+                        // Take first two parameters, convert vars to values and strip quotes on string literals
+                        // Counting distinct gives us 1 if equal and 2 if not.
+                        var isEqual =
+                            parameters.Take(2).Select(param => param.StartsWith("\"") ? param.Trim('"') : variables[param] as string)
+                                      .Distinct().Count() == 1;
+
+                        functionResult = isEqual == wantEqual ? ".True" : ".False";
+                        break;
+                    }
                 }
 
-                var value = variables[first];
-                if (op == "and")
-                {
-                    functionResult = second;
-                    if (value == null || (value is string && string.IsNullOrWhiteSpace((string)value)))
-                    {
-                        functionResult = first;
-                    }
-                    else
-                    {
-                        if (!string.IsNullOrWhiteSpace(third))
-                        {
-                            functionResult = third;
-                            value = variables[second];
-                            if (value == null || (value is string && string.IsNullOrWhiteSpace((string)value)))
-                            {
-                                functionResult = second;
-                            }
-                        }
-                    }
-                }
-                if (op == "or")
-                {
-                    functionResult = first;
-                    if (value == null || (value is string && string.IsNullOrWhiteSpace((string)value)))
-                    {
-                        functionResult = second;
-                        if (!string.IsNullOrWhiteSpace(third))
-                        {
-                            value = variables[second];
-                            if (value == null || (value is string && string.IsNullOrWhiteSpace((string)value)))
-                            {
-                                functionResult = third;
-                            }
-                        }
-                    }
-
-                }
-                template = template.Replace(all, functionResult);
-                AndOrRegexMatches = AndOrRegexMatches.NextMatch();
+                template = template.Remove(functionStartIndex, functionLength)
+                                   .Insert(functionStartIndex, " " + functionResult + " ");
+                // Rerunning match instead of using nextMatch allows us to support nested functions
+                // like {{if and eq (.Var1) "string1" eq (.Var2) "string2"}}
+                // No performance is lost because Match/NextMatch are lazy evaluated and pause execution after first match
+                logicMatch = logicRegex.Match(template);
             }
 
             // handle if ... else ... expression

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -352,7 +352,7 @@ namespace Jackett.Common.Indexers
                         var wantEqual = functionName == "eq";
                         // eq/ne take exactly 2 params. Update the length to match
                         // This removes the whitespace between params 2 and 3.
-                        // It shouldn't matter because we add spaces back in around the result
+                        // It shouldn't matter because the match starts at a word boundary
                         if (parameters.Count > 2)
                             functionLength = logicMatch.Groups[2].Captures[2].Index - functionStartIndex;
 
@@ -368,7 +368,7 @@ namespace Jackett.Common.Indexers
                 }
 
                 template = template.Remove(functionStartIndex, functionLength)
-                                   .Insert(functionStartIndex, " " + functionResult + " ");
+                                   .Insert(functionStartIndex, functionResult);
                 // Rerunning match instead of using nextMatch allows us to support nested functions
                 // like {{if and eq (.Var1) "string1" eq (.Var2) "string2"}}
                 // No performance is lost because Match/NextMatch are lazy evaluated and pause execution after first match


### PR DESCRIPTION
This replaces #8009 and follows the current syntax styles to add functions eq (equals) and ne (not equals). These functions take exactly 2 parameters, and compares their value, returning `.True` or `.False` as appropriate.

I was able to test this on several yml indexers and it doesn't break the existing template logic for and/or.

As a byproduct of where and how I added this, the following extra features are now also available:

* Parentheses around variable names in and/or are now optional
* And/Or now support 2+ variables instead of just 2-3
* Nested functions are now allowable e.g `and eq (.Config.Language) "English" eq (.Results.Page) "3"`
* Parenthesis can be used around nested functions to show grouping precedence
  * `(and .Var1 .Var2)` evaluates to either `(.Var1)` or `(.Var2)`
* New variables `.True` and `.False` now exist and can be used anywhere `.Config` is available (currently everywhere). To emulate their intended values `.True = "True"` (non-empty string evaluates to true in all places) and `.False = null` (null values evaluate to false in all places).

@ngosang I couldn't find a good way to bring this under unit testing, but it is heavily commented to make up for that.