### PR TITLE
core: remove rss feed image (legacy code) #324

### DIFF
--- a/src/Jackett.Common/Models/ChannelInfo.cs
+++ b/src/Jackett.Common/Models/ChannelInfo.cs
@@ -9,10 +9,6 @@ namespace Jackett.Common.Models
         public Uri Link { get; set; }
         public string Language { get; set; }
         public string Category { get; set; }
-        public Uri ImageUrl { get; set; }
-        public string ImageTitle { get; set; }
-        public Uri ImageLink { get; set; }
-        public string ImageDescription { get; set; }
 
         public ChannelInfo()
         {

--- a/src/Jackett.Common/Models/ResultPage.cs
+++ b/src/Jackett.Common/Models/ResultPage.cs
@@ -73,12 +73,6 @@ namespace Jackett.Common.Models
                         new XElement("link", ChannelInfo.Link.AbsoluteUri),
                         new XElement("language", ChannelInfo.Language),
                         new XElement("category", ChannelInfo.Category),
-                        new XElement("image",
-                            new XElement("url", ChannelInfo.ImageUrl.AbsoluteUri),
-                            new XElement("title", ChannelInfo.ImageTitle),
-                            new XElement("link", ChannelInfo.ImageLink.AbsoluteUri),
-                            new XElement("description", ChannelInfo.ImageDescription)
-                        ),
                         from r in Releases
                         select new XElement("item",
                             new XElement("title", RemoveInvalidXMLChars(r.Title)),

--- a/src/Jackett.Server/Controllers/ResultsController.cs
+++ b/src/Jackett.Server/Controllers/ResultsController.cs
@@ -403,11 +403,7 @@ namespace Jackett.Server.Controllers
                 {
                     Title = CurrentIndexer.DisplayName,
                     Description = CurrentIndexer.DisplayDescription,
-                    Link = new Uri(CurrentIndexer.SiteLink),
-                    ImageUrl = new Uri(serverUrl + "logos/" + CurrentIndexer.Id + ".png"),
-                    ImageTitle = CurrentIndexer.DisplayName,
-                    ImageLink = new Uri(CurrentIndexer.SiteLink),
-                    ImageDescription = CurrentIndexer.DisplayName
+                    Link = new Uri(CurrentIndexer.SiteLink)
                 });
 
                 var proxiedReleases = result.Releases.Select(r => AutoMapper.Mapper.Map<ReleaseInfo>(r)).Select(r =>

--- a/src/Jackett.Test/Common/Models/ResultPageTests.cs
+++ b/src/Jackett.Test/Common/Models/ResultPageTests.cs
@@ -48,9 +48,7 @@ namespace Jackett.Test.Common.Models
             var resultPage = new ResultPage(
                 new ChannelInfo // characters in channel info are safe because are provided by us
                 {
-                    Link = link,
-                    ImageUrl = link,
-                    ImageLink = link
+                    Link = link
                 })
                 {
                     Releases = new List<ReleaseInfo>
@@ -75,7 +73,7 @@ namespace Jackett.Test.Common.Models
             var xml = resultPage.ToXml(link);
 
             Assert.AreEqual(5, Regex.Matches(xml, validText).Count);
-            Assert.AreEqual(10, Regex.Matches(xml, validLink).Count);
+            Assert.AreEqual(8, Regex.Matches(xml, validLink).Count);
 
             // this should be in another test but it's here to avoid creating the whole object again
             Assert.True(xml.Contains("Tue, 22 Sep 2020 00:00:00 "));


### PR DESCRIPTION
Indexer logos were removed long time ago. Just removing the Image tag in the RSS feed that points to a broken image.