### PR TITLE
assorted yml: code tidy

### DIFF
--- a/src/Jackett.Common/Definitions/amigosshare.yml
+++ b/src/Jackett.Common/Definitions/amigosshare.yml
@@ -166,7 +166,7 @@ search:
     order: "{{ .Config.type }}"
   # torrents-search.php does not support imdbid search or return imdb links.
   keywordsfilters:
-  # drop the year from searches since site titles do not include year
+    # drop the year from searches since site titles do not include year
     - name: re_replace
       args: ["(19|20[0-9]{2})", ""]
 

--- a/src/Jackett.Common/Definitions/haidan.yml
+++ b/src/Jackett.Common/Definitions/haidan.yml
@@ -142,7 +142,7 @@ search:
       optional: true
       filters:
         - name: append
-          args: " +08:00" #CST
+          args: " +08:00" # CST
         - name: dateparse
           args: "2006-01-02 15:04:05 -07:00"
     date:

--- a/src/Jackett.Common/Definitions/pirateiro.yml
+++ b/src/Jackett.Common/Definitions/pirateiro.yml
@@ -84,7 +84,7 @@ search:
       attribute: title
       filters:
         - name: append
-          args: " +01:00" #CET
+          args: " +01:00" # CET
         - name: dateparse
           args: "02/01/2006 15:04:05 -07:00"
     size:

--- a/src/Jackett.Common/Definitions/tjupt.yml
+++ b/src/Jackett.Common/Definitions/tjupt.yml
@@ -78,7 +78,7 @@ login:
 
 search:
   paths:
-     # https://tjupt.org/torrents.php?incldead=0&spstate=0&picktype=0&inclbookmarked=0&search=&search_area=0&search_mode=0
+    # https://tjupt.org/torrents.php?incldead=0&spstate=0&picktype=0&inclbookmarked=0&search=&search_area=0&search_mode=0
     - path: torrents.php
   inputs:
     $raw: "{{ range .Categories }}cat{{.}}=1&{{end}}"

--- a/src/Jackett.Common/Definitions/wdt.yml
+++ b/src/Jackett.Common/Definitions/wdt.yml
@@ -108,7 +108,7 @@ search:
   paths:
     # https://ultimatewrestlingtorrents.com/browse.php?search=&searchin=title&incldead=0&only_free=1
     # note: site uses the catsX[]=nn method which cardigann does not support. without the cats the site returns nothing. so we hardcode all cats.
-   #  https://ultimatewrestlingtorrents.com/browse.php?cats3[]=14&cats3[]=16&cats3[]=13&cats3[]=15&cats5[]=29&cats5[]=28&cats5[]=30&cats5[]=18&cats1[]=34&cats1[]=9&cats1[]=33&cats6[]=32&cats6[]=31&cats6[]=20&cats7[]=19&cats7[]=35&cats7[]=36&cats2[]=37&cats2[]=38&cats2[]=12&cats2[]=40&cats2[]=44&cats2[]=11&cats2[]=42&cats2[]=43&cats2[]=21&cats2[]=22&cats2[]=41&cats2[]=10&cats4[]=26&cats4[]=24&cats4[]=27&cats4[]=17&cats4[]=23&cats4[]=25&search=&searchin=title&incldead=1
+    # https://ultimatewrestlingtorrents.com/browse.php?cats3[]=14&cats3[]=16&cats3[]=13&cats3[]=15&cats5[]=29&cats5[]=28&cats5[]=30&cats5[]=18&cats1[]=34&cats1[]=9&cats1[]=33&cats6[]=32&cats6[]=31&cats6[]=20&cats7[]=19&cats7[]=35&cats7[]=36&cats2[]=37&cats2[]=38&cats2[]=12&cats2[]=40&cats2[]=44&cats2[]=11&cats2[]=42&cats2[]=43&cats2[]=21&cats2[]=22&cats2[]=41&cats2[]=10&cats4[]=26&cats4[]=24&cats4[]=27&cats4[]=17&cats4[]=23&cats4[]=25&search=&searchin=title&incldead=1
     - path: browse.php
   inputs:
     $raw: "cats3[]=14&cats3[]=16&cats3[]=13&cats3[]=15&cats5[]=29&cats5[]=28&cats5[]=30&cats5[]=18&cats1[]=34&cats1[]=9&cats1[]=33&cats6[]=32&cats6[]=31&cats6[]=20&cats7[]=19&cats7[]=35&cats7[]=36&cats2[]=37&cats2[]=38&cats2[]=12&cats2[]=40&cats2[]=44&cats2[]=11&cats2[]=42&cats2[]=43&cats2[]=21&cats2[]=22&cats2[]=41&cats2[]=10&cats4[]=26&cats4[]=24&cats4[]=27&cats4[]=17&cats4[]=23&cats4[]=25"

--- a/src/Jackett.Common/Definitions/ydypt.yml
+++ b/src/Jackett.Common/Definitions/ydypt.yml
@@ -77,7 +77,7 @@ login:
 
 search:
   paths:
-     # https://pt.hdbd.us/torrents.php?incldead=0&spstate=0&picktype=0&inclbookmarked=0&search=&search_area=0&search_mode=0
+    # https://pt.hdbd.us/torrents.php?incldead=0&spstate=0&picktype=0&inclbookmarked=0&search=&search_area=0&search_mode=0
     - path: torrents.php
   inputs:
     $raw: "{{ range .Categories }}cat{{.}}=1&{{end}}"


### PR DESCRIPTION
lint

I take it where lines are commented out at the first character, e.g. https://github.com/Jackett/Jackett/blob/2be45b6c9dacc068e6693600e8663b1ac76c3652/src/Jackett.Common/Definitions/darktracker.yml#L745-L760 we ignore the lint warning?