### PR TITLE
magnetdl: fix search tests for Sonarr et al

### DIFF
--- a/src/Jackett.Common/Definitions/magnetdl.yml
+++ b/src/Jackett.Common/Definitions/magnetdl.yml
@@ -57,9 +57,10 @@
         args: [" ", "-"]
       - name: tolower
     paths:
-      # return movie results if there are no search parms supplied (for use with the TEST button)
+      # return results for 'of' if there are no search parms supplied (for use with the TEST button)
       # http://www.magnetdl.com/m/midnight-texas-s01e10/
-      - path: "{{ if .Keywords }}{{ re_replace .Keywords \"(.).*\" \"$1\" }}/{{ .Keywords }}/{{else}}download/movies/{{end}}{{ .Config.sort }}/{{ .Config.type }}/"
+      - path: "{{ if .Keywords }}{{ re_replace .Keywords \"(.).*\" \"$1\" }}/{{ .Keywords }}/{{else}}o/of/{{end}}{{ .Config.sort }}/{{ .Config.type }}/"
+      - path: "{{ if .Keywords }}{{ re_replace .Keywords \"(.).*\" \"$1\" }}/{{ .Keywords }}/{{else}}o/of/{{end}}{{ .Config.sort }}/{{ .Config.type }}/2/"
 
     rows:
       selector: tr:has(td.m)


### PR DESCRIPTION
Testing in Sonarr (presumably also Lidarr and others) currently finds no results due to the use of `download/movies/` for empty search.

Searching for `of` was the best fix :
- searching `the` or single characters 404s out
- `of` returns more results than other common words I could think of
- gives a good mix of movies, tv, audio, etc.

Added a second results page (40 per) to improve odds of getting at least one for the relevant cat, and just generally returning search results.

Let me know if there's a downside to any of this that I've missed.