### PR TITLE
[HacheDe] Add BRDISK in the title if the release is a FullBR

### DIFF
--- a/src/Jackett.Common/Definitions/hachede.yml
+++ b/src/Jackett.Common/Definitions/hachede.yml
@@ -173,6 +173,8 @@ search:
       selector: td.torrent_name > a, .newIndicator > a
       filters:
         - name: re_replace
+          args: ["(?i)full", "BRDISK."] # FULL(BR/UHD) -> BRDISK
+        - name: re_replace
           args: ["\\W", "."] # Spaces and other characters -> .
         - name: append
           args: ".Spanish-HacheDe"


### PR DESCRIPTION
This changes was missing yesterday, the FULLBR detects it as HDTV-1080p in the case of HacheDe, with this change it already detects it correctly as BRDISK