### PR TITLE
bb: add option of only searching for freeleech releases

### DIFF
--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataBasicLoginWithFreeleech.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataBasicLoginWithFreeleech.cs
@@ -1,0 +1,14 @@
+namespace Jackett.Common.Models.IndexerConfig
+{
+    public class ConfigurationDataBasicLoginWithFreeleech : ConfigurationDataBasicLogin
+    {
+        public BoolItem Freeleech { get; private set; }
+
+        public ConfigurationDataBasicLoginWithFreeleech(string instructionMessageOptional = null)
+        {
+            Freeleech = new BoolItem() { Name = "Search Freeleech only (optional)", Value = false };
+        }
+
+
+    }
+}


### PR DESCRIPTION
I'm not very familiar with C#, so please inspect the code in detail.

There seems to be an error sometimes when changing the Freeleech option in the web interface:

    An error occurred while updating this indexer
    Specified argument was out of the range of valid values. Parameter name: index

However, sometimes it works properly. And correctly sets the config file, and only freeleech results are returned.