### PR TITLE
bitru: fix search redirect

### DIFF
--- a/src/Jackett.Common/Definitions/bitru.yml
+++ b/src/Jackett.Common/Definitions/bitru.yml
@@ -30,12 +30,9 @@ caps:
 
 settings:
   - name: adverts
-    type: select
+    type: checkbox
     label: Include Advertising
-    default: _
-    options:
-      _: yes
-      no: no
+    default: true
   - name: sort
     type: select
     label: Sort requested from site
@@ -50,8 +47,8 @@ search:
     - path: browse.php
   inputs:
     s: "{{ .Keywords }}"
-    rek: "{{ re_replace .Config.adverts \"_\" \"\" }}"
     sort: "{{ re_replace .Config.sort \"_\" \"\" }}"
+    $raw: "{{ if .Config.adverts }}{{ else }}&rek=no{{ end}}"
 
   rows:
     selector: table.browse-list > tbody > tr


### PR DESCRIPTION
http://bitru.org/browse.php?s=&rek=&sort= or any search including `rek=` instead of `rek=no` redirects to https://yandex.ru/