### PR TITLE
[Feature] add proxy type 'Disabled' to disable proxy. Resolves #8138

### DIFF
--- a/src/Jackett.Common/Content/index.html
+++ b/src/Jackett.Common/Content/index.html
@@ -143,9 +143,10 @@
         <div class="input-area">
             <span class="input-header">Proxy type: </span>
             <select id="jackett-proxy-type" class="form-control input-right">
-                <option value="0">http</option>
-                <option value="1">socks4</option>
-                <option value="2">socks5</option>
+                <option value="0">Disabled</option>
+                <option value="1">http</option>
+                <option value="2">socks4</option>
+                <option value="3">socks5</option>
             </select>
         </div>
         <div id="proxy-warning" hidden>

--- a/src/Jackett.Common/Models/Config/ProxyType.cs
+++ b/src/Jackett.Common/Models/Config/ProxyType.cs
@@ -2,6 +2,7 @@ namespace Jackett.Common.Models.Config
 {
     public enum ProxyType
     {
+        Disabled,
         Http,
         Socks4,
         Socks5,

--- a/src/Jackett.Common/Models/Config/ServerConfig.cs
+++ b/src/Jackett.Common/Models/Config/ServerConfig.cs
@@ -70,7 +70,11 @@ namespace Jackett.Common.Models.Config
                 url = $"{authString}@{url}";
             }
 
-            if (ProxyType != ProxyType.Http)
+            if (ProxyType == ProxyType.Disabled)
+            {
+                return null;
+            }
+            else if (ProxyType != ProxyType.Http)
             {
                 var protocol = (Enum.GetName(typeof(ProxyType), ProxyType) ?? "").ToLower();
                 if (!string.IsNullOrEmpty(protocol))

--- a/src/Jackett.Common/Utils/Clients/WebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/WebClient.cs
@@ -38,7 +38,11 @@ namespace Jackett.Common.Utils.Clients
                 proxy.Dispose();
             webProxy = null;
             webProxyUrl = serverConfig.GetProxyUrl();
-            if (!string.IsNullOrWhiteSpace(webProxyUrl))
+            if (serverConfig.ProxyType == ProxyType.Disabled)
+            {
+                webProxy = null;
+            }
+            else if (!string.IsNullOrWhiteSpace(webProxyUrl))
             {
                 if (serverConfig.ProxyType != ProxyType.Http)
                 {


### PR DESCRIPTION
_Disclaimer: this is a complete stab in the dark by someone (me) who doesn't know C#, or indeed any coding language._

An attempt to resolve #8138 by adding a 'disabled' option to the proxy type list which will disable the proxy. It addresses the minor annoyance of having to retype/paste the URL when you want to re-enable it. Basically an off switch.

Replaces #9469 due to the significant refactor.

Thanks once more to @garfield69 with the equality operators.