### PR TITLE
Update TorrentSyndikat.cs

### DIFF
--- a/src/Jackett.Common/Indexers/TorrentSyndikat.cs
+++ b/src/Jackett.Common/Indexers/TorrentSyndikat.cs
@@ -168,7 +168,7 @@ namespace Jackett.Common.Indexers
 
             }
             foreach (var cat in MapTorznabCapsToTrackers(query))
-                queryCollection.Add("cat[]=" + cat);
+                queryCollection.Add("cat[]",cat);
 
             var searchUrl = SearchUrl + "?" + queryCollection.GetQueryString();
 

--- a/src/Jackett.Common/Indexers/TorrentSyndikat.cs
+++ b/src/Jackett.Common/Indexers/TorrentSyndikat.cs
@@ -168,7 +168,7 @@ namespace Jackett.Common.Indexers
 
             }
             foreach (var cat in MapTorznabCapsToTrackers(query))
-                queryCollection.Add("c" + cat, "1");
+                queryCollection.Add("cat[]=" + cat);
 
             var searchUrl = SearchUrl + "?" + queryCollection.GetQueryString();
 


### PR DESCRIPTION
Query string changed from
[browse.php?incldead=1&rel_type=0&searchin=title&search=TEST&c15=1&c27=1&c53=1&c54=1&c55=1&c56=1](browse.php?incldead=1&rel_type=0&searchin=title&search=TEST&c15=1&c27=1&c53=1&c54=1&c55=1&c56=1)
to
[browse.php?incldead=1&rel_type=0&searchin=title&search=TEST&cat[]=43&cat[]=53&cat[]=54&cat[]=15&cat[]=30](browse.php?incldead=1&rel_type=0&searchin=title&search=TEST&cat[]=43&cat[]=53&cat[]=54&cat[]=15&cat[]=30)