### PR TITLE
magnetdl: fix keywordless search

### DIFF
--- a/src/Jackett.Common/Definitions/magnetdl.yml
+++ b/src/Jackett.Common/Definitions/magnetdl.yml
@@ -62,8 +62,8 @@ search:
   paths:
     # return results for 'of' if there are no search parms supplied (for use with the TEST button)
     # http://www.magnetdl.com/m/midnight-texas-s01e10/
-    - path: "{{ if .Keywords }}{{ re_replace .Keywords \"(.).*\" \"$1\" }}/{{ .Keywords }}/{{else}}o/of/{{end}}{{ .Config.sort }}/{{ .Config.type }}/"
-    - path: "{{ if .Keywords }}{{ re_replace .Keywords \"(.).*\" \"$1\" }}/{{ .Keywords }}/{{else}}o/of/{{end}}{{ .Config.sort }}/{{ .Config.type }}/2/"
+    - path: "{{ if .Keywords }}{{ re_replace .Keywords \"(.).*\" \"$1\" }}/{{ .Keywords }}/{{else}}2/{{ .Today.Year }}/{{end}}{{ .Config.sort }}/{{ .Config.type }}/"
+    - path: "{{ if .Keywords }}{{ re_replace .Keywords \"(.).*\" \"$1\" }}/{{ .Keywords }}/{{else}}2/{{ .Today.Year }}/{{end}}{{ .Config.sort }}/{{ .Config.type }}/2/"
 
   rows:
     selector: tr:has(td.m)


### PR DESCRIPTION
https://www.magnetdl.com/o/of/age/desc/ - 404
change to - https://www.magnetdl.com/2/2020/age/desc/ (or any year up to 2999)

Tested, working