### PR TITLE
Fixed: Unset variable in CardigannIndexer if it's missing in the row

### DIFF
--- a/src/Jackett.Common/Definitions/btgigs.yml
+++ b/src/Jackett.Common/Definitions/btgigs.yml
@@ -79,8 +79,6 @@ search:
   rows:
     selector: table[border="1"][cellpadding=5] > tbody > tr:has(a[href^="details.php?id="])
   fields:
-    is_polish: # Workaround: https://github.com/Jackett/Jackett/issues/8068#issuecomment-610222414
-      text: ""
     is_polish:
       optional: true
       selector: img[src*="cat_pl"]

--- a/src/Jackett.Common/Definitions/hdspain.yml
+++ b/src/Jackett.Common/Definitions/hdspain.yml
@@ -62,8 +62,6 @@ search:
         - name: querystring
           args: cat
     extras:
-      text: ""
-    extras:
       optional: true
       selector: td.titulo a[class]
       filters:

--- a/src/Jackett.Common/Definitions/karagarga.yml
+++ b/src/Jackett.Common/Definitions/karagarga.yml
@@ -119,20 +119,14 @@ search:
     leechers:
       selector: td:nth-child(14)
     subs:
-      text: ""
-    subs:
       selector: span:contains("Subs:")
       optional: true
-    genre:
-      text: ""
     genre:
       selector: td:nth-child(5)
       optional: true
       filters:
         - name: prepend
           args: "Genre: "
-    mom:
-      text: ""
     mom:
       selector: img[title^="CURRENT"]
       attribute: title

--- a/src/Jackett.Common/Definitions/onejav.yml
+++ b/src/Jackett.Common/Definitions/onejav.yml
@@ -43,23 +43,17 @@ search:
       attribute: src
       optional: true
     actress:
-      text: ""
-    actress:
       selector: a[href^="/actress/"]
       optional: true
       filters:
         - name: prepend
           args: "Actress: "
     tags:
-      text: ""
-    tags:
       selector: div.tags
       optional: true
       filters:
         - name: prepend
           args: "Tags: "
-    descr:
-      text: ""
     descr:
       selector: p.level
       optional: true

--- a/src/Jackett.Common/Definitions/torrentleech-pl.yml
+++ b/src/Jackett.Common/Definitions/torrentleech-pl.yml
@@ -137,8 +137,6 @@ search:
       selector: a[href*="imdb.com/title/tt"]
       attribute: href
     description:
-      text: ""
-    description:
       optional: true
       selector: img[src="pic/pl.jpg"]
       filters:

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -1588,7 +1588,10 @@ namespace Jackett.Common.Indexers
                                     if (!variables.ContainsKey(variablesKey))
                                         variables[variablesKey] = null;
                                     if (OptionalFileds.Contains(Field.Key) || FieldModifiers.Contains("optional") || Field.Value.Optional)
+                                    {
+                                        variables[variablesKey] = null;
                                         continue;
+                                    }
                                     throw new Exception(string.Format("Error while parsing field={0}, selector={1}, value={2}: {3}", Field.Key, Field.Value.Selector, (value == null ? "<null>" : value), ex.Message));
                                 }
                             }

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -37,7 +37,7 @@ namespace Jackett.Common.Indexers
             set => base.configData = value;
         }
 
-        protected readonly string[] OptionalFileds = new string[] { "imdb", "rageid", "tvdbid", "banner" };
+        protected readonly string[] OptionalFields = new string[] { "imdb", "rageid", "tvdbid", "banner" };
 
         private static readonly string[] _SupportedLogicFunctions =
         {
@@ -1587,7 +1587,7 @@ namespace Jackett.Common.Indexers
                                 {
                                     if (!variables.ContainsKey(variablesKey))
                                         variables[variablesKey] = null;
-                                    if (OptionalFileds.Contains(Field.Key) || FieldModifiers.Contains("optional") || Field.Value.Optional)
+                                    if (OptionalFields.Contains(Field.Key) || FieldModifiers.Contains("optional") || Field.Value.Optional)
                                     {
                                         variables[variablesKey] = null;
                                         continue;


### PR DESCRIPTION
Currently if an optional variable is defined in a Cardigann indexer, and it exists for one result, all subsequent results have the same incorrect value of the variable set.  I think it needs to be explicitly unset if it's missing in a result to avoid this.

As an example, on bibliotek, I was extracting an author variable and editor variable for each result. Author and editor are optional but at least one will exist. For results that don't have authors (they have editors instead) the author remains set at the last found value even.  So instead of:
Title 1 by author 1
Title 2 by editor2

I'm ending up with:
Title 1 by author 1
Title 2 by author1

This fix resolves the issue for me, though I'm not familiar with Jackett so might have missed a side effect!
