### PR TITLE
Update bithumen.yml

### DIFF
--- a/src/Jackett.Common/Definitions/bithumen.yml
+++ b/src/Jackett.Common/Definitions/bithumen.yml
@@ -145,7 +145,7 @@
           - name: replace
             args: [". ", " "]
           - name: prepend
-            args: "2019."
+            args: "2020."
           - name: re_replace
             args: ["([0-9]{4}).([0-9]+).([0-9]+) (.*)", "$2.$3.$1 $4"]
       date:

--- a/src/Jackett.Common/Definitions/bithumen.yml
+++ b/src/Jackett.Common/Definitions/bithumen.yml
@@ -145,7 +145,7 @@
           - name: replace
             args: [". ", " "]
           - name: prepend
-            args: "2020."
+            args: "{{ .Today.Year }}."
           - name: re_replace
             args: ["([0-9]{4}).([0-9]+).([0-9]+) (.*)", "$2.$3.$1 $4"]
       date:


### PR DESCRIPTION
Fixes release dates for torrents released in 2020.

In search result the site only gives back month.day instead of year-month-day so this needs to be updated every year to get the correct published date.