### PR TITLE
torrentproject2: change search, add categorymappings

### DIFF
--- a/src/Jackett.Common/Definitions/torrentproject2.yml
+++ b/src/Jackett.Common/Definitions/torrentproject2.yml
@@ -17,28 +17,16 @@ legacylinks:
   - https://torrentproject.cc/
 
 caps:
-  categories:
-    "video tv": TV
-    "video dvd": Movies/SD
-    "Video Dvdrip": Movies/SD
-    "video hdrip": Movies/HD
-    "Video Lq": Movies/Foreign
-    "audio mp3": Audio/MP3
-    "audio lossless": Audio/Lossless
-    video: Movies
-    ebooks: Books/EBook
-    "Ebooks Comics": Books/Comics
-    "Ebooks Magazines": Other
-    "Ebooks Audiobook": Audio/Audiobook
-    "Ebooks Tutorials": Books/EBook
-    "Games PC": PC/Games
-    "Games Nintendo": Console
-    "Games PlayStation": Console
-    "Games XBox": Console/XBox
-    Mobile: PC/Mobile-Other
-    Applications: PC
-    Images: Other
-    Other: Other
+  categorymappings:
+    - {id: Movies, cat: Movies, desc: Movies}
+    - {id: Music, cat: Audio, desc: Music}
+    - {id: Apps, cat: PC/0day, desc: Apps}
+    - {id: Mobile, cat: PC/Mobile-Other, desc: Mobile}
+    - {id: Games, cat: PC/Games, desc: Games}
+    - {id: TV, cat: TV, desc: TV}
+    - {id: Documentaries, cat: TV/Documentary, desc: Documentaries}
+    - {id: XXX, cat: XXX, desc: XXX}
+    - {id: Other, cat: Other, desc: Other}
 
   modes:
     search: [q]
@@ -61,10 +49,6 @@ settings:
       oldest: "created asc"
       seeders: seeders
       size: size
-  - name: info_8000
-    type: info
-    label: About TorrentProject2 Categories
-    default: TorrentProject2 does not return categories in its search results page. To add to Sonarr or Radarr replace all categories with 8000(Other).
 
 download:
   selector: "#download > div:nth-child(2) > div:nth-child(1) > a"
@@ -78,8 +62,8 @@ download:
 
 search:
   paths:
-    - path: "?t={{ if .Keywords }}{{ re_replace .Keywords \" \" \"+\" }}{{ else }}test{{ end }}&orderby={{ .Config.sort }}{{ if .Config.filter-verified }}&safe=on{{ else }}{{ end }}"
-      followredirect: true
+    - path: "browse?t={{ if .Keywords }}{{ re_replace .Keywords \" \" \"+\" }}{{ else }}{{ end }}&orderby={{ .Config.sort }}{{ if .Config.filter-verified }}&safe=on{{ else }}{{ end }}"
+    - path: "browse?t={{ if .Keywords }}{{ re_replace .Keywords \" \" \"+\" }}{{ else }}{{ end }}&orderby={{ .Config.sort }}{{ if .Config.filter-verified }}&safe=on{{ else }}{{ end }}&p=1"
 
   rows:
     selector: "#similarfiles div:has(a[href^=\"/t\"])"


### PR DESCRIPTION
Cats can be shown in results by searching using `/browse?t=`.

I have likely missed some, so feel free to double check, but that's all I could find.

Keywordless search gives 50 results per page, but keyword search only gives 20, meaning you get 100 for an update in Sonarr/Radarr/*arr, but only 40 for a search. Not sure whether to bump that up with another page or not.

It's also possible to search by cat on the site, e.g.  `/browse?t=2020 type:music`, but it's not always consistent with the cat id - music, movies, games, xxx, and other all work, but apps is type:applications, and I have no idea what they're using for TV (or documentaries, or mobile). So yea, basically I didn't add that as I couldn't figure it out.