### PR TITLE
core: validate yaml definitions (yamllint part 6 #8575)

### DIFF
--- a/src/Jackett.Common/Definitions/bibliotik.yml
+++ b/src/Jackett.Common/Definitions/bibliotik.yml
@@ -10,11 +10,11 @@ links:
 
 caps:
   categorymappings:
-    - { id: 1, cat: PC, desc: "Applications" }
-    - { id: 3, cat: Audio/Audiobook, desc: "Audiobooks" }
-    - { id: 4, cat: Books/Comics, desc: "Comics" }
-    - { id: 5, cat: Books/Ebook, desc: "eBooks" }
-    - { id: 7, cat: Books/Magazines, desc: "Magazines" }
+    - {id: 1, cat: PC, desc: "Applications"}
+    - {id: 3, cat: Audio/Audiobook, desc: "Audiobooks"}
+    - {id: 4, cat: Books/Comics, desc: "Comics"}
+    - {id: 5, cat: Books/Ebook, desc: "eBooks"}
+    - {id: 7, cat: Books/Magazines, desc: "Magazines"}
 
   modes:
     search: [q]


### PR DESCRIPTION
error    too many spaces inside braces  (braces)