### PR TITLE
Fix auth check for shizaproject

### DIFF
--- a/src/Jackett.Common/Indexers/ShizaProject.cs
+++ b/src/Jackett.Common/Indexers/ShizaProject.cs
@@ -78,8 +78,7 @@ namespace Jackett.Common.Indexers
 
             await ConfigureIfOK(result.Cookies, IsAuthorized(result), () =>
             {
-                const string ErrorSelector = "div.card-content > div.alert-error";
-                var errorMessage = document.QuerySelector(ErrorSelector).Text().Trim();
+                var errorMessage = document.QuerySelector("div.alert-error").Text().Trim();
                 throw new ExceptionWithConfigData(errorMessage, Configuration);
             });
 
@@ -194,7 +193,7 @@ namespace Jackett.Common.Indexers
         private bool IsAuthorized(WebResult result) {
             var parser = new HtmlParser();
             var document = parser.ParseDocument(result.ContentString);
-            return document.QuerySelector("div.header-content > div.profile-menu") != null;
+            return document.QuerySelector("div.profile-menu > a").Attributes["href"].Value.EndsWith("/logout");
         }
 
         private static long getReleaseSize(IElement tr)


### PR DESCRIPTION
Fixes auth check for shizaproject indexer.

Suddenly for now I can't make errorMessage printing work.
During curl requests (with invalid auth) I gets 200 (as in browser) and html. But Jackett gets 302 in this case, I have no idea for now.
/fix #10160