### PR TITLE
Handle downloadvolumefactor query string param in Torznab query

### DIFF
--- a/src/Jackett.Common/Models/DTO/TorznabRequest.cs
+++ b/src/Jackett.Common/Models/DTO/TorznabRequest.cs
@@ -26,6 +26,7 @@ namespace Jackett.Common.Models.DTO
         public string author { get; set; }
         public string title { get; set; }
         public string configured { get; set; }
+        public string downloadvolumefactor { get; set; }
 
         public static TorznabQuery ToTorznabQuery(TorznabRequest request)
         {
@@ -84,6 +85,9 @@ namespace Jackett.Common.Models.DTO
                 query.Title = request.title;
             if (!string.IsNullOrWhiteSpace(request.author))
                 query.Author = request.author;
+
+            if (!string.IsNullOrWhiteSpace(request.downloadvolumefactor))
+                query.DownloadVolumeFactor = double.Parse(request.downloadvolumefactor);
 
             return query;
         }

--- a/src/Jackett.Common/Models/TorznabQuery.cs
+++ b/src/Jackett.Common/Models/TorznabQuery.cs
@@ -19,6 +19,7 @@ namespace Jackett.Common.Models
         public int? TvdbID { get; set; }
         public string ImdbID { get; set; }
         public int? TmdbID { get; set; }
+        public double? DownloadVolumeFactor { get; set; }
 
         public int Season { get; set; }
         public string Episode { get; set; }
@@ -137,7 +138,8 @@ namespace Jackett.Common.Models
                 RageID = RageID,
                 TvdbID = TvdbID,
                 ImdbID = ImdbID,
-                TmdbID = TmdbID
+                TmdbID = TmdbID,
+                DownloadVolumeFactor = DownloadVolumeFactor
             };
             if (Categories?.Length > 0)
             {

--- a/src/Jackett.Server/Controllers/ResultsController.cs
+++ b/src/Jackett.Server/Controllers/ResultsController.cs
@@ -416,6 +416,19 @@ namespace Jackett.Server.Controllers
                     return r;
                 });
 
+                if (CurrentQuery.DownloadVolumeFactor != null)
+                {
+
+                    proxiedReleases = proxiedReleases.Where(r =>
+                    {
+                        if (r.DownloadVolumeFactor != null && r.DownloadVolumeFactor <= CurrentQuery.DownloadVolumeFactor)
+                        {
+                            return true;
+                        }
+                        return false;
+                    });
+                }
+
                 resultPage.Releases = proxiedReleases.ToList();
 
                 var xml = resultPage.ToXml(new Uri(serverUrl));


### PR DESCRIPTION
This PR addresses a limited, but probably the most common, case of https://github.com/Jackett/Jackett/issues/1858: filtering by `downloadvolumefactor` to grab only freeleech releases.

I added a new field to the `TorznabQuery` of `DownloadVolumeFactor`, as well as a `downloadvolumefactor` field field to `TorznabRequest`. 

Then, when results are about to be returned for a torznab query, I check if this parameter is present, and if it is I filter by the `DownloadVolumeFactor` property of the `ReleaseInfo`, only accepting results less than or equal to the passed in `downloadvolumefactor`.

Ultimately, this means that if you pass `downloadvolumefactor=0` query parameter to Jackett for a torznab query, it will only return Freeleech results. You could also pass other double values for this, though those are probably less useful.