### PR TITLE
fixed torrent names on SKTorrent and Trezzor tracker

### DIFF
--- a/src/Jackett.Common/Definitions/sktorrent.yml
+++ b/src/Jackett.Common/Definitions/sktorrent.yml
@@ -91,12 +91,13 @@ search:
           args: category
     title:
       selector: a[href^="details.php?name="]
-      attribute: title
       filters:
         - name: re_replace
           args: [".*? / ", ""]
         - name: diacritics
           args: replace
+        - name: re_replace
+          args: ["( = CSFD \\d+\\%)", ""]
         - name: re_replace
           args: ["(?i)serie", ""]
         - name: re_replace

--- a/src/Jackett.Common/Definitions/trezzor.yml
+++ b/src/Jackett.Common/Definitions/trezzor.yml
@@ -94,6 +94,10 @@ search:
         - name: re_replace
           args: ["(?i)(Zobrazit detaily: |View details: )", ""]
         - name: re_replace
+          args: ["(Detaily: )", ""]
+        - name: re_replace
+          args: ["(\\w)\\.(\\w)", "$1 $2"]
+        - name: re_replace
           args: [".*? / ", ""]
         - name: diacritics
           args: replace


### PR DESCRIPTION
SKTorrent had category embedded to the torrent name, now checking for innertext instead of title
also SKTorrent added czech movie database rating to the torrent name

Trezzor had "Detaily: " as prefix for all links, removed with regex and improved readability by replacing . with space