### PR TITLE
core: rewrite category code from scratch. resolves #8049

### DIFF
--- a/src/Jackett.Common/Models/DTO/Indexer.cs
+++ b/src/Jackett.Common/Models/DTO/Indexer.cs
@@ -51,14 +51,11 @@ namespace Jackett.Common.Models.DTO
             site_link = indexer.SiteLink;
             language = indexer.Language;
             last_error = indexer.LastError;
-            potatoenabled = indexer.TorznabCaps.Categories.GetTorznabCategories().Any(i => TorznabCatType.Movies.Contains(i));
+            potatoenabled = indexer.TorznabCaps.Categories.GetTorznabCategoryTree().Any(i => TorznabCatType.Movies.Contains(i));
 
             alternativesitelinks = indexer.AlternativeSiteLinks;
 
-            caps = indexer.TorznabCaps.Categories.GetTorznabCategories()
-                .GroupBy(p => p.ID)
-                .Select(g => g.First())
-                .OrderBy(c => c.ID < 100000 ? "z" + c.ID.ToString() : c.Name)
+            caps = indexer.TorznabCaps.Categories.GetTorznabCategoryList(true)
                 .Select(c => new Capability
                 {
                     ID = c.ID.ToString(),

--- a/src/Jackett.Common/Models/TorznabCapabilities.cs
+++ b/src/Jackett.Common/Models/TorznabCapabilities.cs
@@ -250,7 +250,7 @@ namespace Jackett.Common.Models
                             new XAttribute("available", MusicSearchAvailable ? "yes" : "no"),
                             new XAttribute("supportedParams", SupportedMusicSearchParams())
                         ),
-                        // inconsistend but apparently already used by various newznab indexers (see #1896)
+                        // inconsistent but apparently already used by various newznab indexers (see #1896)
                         new XElement("audio-search",
                             new XAttribute("available", MusicSearchAvailable ? "yes" : "no"),
                             new XAttribute("supportedParams", SupportedMusicSearchParams())
@@ -261,7 +261,7 @@ namespace Jackett.Common.Models
                         )
                     ),
                     new XElement("categories",
-                        from c in Categories.GetTorznabCategories().OrderBy(x => x.ID < 100000 ? "z" + x.ID.ToString() : x.Name)
+                        from c in Categories.GetTorznabCategoryTree(true)
                         select new XElement("category",
                             new XAttribute("id", c.ID),
                             new XAttribute("name", c.Name),

--- a/src/Jackett.Common/Models/TorznabCapabilitiesCategories.cs
+++ b/src/Jackett.Common/Models/TorznabCapabilitiesCategories.cs
@@ -6,21 +6,52 @@ namespace Jackett.Common.Models
 {
     public class TorznabCapabilitiesCategories
     {
-        private readonly List<TorznabCategory> _categories = new List<TorznabCategory>();
         private readonly List<CategoryMapping> _categoryMapping = new List<CategoryMapping>();
-
-        public List<TorznabCategory> GetTorznabCategories() => _categories;
+        private readonly List<TorznabCategory> _torznabCategoryTree = new List<TorznabCategory>();
 
         public List<string> GetTrackerCategories() => _categoryMapping.Select(x => x.TrackerCategory).ToList();
 
+        public List<TorznabCategory> GetTorznabCategoryTree(bool sorted = false)
+        {
+            if (!sorted)
+                return _torznabCategoryTree;
+
+            // we build a new tree, original is unsorted
+            // first torznab categories ordered by id and then custom cats ordered by name
+            var sortedTree = _torznabCategoryTree
+                .Select(c =>
+                {
+                    var sortedSubCats = c.SubCategories.OrderBy(x => x.ID);
+                    var newCat = new TorznabCategory(c.ID, c.Name);
+                    newCat.SubCategories.AddRange(sortedSubCats);
+                    return newCat;
+                }).OrderBy(x => x.ID > 100000 ? "zzz" + x.Name : x.ID.ToString()).ToList();
+
+            return sortedTree;
+        }
+
+        public List<TorznabCategory> GetTorznabCategoryList(bool sorted = false)
+        {
+            var tree = GetTorznabCategoryTree(sorted);
+
+            // create a flat list (without subcategories)
+            var newFlatList = new List<TorznabCategory>();
+            foreach (var cat in tree)
+            {
+                newFlatList.Add(cat.CopyWithoutSubCategories());
+                newFlatList.AddRange(cat.SubCategories);
+            }
+            return newFlatList;
+        }
+
         public void AddCategoryMapping(string trackerCategory, TorznabCategory torznabCategory, string trackerCategoryDesc = null)
         {
+            // add torznab cat
             _categoryMapping.Add(new CategoryMapping(trackerCategory, trackerCategoryDesc, torznabCategory.ID));
+            AddTorznabCategoryTree(torznabCategory);
 
-            if (!_categories.Contains(torznabCategory))
-                _categories.Add(torznabCategory);
-
-            // add 1:1 categories
+            // TODO: fix this. it's only working for integer "trackerCategory"
+            // create custom cats (1:1 categories)
             if (trackerCategoryDesc != null && trackerCategory != null)
             {
                 //TODO convert to int.TryParse() to avoid using throw as flow control
@@ -28,8 +59,7 @@ namespace Jackett.Common.Models
                 {
                     var trackerCategoryInt = int.Parse(trackerCategory);
                     var customCat = new TorznabCategory(trackerCategoryInt + 100000, trackerCategoryDesc);
-                    if (!_categories.Contains(customCat))
-                        _categories.Add(customCat);
+                    AddTorznabCategoryTree(customCat);
                 }
                 catch (FormatException)
                 {
@@ -131,15 +161,54 @@ namespace Jackett.Common.Models
         {
             if (categories == null)
                 return false;
-            var subCategories = _categories.SelectMany(c => c.SubCategories);
-            var allCategories = _categories.Concat(subCategories);
+            var subCategories = _torznabCategoryTree.SelectMany(c => c.SubCategories);
+            var allCategories = _torznabCategoryTree.Concat(subCategories);
             var supportsCategory = allCategories.Any(i => categories.Any(c => c == i.ID));
             return supportsCategory;
         }
 
-        public void Concat(TorznabCapabilitiesCategories rhs) =>
+        public void Concat(TorznabCapabilitiesCategories rhs)
+        {
             // exclude indexer specific categories (>= 100000)
             // we don't concat _categoryMapping because it makes no sense for the aggregate indexer
-            _categories.AddRange(rhs._categories.Where(x => x.ID < 100000).Except(_categories));
+            rhs.GetTorznabCategoryList().Where(x => x.ID < 100000).ToList().ForEach(AddTorznabCategoryTree);
+        }
+
+        private void AddTorznabCategoryTree(TorznabCategory torznabCategory)
+        {
+            // build the category tree
+            if (TorznabCatType.ParentCats.Contains(torznabCategory))
+            {
+                // parent cat
+                if (!_torznabCategoryTree.Contains(torznabCategory))
+                    _torznabCategoryTree.Add(torznabCategory.CopyWithoutSubCategories());
+            }
+            else
+            {
+                // child or custom cat
+                var parentCat = TorznabCatType.ParentCats.FirstOrDefault(c => c.Contains(torznabCategory));
+                if (parentCat != null)
+                {
+                    // child cat
+                    var nodeCat = _torznabCategoryTree.FirstOrDefault(c => c.Equals(parentCat));
+                    if (nodeCat != null)
+                    {
+                        // parent cat already exists
+                        if (!nodeCat.Contains(torznabCategory))
+                            nodeCat.SubCategories.Add(torznabCategory);
+                    }
+                    else
+                    {
+                        // create parent cat and add child
+                        nodeCat = parentCat.CopyWithoutSubCategories();
+                        nodeCat.SubCategories.Add(torznabCategory);
+                        _torznabCategoryTree.Add(nodeCat);
+                    }
+                }
+                else
+                    // custom cat
+                    _torznabCategoryTree.Add(torznabCategory);
+            }
+        }
     }
 }

--- a/src/Jackett.Common/Models/TorznabCatType.cs
+++ b/src/Jackett.Common/Models/TorznabCatType.cs
@@ -265,27 +265,8 @@ namespace Jackett.Common.Models
             Other.SubCategories.AddRange(new List<TorznabCategory> {OtherMisc, OtherHashed});
         }
 
-        public static bool QueryContainsParentCategory(int[] queryCats, ICollection<int> releaseCats)
-        {
-            //return (from releaseCat in releaseCats
-            //        select AllCats.FirstOrDefault(c => c.ID == releaseCat)
-            //        into cat
-            //        where cat != null && queryCats != null
-            //        select cat.SubCategories.Any(c => queryCats.Contains(c.ID)))
-            //    .FirstOrDefault();
-            // Is equal to:
-            foreach (var releaseCat in releaseCats)
-            {
-                var cat = AllCats.FirstOrDefault(c => c.ID == releaseCat);
-                if (cat != null && queryCats != null)
-                    return cat.SubCategories.Any(c => queryCats.Contains(c.ID));
-            }
-
-            return false;
-        }
-
-        public static string GetCatDesc(int newznabcat) =>
-            AllCats.FirstOrDefault(c => c.ID == newznabcat)?.Name ?? string.Empty;
+        public static string GetCatDesc(int torznabCatId) =>
+            AllCats.FirstOrDefault(c => c.ID == torznabCatId)?.Name ?? string.Empty;
 
         public static TorznabCategory GetCatByName(string name) => AllCats.FirstOrDefault(c => c.Name == name);
     }

--- a/src/Jackett.Common/Models/TorznabCategory.cs
+++ b/src/Jackett.Common/Models/TorznabCategory.cs
@@ -34,5 +34,7 @@ namespace Jackett.Common.Models
         // Get Hash code should be calculated off read only properties.
         // ID is not readonly
         public override int GetHashCode() => ID;
+
+        public TorznabCategory CopyWithoutSubCategories() => new TorznabCategory(ID, Name);
     }
 }

--- a/src/Jackett.Test/Common/Indexers/CardigannIndexerTests.cs
+++ b/src/Jackett.Test/Common/Indexers/CardigannIndexerTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Jackett.Common.Indexers;
 using Jackett.Common.Models;
+using Jackett.Test.TestHelpers;
 using NUnit.Framework;
 
 namespace Jackett.Test.Common.Indexers
@@ -48,7 +49,7 @@ namespace Jackett.Test.Common.Indexers
             Assert.False(indexer.TorznabCaps.BookSearchAvailable);
             Assert.False(indexer.TorznabCaps.BookSearchTitleAvailable);
             Assert.False(indexer.TorznabCaps.BookSearchAuthorAvailable);
-            Assert.AreEqual(0, indexer.TorznabCaps.Categories.GetTorznabCategories().Count);
+            Assert.AreEqual(0, indexer.TorznabCaps.Categories.GetTorznabCategoryTree().Count);
 
             definition = new IndexerDefinition // test categories (same as in C# indexer)
             {
@@ -91,16 +92,20 @@ namespace Jackett.Test.Common.Indexers
             };
             indexer = new CardigannIndexer(null, null, null, null, definition);
 
-            // TODO: test duplicates
-            var cats = indexer.TorznabCaps.Categories.GetTorznabCategories();
-            Assert.AreEqual(7, cats.Count);
-            Assert.AreEqual(2000, cats[0].ID);
-            Assert.AreEqual(2030, cats[1].ID);
-            Assert.AreEqual(7030, cats[2].ID);
-            Assert.AreEqual(1040, cats[3].ID);
-            Assert.AreEqual(100044, cats[4].ID);
-            Assert.AreEqual(1030, cats[5].ID);
-            Assert.AreEqual(100045, cats[6].ID);
+            // test categories
+            var expected = new List<TorznabCategory>
+            {
+                TorznabCatType.Movies.CopyWithoutSubCategories(),
+                TorznabCatType.Books.CopyWithoutSubCategories(),
+                TorznabCatType.Console.CopyWithoutSubCategories(),
+                new TorznabCategory(100044, "Console/Xbox_c"),
+                new TorznabCategory(100045, "Console/Xbox_c2")
+            };
+            expected[0].SubCategories.Add(TorznabCatType.MoviesSD.CopyWithoutSubCategories());
+            expected[1].SubCategories.Add(TorznabCatType.BooksComics.CopyWithoutSubCategories());
+            expected[2].SubCategories.Add(TorznabCatType.ConsoleXBox.CopyWithoutSubCategories());
+            expected[2].SubCategories.Add(TorznabCatType.ConsoleWii.CopyWithoutSubCategories());
+            TestCategories.CompareCategoryTrees(expected, indexer.TorznabCaps.Categories.GetTorznabCategoryTree());
 
             definition = new IndexerDefinition // test search modes
             {

--- a/src/Jackett.Test/Common/Models/DTO/IndexerTests.cs
+++ b/src/Jackett.Test/Common/Models/DTO/IndexerTests.cs
@@ -37,14 +37,16 @@ namespace Jackett.Test.Common.Models.DTO
             // test Jackett UI categories (internal JSON)
             var dto = new Indexer(indexer);
             var dtoCaps = dto.caps.ToList();
-            Assert.AreEqual(7, dtoCaps.Count);
-            Assert.AreEqual("100044", dtoCaps[0].ID);
-            Assert.AreEqual("100045", dtoCaps[1].ID);
-            Assert.AreEqual("1030", dtoCaps[2].ID);
-            Assert.AreEqual("1040", dtoCaps[3].ID);
-            Assert.AreEqual("2000", dtoCaps[4].ID);
-            Assert.AreEqual("2030", dtoCaps[5].ID);
+            Assert.AreEqual(9, dtoCaps.Count);
+            Assert.AreEqual("1000", dtoCaps[0].ID);
+            Assert.AreEqual("1030", dtoCaps[1].ID);
+            Assert.AreEqual("1040", dtoCaps[2].ID);
+            Assert.AreEqual("2000", dtoCaps[3].ID);
+            Assert.AreEqual("2030", dtoCaps[4].ID);
+            Assert.AreEqual("7000", dtoCaps[5].ID);
             Assert.AreEqual("7030", dtoCaps[6].ID);
+            Assert.AreEqual("100044", dtoCaps[7].ID);
+            Assert.AreEqual("100040", dtoCaps[8].ID);
 
             // movies categories enable potato search
             Assert.True(dto.potatoenabled);

--- a/src/Jackett.Test/Common/Models/TorznabCapabilitiesTests.cs
+++ b/src/Jackett.Test/Common/Models/TorznabCapabilitiesTests.cs
@@ -42,7 +42,7 @@ namespace Jackett.Test.Common.Models
             Assert.False(torznabCaps.BookSearchTitleAvailable);
             Assert.False(torznabCaps.BookSearchAuthorAvailable);
 
-            Assert.IsEmpty(torznabCaps.Categories.GetTorznabCategories());
+            Assert.IsEmpty(torznabCaps.Categories.GetTorznabCategoryTree());
             Assert.IsEmpty(torznabCaps.Categories.GetTrackerCategories());
         }
 
@@ -405,40 +405,32 @@ namespace Jackett.Test.Common.Models
             Assert.AreEqual("q,title,author", xDocumentSearching?.Element("book-search")?.Attribute("supportedParams")?.Value);
 
             // test categories
-            torznabCaps = new TorznabCapabilities();
-            torznabCaps.Categories.AddCategoryMapping("c1", TorznabCatType.MoviesSD); // child category
+            torznabCaps = new TorznabCapabilities(); // child category
+            torznabCaps.Categories.AddCategoryMapping("c1", TorznabCatType.MoviesSD); 
             xDocument = torznabCaps.GetXDocument();
             var xDocumentCategories = xDocument.Root?.Element("categories")?.Elements("category").ToList();
             Assert.AreEqual(1, xDocumentCategories?.Count);
-            Assert.AreEqual(TorznabCatType.MoviesSD.ID.ToString(), xDocumentCategories?.First().Attribute("id")?.Value);
-            Assert.AreEqual(TorznabCatType.MoviesSD.Name, xDocumentCategories?.First().Attribute("name")?.Value);
+            Assert.AreEqual(TorznabCatType.Movies.ID.ToString(), xDocumentCategories?[0].Attribute("id")?.Value);
+            Assert.AreEqual(TorznabCatType.Movies.Name, xDocumentCategories?[0].Attribute("name")?.Value);
+            var xDocumentSubCategories = xDocumentCategories?[0]?.Elements("subcat").ToList();
+            Assert.AreEqual(1, xDocumentSubCategories?.Count);
+            Assert.AreEqual(TorznabCatType.MoviesSD.ID.ToString(), xDocumentSubCategories?[0].Attribute("id")?.Value);
+            Assert.AreEqual(TorznabCatType.MoviesSD.Name, xDocumentSubCategories?[0].Attribute("name")?.Value);
 
-            // TODO: child category is duplicated. should we add just parent and child without other subcats?
-            torznabCaps = new TorznabCapabilities();
-            torznabCaps.Categories.AddCategoryMapping("c1", TorznabCatType.Movies); // parent and child category
+            torznabCaps = new TorznabCapabilities(); // parent (with description generates a custom cat) and child category
+            torznabCaps.Categories.AddCategoryMapping("1", TorznabCatType.Movies, "Classic Movies"); 
             torznabCaps.Categories.AddCategoryMapping("c2", TorznabCatType.MoviesSD);
             xDocument = torznabCaps.GetXDocument();
             xDocumentCategories = xDocument.Root?.Element("categories")?.Elements("category").ToList();
             Assert.AreEqual(2, xDocumentCategories?.Count);
-            Assert.AreEqual(TorznabCatType.Movies.ID.ToString(), xDocumentCategories?.First().Attribute("id")?.Value);
-            Assert.AreEqual(TorznabCatType.Movies.Name, xDocumentCategories?.First().Attribute("name")?.Value);
-            Assert.AreEqual(TorznabCatType.MoviesSD.ID.ToString(), xDocumentCategories?[1].Attribute("id")?.Value);
-            Assert.AreEqual(TorznabCatType.MoviesSD.Name, xDocumentCategories?[1].Attribute("name")?.Value);
-            var xDocumentSubCategories = xDocumentCategories?.First()?.Elements("subcat").ToList();
-            Assert.AreEqual(9, xDocumentSubCategories?.Count);
-            Assert.AreEqual(TorznabCatType.MoviesForeign.ID.ToString(), xDocumentSubCategories?.First().Attribute("id")?.Value);
-            Assert.AreEqual(TorznabCatType.MoviesForeign.Name, xDocumentSubCategories?.First().Attribute("name")?.Value);
-
-            torznabCaps = new TorznabCapabilities();
-            torznabCaps.Categories.AddCategoryMapping("c1", new TorznabCategory(100001, "CustomCat")); // custom category
-            torznabCaps.Categories.AddCategoryMapping("c2", TorznabCatType.MoviesSD);
-            xDocument = torznabCaps.GetXDocument();
-            xDocumentCategories = xDocument.Root?.Element("categories")?.Elements("category").ToList();
-            Assert.AreEqual(2, xDocumentCategories?.Count);
-            Assert.AreEqual("100001", xDocumentCategories?[0].Attribute("id")?.Value); // custom cats are first in the list
-            Assert.AreEqual("CustomCat", xDocumentCategories?[0].Attribute("name")?.Value);
-            Assert.AreEqual(TorznabCatType.MoviesSD.ID.ToString(), xDocumentCategories?[1].Attribute("id")?.Value);
-            Assert.AreEqual(TorznabCatType.MoviesSD.Name, xDocumentCategories?[1].Attribute("name")?.Value);
+            Assert.AreEqual(TorznabCatType.Movies.ID.ToString(), xDocumentCategories?[0].Attribute("id")?.Value);
+            Assert.AreEqual(TorznabCatType.Movies.Name, xDocumentCategories?[0].Attribute("name")?.Value);
+            xDocumentSubCategories = xDocumentCategories?[0]?.Elements("subcat").ToList();
+            Assert.AreEqual(1, xDocumentSubCategories?.Count);
+            Assert.AreEqual(TorznabCatType.MoviesSD.ID.ToString(), xDocumentSubCategories?[0].Attribute("id")?.Value);
+            Assert.AreEqual(TorznabCatType.MoviesSD.Name, xDocumentSubCategories?[0].Attribute("name")?.Value);
+            Assert.AreEqual("100001", xDocumentCategories?[1].Attribute("id")?.Value); // custom cats are first in the list
+            Assert.AreEqual("Classic Movies", xDocumentCategories?[1].Attribute("name")?.Value);
         }
 
         [Test]
@@ -450,15 +442,17 @@ namespace Jackett.Test.Common.Models
             // test Torznab caps (XML) => more in Common.Model.TorznabCapabilitiesTests
             var xDocument = torznabCaps.GetXDocument();
             var xDocumentCategories = xDocument.Root?.Element("categories")?.Elements("category").ToList();
-            Assert.AreEqual(7, xDocumentCategories?.Count);
-            Assert.AreEqual("100044", xDocumentCategories?[0].Attribute("id")?.Value);
-            Assert.AreEqual("100045", xDocumentCategories?[1].Attribute("id")?.Value);
-            Assert.AreEqual("1030", xDocumentCategories?[2].Attribute("id")?.Value);
-            Assert.AreEqual("1040", xDocumentCategories?[3].Attribute("id")?.Value);
-            Assert.AreEqual("2000", xDocumentCategories?[4].Attribute("id")?.Value); // Movies
-            Assert.AreEqual("2030", xDocumentCategories?[5].Attribute("id")?.Value);
-            Assert.AreEqual("7030", xDocumentCategories?[6].Attribute("id")?.Value);
-            Assert.AreEqual(9, xDocumentCategories?[4]?.Elements("subcat").ToList().Count); // Movies
+            Assert.AreEqual(5, xDocumentCategories?.Count);
+            Assert.AreEqual("1000", xDocumentCategories?[0].Attribute("id")?.Value);
+            Assert.AreEqual(2, xDocumentCategories?[0]?.Elements("subcat").ToList().Count);
+            Assert.AreEqual("2000", xDocumentCategories?[1].Attribute("id")?.Value);
+            Assert.AreEqual(1, xDocumentCategories?[1]?.Elements("subcat").ToList().Count);
+            Assert.AreEqual("7000", xDocumentCategories?[2].Attribute("id")?.Value);
+            Assert.AreEqual(1, xDocumentCategories?[2]?.Elements("subcat").ToList().Count);
+            Assert.AreEqual("100044", xDocumentCategories?[3].Attribute("id")?.Value);
+            Assert.AreEqual(0, xDocumentCategories?[3]?.Elements("subcat").ToList().Count);
+            Assert.AreEqual("100040", xDocumentCategories?[4].Attribute("id")?.Value);
+            Assert.AreEqual(0, xDocumentCategories?[4]?.Elements("subcat").ToList().Count);
         }
 
         [Test]
@@ -473,7 +467,7 @@ namespace Jackett.Test.Common.Models
             Assert.IsEmpty(res.MovieSearchParams);
             Assert.IsEmpty(res.MusicSearchParams);
             Assert.IsEmpty(res.BookSearchParams);
-            Assert.IsEmpty(res.Categories.GetTorznabCategories());
+            Assert.IsEmpty(res.Categories.GetTorznabCategoryTree());
 
             torznabCaps1 = new TorznabCapabilities
             {
@@ -502,7 +496,7 @@ namespace Jackett.Test.Common.Models
             Assert.True(res.MovieSearchParams.Count == 2);
             Assert.True(res.MusicSearchParams.Count == 2);
             Assert.True(res.BookSearchParams.Count == 2);
-            Assert.True(res.Categories.GetTorznabCategories().Count == 3); // only CustomCat2 is removed
+            Assert.True(res.Categories.GetTorznabCategoryTree().Count == 3); // only CustomCat2 is removed
         }
     }
 }

--- a/src/Jackett.Test/TestHelpers/TestCategories.cs
+++ b/src/Jackett.Test/TestHelpers/TestCategories.cs
@@ -1,4 +1,6 @@
+using System.Collections.Generic;
 using Jackett.Common.Models;
+using NUnit.Framework;
 
 namespace Jackett.Test.TestHelpers
 {
@@ -11,12 +13,24 @@ namespace Jackett.Test.TestHelpers
             // - with and without description
             // - parent and child categories
             // - custom categories are not added automatically but they are created from other categories automatically
+            // - categories and subcategories are unsorted to test the sort when required
             tcc.AddCategoryMapping("1", TorznabCatType.Movies);
             tcc.AddCategoryMapping("mov_sd", TorznabCatType.MoviesSD);
             tcc.AddCategoryMapping("33", TorznabCatType.BooksComics);
             tcc.AddCategoryMapping("44", TorznabCatType.ConsoleXBox, "Console/Xbox_c");
             tcc.AddCategoryMapping("con_wii", TorznabCatType.ConsoleWii, "Console/Wii_c");
-            tcc.AddCategoryMapping("45", TorznabCatType.ConsoleXBox, "Console/Xbox_c2");
+            tcc.AddCategoryMapping("40", TorznabCatType.ConsoleXBox, "Console/Xbox_c2");
+        }
+
+        public static void CompareCategoryTrees(List<TorznabCategory> tree1, List<TorznabCategory> tree2)
+        {
+            Assert.AreEqual(tree1.Count, tree2.Count);
+            for (var i = 0; i < tree1.Count; i++)
+            {
+                Assert.AreEqual(tree1[i].ID, tree2[i].ID);
+                Assert.AreEqual(tree1[i].Name, tree2[i].Name);
+                CompareCategoryTrees(tree1[i].SubCategories, tree2[i].SubCategories);
+            }
         }
     }
 }


### PR DESCRIPTION
* Core: Categories are stored in a real tree
* Sorting: First Torznab categories sorted by Id and then custom cats sorted by Name
* Filtering: Results with child category are not removed when searching by parent category. Details in #8049
* Jacket UI: Add parent category when at least one child category exists
* Torznab (caps): Remove non existent children categories. Remove duplicated categories. Details in #10006