### PR TITLE
core: add custom cats in indexers with string categories. resolves #9746

### DIFF
--- a/src/Jackett.Common/Indexers/BaseIndexer.cs
+++ b/src/Jackett.Common/Indexers/BaseIndexer.cs
@@ -266,16 +266,8 @@ namespace Jackett.Common.Indexers
             if (query.Categories.Length == 0)
                 return results;
 
-            // TODO: move this code to TorznabCapabilitiesCategories and use indexer tree instead of general
             // expand parent categories from the query
-            var expandedQueryCats = new List<int>();
-            foreach (var queryCategory in query.Categories)
-            {
-                expandedQueryCats.Add(queryCategory);
-                var parentCat = TorznabCatType.ParentCats.FirstOrDefault(c => c.ID == queryCategory);
-                if (parentCat != null)
-                    expandedQueryCats.AddRange(parentCat.SubCategories.Select(c => c.ID));
-            }
+            var expandedQueryCats = TorznabCaps.Categories.ExpandTorznabQueryCategories(query);
 
             var filteredResults = results.Where(result =>
                 result.Category?.Any() != true ||

--- a/src/Jackett.Common/Indexers/SolidTorrents.cs
+++ b/src/Jackett.Common/Indexers/SolidTorrents.cs
@@ -69,18 +69,18 @@ namespace Jackett.Common.Indexers
             Language = "en-us";
             Type = "public";
 
-            AddCategoryMapping("Audio", TorznabCatType.Audio);
-            AddCategoryMapping("Video", TorznabCatType.Movies);
-            AddCategoryMapping("Image", TorznabCatType.OtherMisc);
-            AddCategoryMapping("Document", TorznabCatType.BooksComics);
-            AddCategoryMapping("eBook", TorznabCatType.BooksEBook);
-            AddCategoryMapping("Program", TorznabCatType.PC0day);
-            AddCategoryMapping("Android", TorznabCatType.PCMobileAndroid);
-            AddCategoryMapping("Archive", TorznabCatType.Other);
-            AddCategoryMapping("Diskimage", TorznabCatType.PCISO);
-            AddCategoryMapping("Sourcecode", TorznabCatType.MoviesOther);
-            AddCategoryMapping("Database", TorznabCatType.MoviesDVD);
-            AddCategoryMapping("Unknown", TorznabCatType.Other);
+            AddCategoryMapping("Audio", TorznabCatType.Audio, "Audio");
+            AddCategoryMapping("Video", TorznabCatType.Movies, "Video");
+            AddCategoryMapping("Image", TorznabCatType.OtherMisc, "Image");
+            AddCategoryMapping("Document", TorznabCatType.BooksComics, "Document");
+            AddCategoryMapping("eBook", TorznabCatType.BooksEBook, "eBook");
+            AddCategoryMapping("Program", TorznabCatType.PC0day, "Program");
+            AddCategoryMapping("Android", TorznabCatType.PCMobileAndroid, "Android");
+            AddCategoryMapping("Archive", TorznabCatType.Other, "Archive");
+            AddCategoryMapping("Diskimage", TorznabCatType.PCISO, "Diskimage");
+            AddCategoryMapping("Sourcecode", TorznabCatType.MoviesOther, "Sourcecode");
+            AddCategoryMapping("Database", TorznabCatType.MoviesDVD, "Database");
+            AddCategoryMapping("Unknown", TorznabCatType.Other, "Unknown");
         }
 
         public override async Task<IndexerConfigurationStatus> ApplyConfiguration(JToken configJson)

--- a/src/Jackett.Test/Common/Indexers/BaseWebIndexerTests.cs
+++ b/src/Jackett.Test/Common/Indexers/BaseWebIndexerTests.cs
@@ -45,6 +45,7 @@ namespace Jackett.Test.Common.Indexers
         public void TestFilterResults()
         {
             var indexer = new TestWebIndexer();
+            indexer.AddTestCategories();
             var results = new List<ReleaseInfo>
             {
                 new ReleaseInfo
@@ -59,12 +60,16 @@ namespace Jackett.Test.Common.Indexers
                 {
                     Category = new List<int> { TorznabCatType.BooksEBook.ID, 100004 } // torznab (mandatory) + custom cat
                 },
+                new ReleaseInfo
+                {
+                    Category = new List<int> { TorznabCatType.AudioLossless.ID } // unsupported category in this indexer
+                },
                 new ReleaseInfo()
             };
 
             var query = new TorznabQuery(); // without categories
             var filteredResults = indexer._FilterResults(query, results).ToList();
-            Assert.AreEqual(4, filteredResults.Count);
+            Assert.AreEqual(5, filteredResults.Count);
 
             query = new TorznabQuery // with child category
             {
@@ -148,11 +153,9 @@ namespace Jackett.Test.Common.Indexers
             indexer.AddTestCategories();
 
             // you can find more complex tests in TorznabCapabilitiesCategoriesTests.cs
-            // TODO: this is wrong, custom cat 100001 doesn't exists (it's not defined by us)
             var torznabCats = indexer._MapTrackerCatToNewznab("1").ToList();
-            Assert.AreEqual(2, torznabCats.Count);
+            Assert.AreEqual(1, torznabCats.Count);
             Assert.AreEqual(2000, torznabCats[0]);
-            Assert.AreEqual(100001, torznabCats[1]);
         }
 
         [Test]
@@ -163,8 +166,9 @@ namespace Jackett.Test.Common.Indexers
 
             // you can find more complex tests in TorznabCapabilitiesCategoriesTests.cs
             var torznabCats = indexer._MapTrackerCatDescToNewznab("Console/Wii_c").ToList();
-            Assert.AreEqual(1, torznabCats.Count);
+            Assert.AreEqual(2, torznabCats.Count);
             Assert.AreEqual(1030, torznabCats[0]);
+            Assert.AreEqual(137107, torznabCats[1]);
         }
     }
 }

--- a/src/Jackett.Test/Common/Indexers/CardigannIndexerTests.cs
+++ b/src/Jackett.Test/Common/Indexers/CardigannIndexerTests.cs
@@ -99,6 +99,7 @@ namespace Jackett.Test.Common.Indexers
                 TorznabCatType.Books.CopyWithoutSubCategories(),
                 TorznabCatType.Console.CopyWithoutSubCategories(),
                 new TorznabCategory(100044, "Console/Xbox_c"),
+                new TorznabCategory(137107, "Console/Wii_c"),
                 new TorznabCategory(100045, "Console/Xbox_c2")
             };
             expected[0].SubCategories.Add(TorznabCatType.MoviesSD.CopyWithoutSubCategories());

--- a/src/Jackett.Test/Common/Models/DTO/IndexerTests.cs
+++ b/src/Jackett.Test/Common/Models/DTO/IndexerTests.cs
@@ -37,7 +37,7 @@ namespace Jackett.Test.Common.Models.DTO
             // test Jackett UI categories (internal JSON)
             var dto = new Indexer(indexer);
             var dtoCaps = dto.caps.ToList();
-            Assert.AreEqual(9, dtoCaps.Count);
+            Assert.AreEqual(10, dtoCaps.Count);
             Assert.AreEqual("1000", dtoCaps[0].ID);
             Assert.AreEqual("1030", dtoCaps[1].ID);
             Assert.AreEqual("1040", dtoCaps[2].ID);
@@ -45,8 +45,9 @@ namespace Jackett.Test.Common.Models.DTO
             Assert.AreEqual("2030", dtoCaps[4].ID);
             Assert.AreEqual("7000", dtoCaps[5].ID);
             Assert.AreEqual("7030", dtoCaps[6].ID);
-            Assert.AreEqual("100044", dtoCaps[7].ID);
-            Assert.AreEqual("100040", dtoCaps[8].ID);
+            Assert.AreEqual("137107", dtoCaps[7].ID);
+            Assert.AreEqual("100044", dtoCaps[8].ID);
+            Assert.AreEqual("100040", dtoCaps[9].ID);
 
             // movies categories enable potato search
             Assert.True(dto.potatoenabled);

--- a/src/Jackett.Test/Common/Models/TorznabCapabilitiesTests.cs
+++ b/src/Jackett.Test/Common/Models/TorznabCapabilitiesTests.cs
@@ -442,17 +442,19 @@ namespace Jackett.Test.Common.Models
             // test Torznab caps (XML) => more in Common.Model.TorznabCapabilitiesTests
             var xDocument = torznabCaps.GetXDocument();
             var xDocumentCategories = xDocument.Root?.Element("categories")?.Elements("category").ToList();
-            Assert.AreEqual(5, xDocumentCategories?.Count);
+            Assert.AreEqual(6, xDocumentCategories?.Count);
             Assert.AreEqual("1000", xDocumentCategories?[0].Attribute("id")?.Value);
             Assert.AreEqual(2, xDocumentCategories?[0]?.Elements("subcat").ToList().Count);
             Assert.AreEqual("2000", xDocumentCategories?[1].Attribute("id")?.Value);
             Assert.AreEqual(1, xDocumentCategories?[1]?.Elements("subcat").ToList().Count);
             Assert.AreEqual("7000", xDocumentCategories?[2].Attribute("id")?.Value);
             Assert.AreEqual(1, xDocumentCategories?[2]?.Elements("subcat").ToList().Count);
-            Assert.AreEqual("100044", xDocumentCategories?[3].Attribute("id")?.Value);
+            Assert.AreEqual("137107", xDocumentCategories?[3].Attribute("id")?.Value);
             Assert.AreEqual(0, xDocumentCategories?[3]?.Elements("subcat").ToList().Count);
-            Assert.AreEqual("100040", xDocumentCategories?[4].Attribute("id")?.Value);
+            Assert.AreEqual("100044", xDocumentCategories?[4].Attribute("id")?.Value);
             Assert.AreEqual(0, xDocumentCategories?[4]?.Elements("subcat").ToList().Count);
+            Assert.AreEqual("100040", xDocumentCategories?[5].Attribute("id")?.Value);
+            Assert.AreEqual(0, xDocumentCategories?[5]?.Elements("subcat").ToList().Count);
         }
 
         [Test]

--- a/src/Jackett.Test/TestHelpers/TestCategories.cs
+++ b/src/Jackett.Test/TestHelpers/TestCategories.cs
@@ -10,7 +10,7 @@ namespace Jackett.Test.TestHelpers
         {
             // these categories are chosen to test all kind of category types:
             // - with integer and string id
-            // - with and without description
+            // - with and without description (with description we generate custom cats)
             // - parent and child categories
             // - custom categories are not added automatically but they are created from other categories automatically
             // - categories and subcategories are unsorted to test the sort when required


### PR DESCRIPTION
* When category ids in the indexer are "strings" we create a unique hash to make it compatible with Torznab
* This PR also fix several issues related to custom cats