### PR TITLE
Update hdspain.yml

### DIFF
--- a/src/Jackett.Common/Definitions/hdspain.yml
+++ b/src/Jackett.Common/Definitions/hdspain.yml
@@ -83,7 +83,7 @@ search:
         - name: prepend
           args: "{{ .Result.extras }} "
         - name: append
-          args: " [Spanish]"
+          args: " Spanish"
         - name: re_replace
           args: ["(?i)T(\\d{1,2})\\b", "S$1"]
     details:


### PR DESCRIPTION
Language identification correction for Radarr and pyMedusa.

Radarr and pyMedusa use the last block in brackets as Group.
Searches always appear in English.

After change, that is the result.
![Captura](https://user-images.githubusercontent.com/17994549/100516026-0dfa9400-3181-11eb-8a94-041efbdf8360.PNG)