### PR TITLE
ettv: remove ettvdl.com & add ettv.be

### DIFF
--- a/src/Jackett.Common/Definitions/ettv.yml
+++ b/src/Jackett.Common/Definitions/ettv.yml
@@ -7,8 +7,8 @@ type: public
 encoding: UTF-8
 followredirect: true
 links:
-  - https://www.ettvdl.com/
   - https://www.ettvcentral.com/
+  - https://www.ettv.be/
   - https://ettv.unblockninja.com/
   - https://ettv.root.yt/
   - https://ettv.unblockit.top/
@@ -29,6 +29,7 @@ legacylinks:
   - https://ettv.unblockit.pw/
   - https://ettv.unblockit.id/
   - https://ettv.unblockit.win/
+  - https://www.ettvdl.com/
 
 caps:
   categorymappings:


### PR DESCRIPTION
ettvdl.com redirects to ettvcentral.com

Announcement - https://www.ettvcentral.com/forum/view/topic/domain-change-s01e02-upload-rights--1225

Official proxy list - https://ettvproxies.com/