### PR TITLE
kickasstorrent & kickasstorrent-kathow: switch unblockninja proxy

### DIFF
--- a/src/Jackett.Common/Definitions/kickasstorrent-kathow.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrent-kathow.yml
@@ -9,6 +9,7 @@ followredirect: true
 links:
   - https://kickass.ws/
   - https://kickass.unblockit.top/
+  - https://kickasstorrents.unblockninja.com/
 legacylinks:
   - https://kickass.gg/
   - https://katcr.io/
@@ -16,7 +17,6 @@ legacylinks:
   - https://thekat.se/
   - https://kat.how/
   - https://kat.li/
-  - https://kickasstorrents.unblockninja.com/ # kickasstorrent proxy, not kickasstorrent-kathow
   - https://katcr.to/ # possible 3rd kickasstorrent site/clone?
   - https://kickasstorrent.cr/ # possible 3rd kickasstorrent site/clone?
   - https://kickass.unblockit.pro/

--- a/src/Jackett.Common/Definitions/kickasstorrent.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrent.yml
@@ -9,7 +9,6 @@ followredirect: true
 links:
   - https://newkatcr.co/
   - https://kat.root.yt/
-  - https://kickasstorrents.unblockninja.com/
   - https://kat.unblockit.top/
   - https://katcr.unblocked.bar/
   - https://katcr.proxyportal.pw/
@@ -28,6 +27,7 @@ legacylinks:
   - https://katcr.co/
   - https://kat.unblockit.id/
   - https://kat.unblockit.win/
+  - https://kickasstorrents.unblockninja.com/ # now kickasstorrent-kathow proxy
 
 caps:
   categorymappings:


### PR DESCRIPTION
Not sure if this is just a fallback while newkatcr.co is down, but the proxy has switched to kathow, for now at least. I'll check after newkatcr.co is back up if this reverts.