### PR TITLE
yourbittorrent: remove *.host proxy

### DIFF
--- a/src/Jackett.Common/Definitions/yourbittorrent.yml
+++ b/src/Jackett.Common/Definitions/yourbittorrent.yml
@@ -8,6 +8,7 @@
   links:
     - https://yourbittorrent.com/
     - https://yourbittorrent2.com/
+  legacylinks:
     - https://yourbittorrent.host/
 
   caps:


### PR DESCRIPTION
HTML has diverged from *.com and *2.com - no longer works with Jackett.

If someone wants to have a look to see if it's salvageable, feel free. I couldn't see anything.