### PR TITLE
Demonoid: add dnoid.to & dnoid.pw

### DIFF
--- a/src/Jackett.Common/Definitions/demonoid.yml
+++ b/src/Jackett.Common/Definitions/demonoid.yml
@@ -8,9 +8,10 @@ encoding: UTF-8
 followredirect: true
 links:
   - https://www.demonoid.is/
+  - https://www.dnoid.to/
+  - https://www.dnoid.pw/
   - https://demonoid.unblockit.top/
 legacylinks:
-  - https://www.dnoid.to/
   - https://demonoid.unblockit.pro/
   - https://demonoid.unblockit.one/
   - https://demonoid.unblockit.me/


### PR DESCRIPTION
```
Newspost - July 17th, 2020	
Additional domains
We are adding two additional domains where you can visit us.
The first domain is Dnoid.pw
The second domain is Dnoid.to
```

untested due to use of Cloudflare's DDoS protection hcaptcha challenge