### PR TITLE
magnetdl: add official .org proxy

### DIFF
--- a/src/Jackett.Common/Definitions/magnetdl.yml
+++ b/src/Jackett.Common/Definitions/magnetdl.yml
@@ -8,6 +8,7 @@
   followredirect: true
   links:
     - https://www.magnetdl.com/
+    - https://www.magnetdl.org/
     - https://magnetdl.unblockninja.com/
     - https://magnetdl.unblockit.one/
   legacylinks:


### PR DESCRIPTION
Listed in the Accessing MagnetDL section from https://www.magnetdl.com/site/help/