### PR TITLE
[HDCity] Removed English from not VOSE

### DIFF
--- a/src/Jackett.Common/Definitions/hdcity.yml
+++ b/src/Jackett.Common/Definitions/hdcity.yml
@@ -184,7 +184,7 @@ search:
       optional: true
       filters:
         - name: append
-          args: " [Spanish] [English]"
+          args: " [Spanish]"
         - name: re_replace
           args: ["(?i)T[\\s-_]?(\\d{1,2})\\b", " S$1 "]
         - name: re_replace


### PR DESCRIPTION
Until Sonarr add double language managment at titles like radarr, it is better to removed.