### PR TITLE
cili180: add liaorenso1#.xyz proxies

### DIFF
--- a/src/Jackett.Common/Definitions/cili180.yml
+++ b/src/Jackett.Common/Definitions/cili180.yml
@@ -18,6 +18,7 @@
   legacylinks:
     -  http://www.cili180.com/
     -  http://www.cilijj.xyz/
+    -  https://www.liaorenso.xyz/ # proxy list only
     -  https://www.liaorenso19.xyz/ # proxy list only
 
   caps:

--- a/src/Jackett.Common/Definitions/cili180.yml
+++ b/src/Jackett.Common/Definitions/cili180.yml
@@ -7,9 +7,18 @@
   encoding: UTF-8
   links:
     -  https://www.cilijj.xyz/
+    -  https://www.liaorenso11.xyz/
+    -  https://www.liaorenso12.xyz/
+    -  https://www.liaorenso13.xyz/
+    -  https://www.liaorenso14.xyz/
+    -  https://www.liaorenso15.xyz/
+    -  https://www.liaorenso16.xyz/
+    -  https://www.liaorenso17.xyz/
+    -  https://www.liaorenso18.xyz/
   legacylinks:
     -  http://www.cili180.com/
     -  http://www.cilijj.xyz/
+    -  https://www.liaorenso19.xyz/ # proxy list only
 
   caps:
     categories:


### PR DESCRIPTION
[Proxy list](https://www.liaorenso19.xyz/) found on the homepage:
![cili180](https://user-images.githubusercontent.com/59480337/80289542-eea50f80-8736-11ea-89c7-fe1b19b51d97.png)

Proxies listed as http, but https works fine.

Not sure if Cili180 is another candidate for https://github.com/Jackett/Jackett/issues/8355, but I left cilijj.xyz as the primary URL. It still works fine. Happy to move it down if that's preferred.