### PR TITLE
core: allow to rename indexer id (part 3 #8355)

### DIFF
--- a/src/Jackett.Common/Definitions/vhstapes.yml
+++ b/src/Jackett.Common/Definitions/vhstapes.yml
@@ -1,5 +1,5 @@
 ---
-id: nostalgic
+id: vhstapes
 name: VHSTAPES
 description: "VHSTAPES (The Archive / Nostalgic) is a Private Torrent Tracker for MOVIES / TV / GENERAL NOSTALGIA"
 language: en-us

--- a/src/Jackett.Common/Services/IndexerManagerService.cs
+++ b/src/Jackett.Common/Services/IndexerManagerService.cs
@@ -66,9 +66,11 @@ namespace Jackett.Common.Services
                 var oldPath = configService.GetIndexerConfigFilePath(oldId);
                 if (File.Exists(oldPath))
                 {
-                    // if the old configuration exists, we rename if to be used by the renamed indexer
+                    // if the old configuration exists, we rename it to be used by the renamed indexer
                     var newPath = configService.GetIndexerConfigFilePath(renamedIndexers[oldId]);
                     File.Move(oldPath, newPath);
+                    if (File.Exists(oldPath + ".bak"))
+                        File.Move(oldPath + ".bak", newPath + ".bak");
                     logger.Info($"Configuration renamed: {oldPath} => {newPath}");
                 }
             }

--- a/src/Jackett.Common/Services/Interfaces/IIndexerConfigurationService.cs
+++ b/src/Jackett.Common/Services/Interfaces/IIndexerConfigurationService.cs
@@ -8,5 +8,6 @@ namespace Jackett.Common.Services.Interfaces
         void Load(IIndexer indexer);
         void Save(IIndexer indexer, JToken config);
         void Delete(IIndexer indexer);
+        string GetIndexerConfigFilePath(string indexerId);
     }
 }

--- a/src/Jackett.Updater/Program.cs
+++ b/src/Jackett.Updater/Program.cs
@@ -337,6 +337,7 @@ namespace Jackett.Updater
                 "Definitions/music-master.yml",
                 "Definitions/nachtwerk.yml",
                 "Definitions/nexttorrent.yml",
+                "Definitions/nostalgic.yml",
                 "Definitions/nyaa.yml",
                 "Definitions/nyoo.yml",
                 "Definitions/passionetorrent.yml",


### PR DESCRIPTION
The PR allows to change the indexer id without breaking backward compatibility. Note that changing the id must be justified.

Steps to rename the id:
1. Rename the indexer id (in yaml or c#)
2. Edit `IndexerManagerService.cs` to add `old id` and `new id` in the map
3. Optional: you can rename the yaml / c# too
* yaml: rename the file and add the `old file name` into `Program.cs` to be removed by the updater
* c#: rename the file and the class name (not need to change `Program.cs`)
4. Optional: The tracker name / description is not related to the id and it can be changed anytime

How it works for the user:
1. The updater will remove the old .yaml definition (if it's a .yaml indexer) and the new one will be extracted in the folder.
2. In the first start, Jackett will rename the old configuration file into the new one. The user will see this trace. `Info Configuration renamed: /home/XX/.config/Jackett/Indexers/nostalgic.json => /home/XX/.config/Jackett/Indexers/vhstapes.json `
3. The indexer is able to load the previous configuration without problem. From this moment, there are no longer remains of the old id.
4. Some users will be using the Torznab/Potato/RSS feeds in 3rd party apps. Those URLs contains the `old id`. Eg `http://127.0.0.1:9117/api/v2.0/indexers/nostalgic/results/torznab/api?apikey=ygm5 ..`
The old URL still works after the change. You can use nostalgic (old) or vhstapes (new), both work. If you use the deprecated id, you will see a warning in the log with each request (until you change nostalgic to vhstapes in the URLs). `Warn Indexer nostalgic has been renamed to vhstapes. Please, update the URL of the feeds. This may stop working in the future.`

@garfield69 You should save this info in the wiki or somewhere because there are several steps and that kind of renames are infrequent.

I think the code is ready to merge, just do some tests or review the typos if you want. English is my 4th language, you now...