### PR TITLE
torrent9: remove *.is from legacylinks

### DIFF
--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -31,7 +31,6 @@ legacylinks:
   - https://wvw.t9.pe/
   - https://www4.torrent9.to/
   - https://www.torrent9.cat/
-  - https://www.torrent9.is/
   - https://www.torrent09.uno/
   - https://torrent9.unblockninja.com/ # this is a proxy for torrent9clone
   - https://www.torrent9.pl/ # this is a proxy for torrent9clone


### PR DESCRIPTION
Fix for https://github.com/Jackett/Jackett/pull/9299