### PR TITLE
core: fix cookie login message

### DIFF
--- a/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
@@ -110,7 +110,7 @@ namespace Jackett.Common.Indexers.Abstract
                     var results = await PerformQuery(new TorznabQuery());
                     if (!results.Any())
                     {
-                        throw new Exception("Your cookie did not work");
+                        throw new Exception("Found 0 results in the tracker");
                     }
 
                     IsConfigured = true;

--- a/src/Jackett.Common/Indexers/BitHdtv.cs
+++ b/src/Jackett.Common/Indexers/BitHdtv.cs
@@ -93,7 +93,7 @@ namespace Jackett.Common.Indexers
                 {
                     var results = await PerformQuery(new TorznabQuery());
                     if (!results.Any())
-                        throw new Exception("Your cookie did not work");
+                        throw new Exception("Found 0 results in the tracker");
                     IsConfigured = true;
                     SaveConfig();
                     return IndexerConfigurationStatus.Completed;

--- a/src/Jackett.Common/Indexers/DigitalHive.cs
+++ b/src/Jackett.Common/Indexers/DigitalHive.cs
@@ -132,7 +132,7 @@ namespace Jackett.Common.Indexers
                     var results = await PerformQuery(new TorznabQuery());
                     if (!results.Any())
                     {
-                        throw new Exception("Your cookie did not work");
+                        throw new Exception("Found 0 results in the tracker");
                     }
 
                     IsConfigured = true;

--- a/src/Jackett.Common/Indexers/Fuzer.cs
+++ b/src/Jackett.Common/Indexers/Fuzer.cs
@@ -138,7 +138,7 @@ namespace Jackett.Common.Indexers
                 {
                     var results = await PerformQuery(new TorznabQuery());
                     if (!results.Any())
-                        throw new Exception("Your cookie did not work");
+                        throw new Exception("Found 0 results in the tracker");
                     IsConfigured = true;
                     SaveConfig();
                     return IndexerConfigurationStatus.Completed;

--- a/src/Jackett.Common/Indexers/GazelleGames.cs
+++ b/src/Jackett.Common/Indexers/GazelleGames.cs
@@ -184,7 +184,7 @@ namespace Jackett.Common.Indexers
                 var results = await PerformQuery(new TorznabQuery());
                 if (results.Count() == 0)
                 {
-                    throw new Exception("Your cookie did not work");
+                    throw new Exception("Found 0 results in the tracker");
                 }
 
                 IsConfigured = true;

--- a/src/Jackett.Common/Indexers/IPTorrents.cs
+++ b/src/Jackett.Common/Indexers/IPTorrents.cs
@@ -145,7 +145,7 @@ namespace Jackett.Common.Indexers
             {
                 var results = await PerformQuery(new TorznabQuery());
                 if (!results.Any())
-                    throw new Exception("Your cookie did not work");
+                    throw new Exception("Found 0 results in the tracker");
 
                 IsConfigured = true;
                 SaveConfig();

--- a/src/Jackett.Common/Indexers/SceneHD.cs
+++ b/src/Jackett.Common/Indexers/SceneHD.cs
@@ -71,7 +71,7 @@ namespace Jackett.Common.Indexers
                 var results = await PerformQuery(new TorznabQuery());
                 if (results.Count() == 0)
                 {
-                    throw new Exception("Your cookie did not work");
+                    throw new Exception("Found 0 results in the tracker");
                 }
 
                 IsConfigured = true;

--- a/src/Jackett.Common/Indexers/Superbits.cs
+++ b/src/Jackett.Common/Indexers/Superbits.cs
@@ -82,7 +82,7 @@ namespace Jackett.Common.Indexers
                 var results = await PerformQuery(new TorznabQuery());
                 if (results.Count() == 0)
                 {
-                    throw new Exception("Your cookie did not work");
+                    throw new Exception("Found 0 results in the tracker");
                 }
 
                 IsConfigured = true;

--- a/src/Jackett.Common/Indexers/TorrentDay.cs
+++ b/src/Jackett.Common/Indexers/TorrentDay.cs
@@ -154,7 +154,7 @@ namespace Jackett.Common.Indexers
                 {
                     var results = await PerformQuery(new TorznabQuery());
                     if (!results.Any())
-                        throw new Exception("no results found, please report this bug");
+                        throw new Exception("Found 0 results in the tracker");
 
                     IsConfigured = true;
                     SaveConfig();

--- a/src/Jackett.Common/Indexers/TorrentLeech.cs
+++ b/src/Jackett.Common/Indexers/TorrentLeech.cs
@@ -141,7 +141,7 @@ namespace Jackett.Common.Indexers
                 {
                     var results = await PerformQuery(new TorznabQuery());
                     if (!results.Any())
-                        throw new Exception("Your cookie did not work");
+                        throw new Exception("Found 0 results in the tracker");
 
                     IsConfigured = true;
                     SaveConfig();

--- a/src/Jackett.Common/Indexers/digitalcore.cs
+++ b/src/Jackett.Common/Indexers/digitalcore.cs
@@ -94,7 +94,7 @@ namespace Jackett.Common.Indexers
                 var results = await PerformQuery(new TorznabQuery());
                 if (results.Count() == 0)
                 {
-                    throw new Exception("Your cookie did not work");
+                    throw new Exception("Found 0 results in the tracker");
                 }
 
                 IsConfigured = true;


### PR DESCRIPTION
Before this change the message was:
Your cookie did not work: Your cookie did not work
Now:
Your cookie did not work: Found 0 results in the tracker