### PR TITLE
assorted: add torrentbay proxies

### DIFF
--- a/src/Jackett.Common/Definitions/demonoid.yml
+++ b/src/Jackett.Common/Definitions/demonoid.yml
@@ -11,6 +11,7 @@ links:
   - https://www.dnoid.to/
   - https://www.dnoid.pw/
   - https://demonoid.unblockit.app/
+  - https://demonoid.torrentbay.to/
 legacylinks:
   - https://demonoid.unblockit.pro/
   - https://demonoid.unblockit.one/

--- a/src/Jackett.Common/Definitions/exttorrents.yml
+++ b/src/Jackett.Common/Definitions/exttorrents.yml
@@ -8,8 +8,9 @@ encoding: UTF-8
 links:
   - https://ext.to/
   - https://torrent.extto.com/
+  - https://ext.torrentbay.to/
 legacylinks:
-  - https://ext.unblockninja.com/ # currently redirects to https://ext.to/
+  - https://ext.unblockninja.com/ # currently redirects to https://ext.torrentbay.to/
   - https://t.extto.com/ # redirects to https://torrent.extto.com/
 
 caps:
@@ -84,6 +85,9 @@ download:
 search:
   paths:
     - path: "{{ if .Keywords }}search/?q={{ .Keywords }}&{{ else }}latest/?{{ end }}order={{ .Config.sort }}&sort={{ .Config.type }}"
+    - path: "{{ if .Keywords }}search/?q={{ .Keywords }}/2/&{{ else }}latest/2/?{{ end }}order={{ .Config.sort }}&sort={{ .Config.type }}"
+    - path: "{{ if .Keywords }}search/?q={{ .Keywords }}/3/&{{ else }}latest/3/?{{ end }}order={{ .Config.sort }}&sort={{ .Config.type }}"
+    - path: "{{ if .Keywords }}search/?q={{ .Keywords }}/4/&{{ else }}latest/4/?{{ end }}order={{ .Config.sort }}&sort={{ .Config.type }}"
 
   rows:
     selector: table.table-striped > tbody > tr

--- a/src/Jackett.Common/Definitions/ilcorsaronero.yml
+++ b/src/Jackett.Common/Definitions/ilcorsaronero.yml
@@ -10,6 +10,7 @@ links:
   - https://ilcorsaronero.link/
   - https://ilcorsaronero.fun/
   - https://ilcorsaronero.pro/
+  - https://ilcorsaronero.torrentbay.to/
 legacylinks:
   - https://ilcorsaronero.live/
   - https://ilcorsaronero.vip/
@@ -22,7 +23,7 @@ legacylinks:
   - https://ilcorsaronero.unblockit.one/
   - https://ilcorsaronero.xyz/
   - https://ilcorsaronero.unblockit.me/
-  - https://ilcorsaronero.unblockit.pw/ # not working, likely to be removed soon
+  - https://ilcorsaronero.unblockit.pw/
 
 caps:
   categorymappings:
@@ -60,9 +61,6 @@ search:
     - path: "{{ if .Keywords }}advsearch.php?&category={{ range .Categories }}{{.}};{{end}}&search={{ .Keywords }}&order=data&by=DESC&page=0{{ else }}/browse/0{{ end }}"
     - path: "{{ if .Keywords }}advsearch.php?&category={{ range .Categories }}{{.}};{{end}}&search={{ .Keywords }}&order=data&by=DESC&page=1{{ else }}/browse/1{{ end }}"
     - path: "{{ if .Keywords }}advsearch.php?&category={{ range .Categories }}{{.}};{{end}}&search={{ .Keywords }}&order=data&by=DESC&page=2{{ else }}/browse/2{{ end }}"
-    - path: "{{ if .Keywords }}advsearch.php?&category={{ range .Categories }}{{.}};{{end}}&search={{ .Keywords }}&order=data&by=DESC&page=3{{ else }}/browse/3{{ end }}"
-    - path: "{{ if .Keywords }}advsearch.php?&category={{ range .Categories }}{{.}};{{end}}&search={{ .Keywords }}&order=data&by=DESC&page=4{{ else }}/browse/4{{ end }}"
-    - path: "{{ if .Keywords }}advsearch.php?&category={{ range .Categories }}{{.}};{{end}}&search={{ .Keywords }}&order=data&by=DESC&page=5{{ else }}/browse/5{{ end }}"
   keywordsfilters:
     - name: re_replace # S01 to 1
       args: ["(?i)\\bS0*(\\d+)\\b", "$1"]


### PR DESCRIPTION
TorrentBay and Unblock Ninja seem to be related in some way, so just using the proxies not included or working on Unblock Ninja:
- https://ext.unblockninja.com/ redirects to https://ext.torrentbay.to/
- https://torrent9.torrentbay.to/ has Unblock Ninja in its title

The proxy for TorrentProject is for https://torrentproject.to/ which is a separate site.

Also added 3 more results pages to EXT (25 per, now 100 total), and removed 3 from Il Corsaro Nero (40 per, now 120 total).