### PR TITLE
torrent9: remove *.li domain

### DIFF
--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -84,16 +84,17 @@ settings:
   - name: sort
     type: select
     label: Sort requested from site (Only works for searches with Keywords)
-    default: ?trie-date-d
+    default: ".html"
     options:
-      ?trie-date-d: created desc
-      ?trie-date-a: created asc
-      ?trie-seeds-d: seeders desc
-      ?trie-seeds-a: seeders asc
-      ?trie-poid-d: size desc
-      ?trie-poid-a: size asc
-      ?trie-nom-d: title desc
-      ?trie-nom-a: title asc
+      ".html": best
+      ".html,trie-date-d": created desc
+      ".html,trie-date-a": created asc
+      ".html,trie-seeds-d": seeders desc
+      ".html,trie-seeds-a": seeders asc
+      ".html,trie-poid-d": size desc
+      ".html,trie-poid-a": size asc
+      ".html,trie-nom-d": title desc
+      ".html,trie-nom-a": title asc
   - name: info_131681
     type: info
     label: About Torrent9 Categories
@@ -105,13 +106,15 @@ download:
 
 search:
   paths:
-    - path: "{{ if .Keywords }}/search_torrent/{{ .Keywords }}{{ .Config.sort }}{{ else }}/top_torrent/{{ end }}"
+    - path: "{{ if .Keywords }}/search_torrent/{{ .Keywords }}{{ .Config.sort }}{{ else }}/top_torrent.html{{ end }}"
   keywordsfilters:
     # if searching for season packs with S01 to saison 1 #9712
     - name: re_replace
       args: ["(?i)(S0)(\\d{1,2})$", "saison $2"]
     - name: re_replace
       args: ["(?i)(S)(\\d{1,3})$", "saison $2"]
+    - name: replace
+      args: [" ", "-"]
 
   rows:
     selector: table.table-striped > tbody > tr
@@ -179,7 +182,6 @@ search:
     size:
       selector: td:nth-child(2)
       filters:
-        # support for proxies
         - name: replace
           args: ["Ko", "KB"]
         - name: replace

--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -7,8 +7,8 @@ type: public
 encoding: UTF-8
 followredirect: true
 links:
-  - https://www.torrent9.gg/
   - https://torrent9.to/
+  - https://www.torrent9.gg/
   - https://torrent9.unblockninja.com/
   - https://www.oxtorrent.me/
 

--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -10,7 +10,6 @@ links:
   - https://www.oxtorrent.me/
   - https://www.torrent9.gg/
   - https://torrent9.to/
-  - https://torrent9.li/
   - https://torrent9.unblockninja.com/
 
 legacylinks:
@@ -43,6 +42,7 @@ legacylinks:
   - https://ww1.torrent9.is/
   - https://ww1.torrent9.to/
   - https://www.torrent9.is/
+  - https://torrent9.li/ # not a proxy for torrent9 or torrent9clone
 
 caps:
   categorymappings:
@@ -188,9 +188,6 @@ search:
           args: ["Go", "GB"]
         - name: replace
           args: ["To", "TB"]
-        # support for search with keywords on *.li which returns sizes nnnnn.n without unit indicator.
-        - name: re_replace
-          args: ["(\\d+)\\.\\d(?!KB|MB|GB|TB)", "$1 MB"]
     seeders:
       text: 0
     seeders:

--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -7,10 +7,10 @@ type: public
 encoding: UTF-8
 followredirect: true
 links:
-  - https://www.oxtorrent.me/
   - https://www.torrent9.gg/
   - https://torrent9.to/
   - https://torrent9.unblockninja.com/
+  - https://www.oxtorrent.me/
 
 legacylinks:
   - http://www.torrent9.ec/


### PR DESCRIPTION
Relates to https://github.com/Jackett/Jackett/commit/e2defbcb839006d7daa9a46e542140804e559398

https://torrent9.to/search_torrent/bad-boys-for-life.html,trie-date-d
and
https://torrent9.to/search_torrent/bad%20boys%20for%20life%3Ftrie-date-d
return the same results (same for .gg and .me)

The only issues are with
https://torrent9.to/search_torrent/bad-boys-for-life,trie-date-d
and
https://torrent9.to/search_torrent/bad%20boys%20for%20life%2Ctrie-date-d
which include `,trie-date-d` in the search term (same for .gg and .me)