### PR TITLE
assorted: change unblocked proxy domain to *.rest

### DIFF
--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -16,9 +16,7 @@ links:
   - https://x1337x.se/
   - https://1337.root.yt/
   - https://1337x.unblockit.top/
-  - https://1337x.unblocked.bar/
-  - https://1337x.proxyportal.pw/
-  - https://1337x.uk-unblock.pro/
+  - https://1337x.unblocked.rest/
 legacylinks:
   - https://1337x.unblocked.earth/
   - https://1337x.unblockit.pro/
@@ -33,6 +31,9 @@ legacylinks:
   - https://1337x.unblockit.pw/
   - https://1337x.unblockit.id/
   - https://1337x.unblockit.win/
+  - https://1337x.unblocked.bar/
+  - https://1337x.proxyportal.pw/
+  - https://1337x.uk-unblock.pro/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/btdb.yml
+++ b/src/Jackett.Common/Definitions/btdb.yml
@@ -8,9 +8,6 @@ encoding: UTF-8
 followredirect: true
 links:
   - https://btdb.eu/
-  - https://btdb.unblocked.bar/
-  - https://btdb.proxyportal.pw/
-  - https://btdb.uk-unblock.pro/
   - https://btdb.unblockit.top/
 legacylinks:
   - https://btdb.to/
@@ -27,6 +24,9 @@ legacylinks:
   - https://btdb.unblockit.pw/
   - https://btdb.unblockit.id/
   - https://btdb.unblockit.win/
+  - https://btdb.unblocked.bar/
+  - https://btdb.proxyportal.pw/
+  - https://btdb.uk-unblock.pro/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/ettv.yml
+++ b/src/Jackett.Common/Definitions/ettv.yml
@@ -10,11 +10,8 @@ links:
   - https://www.ettvcentral.com/
   - https://www.ettv.be/
   - https://ettv.unblockninja.com/
-  - https://ettv.root.yt/
   - https://ettv.unblockit.top/
-  - https://ettv.unblocked.bar/
-  - https://ettv.proxyportal.pw/
-  - https://ettv.uk-unblock.pro/
+  - https://ettv.unblocked.rest/
 legacylinks:
   - https://www.ettv.tv/
   - https://www.ettv.to/
@@ -30,6 +27,10 @@ legacylinks:
   - https://ettv.unblockit.id/
   - https://ettv.unblockit.win/
   - https://www.ettvdl.com/
+  - https://ettv.unblocked.bar/
+  - https://ettv.proxyportal.pw/
+  - https://ettv.uk-unblock.pro/
+  - https://ettv.root.yt/ # currently redirects to ettvcentral.com
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/eztv.yml
+++ b/src/Jackett.Common/Definitions/eztv.yml
@@ -12,9 +12,7 @@ links:
   - https://eztv.root.yt/
   - https://eztv.unblockninja.com/
   - https://eztv.unblockit.top/
-  - https://eztv.unblocked.bar/
-  - https://eztv.proxyportal.pw/
-  - https://eztv.uk-unblock.pro/
+  - https://eztv.unblocked.rest/
 legacylinks:
   - https://eztv.ag/ # redirects to .io
   - https://eztv.re/ # redirects to .io
@@ -31,6 +29,9 @@ legacylinks:
   - https://eztv.unblockit.pw/
   - https://eztv.unblockit.id/
   - https://eztv.unblockit.win/
+  - https://eztv.unblocked.bar/
+  - https://eztv.proxyportal.pw/
+  - https://eztv.uk-unblock.pro/
 
 caps:
   categories:

--- a/src/Jackett.Common/Definitions/glodls.yml
+++ b/src/Jackett.Common/Definitions/glodls.yml
@@ -10,9 +10,7 @@ links:
   - https://gtdb.to/
   - https://glodls.to/
   - https://glotorrents.unblockit.top/
-  - https://glodls.unblocked.bar/
-  - https://glodls.proxyportal.pw/
-  - https://glodls.uk-unblock.pro/
+  - https://glodls.unblocked.rest/
 legacylinks:
   - https://glodls.rocks/
   - https://glotorrents.unblockit.pro/
@@ -26,6 +24,9 @@ legacylinks:
   - https://glotorrents.unblockit.pw/
   - https://glotorrents.unblockit.id/
   - https://glotorrents.unblockit.win/
+  - https://glodls.unblocked.bar/
+  - https://glodls.proxyportal.pw/
+  - https://glodls.uk-unblock.pro/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/idope.yml
+++ b/src/Jackett.Common/Definitions/idope.yml
@@ -7,15 +7,16 @@ type: public
 encoding: UTF-8
 links:
   - https://idope.se/
-  - https://idope.unblocked.bar/
-  - https://idope.proxyportal.pw/
-  - https://idope.uk-unblock.pro/
+  - https://idope.unblocked.rest/
 legacylinks:
   - https://idope.black-mirror.xyz/
   - https://idope.unblocked.casa/
   - https://idope.proxyportal.fun/
   - https://idope.uk-unblock.xyz/
   - https://idope.ind-unblock.xyz/
+  - https://idope.unblocked.bar/
+  - https://idope.proxyportal.pw/
+  - https://idope.uk-unblock.pro/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/kickasstorrent.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrent.yml
@@ -10,9 +10,7 @@ links:
   - https://newkatcr.co/
   - https://kat.root.yt/
   - https://kat.unblockit.top/
-  - https://katcr.unblocked.bar/
-  - https://katcr.proxyportal.pw/
-  - https://katcr.uk-unblock.pro/
+  - https://katcr.unblocked.rest/
 legacylinks:
   - https://kickasstorrent.cr/ # possible 3rd kickasstorrent site/clone?
   - https://katcr.to/ # possible 3rd kickasstorrent site/clone?
@@ -28,6 +26,9 @@ legacylinks:
   - https://kat.unblockit.id/
   - https://kat.unblockit.win/
   - https://kickasstorrents.unblockninja.com/ # now kickasstorrent-kathow proxy
+  - https://katcr.unblocked.bar/
+  - https://katcr.proxyportal.pw/
+  - https://katcr.uk-unblock.pro/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/magnet4you.yml
+++ b/src/Jackett.Common/Definitions/magnet4you.yml
@@ -7,9 +7,7 @@ type: public
 encoding: UTF-8
 links:
   - https://magnet4you.me/
-  - https://magnet4you.unblocked.bar/
-  - https://magnet4you.proxyportal.pw/
-  - https://magnet4you.uk-unblock.pro/
+  - https://magnet4you.unblocked.rest/
 legacylinks:
   - http://magnet4you.me/
   - https://magnet4you.black-mirror.xyz/
@@ -17,6 +15,9 @@ legacylinks:
   - https://magnet4you.proxyportal.fun/
   - https://magnet4you.uk-unblock.xyz/
   - https://magnet4you.ind-unblock.xyz/
+  - https://magnet4you.unblocked.bar/
+  - https://magnet4you.proxyportal.pw/
+  - https://magnet4you.uk-unblock.pro/
 
 caps:
   categories:

--- a/src/Jackett.Common/Definitions/monova.yml
+++ b/src/Jackett.Common/Definitions/monova.yml
@@ -10,9 +10,7 @@ links:
   - https://monova.org/
   - https://monova.to/
   - https://monova.unblockit.id/
-  - https://monova.unblocked.bar/
-  - https://monova.proxyportal.pw/
-  - https://monova.uk-unblock.pro/
+  - https://monova.unblocked.rest/
 legacylinks:
   - https://monova.unblockninja.com/ # currently redirects to https://monova.org/
   - https://monova.unblockit.pro/
@@ -24,6 +22,9 @@ legacylinks:
   - https://monova.ind-unblock.xyz/
   - https://monova.unblockit.me/
   - https://monova.unblockit.pw/
+  - https://monova.unblocked.bar/
+  - https://monova.proxyportal.pw/
+  - https://monova.uk-unblock.pro/
 
 caps:
   categories:

--- a/src/Jackett.Common/Definitions/nyaasi.yml
+++ b/src/Jackett.Common/Definitions/nyaasi.yml
@@ -7,16 +7,16 @@ type: public
 encoding: UTF-8
 links:
   - https://nyaa.si/
+  - https://nyaa.root.yt/
 legacylinks:
   - https://nyaa.black-mirror.xyz/
   - https://nyaa.unblocked.casa/
   - https://nyaa.proxyportal.fun/
   - https://nyaa.uk-unblock.xyz/
   - https://nyaa.ind-unblock.xyz/
-  - https://nyaa.unblocked.bar/ # only magnets work in Jackett
-  - https://nyaa.proxyportal.pw/ # only magnets work in Jackett
-  - https://nyaa.uk-unblock.pro/ # only magnets work in Jackett
-  - https://nyaa.root.yt/ # 402 Payment Required
+  - https://nyaa.unblocked.bar/
+  - https://nyaa.proxyportal.pw/
+  - https://nyaa.uk-unblock.pro/
 
 settings:
   - name: filter-id

--- a/src/Jackett.Common/Definitions/oxtorrent.yml
+++ b/src/Jackett.Common/Definitions/oxtorrent.yml
@@ -9,9 +9,7 @@ followredirect: true
 links:
   - https://www.oxtorrent.cc/
   - https://www.oxtorrent.co/
-  - https://oxtorrent.unblocked.bar/
-  - https://oxtorrent.proxyportal.pw/
-  - https://oxtorrent.uk-unblock.pro/
+  - https://oxtorrent.unblocked.rest/
 legacylinks:
   - https://wwv.oxtorrent.com/
   - https://www.smartorrent.tv/
@@ -22,6 +20,9 @@ legacylinks:
   - https://oxtorrent.ind-unblock.xyz/
   - https://www.oxtorrent.com/
   - https://www.oxtorrent.pw/
+  - https://oxtorrent.unblocked.bar/
+  - https://oxtorrent.proxyportal.pw/
+  - https://oxtorrent.uk-unblock.pro/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/prostylex.yml
+++ b/src/Jackett.Common/Definitions/prostylex.yml
@@ -7,9 +7,7 @@ type: semi-private
 encoding: UTF-8
 links:
   - https://prostylex.org/
-  - https://prostylex.unblocked.bar/
-  - https://prostylex.proxyportal.pw/
-  - https://prostylex.uk-unblock.pro/
+  - https://prostylex.unblocked.rest/
 legacylinks:
   - http://prostylex.com/
   - https://prostylex.black-mirror.xyz/
@@ -17,6 +15,9 @@ legacylinks:
   - https://prostylex.proxyportal.fun/
   - https://prostylex.uk-unblock.xyz/
   - https://prostylex.ind-unblock.xyz/
+  - https://prostylex.unblocked.bar/
+  - https://prostylex.proxyportal.pw/
+  - https://prostylex.uk-unblock.pro/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/rutor.yml
+++ b/src/Jackett.Common/Definitions/rutor.yml
@@ -8,10 +8,7 @@ encoding: UTF-8
 links:
   - http://rutor.info/ # site does not support https ERR_CONNECTION_REFUSED
   - http://rutor.is/ # site does not support https ERR_CONNECTION_REFUSED
-  - https://rutor.unblocked.bar/
-  - https://rutor.proxyportal.pw/
-  - https://rutor.uk-unblock.pro/
-  - https://rutor.root.yt/
+  - https://rutor.unblocked.rest/
 legacylinks:
   - http://live-rutor.org/ # domain expired 9 Feb 2020
   - http://new-rutor.org/ # ERR_NAME_NOT_RESOLVED
@@ -20,6 +17,10 @@ legacylinks:
   - https://rutor.proxyportal.fun/
   - https://rutor.uk-unblock.xyz/
   - https://rutor.ind-unblock.xyz/
+  - https://rutor.unblocked.bar/
+  - https://rutor.proxyportal.pw/
+  - https://rutor.uk-unblock.pro/
+  - https://rutor.root.yt/ # Error 504 Gateway time-out
 
 caps:
   # unfortunately RuTor does not display categories anywhere in its search results page :-(

--- a/src/Jackett.Common/Definitions/tokyotosho.yml
+++ b/src/Jackett.Common/Definitions/tokyotosho.yml
@@ -7,15 +7,16 @@ type: public
 encoding: UTF-8
 links:
   - https://www.tokyotosho.info/
-  - https://tokyotosho.unblocked.bar/
-  - https://tokyotosho.proxyportal.pw/
-  - https://tokyotosho.uk-unblock.pro/
+  - https://tokyotosho.unblocked.rest/
 legacylinks:
   - https://tokyotosho.black-mirror.xyz/
   - https://tokyotosho.unblocked.casa/
   - https://tokyotosho.proxyportal.fun/
   - https://tokyotosho.uk-unblock.xyz/
   - https://tokyotosho.ind-unblock.xyz/
+  - https://tokyotosho.unblocked.bar/
+  - https://tokyotosho.proxyportal.pw/
+  - https://tokyotosho.uk-unblock.pro/
 
 settings:
   - name: type-id

--- a/src/Jackett.Common/Definitions/torrent9clone.yml
+++ b/src/Jackett.Common/Definitions/torrent9clone.yml
@@ -8,9 +8,7 @@ encoding: UTF-8
 followredirect: true
 links:
   - https://www.torrent9.so/
-  - https://torrent9.unblocked.bar/
-  - https://torrent9.proxyportal.pw/
-  - https://torrent9.uk-unblock.pro/
+  - https://torrent9.unblocked.rest/
   - https://torrent9.unblockninja.com/
 
 legacylinks:
@@ -42,6 +40,9 @@ legacylinks:
   - https://torrent9.ind-unblock.xyz/
   - https://www.torrent9.pl/
   - https://www.torrent9.ac/
+  - https://torrent9.unblocked.bar/
+  - https://torrent9.proxyportal.pw/
+  - https://torrent9.uk-unblock.pro/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/torrentdownload.yml
+++ b/src/Jackett.Common/Definitions/torrentdownload.yml
@@ -9,9 +9,7 @@ followredirect: true
 links:
   - https://www.torrentdownload.info/
   - https://torrentdownload.unblockit.top/
-  - https://torrentdownload.unblocked.bar/
-  - https://torrentdownload.proxyportal.pw/
-  - https://torrentdownload.uk-unblock.pro/
+  - https://torrentdownload.unblocked.rest/
 legacylinks:
   - https://torrentdownload.unblockit.pro/
   - https://torrentdownload.unblockit.one/
@@ -24,6 +22,9 @@ legacylinks:
   - https://torrentdownload.unblockit.pw/
   - https://torrentdownload.unblockit.id/
   - https://torrentdownload.unblockit.win/
+  - https://torrentdownload.unblocked.bar/
+  - https://torrentdownload.proxyportal.pw/
+  - https://torrentdownload.uk-unblock.pro/
 
 caps:
   categories:

--- a/src/Jackett.Common/Definitions/torrentdownloads.yml
+++ b/src/Jackett.Common/Definitions/torrentdownloads.yml
@@ -10,9 +10,7 @@ links:
   - https://www.torrentdownloads.info/
   - https://www.torrentdownloads.me/
   - https://torrentdownloads.unblockit.top/
-  - https://torrentdownloads.unblocked.bar/
-  - https://torrentdownloads.proxyportal.pw/
-  - https://torrentdownloads.uk-unblock.pro/
+  - https://torrentdownloads.unblocked.rest/
 legacylinks:
   - https://torrentdownloads.unblockit.pro/
   - https://torrentdownloads.unblockit.one/
@@ -25,6 +23,9 @@ legacylinks:
   - https://torrentdownloads.unblockit.pw/
   - https://torrentdownloads.unblockit.id/
   - https://torrentdownloads.unblockit.win/
+  - https://torrentdownloads.unblocked.bar/
+  - https://torrentdownloads.proxyportal.pw/
+  - https://torrentdownloads.uk-unblock.pro/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/torrentz2.yml
+++ b/src/Jackett.Common/Definitions/torrentz2.yml
@@ -12,9 +12,7 @@ links:
   - https://torrentz.pl/
   - https://torrentz2.unblockninja.com/
   - https://torrentz.unblockit.top/
-  - https://torrentz2.unblocked.bar/
-  - https://torrentz2.proxyportal.pw/
-  - https://torrentz2.uk-unblock.pro/
+  - https://torrentz2.unblocked.rest/
 legacylinks:
   - https://torrentz.unblockit.pro/
   - https://torrentz.unblockit.one/
@@ -28,6 +26,9 @@ legacylinks:
   - https://torrentz2.eu/ # domain suspended by registry
   - https://torrentz.unblockit.id/
   - https://torrentz.unblockit.win/
+  - https://torrentz2.unblocked.bar/
+  - https://torrentz2.proxyportal.pw/
+  - https://torrentz2.uk-unblock.pro/
 
 caps:
   categories:

--- a/src/Jackett.Common/Definitions/zooqle.yml
+++ b/src/Jackett.Common/Definitions/zooqle.yml
@@ -10,9 +10,7 @@ links:
   - https://zooqle.com/
   - https://zooqle.unblockninja.com/
   - https://zooqle.unblockit.top/
-  - https://zooqle.unblocked.bar/
-  - https://zooqle.proxyportal.pw/
-  - https://zooqle.uk-unblock.pro/
+  - https://zooqle.unblocked.rest/
 legacylinks:
   - https://zooqle.unblockit.pro/
   - https://zooqle.unblockit.one/
@@ -25,6 +23,9 @@ legacylinks:
   - https://zooqle.unblockit.pw/
   - https://zooqle.unblockit.id/
   - https://zooqle.unblockit.win/
+  - https://zooqle.unblocked.bar/
+  - https://zooqle.proxyportal.pw/
+  - https://zooqle.uk-unblock.pro/
 
 caps:
   categories:


### PR DESCRIPTION
proxyportal.pw & uk-unblock.pro have also been dropped

KAT obviously untested

BTDB & nyaa.si removed by proxy site