### PR TITLE
assorted kickasstorrents clones: add and amend proxies

### DIFF
--- a/src/Jackett.Common/Definitions/kickasstorrent-kathow.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrent-kathow.yml
@@ -8,7 +8,13 @@ encoding: UTF-8
 followredirect: true
 links:
   - https://kickass.ws/
-  - https://kickasstorrents.unblockninja.com/
+  - https://kickasstorrents.bz/
+  - https://kkickass.com/
+  - https://kkat.net/
+  - https://kickass-kat.com/
+  - https://kickasst.net/
+  - https://kickasstorrents.id/
+  - https://thekat.cc/
 legacylinks:
   - https://kickass.gg/
   - https://katcr.io/
@@ -16,8 +22,8 @@ legacylinks:
   - https://thekat.se/
   - https://kat.how/
   - https://kat.li/
-  - https://katcr.to/ # possible 3rd kickasstorrent site/clone?
-  - https://kickasstorrent.cr/ # possible 3rd kickasstorrent site/clone?
+  - https://katcr.to/ # kickasstorrents-to proxy
+  - https://kickasstorrent.cr/ # kickasstorrents-to proxy
   - https://kickass.unblockit.pro/
   - https://kickass.unblockit.one/
   - https://kickass.unblockit.me/
@@ -25,6 +31,7 @@ legacylinks:
   - https://kickass.unblockit.id/
   - https://kickass.unblockit.win/
   - https://kickass.unblockit.top/ # currently redirects to https://kat.unblockit.lat/ (newkatcr.co proxy)
+  - https://kickasstorrents.unblockninja.com/ # currently kickasstorrents-to proxy
 
 caps:
   categories:

--- a/src/Jackett.Common/Definitions/kickasstorrent.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrent.yml
@@ -11,8 +11,8 @@ links:
   - https://kat.unblockit.lat/
   - https://katcr.unblocked.rest/
 legacylinks:
-  - https://kickasstorrent.cr/ # possible 3rd kickasstorrent site/clone?
-  - https://katcr.to/ # possible 3rd kickasstorrent site/clone?
+  - https://kickasstorrent.cr/ # kickasstorrents-to proxy
+  - https://katcr.to/ # kickasstorrents-to proxy
   - https://kat.unblockit.one/
   - https://katcr.black-mirror.xyz/
   - https://katcr.unblocked.casa/
@@ -24,12 +24,12 @@ legacylinks:
   - https://katcr.co/
   - https://kat.unblockit.id/
   - https://kat.unblockit.win/
-  - https://kickasstorrents.unblockninja.com/ # now kickasstorrent-kathow proxy
+  - https://kickasstorrents.unblockninja.com/ # currently kickasstorrents-to proxy
   - https://katcr.unblocked.bar/
   - https://katcr.proxyportal.pw/
   - https://katcr.uk-unblock.pro/
   - https://kat.unblockit.top/
-  - https://kat.root.yt/ # 403 Forbidden
+  - https://kat.root.yt/ # currently kickasstorrents-to proxy
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/kickasstorrents-to.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrents-to.yml
@@ -7,6 +7,8 @@ type: public
 encoding: UTF-8
 links:
   - https://kickasstorrents.to/
+  - https://kickasstorrent.cr/
+  - https://katcr.to/
 
 caps:
   categories:

--- a/src/Jackett.Common/Definitions/kickasstorrents-to.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrents-to.yml
@@ -9,6 +9,8 @@ links:
   - https://kickasstorrents.to/
   - https://kickasstorrent.cr/
   - https://katcr.to/
+  - https://kickasstorrents.unblockninja.com/
+  - https://kat.root.yt/
 
 caps:
   categories:


### PR DESCRIPTION
Proxy list for kathow - https://ww2.kickass.how/

Ignore https://thekat.app/, https://kickasshydra.dev/, and https://kickasshydra.net/