### PR TITLE
anidub: fix search, don't replace spaces with +

### DIFF
--- a/src/Jackett.Common/Indexers/AniDUB.cs
+++ b/src/Jackett.Common/Indexers/AniDUB.cs
@@ -614,9 +614,6 @@ namespace Jackett.Common.Indexers
                 searchQuery = SeasonInfoRegex.Replace(searchQuery, string.Empty);
                 searchQuery += $" TV-{query.Season}";
             }
-
-            // Search is normalized with '+' instead of spaces
-            return searchQuery.ToLowerInvariant().Replace(" ", "+");
         }
     }
 }

--- a/src/Jackett.Common/Indexers/AniDUB.cs
+++ b/src/Jackett.Common/Indexers/AniDUB.cs
@@ -613,9 +613,9 @@ namespace Jackett.Common.Indexers
                 // Replace "TV- " with season from query
                 searchQuery = SeasonInfoRegex.Replace(searchQuery, string.Empty);
                 searchQuery += $" TV-{query.Season}";
+            }
 
             return searchQuery.ToLowerInvariant();
-            }
         }
     }
 }

--- a/src/Jackett.Common/Indexers/AniDUB.cs
+++ b/src/Jackett.Common/Indexers/AniDUB.cs
@@ -613,6 +613,8 @@ namespace Jackett.Common.Indexers
                 // Replace "TV- " with season from query
                 searchQuery = SeasonInfoRegex.Replace(searchQuery, string.Empty);
                 searchQuery += $" TV-{query.Season}";
+
+            return searchQuery.ToLowerInvariant();
             }
         }
     }


### PR DESCRIPTION
https://github.com/Jackett/Jackett/issues/8962#issuecomment-734485190

As used by Sonarr, `value="digimon+adventure+27"`
```
Информация
К сожалению, поиск по сайту не дал никаких результатов. Попробуйте изменить или сократить Ваш запрос.
```
```
Information
Sorry, your site search did not return any results. Please try to change or shorten your request.
```
Confirmed in browser.

`value="digimon adventure 27"`
Gives appropriate results in browser.