### PR TITLE
topnow: fix keywordless search

### DIFF
--- a/src/Jackett.Common/Definitions/topnow.yml
+++ b/src/Jackett.Common/Definitions/topnow.yml
@@ -24,9 +24,7 @@ settings: []
 search:
   paths:
     # https://topnow.se/index.php?search=
-    - path: index.php
-  inputs:
-    search: "{{ .Keywords }}"
+    - path: "index.php{{if .Keywords}}?search={{ .Keywords }}{{else}}{{end}}"
   keywordsfilters:
     # the site uses % for wildcard
     - name: re_replace


### PR DESCRIPTION
`https://topnow.se/index.php?search=` - no results
`https://topnow.se/index.php` - homepage with latest torrents