### PR TITLE
vizuk: ignore expired certificate.

### DIFF
--- a/src/Jackett.Common/Definitions/vizuk.yml
+++ b/src/Jackett.Common/Definitions/vizuk.yml
@@ -10,7 +10,7 @@
   legacylinks:
     - http://torrent.vizuk.li/
   certificates:
-    - ef305c114b583a155728ec7802f4e8c4bcd9a526 # expired 28 Dec 19
+    - 96E34ED4DABD2385DCE9538C80F6F0F02B44AE1A # expired 26 april 20
 
   caps:
     categorymappings:


### PR DESCRIPTION
Certificate expired on 26 april