### PR TITLE
core: immutable query. resolves #8531

### DIFF
--- a/src/Jackett.Common/Indexers/Meta/BaseMetaIndexer.cs
+++ b/src/Jackett.Common/Indexers/Meta/BaseMetaIndexer.cs
@@ -72,7 +72,7 @@ namespace Jackett.Common.Indexers.Meta
 
             var fallbackStrategies = fallbackStrategyProvider.FallbackStrategiesForQuery(query);
             var fallbackQueries = fallbackStrategies.Select(async f => await f.FallbackQueries()).SelectMany(t => t.Result);
-            var fallbackTasks = fallbackQueries.SelectMany(q => indexers.Where(i => !i.CanHandleQuery(query) && i.CanHandleQuery(q)).Select(i => i.ResultsForQuery(q.Clone(), true)));
+            var fallbackTasks = fallbackQueries.SelectMany(q => indexers.Where(i => !i.CanHandleQuery(query) && i.CanHandleQuery(q)).Select(i => i.ResultsForQuery(q, true)));
             var tasks = supportedTasks.Concat(fallbackTasks.ToList()); // explicit conversion to List to execute LINQ query
 
             // When there are many indexers used by a metaindexer querying each and every one of them can take very very


### PR DESCRIPTION
Not tested!

@cadatoiva I need your knowledge. Take a look at #8531 first. The query object is shared across all indexers. Ideally I want to make that object immutable or readonly so it can't be modified after creation. If one tracker, like BakaBT, tries to change some attribute it must fail (not compile ideally).

I don't know how to do that so in this PR I'm cloning the object before running the tasks. This should work but I'm not comfortable because maybe I forget some usage more.

Update: #8531 was fixed in #8666 but this PR is still need to avoid future problems in other indexers.