### PR TITLE
liaorencili: update proxies

### DIFF
--- a/src/Jackett.Common/Definitions/liaorencili.yml
+++ b/src/Jackett.Common/Definitions/liaorencili.yml
@@ -6,32 +6,61 @@ language: en-us
 type: public
 encoding: UTF-8
 links:
-  - https://www.lrcili1.xyz/
-  - https://www.lrcili2.xyz/
   - https://www.lrcili3.xyz/
   - https://www.lrcili4.xyz/
   - https://www.lrcili5.xyz/
   - https://www.lrcili6.xyz/
-  - https://www.lrcili7.xyz/
   - https://www.lrcili8.xyz/
   - https://www.lrcili9.xyz/
   - https://www.lrcili10.xyz/
-legacylinks:
-  - http://www.cili180.com/
-  - http://www.cilijj.xyz/
-  - https://www.cilijj.xyz/
-  - https://www.liaorenso.xyz/
-  - https://www.liaorenso11.xyz/
-  - https://www.liaorenso12.xyz/
+  - https://www.liaorenso1.xyz/
+  - https://www.liaorenso2.xyz/
+  - https://www.liaorenso3.xyz/
+  - https://www.liaorenso4.xyz/
+  - https://www.liaorenso5.xyz/
+  - https://www.liaorenso6.xyz/
+  - https://www.liaorenso7.xyz/
+  - https://www.liaorenso8.xyz/
+  - https://www.liaorenso9.xyz/
   - https://www.liaorenso13.xyz/
   - https://www.liaorenso14.xyz/
   - https://www.liaorenso15.xyz/
   - https://www.liaorenso16.xyz/
   - https://www.liaorenso17.xyz/
   - https://www.liaorenso18.xyz/
+  - http://www.lrsoso1.xyz/
+  - http://www.lrsoso2.xyz/
+  - http://www.lrsoso3.xyz/
+  - http://www.lrsoso4.xyz/
+  - http://www.lrsoso5.xyz/
+  - http://www.lrsoso6.xyz/
+  - http://www.lrsoso7.xyz/
+  - http://www.lrsoso8.xyz/
+  - http://www.lrsoso9.xyz/
+  - http://www.lrsoso10.xyz/
+  - http://www.cilinb1.xyz/
+  - http://www.cilinb2.xyz/
+  - http://www.cilinb3.xyz/
+  - http://www.cilinb4.xyz/
+  - http://www.cilinb5.xyz/
+  - http://www.cilinb6.xyz/
+  - http://www.cilinb7.xyz/
+  - http://www.cilinb8.xyz/
+  - http://www.cilinb9.xyz/
+  - http://www.cilinb10.xyz/
+  - http://www.cilijj.xyz/
+legacylinks:
+  - http://www.cili180.com/
+  - https://www.cilijj.xyz/
+  - https://www.liaorenso.xyz/
+  - https://www.liaorenso11.xyz/
+  - https://www.liaorenso12.xyz/
   - https://www.liaorenso19.xyz/
   - http://lrcili.xyz/ # proxy list only
   - http://www.lrcili.xyz/ # proxy list only
+  - https://www.lrcili1.xyz/ # ERR_CONNECTION_TIMED_OUT
+  - https://www.lrcili2.xyz/ # ERR_CONNECTION_TIMED_OUT
+  - https://www.lrcili7.xyz/ # 404 Not Found
 
 caps:
   categories:


### PR DESCRIPTION
Sources:
http://www.lrcili.xyz/
https://www.cilipro.xyz/
and some older sites working again

Tested, working.