### PR TITLE
torrentdownloads: add cat. Resolves #8445

### DIFF
--- a/src/Jackett.Common/Definitions/torrentdownloads.yml
+++ b/src/Jackett.Common/Definitions/torrentdownloads.yml
@@ -28,6 +28,7 @@
       - {id: 1, cat: TV/Anime, desc: "Anime"}
       - {id: 2, cat: Books, desc: "Books"}
       - {id: 9, cat: Other, desc: "Other"}
+      - {id: 9, cat: Other, desc: "Pictures"} # not used or searchable on site, only appears in results
 
     modes:
       search: [q]


### PR DESCRIPTION
/menuicon6.png uses the same icon as Anime (1).

Appears to be all images (so the listing for iso may just be confusion over the intended use of the word on the uploader's part).

Category 6 only shows in results, it isn't searchable on the site, even by changing the URL to &s_cat=6 (returns results for 0, All).