### PR TITLE
Update hdcity.yml

### DIFF
--- a/src/Jackett.Common/Definitions/hdcity.yml
+++ b/src/Jackett.Common/Definitions/hdcity.yml
@@ -172,7 +172,7 @@ search:
       optional: true
       filters:
         - name: append
-          args: " [English]"
+          args: " English"
         - name: re_replace
           args: ["(?i)T[\\s-_]?(\\d{1,2})\\b", " S$1 "]
         - name: re_replace
@@ -184,7 +184,7 @@ search:
       optional: true
       filters:
         - name: append
-          args: " [Spanish]"
+          args: " Spanish"
         - name: re_replace
           args: ["(?i)T[\\s-_]?(\\d{1,2})\\b", " S$1 "]
         - name: re_replace


### PR DESCRIPTION
Language identification correction for Radarr and pyMedusa.

Radarr and pyMedusa use the last block in brackets as Group.
Searches always appear in English.

After change, that is the result.
![Captura](https://user-images.githubusercontent.com/17994549/100516026-0dfa9400-3181-11eb-8a94-041efbdf8360.PNG)
