### PR TITLE
btsow: new URL

### DIFF
--- a/src/Jackett.Common/Definitions/btsow.yml
+++ b/src/Jackett.Common/Definitions/btsow.yml
@@ -6,10 +6,11 @@ language: en-us
 type: public
 encoding: UTF-8
 links:
-  - https://btsow.club/
+  - https://bteve.com/
 legacylinks:
   - https://btos.pw/
   - https://btio.pw/
+  - https://btsow.club/
 
 caps:
   categories:


### PR DESCRIPTION
current - https://btsow.club/
redirect - https://tellme.pw/btsow
new - https://bteve.com/

tested, working