### PR TITLE
assorted: removed down proxies

### DIFF
--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -17,15 +17,14 @@
     - https://1337x.unblockit.one/
     - https://1337.root.yt/
     - https://1337x.unblockninja.com/
-    - https://1337x.black-mirror.xyz/
-    - https://1337x.unblocked.casa/
-    - https://1337x.proxyportal.fun/
-    - https://1337x.uk-unblock.xyz/
-    - https://1337x.ind-unblock.xyz/
   legacylinks:
     - https://1337x.unblocked.earth/
     - https://1337x.unblockit.pro/
-    - https://1337x.black-mirror.xyz/ # nbg
+    - https://1337x.black-mirror.xyz/ # removed from black-mirror.xyz
+    - https://1337x.unblocked.casa/ # removed from black-mirror.xyz
+    - https://1337x.proxyportal.fun/ # removed from black-mirror.xyz
+    - https://1337x.uk-unblock.xyz/ # removed from black-mirror.xyz
+    - https://1337x.ind-unblock.xyz/ # removed from black-mirror.xyz
 
   caps:
     categorymappings:

--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -16,7 +16,6 @@
     - https://x1337x.se/
     - https://1337x.unblockit.one/
     - https://1337.root.yt/
-    - https://1337x.unblockninja.com/
   legacylinks:
     - https://1337x.unblocked.earth/
     - https://1337x.unblockit.pro/
@@ -25,6 +24,7 @@
     - https://1337x.proxyportal.fun/ # removed from black-mirror.xyz
     - https://1337x.uk-unblock.xyz/ # removed from black-mirror.xyz
     - https://1337x.ind-unblock.xyz/ # removed from black-mirror.xyz
+    - https://1337x.unblockninja.com/ # 403 Forbidden
 
   caps:
     categorymappings:

--- a/src/Jackett.Common/Definitions/btdb.yml
+++ b/src/Jackett.Common/Definitions/btdb.yml
@@ -9,16 +9,16 @@
   links:
     - https://btdb.io/
     - https://btdb.unblockit.one/ # redirects to btdb.io in browser but appears to have no issue in Jackett
-    - https://btdb.black-mirror.xyz/
-    - https://btdb.unblocked.casa/
-    - https://btdb.proxyportal.fun/
-    - https://btdb.uk-unblock.xyz/
-    - https://btdb.ind-unblock.xyz/
   legacylinks:
     - https://btdb.to/
     - https://btdb.unblocked.app/
     - https://btdb.eu/
     - https://btdb.unblockit.pro/
+    - https://btdb.black-mirror.xyz/ # removed from black-mirror.xyz
+    - https://btdb.unblocked.casa/ # removed from black-mirror.xyz
+    - https://btdb.proxyportal.fun/ # removed from black-mirror.xyz
+    - https://btdb.uk-unblock.xyz/ # removed from black-mirror.xyz
+    - https://btdb.ind-unblock.xyz/ # removed from black-mirror.xyz
 
   caps:
     categorymappings:

--- a/src/Jackett.Common/Definitions/demonoid.yml
+++ b/src/Jackett.Common/Definitions/demonoid.yml
@@ -8,15 +8,15 @@
   followredirect: true
   links:
     - https://www.demonoid.is/
-    - https://dnoid.black-mirror.xyz/
-    - https://dnoid.unblocked.casa/
-    - https://dnoid.proxyportal.fun/
-    - https://dnoid.uk-unblock.xyz/
-    - https://dnoid.ind-unblock.xyz/
   legacylinks:
     - https://www.dnoid.to/
     - https://demonoid.unblockit.pro/
     - https://demonoid.unblockit.one/ # currently down
+    - https://dnoid.black-mirror.xyz/ # proxy's IP blocked
+    - https://dnoid.unblocked.casa/ # proxy's IP blocked
+    - https://dnoid.proxyportal.fun/ # proxy's IP blocked
+    - https://dnoid.uk-unblock.xyz/ # proxy's IP blocked
+    - https://dnoid.ind-unblock.xyz/ # proxy's IP blocked
 
   caps:
     categorymappings:

--- a/src/Jackett.Common/Definitions/rutor.yml
+++ b/src/Jackett.Common/Definitions/rutor.yml
@@ -7,15 +7,15 @@
   encoding: UTF-8
   links:
     - http://rutor.info/ # site does not support https ERR_CONNECTION_REFUSED
-    - http://new-rutor.org/
-    - https://rutor.black-mirror.xyz/
-    - https://rutor.unblocked.casa/
-    - https://rutor.proxyportal.fun/
-    - https://rutor.uk-unblock.xyz/
-    - https://rutor.ind-unblock.xyz/
   legacylinks:
     - http://live-rutor.org/ # domain expired 9 Feb 2020
     - https://rutor.root.yt/ # currently down
+    - http://new-rutor.org/ # ERR_NAME_NOT_RESOLVED
+    - https://rutor.black-mirror.xyz/ # uses new-rutor.org
+    - https://rutor.unblocked.casa/ # uses new-rutor.org
+    - https://rutor.proxyportal.fun/ # uses new-rutor.org
+    - https://rutor.uk-unblock.xyz/ # uses new-rutor.org
+    - https://rutor.ind-unblock.xyz/ # uses new-rutor.org
 
   caps:
     # unfortunately RuTor does not display categories anywhere in its search results page :-(


### PR DESCRIPTION
Following up on https://github.com/Jackett/Jackett/issues/8381 and https://github.com/Jackett/Jackett/commit/832dcc82c49a4f9055bf7d3f56f4123f425e50aa

Proxies checked:
- black-mirror.xyz
- unblockninja.com
- unblockit.one
- root.yt

new-rutor.org is also down