### PR TITLE
Removed handling that removed the original audio from the details.

### DIFF
--- a/src/Jackett.Common/Indexers/BJShare.cs
+++ b/src/Jackett.Common/Indexers/BJShare.cs
@@ -329,10 +329,6 @@ namespace Jackett.Common.Indexers
                         release.Description = release.Description.Replace("4K", "2160p");
                         release.Description = release.Description.Replace("SD", "480p");
                         release.Description = release.Description.Replace("Dual Áudio", "Dual");
-                        // If it ain't nacional there will be the type of the audio / original audio
-                        if (!release.Description.Contains("Nacional"))
-                            release.Description = Regex.Replace(
-                                release.Description, @"(Dual|Legendado|Dublado) \/ (.*?) \/", "$1 /");
 
                         // Adjust the description in order to can be read by Radarr and Sonarr
                         var cleanDescription = release.Description.Trim().TrimStart('[').TrimEnd(']');


### PR DESCRIPTION
Removed handling that removed the original audio from the details, since the tracker doesn't use it anymore and it was causing some issues.

Signed-off-by: Christian Franchin dos Santos <christianfranchin@gmail.com>