### PR TITLE
Update BJShare.cs to receive year for animes

### DIFF
--- a/src/Jackett.Common/Indexers/BJShare.cs
+++ b/src/Jackett.Common/Indexers/BJShare.cs
@@ -150,12 +150,7 @@ namespace Jackett.Common.Indexers
                 if (!string.Equals(newTitle, cleanTitle, StringComparison.CurrentCultureIgnoreCase))
                     cleanTitle = newTitle;
             }
-
-            // do not include year to animes
-            if (categoryStr == "14")
-                cleanTitle += " " + seasonEp;
-            else
-                cleanTitle += " " + year + " " + seasonEp;
+            cleanTitle += " " + year + " " + seasonEp;
             return FixAbsoluteNumbering(cleanTitle);
         }
 


### PR DESCRIPTION
In the current version, BJShare doesn't append the collected year to animes parsed. This causes mismatches in Sonarr and Radarr because they use the year of the show when parsing the data. This causes Anime that are reboots (like Digimon Adventure 2020) to not be identified and anime movies (that are in the anime section) to not be correctly identified.