### PR TITLE
Fix login handling for pleasuredome

### DIFF
--- a/src/Jackett.Common/Definitions/pleasuredome.yml
+++ b/src/Jackett.Common/Definitions/pleasuredome.yml
@@ -94,9 +94,9 @@ settings:
       "ASC": "asc"
 
 login:
-  path: login2.php
+  path: index.php
   method: form
-  form: form[action="login2.php"]
+  form: form[action="login3.php"]
   inputs:
     uid: "{{ .Config.username }}"
     pwd: "{{ .Config.password }}"


### PR DESCRIPTION
Existing pleasuredome definition breaks on login due to site changes renaming the form and login page locations. This changes fixes it in my testing.