### PR TITLE
core: fix custom user-agent. resolves #8153

### DIFF
--- a/src/Jackett.Common/Definitions/demonoid.yml
+++ b/src/Jackett.Common/Definitions/demonoid.yml
@@ -283,6 +283,14 @@
       type: info
       label: How to get the Cookie
       default: "<ol><li>Access this tracker with your browser<li>click on the <b>Apply Filter</b> button on the page to invoke the search and solve the challenge<li>Open the <b>DevTools</b> panel by pressing <b>F12</b><li>Select the <b>Network</b> tab<li>Click on the <b>Doc</b> button<li>Refresh the page by pressing <b>F5</b><li>Select the <b>Headers</b> tab<li>Find <b>'cookie:'</b> in the <b>Request Headers</b> section<li><b>Select</b> and <b>Copy</b> the whole cookie string <i>(everything after 'cookie: ')</i> and <b>Paste</b> here.</ol>"
+    - name: useragent
+      type: text
+      label: User-Agent
+      label: User-Agent
+    - name: info_useragent
+      type: info
+      label: How to get the User-Agent
+      default: "<ol><li>From the same place you fetched the cookie,<li>Find <b>'user-agent:'</b> in the <b>Request Headers</b> section<li><b>Select</b> and <b>Copy</b> the whole user-agent string <i>(everything after 'user-agent: ')</i> and <b>Paste</b> here.</ol>"
     - name: sort
       type: select
       label: Sort requested from site
@@ -301,8 +309,11 @@
 
   login:
     method: cookie
+    inputs:
+      cookie: "{{ .Config.cookie }}"
     test:
-      path: files/
+      # CloudFlare is only in /files/ path, not in /
+      path: /files/
 
   download:
     selector: a[href^="magnet:?xt="]
@@ -313,6 +324,8 @@
       # https://www.demonoid.is/files/?c154&language=0&quality=0&seeded=2&query=world&to=1&sort=
       # https://www.demonoid.is/files/?seeded=2&language=0&quality=0&to=1&query=world
       - path: files/
+    headers:
+      User-Agent: ["{{ .Config.useragent }}"]
     inputs:
       $raw: "{{ range .Categories }}c{{.}}&{{end}}"
       # 0 seeded 1 unseeded 2 both

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
@@ -211,7 +211,13 @@ namespace Jackett.Common.Utils.Clients
                                 request.Method = HttpMethod.Get;
                             }
 
-                            using (response = await client.SendAsync(request))
+                            // if we set the User-Agent header in one indexer, we have to create a new client without CloudflareSolverRe
+                            // handler because it overrides the User-Agent. we can't solve cloudflare challenge in this case
+                            var requestClient = client;
+                            if (request.Headers?.Contains("User-Agent") == true)
+                                requestClient = new HttpClient(clientHandlr);
+
+                            using (response = await requestClient.SendAsync(request))
                             {
                                 var result = new WebClientByteResult
                                 {

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
@@ -230,7 +230,13 @@ namespace Jackett.Common.Utils.Clients
                 request.Method = HttpMethod.Get;
             }
 
-            response = await client.SendAsync(request);
+            // if we set the User-Agent header in one indexer, we have to create a new client without CloudflareSolverRe
+            // handler because it overrides the User-Agent. we can't solve cloudflare challenge in this case
+            var requestClient = client;
+            if (request.Headers?.Contains("User-Agent") == true)
+                requestClient = new HttpClient(clientHandlr);
+
+            response = await requestClient.SendAsync(request);
 
             var result = new WebClientByteResult
             {

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2NetCore.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2NetCore.cs
@@ -226,7 +226,13 @@ namespace Jackett.Common.Utils.Clients
                 request.Method = HttpMethod.Get;
             }
 
-            response = await client.SendAsync(request);
+            // if we set the User-Agent header in one indexer, we have to create a new client without CloudflareSolverRe
+            // handler because it overrides the User-Agent. we can't solve cloudflare challenge in this case
+            var requestClient = client;
+            if (request.Headers?.Contains("User-Agent") == true)
+                requestClient = new HttpClient(clientHandlr);
+
+            response = await requestClient.SendAsync(request);
 
             var result = new WebClientByteResult
             {

--- a/src/Jackett.Common/Utils/Clients/HttpWebClientNetCore.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClientNetCore.cs
@@ -210,7 +210,13 @@ namespace Jackett.Common.Utils.Clients
                                 request.Method = HttpMethod.Get;
                             }
 
-                            using (response = await client.SendAsync(request))
+                            // if we set the User-Agent header in one indexer, we have to create a new client without CloudflareSolverRe
+                            // handler because it overrides the User-Agent. we can't solve cloudflare challenge in this case
+                            var requestClient = client;
+                            if (request.Headers?.Contains("User-Agent") == true)
+                                requestClient = new HttpClient(clientHandlr);
+
+                            using (response = await requestClient.SendAsync(request))
                             {
                                 var result = new WebClientByteResult
                                 {


### PR DESCRIPTION
* Allow GoTemplates in search.headers
* Send search.headers in login.test and download requests
* Create a new client without CloudflareSolverRe when user-agent is set
* Fix Demonoid

@cadatoiva are you going to finish the webclient refactor?
@garfield69 this is tested with httpwebclient2netcore only, this MUST be tested with httpwebclient before merging. I can't test it. I have probably broken the cloudflare challenge on that client. Can you try a tracker that needs to solve the challenge?

Update: I don't like this solution. It is a hack over a lot of hacks that already existed before. Until the web client refactor is done and we start working on the CardigannIndexer it can't be done any better.