### PR TITLE
jpopsuki: use ajax.php for searching and fix search query params

### DIFF
--- a/src/Jackett.Common/Definitions/jpopsuki.yml
+++ b/src/Jackett.Common/Definitions/jpopsuki.yml
@@ -1,5 +1,3 @@
-# looks like gazelle but ajax.php seems to be disabled:
-# https://jpopsuki.eu/ajax.php?action=browse&order_by=time&order_way=desc => Invalid
 ---
 id: jpopsuki
 name: JPopsuki
@@ -48,7 +46,7 @@ ratio:
 
 search:
   paths:
-    - path: torrents.php
+    - path: ajax.php
   inputs:
     $raw: "{{ range .Categories }}filter_cat[{{.}}]=1&{{end}}"
     searchstr: "{{ if .Query.Artist }}{{ .Query.Artist }}{{ else }}{{ .Keywords }}{{ end }}"
@@ -56,11 +54,8 @@ search:
     order_by: s3
     # desc, asc
     order_way: desc
-    # basic, advanced
-    action: basic
-    # 0 any, 1 all
-    searchtags: 0
     disablegrouping: 1
+    section: torrents
 
   rows:
     selector: table#torrent_table > tbody > tr[class^="torrent"]

--- a/src/Jackett.Common/Definitions/jpopsuki.yml
+++ b/src/Jackett.Common/Definitions/jpopsuki.yml
@@ -48,7 +48,7 @@ search:
   paths:
     - path: ajax.php
   inputs:
-    $raw: "{{ range .Categories }}filter_cat[{{.}}]=1&{{end}}"
+    $raw: "{{ range .Categories }}filter_cat[{{.}}]=1&{{end}}{{ if or .Query.Artist .Keywords }}{{ else }}searchtags=japanese&tags_type=0&{{ end }}"
     searchstr: "{{ if .Query.Artist }}{{ .Query.Artist }}{{ else }}{{ .Keywords }}{{ end }}"
     # s1 name, s2 year, s3 added, s4 size, s5 snatched, s6 seeders, s7 leechers
     order_by: s3


### PR DESCRIPTION
Fixes #9125 for real and opts to use ajax.php instead of torrents.php to slim down request size.

Tested and confirmed working:
```
2020-07-11 08:15:01.6590 Info Jackett startup finished in 3.516 s
2020-07-11 08:15:22.0874 Info CardigannIndexer (jpopsuki): Relogin required
2020-07-11 08:15:37.5195 Info Manual search for "test" on jpopsuki with 50 results.
```

PLEASE NOTE:
Currently jpopsuki has issues if you try to do searches with an empty searchstr in tandem with `disablegrouping=1`. This usually results in an HTTP 200 `Database Error` response. This issue is with jpopsuki though, so there's nothing much we could do unless we wanted to work around parsing while torrent grouping was enabled, which is basically impossible since ordering is not correct with grouping enabled among other issues.

This means that until jpopsuki is fixed, any search with a searchstr will work, but empty searches (such as a test) will still fail.