### PR TITLE
core: search cache optimizations #10382

### DIFF
--- a/src/Jackett.Common/Services/Interfaces/ICacheService.cs
+++ b/src/Jackett.Common/Services/Interfaces/ICacheService.cs
@@ -10,5 +10,6 @@ namespace Jackett.Common.Services.Interfaces
         void CacheResults(IIndexer indexer, TorznabQuery query, List<ReleaseInfo> releases);
         List<TrackerCacheResult> GetCachedResults();
         void CleanIndexerCache(IIndexer indexer);
+        void CleanCache();
     }
 }


### PR DESCRIPTION
* Empty cache when user changes proxy configuration
* Reduce the CPU needed to clean up results that exceed the limit per indexer