### PR TITLE
Cardigann: add check for redirect when pulling login page

### DIFF
--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -880,6 +880,11 @@ namespace Jackett.Common.Indexers
                 configData.CookieHeader.Value = string.Join("; ", Login.Cookies);
             landingResult = await RequestWithCookiesAsync(LoginUrl.AbsoluteUri, referer: SiteLink);
 
+            if (landingResult.IsRedirect)
+            {
+                await FollowIfRedirect(landingResult, LoginUrl.AbsoluteUri, overrideCookies: landingResult.Cookies, accumulateCookies: true);
+            }
+
             var htmlParser = new HtmlParser();
             landingResultDocument = htmlParser.ParseDocument(landingResult.ContentString);
 

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -880,7 +880,9 @@ namespace Jackett.Common.Indexers
                 configData.CookieHeader.Value = string.Join("; ", Login.Cookies);
             landingResult = await RequestWithCookiesAsync(LoginUrl.AbsoluteUri, referer: SiteLink);
 
-            if (landingResult.IsRedirect)
+            // Some sites have a temporary redirect before the login page, we need to process it.
+            // This check only apply to sites requiring it, which is currently: Yggtorrent
+            if (Definition.Id == "yggtorrent" && landingResult.IsRedirect)
             {
                 await FollowIfRedirect(landingResult, LoginUrl.AbsoluteUri, overrideCookies: landingResult.Cookies, accumulateCookies: true);
             }

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -881,8 +881,7 @@ namespace Jackett.Common.Indexers
             landingResult = await RequestWithCookiesAsync(LoginUrl.AbsoluteUri, referer: SiteLink);
 
             // Some sites have a temporary redirect before the login page, we need to process it.
-            // This check only apply to sites requiring it, which is currently: Yggtorrent
-            if (Definition.Id == "yggtorrent" && landingResult.IsRedirect)
+            if (Definition.Followredirect)
             {
                 await FollowIfRedirect(landingResult, LoginUrl.AbsoluteUri, overrideCookies: landingResult.Cookies, accumulateCookies: true);
             }


### PR DESCRIPTION
As per @ilike2burnthing [request](https://github.com/Jackett/Jackett/issues/9029#issuecomment-716907578), here's a PR that add a check for redirect when pulling the login page.

This fix the redirect(307) issue with yggtorrent. See https://github.com/Jackett/Jackett/issues/9959#issuecomment-716058618 for more info.

It was not tested with other indexers.