### PR TITLE
Revert "divteam: drop pinned results resolves #10196"

### DIFF
--- a/src/Jackett.Common/Definitions/divteam.yml
+++ b/src/Jackett.Common/Definitions/divteam.yml
@@ -115,7 +115,7 @@ search:
     # does not support imdbid search and does not supply imdb link in results.
 
   rows:
-    selector: table.table.table-bordered > tbody > tr:has(a[href^="download.php?id="]):not(:has(td[style*="background-color"]))
+    selector: table.table.table-bordered > tbody > tr:has(a[href^="download.php?id="])
 
   fields:
     download:


### PR DESCRIPTION
Related to issue #10196

A result can be highlighted or not, but not both. When a search is performed and the item is highlighted, it is not currently displayed as a result. Roll back to find a way to filter only when empty search is performed.

In the empty search, the highlighted elements should also be shown but only if their date is less than the last element to show according to the number of elements that the user has selected to show. Not trivial.

This reverts commit e74b64d4117c087c78e8cf633614a3d320b4edb4.