### PR TITLE
Update macOS install script

### DIFF
--- a/install_service_macos
+++ b/install_service_macos
@@ -1,6 +1,6 @@
-#!/bin/bash
+#!/bin/zsh
 
-#Setting up colors
+# Setting up colors
 BOLDRED="$(printf '\033[1;31m')"
 BOLDGREEN="$(printf '\033[1;32m')"
 NC="$(printf '\033[0m')" # No Color
@@ -53,6 +53,13 @@ cat >~/Library/LaunchAgents/org.user.Jackett.plist <<EOL
 </plist>
 
 EOL
+
+# Un-quarantine all dylib and DLL files
+echo "Removing Jackett executable and all .dylib and .dll files from quarantine..."
+qstr="$(xattr -p com.apple.quarantine jackett)"
+qstr="00c1${qstr:4}"
+xattr -w com.apple.quarantine $qstr jackett
+xattr -w com.apple.quarantine $qstr *.{dylib,dll}
 
 # Run the agent
 launchctl load ~/Library/LaunchAgents/org.user.Jackett.plist


### PR DESCRIPTION
TL/DR: Update macOS install script with quarantine permissions; should fix #5589

The added lines read the `com.apple.quarantine` attribute from the `jackett` executable, replace the first 4 characters (`0081` -> `00c1`) so Gatekeeper won't complain anymore and set the modified attribute for the `jackett` executable and all DLL and dylib files.