### PR TITLE
core: change seeds/leechers type to long. resolves #6558

### DIFF
--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -1519,15 +1519,17 @@ namespace Jackett.Common.Indexers
                                             value = release.Size.ToString();
                                             break;
                                         case "leechers":
-                                            var Leechers = ParseUtil.CoerceInt(value);
+                                            var leechers = ParseUtil.CoerceLong(value);
+                                            leechers = leechers < 5000000L ? leechers : 0; // to fix #6558
                                             if (release.Peers == null)
-                                                release.Peers = Leechers;
+                                                release.Peers = leechers;
                                             else
-                                                release.Peers += Leechers;
-                                            value = Leechers.ToString();
+                                                release.Peers += leechers;
+                                            value = leechers.ToString();
                                             break;
                                         case "seeders":
-                                            release.Seeders = ParseUtil.CoerceInt(value);
+                                            release.Seeders = ParseUtil.CoerceLong(value);
+                                            release.Seeders = release.Seeders < 5000000L ? release.Seeders : 0; // to fix #6558
                                             if (release.Peers == null)
                                                 release.Peers = release.Seeders;
                                             else

--- a/src/Jackett.Common/Models/DTO/TorrentPotatoResponseItem.cs
+++ b/src/Jackett.Common/Models/DTO/TorrentPotatoResponseItem.cs
@@ -10,8 +10,8 @@ namespace Jackett.Common.Models.DTO
         public bool freeleech { get; set; }
         public string type { get; set; }
         public long size { get; set; }
-        public int leechers { get; set; }
-        public int seeders { get; set; }
+        public long leechers { get; set; }
+        public long seeders { get; set; }
         public string publish_date { get; set; }
     }
 }

--- a/src/Jackett.Common/Models/ReleaseInfo.cs
+++ b/src/Jackett.Common/Models/ReleaseInfo.cs
@@ -26,8 +26,8 @@ namespace Jackett.Common.Models
         public long? TMDb { get; set; }
         public string Author { get; set; }
         public string BookTitle { get; set; }
-        public int? Seeders { get; set; }
-        public int? Peers { get; set; }
+        public long? Seeders { get; set; }
+        public long? Peers { get; set; }
         public Uri BannerUrl { get; set; }
         public string InfoHash { get; set; }
         public Uri MagnetUri { get; set; }


### PR DESCRIPTION
There are several sites with wrong seeds/leechers like 4,294,967,295
We can fix that by increasing the variable to long (to avoid casting error)
and then set a valid value (0 seeds/leechers)