### PR TITLE
assorted: correct MST and MR

### DIFF
--- a/src/Jackett.Common/Definitions/brasiltracker.yml
+++ b/src/Jackett.Common/Definitions/brasiltracker.yml
@@ -133,8 +133,8 @@ search:
         - name: append
           args: " {{ .Result.title_details }}"
     minimumratio:
-      text: 0.6
+      text: 1.0
     minimumseedtime:
-      # 3 days (as seconds = 3 x 24 x 60 x 60)
-      text: 259200
+      # 2 days (as seconds = 2 x 24 x 60 x 60)
+      text: 172800
 # Project Gazelle

--- a/src/Jackett.Common/Definitions/gigatorrents.yml
+++ b/src/Jackett.Common/Definitions/gigatorrents.yml
@@ -165,6 +165,9 @@ search:
       filters:
         - name: trim
           args: "x"
+    minimumseedtime:
+      # 2 days (as seconds = 2 x 24 x 60 x 60)
+      text: 172800
     date:
       selector: td:nth-child(2)
       remove: a

--- a/src/Jackett.Common/Definitions/gigatorrents.yml
+++ b/src/Jackett.Common/Definitions/gigatorrents.yml
@@ -165,6 +165,8 @@ search:
       filters:
         - name: trim
           args: "x"
+    minimumratio:
+      text: 0.5
     minimumseedtime:
       # 2 days (as seconds = 2 x 24 x 60 x 60)
       text: 172800

--- a/src/Jackett.Common/Definitions/greekdiamond.yml
+++ b/src/Jackett.Common/Definitions/greekdiamond.yml
@@ -182,4 +182,7 @@ search:
       text: 1
     minimumratio:
       text: 1.0
+    minimumseedtime:
+      # 3 days (as seconds = 3 x 24 x 60 x 60)
+      text: 259200
 # xbtit dt fm v20.0

--- a/src/Jackett.Common/Definitions/hddisk.yml
+++ b/src/Jackett.Common/Definitions/hddisk.yml
@@ -165,6 +165,8 @@ search:
         img.pro_free2up: 2
         img.pro_2up: 2
         "*": 1
+    minimumratio:
+      text: 0.8
     description:
       selector: td:nth-child(2)
       remove: a, img

--- a/src/Jackett.Common/Definitions/hdzone.yml
+++ b/src/Jackett.Common/Definitions/hdzone.yml
@@ -191,6 +191,11 @@ search:
         img.pro_free2up: 2
         img.pro_2up: 2
         "*": 1
+    minimumratio:
+      text: 1.2
+    minimumseedtime:
+      # 14 days (as seconds = 2 x 24 x 60 x 60)
+      text: 1209600
     description:
       selector: td:nth-child(2)
       remove: a, img

--- a/src/Jackett.Common/Definitions/hdzone.yml
+++ b/src/Jackett.Common/Definitions/hdzone.yml
@@ -193,9 +193,10 @@ search:
         "*": 1
     minimumratio:
       text: 1.2
-    minimumseedtime:
-      # 14 days (as seconds = 2 x 24 x 60 x 60)
-      text: 1209600
+# does not appear to be implemented, no h&r tag found
+#     minimumseedtime:
+#       # 14 days (as seconds = 2 x 24 x 60 x 60)
+#       text: 1209600
     description:
       selector: td:nth-child(2)
       remove: a, img

--- a/src/Jackett.Common/Definitions/polishsource.yml
+++ b/src/Jackett.Common/Definitions/polishsource.yml
@@ -158,4 +158,7 @@ search:
       text: 0
     uploadvolumefactor:
       text: 1
+    minimumseedtime:
+      # 2 days (as seconds = 2 x 24 x 60 x 60)
+      text: 172800
 # engine n/a

--- a/src/Jackett.Common/Definitions/uniongang.yml
+++ b/src/Jackett.Common/Definitions/uniongang.yml
@@ -120,4 +120,6 @@ search:
         "*": 1
     uploadvolumefactor:
       text: 1
+    minimumratio:
+      text: 0.2
 # engine tbd

--- a/src/Jackett.Common/Definitions/uniongang.yml
+++ b/src/Jackett.Common/Definitions/uniongang.yml
@@ -121,5 +121,5 @@ search:
     uploadvolumefactor:
       text: 1
     minimumratio:
-      text: 0.2
+      text: 0.3
 # engine tbd


### PR DESCRIPTION
See commits for comments.

Only ones that gave me pause:
**GigaTorrents** - it has a global MR but none for individual seeds, so do we leave this out?
**HDZone** - in a quick browse through their recent torrents, I haven't seen an H&R logo, but should we account for a download having one and include the 14 day MST?