### PR TITLE
torrentz2: restore fixed unblockit proxy

### DIFF
--- a/src/Jackett.Common/Definitions/torrentz2.yml
+++ b/src/Jackett.Common/Definitions/torrentz2.yml
@@ -8,6 +8,7 @@ encoding: UTF-8
 followredirect: true
 links:
   - https://torrentz2.is/
+  - https://torrentz.unblockit.id/
   - https://torrentz2.unblocked.bar/
   - https://torrentz2.proxyportal.pw/
   - https://torrentz2.uk-unblock.pro/
@@ -22,7 +23,6 @@ legacylinks:
   - https://torrentz.unblockit.me/
   - https://torrentz.unblockit.pw/
   - https://torrentz2.eu/ # domain suspended by registry
-  - https://torrentz.unblockit.id/ # broken, probably depended on .eu
   - https://torrentz2.unblockninja.com/ # only supports search?f=
 
 caps:


### PR DESCRIPTION
Site is working, but untested in Jackett due to `Clearance failed after 10 attempt(s).`