### PR TITLE
Restore filter config for nyaasi

### DIFF
--- a/src/Jackett.Common/Definitions/nyaasi.yml
+++ b/src/Jackett.Common/Definitions/nyaasi.yml
@@ -15,6 +15,14 @@
     - https://nyaa.ind-unblock.xyz/
 
   settings:
+    - name: filter-id
+      type: select
+      label: Filter
+      default: "0"
+      options:
+        0: No filter
+        1: No remakes
+        2: Trusted only
     - name: cat-id
       type: select
       label: Category
@@ -106,7 +114,7 @@
       - path: /
     inputs:
       q: "{{ .Keywords }}"
-      f: 0
+      f: "{{ .Config.filter-id }}"
       c: "{{ .Config.cat-id }}"
       s: "{{ .Config.sort }}"
       o: "{{ .Config.type }}"


### PR DESCRIPTION
This was removed in fe5c1d49629c004c7f186317525d2c4563c80336 and I'm not sure why.