### PR TITLE
[Feature] added searchEngine support

### DIFF
--- a/src/Jackett.Common/Indexers/AnimeBytes.cs
+++ b/src/Jackett.Common/Indexers/AnimeBytes.cs
@@ -51,7 +51,10 @@ namespace Jackett.Common.Indexers
                                                  TorznabCatType.PCGames,
                                                  TorznabCatType.AudioMP3,
                                                  TorznabCatType.AudioLossless,
-                                                 TorznabCatType.AudioOther),
+                                                 TorznabCatType.AudioOther)
+                   {
+                       SearchType = TorznabCapabilities.SearchEngineType.raw
+                   },
                    logger: l,
                    p: ps,
                    configData: new ConfigurationDataAnimeBytes("Note: Go to AnimeBytes site and open your account settings. Go to 'Account' tab, move cursor over black part near 'Passkey' and copy its value. Your username is case sensitive."))
@@ -104,7 +107,7 @@ namespace Jackett.Common.Indexers
 
         private string StripEpisodeNumber(string term)
         {
-            // Tracer does not support searching with episode number so strip it if we have one
+            // Tracker does not support searching with episode number so strip it if we have one
             term = Regex.Replace(term, @"\W(\dx)?\d?\d$", string.Empty);
             term = Regex.Replace(term, @"\W(S\d\d?E)?\d?\d$", string.Empty);
             term = Regex.Replace(term, @"\W\d+$", string.Empty);
@@ -115,16 +118,17 @@ namespace Jackett.Common.Indexers
         {
             // The result list
             var releases = new List<ReleaseInfo>();
+            var searchTerm = null != query.SearchTerm ? query.SearchTerm : "";
 
             if (ContainsMusicCategories(query.Categories))
             {
-                foreach (var result in await GetResults(query, "music", query.SanitizedSearchTerm))
+                foreach (var result in await GetResults(query, "music", searchTerm))
                 {
                     releases.Add(result);
                 }
             }
 
-            foreach (var result in await GetResults(query, "anime", StripEpisodeNumber(query.SanitizedSearchTerm)))
+            foreach (var result in await GetResults(query, "anime", StripEpisodeNumber(searchTerm)))
             {
                 releases.Add(result);
             }

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -1244,7 +1244,7 @@ namespace Jackett.Common.Indexers
             //variables[".Query.Genre"] = query.Genre ?? new List<string>();
             variables[".Query.Episode"] = query.GetEpisodeSearchString();
             variables[".Query.Author"] = query.Author;
-            variables[".Query.Title"] = query.Title;
+            variables[".Query.BookTitle"] = query.BookTitle;
 
             var mappedCategories = MapTorznabCapsToTrackers(query);
             if (mappedCategories.Count == 0)

--- a/src/Jackett.Common/Models/DTO/TorznabRequest.cs
+++ b/src/Jackett.Common/Models/DTO/TorznabRequest.cs
@@ -7,6 +7,7 @@ namespace Jackett.Common.Models.DTO
     {
         public string t { get; set; }
         public string q { get; set; }
+        public string title { get; set; }
         public string cat { get; set; }
         public string imdbid { get; set; }
         public string tmdbid { get; set; }
@@ -24,7 +25,7 @@ namespace Jackett.Common.Models.DTO
         public string year { get; set; }
         public string genre { get; set; }
         public string author { get; set; }
-        public string title { get; set; }
+        public string booktitle { get; set; }
         public string configured { get; set; }
 
         public static TorznabQuery ToTorznabQuery(TorznabRequest request)
@@ -44,6 +45,10 @@ namespace Jackett.Common.Models.DTO
                 query.Limit = ParseUtil.CoerceInt(request.limit);
             if (!string.IsNullOrWhiteSpace(request.offset))
                 query.Offset = ParseUtil.CoerceInt(request.offset);
+
+            // For Sonarr's latest support of Raw SearchTerm. See https://github.com/Jackett/Jackett/issues/8246
+            if (!string.IsNullOrWhiteSpace(request.title) && string.IsNullOrWhiteSpace(request.q))
+                query.SearchTerm = request.title;
 
             if (request.cat != null)
             {
@@ -80,8 +85,8 @@ namespace Jackett.Common.Models.DTO
             if (!string.IsNullOrWhiteSpace(request.genre))
                 query.Genre = request.genre.Split(',');
 
-            if (!string.IsNullOrWhiteSpace(request.title))
-                query.Title = request.title;
+            if (!string.IsNullOrWhiteSpace(request.booktitle))
+                query.BookTitle = request.booktitle;
             if (!string.IsNullOrWhiteSpace(request.author))
                 query.Author = request.author;
 

--- a/src/Jackett.Common/Models/TorznabQuery.cs
+++ b/src/Jackett.Common/Models/TorznabQuery.cs
@@ -32,7 +32,7 @@ namespace Jackett.Common.Models
         public ICollection<string> Genre { get; set; }
 
         public string Author { get; set; }
-        public string Title { get; set; }
+        public string BookTitle { get; set; }
 
         public bool IsTest { get; set; }
 
@@ -133,7 +133,7 @@ namespace Jackett.Common.Models
                 Track = Track,
                 Year = Year,
                 Author = Author,
-                Title = Title,
+                BookTitle = BookTitle,
                 RageID = RageID,
                 TvdbID = TvdbID,
                 ImdbID = ImdbID,


### PR DESCRIPTION
In lieu of https://github.com/Jackett/Jackett/issues/8246, this PR attempts to support `title` query and `searchEngine` attribute.

**Problem Overview**
Currently, both Sonarr and Jackett are performing Sanitization. This is a huge problem especially when special characters are necessary to distinguish between different types of Anime/Seasons. For instance, `Shinryaku! Ika Musume` is Season 1 and `Shinryaku!? Ika Musume` is Season 2. The subtle difference is distinguished by special characters. The current protocol between Sonarr and Jackett would immediately strip off all special characters, making it impossible to search correctly at times.

**Proposed Approach**
The proposal in the aforementioned PR states the usage of `title` as the supported parameter query and `searchEngine` as the type of search. By doing so, this ensures that Sonarr will submit raw search titles. The handling for such search titles is left to each indexer. If an indexer supports `searchEngine=raw`, then it should presume the usage of `query.SearchTerm` instead of `query.SanitizedSearchTerm`. I've committed an example of this handling via Animebytes.

<details>
   <summary>Sample output:</summary>

```xml
<?xml version="1.0" encoding="UTF-8"?>
<caps>
  <server title="Jackett" />
  <searching>
    <search available="yes" supportedParams="q,title" searchEngine="raw" />
    <tv-search available="yes" supportedParams="q,season,ep,title" searchEngine="raw" />
    <movie-search available="yes" supportedParams="q" />
    <music-search available="no" supportedParams="" />
    <audio-search available="no" supportedParams="" />
    <book-search available="no" supportedParams="q" />
  </searching>
  <categories>
    <category id="1020" name="Console/PSP" />
    <category id="1090" name="Console/Other" />
    <category id="2000" name="Movies">
      <subcat id="2010" name="Movies/Foreign" />
      <subcat id="2020" name="Movies/Other" />
      <subcat id="2030" name="Movies/SD" />
      <subcat id="2040" name="Movies/HD" />
      <subcat id="2045" name="Movies/UHD" />
      <subcat id="2050" name="Movies/3D" />
      <subcat id="2060" name="Movies/BluRay" />
      <subcat id="2070" name="Movies/DVD" />
      <subcat id="2080" name="Movies/WEBDL" />
    </category>
    <category id="3010" name="Audio/MP3" />
    <category id="3040" name="Audio/Lossless" />
    <category id="3050" name="Audio/Other" />
    <category id="4050" name="PC/Games" />
    <category id="5070" name="TV/Anime" />
    <category id="8020" name="Books/Comics" />
  </categories>
</caps>
```
</details>

**Additional Note**
The current `TorznabRequest` handles `title` as a book title. According to the specifications, this is incorrect and has been renamed to `booktitle` instead. As mentioned by @Taloth, `title` is currently untouched/unused in the specifications, which means only Sonarr will be using it for now (I've not checked if Radarr has cherry-picked this implementation yet).

References: 
- https://github.com/Sonarr/Sonarr/blob/develop/schemas/torznab.xsd
- https://newznab.readthedocs.io/en/latest/misc/api/#predefined-attributes