### PR TITLE
Fix for iptorrents website update with 'by <group>'

### DIFF
--- a/src/Jackett.Common/Indexers/IPTorrents.cs
+++ b/src/Jackett.Common/Indexers/IPTorrents.cs
@@ -221,7 +221,7 @@ namespace Jackett.Common.Indexers
                     var link = new Uri(SiteLink + qLink.GetAttribute("href").TrimStart('/'));
 
                     var descrSplit = row.QuerySelector("div.sub").TextContent.Split('|');
-                    var publishDate = DateTimeUtil.FromTimeAgo(descrSplit.Last());
+                    var publishDate = DateTimeUtil.FromTimeAgo(descrSplit.Last().Substring(0, descrSplit.Last().LastIndexOf("by") + 1));
                     var description = descrSplit.Length > 1 ? "Tags: " + descrSplit.First().Trim() : "";
 
                     var catIcon = row.QuerySelector("td:nth-of-type(1) a");


### PR DESCRIPTION
This removes everything after the 'by <group>' page additions that IPT released.