### PR TITLE
assorted yaml: add info about flaresolverr

### DIFF
--- a/src/Jackett.Common/Definitions/cpabien.yml
+++ b/src/Jackett.Common/Definitions/cpabien.yml
@@ -66,6 +66,10 @@ settings:
     type: info
     label: How to get the User-Agent
     default: "<ol><li>From the same place you fetched the cookie,<li>Find <b>'user-agent:'</b> in the <b>Request Headers</b> section<li><b>Select</b> and <b>Copy</b> the whole user-agent string <i>(everything after 'user-agent: ')</i> and <b>Paste</b> here.</ol>"
+  - name: flaresolverr
+    type: info
+    label: FlareSolverr
+    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
   - name: info_8000
     type: info
     label: About cpasbien Categories

--- a/src/Jackett.Common/Definitions/dmhy.yml
+++ b/src/Jackett.Common/Definitions/dmhy.yml
@@ -41,7 +41,11 @@ caps:
     music-search: [q]
     book-search: [q]
 
-settings: []
+settings:
+  - name: flaresolverr
+    type: info
+    label: FlareSolverr
+    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/epizod.yml
+++ b/src/Jackett.Common/Definitions/epizod.yml
@@ -45,6 +45,10 @@ settings:
     type: checkbox
     label: Replace VOSTFR with ENGLISH
     default: false
+  - name: flaresolverr
+    type: info
+    label: FlareSolverr
+    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
 
 download:
   selector: a[href^="magnet:?xt="]

--- a/src/Jackett.Common/Definitions/exttorrents.yml
+++ b/src/Jackett.Common/Definitions/exttorrents.yml
@@ -76,7 +76,10 @@ settings:
     options:
       desc: desc
       asc: asc
-
+  - name: flaresolverr
+    type: info
+    label: FlareSolverr
+    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
 
 download:
   selector: a[href^="magnet:?xt="]

--- a/src/Jackett.Common/Definitions/hddolby.yml
+++ b/src/Jackett.Common/Definitions/hddolby.yml
@@ -47,6 +47,10 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
+  - name: flaresolverr
+    type: info
+    label: FlareSolverr
+    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
   - name: info_tpp
     type: info
     label: Results Per Page

--- a/src/Jackett.Common/Definitions/mypornclub.yml
+++ b/src/Jackett.Common/Definitions/mypornclub.yml
@@ -17,7 +17,11 @@ caps:
     tv-search: [q]
     movie-search: [q]
 
-settings: []
+settings:
+  - name: flaresolverr
+    type: info
+    label: FlareSolverr
+    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
 
 download:
   selector: a[href^="magnet:?xt="]

--- a/src/Jackett.Common/Definitions/pirateiro.yml
+++ b/src/Jackett.Common/Definitions/pirateiro.yml
@@ -48,6 +48,10 @@ settings:
       enviado: created
       seeders: seeders
       tamanho: size
+  - name: flaresolverr
+    type: info
+    label: FlareSolverr
+    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/prostylex.yml
+++ b/src/Jackett.Common/Definitions/prostylex.yml
@@ -105,6 +105,10 @@ settings:
     options:
       desc: desc
       asc: asc
+  - name: flaresolverr
+    type: info
+    label: FlareSolverr
+    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
 
 login:
   path: account-login.php

--- a/src/Jackett.Common/Definitions/torrentbomb.yml
+++ b/src/Jackett.Common/Definitions/torrentbomb.yml
@@ -41,7 +41,11 @@ caps:
     movie-search: [q]
     music-search: [q]
 
-settings: []
+settings:
+  - name: flaresolverr
+    type: info
+    label: FlareSolverr
+    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
 
 download:
   # https://lngui.xyz/magnetgo.php?magnet:?xt=urn:btih:6d9551ec2c62c4ae8eef6709adc6be9b3fd7a709

--- a/src/Jackett.Common/Definitions/torrentkitty.yml
+++ b/src/Jackett.Common/Definitions/torrentkitty.yml
@@ -22,6 +22,10 @@ caps:
     movie-search: [q]
 
 settings:
+  - name: flaresolverr
+    type: info
+    label: FlareSolverr
+    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
   - name: info_8000
     type: info
     label: About TorrentKitty Categories

--- a/src/Jackett.Common/Definitions/torrentproject.yml
+++ b/src/Jackett.Common/Definitions/torrentproject.yml
@@ -60,6 +60,10 @@ settings:
       seeders: seeders
       sizebg: "size desc"
       sizesm: "size asc"
+  - name: flaresolverr
+    type: info
+    label: FlareSolverr
+    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/torrentz2k.yml
+++ b/src/Jackett.Common/Definitions/torrentz2k.yml
@@ -31,7 +31,11 @@ caps:
     music-search: [q]
     book-search: [q]
 
-settings: []
+settings:
+  - name: flaresolverr
+    type: info
+    label: FlareSolverr
+    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
 
 search:
   # https://torrentz2k.xyz/search/

--- a/src/Jackett.Common/Definitions/yggcookie.yml
+++ b/src/Jackett.Common/Definitions/yggcookie.yml
@@ -8,7 +8,7 @@ encoding: UTF-8
 followredirect: true
 links:
   - https://www.yggtorrent.si/
-  # don't forget to also change bellow in settings !
+  # don't forget to also change below in settings !
 legacylinks:
   - https://yggtorrent.com/
   - https://ww1.yggtorrent.com/
@@ -178,6 +178,10 @@ settings:
     options:
       desc: desc
       asc: asc
+  - name: flaresolverr
+    type: info
+    label: FlareSolverr
+    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
 
 login:
   method: cookie

--- a/src/Jackett.Common/Definitions/yggtorrent.yml
+++ b/src/Jackett.Common/Definitions/yggtorrent.yml
@@ -8,7 +8,7 @@ encoding: UTF-8
 followredirect: true
 links:
   - https://www.yggtorrent.si/
-  # don't forget to also change bellow in settings !
+  # don't forget to also change below in settings !
 legacylinks:
   - https://yggtorrent.com/
   - https://ww1.yggtorrent.com/
@@ -169,6 +169,10 @@ settings:
     options:
       desc: desc
       asc: asc
+  - name: flaresolverr
+    type: info
+    label: FlareSolverr
+    default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
 
 login:
   method: form


### PR DESCRIPTION
Re: https://github.com/Jackett/Jackett/issues/10500 - only one not included is mejortorrent (C#)

Also checked my (very out of date) list of sites using Cloudflare DDoS Protection - https://github.com/Jackett/Jackett/issues/7325#issuecomment-603887196

From that, I _think_ I have seen extratorrent-cd and pornleech using it recently, but I may be misremembering, so I'll leave them for now.

The official proxies for 1337x and LimeTorrent are still using it, but the main sites aren't, so I wasn't sure if the info should be included/edited.

Open for suggestions on phrasing, formatting, positioning, etc.