### PR TITLE
Update pornbay.yml

### DIFF
--- a/src/Jackett.Common/Definitions/pornbay.yml
+++ b/src/Jackett.Common/Definitions/pornbay.yml
@@ -65,10 +65,14 @@ caps:
     type: checkbox
     label: Search freeleech only
     default: false
-  - name: info_grd
+  - name: info_grid
     type: info
     label: GRID view
     default: This indexer does not support the GRID view on the torrent search page. Change the <b>GRID</b> setting to <b>OFF</b> on your account profile. If set to <i>ON</i> will cause no results to be returned.
+  - name: info_tpp
+    type: info
+    label: Results Per Page
+    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
 
 login:
   path: login.php

--- a/src/Jackett.Common/Definitions/pornbay.yml
+++ b/src/Jackett.Common/Definitions/pornbay.yml
@@ -72,7 +72,7 @@ caps:
   - name: info_tpp
     type: info
     label: Results Per Page
-    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
+    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile. The default is <i>25</i>.
 
 login:
   path: login.php

--- a/src/Jackett.Common/Definitions/pornbay.yml
+++ b/src/Jackett.Common/Definitions/pornbay.yml
@@ -1,8 +1,7 @@
-# Pornbay is based on Gazelle, but I used the Empornium definition as a base.
 ---
 id: pornbay
 name: Pornbay
-description: "Pornbay is a Private Torrent Tracker for XXX"
+description: "Pornbay is a Private Torrent Tracker for 3X"
 language: en-us
 type: private
 encoding: UTF-8
@@ -22,6 +21,7 @@ caps:
     - {id: 32, cat: XXX, desc: "Classic"}
     - {id: 8, cat: XXX, desc: "Clips"}
     - {id: 9, cat: XXX, desc: "Creampie"}
+    - {id: 10, cat: XXX, desc: "DVD-R"}
     - {id: 11, cat: XXX, desc: "Feature"}
     - {id: 12, cat: XXX, desc: "Fetish"}
     - {id: 13, cat: XXX, desc: "Foreign"}
@@ -36,6 +36,7 @@ caps:
     - {id: 22, cat: XXX, desc: "Lesbian"}
     - {id: 23, cat: XXX, desc: "Mature"}
     - {id: 47, cat: XXX, desc: "Megapack"}
+    - {id: 49, cat: XXX, desc: "Old+Young"}
     - {id: 24, cat: XXX, desc: "Orgy"}
     - {id: 25, cat: XXX, desc: "Other"}
     - {id: 26, cat: XXX, desc: "Pics"}
@@ -46,6 +47,7 @@ caps:
     - {id: 28, cat: XXX, desc: "Straight"}
     - {id: 29, cat: XXX, desc: "Teen"}
     - {id: 51, cat: XXX, desc: "VR Porn"}
+    - {id: 33, cat: XXX, desc: "Transsexual"}
 
   modes:
     search: [q]
@@ -63,6 +65,10 @@ caps:
     type: checkbox
     label: Search freeleech only
     default: false
+  - name: info_grd
+    type: info
+    label: GRID view
+    default: This indexer does not support the GRID view on the torrent search page. Change the <b>GRID</b> setting to <b>OFF</b> on your account profile. If set to <i>ON</i> will cause no results to be returned.
 
 login:
   path: login.php
@@ -82,18 +88,19 @@ search:
     - path: torrents.php
   inputs:
     $raw: "{{range .Categories}}filter_cat[{{.}}]=1&{{end}}"
-    title: "{{ .Query.Keywords }}"
+    searchtext: ""
+    title: "{{ .Keywords }}"
     order_by: time
     order_way: desc
-    #action: basic
     action: advanced
     filter_freeleech: "{{ if .Config.freeleech }}1{{ else }}{{ end }}"
     filelist: ""
     taglist: ""
-    searchsubmit: 1
+
   rows:
     # exclude redbar torrents
     selector: table#torrent_table > tbody > tr[class^="torrent row"]
+
   fields:
     download:
       selector: a[href^="torrents.php?action=download&id="]
@@ -128,7 +135,7 @@ search:
       attribute: title
       filters:
         - name: append
-          args: " +00:00"
+          args: " +00:00" # GMT
         - name: dateparse
           args: "Jan 02 2006, 15:04 -07:00"
     size:
@@ -142,8 +149,8 @@ search:
     downloadvolumefactor:
       case:
         span.icon[title*="Freeleech"]: 0
-        "img[alt=\"Freeleech\"]": "0"
-        "*": "1"
+        img[alt="Freeleech"]: 0
+        "*": 1
     uploadvolumefactor:
-      case:
-        "*": "1"
+      text: 1
+ # Gazelle

--- a/src/Jackett.Common/Definitions/pornbay.yml
+++ b/src/Jackett.Common/Definitions/pornbay.yml
@@ -51,6 +51,18 @@ caps:
     search: [q]
     tv-search: [q]
     movie-search: [q]
+    
+    settings:
+  - name: username
+    type: text
+    label: Username
+  - name: password
+    type: password
+    label: Password
+  - name: freeleech
+    type: checkbox
+    label: Search freeleech only
+    default: false
 
 login:
   path: login.php
@@ -73,7 +85,11 @@ search:
     title: "{{ .Query.Keywords }}"
     order_by: time
     order_way: desc
-    action: basic
+    #action: basic
+    action: advanced
+    filter_freeleech: "{{ if .Config.freeleech }}1{{ else }}{{ end }}"
+    filelist: ""
+    taglist: ""
     searchsubmit: 1
   rows:
     # exclude redbar torrents

--- a/src/Jackett.Common/Definitions/pornbay.yml
+++ b/src/Jackett.Common/Definitions/pornbay.yml
@@ -53,8 +53,8 @@ caps:
     search: [q]
     tv-search: [q]
     movie-search: [q]
-    
-    settings:
+
+settings:
   - name: username
     type: text
     label: Username
@@ -157,4 +157,4 @@ search:
         "*": 1
     uploadvolumefactor:
       text: 1
- # Gazelle
+# Gazelle


### PR DESCRIPTION
[Pornbay] Include Freeleech torrents only in setting #9772

taken from emp
` {
    "id": "searchfreeleechonly",
    "type": "inputbool",
    "name": "Search freeleech only",
    "value": true
  } `

this needs to be added to `\Indexers\pornbay.json`

I was able to do it locally and test successfully
![Screenshot_68](https://user-images.githubusercontent.com/16240121/95335957-aa18c500-08cd-11eb-9741-5628494094de.jpg)

I read something about index manager....does it generate automatically?