### PR TITLE
Cardigann: Add .Today.Year to template variables. Resolves #8258

### DIFF
--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -234,7 +234,7 @@ namespace Jackett.Common.Indexers
                 [".Today.Year"] = DateTime.Today.Year.ToString()
             };
             foreach (var setting in Definition.Settings)
-                variables[".Config" + setting.Name] = configData.GetDynamic(setting.Name) switch
+                variables[".Config." + setting.Name] = configData.GetDynamic(setting.Name) switch
                 {
                     CheckboxItem checkbox => checkbox.Values,
                     BoolItem boolItem => variables[boolItem.Value ? ".True" : ".False"],


### PR DESCRIPTION
This adds a Template variable .Today.Year that includes the current year to resolve #8258. It also updates the `getTemplateVariablesFromConfigData()` code to utilize C#8 features to be more concise.

Seeing as this is the simplest place to add global template variables and we've added multiple non-config data variables here because of that, I've also renamed the function to match the intended purpose.