### PR TITLE
[Bugfix] Fix BlackholeController exception when torrent name is very long

### DIFF
--- a/src/Jackett.Server/Controllers/BlackholeController.cs
+++ b/src/Jackett.Server/Controllers/BlackholeController.cs
@@ -88,7 +88,17 @@ namespace Jackett.Server.Controllers
                 else
                     fileName += "-" + StringUtil.MakeValidFileName(file + fileExtension, '_', false); // call MakeValidFileName() again to avoid any possibility of path traversal attacks
 
-                System.IO.File.WriteAllBytes(Path.Combine(serverConfig.BlackholeDir, fileName), downloadBytes);
+                try
+                {
+                    System.IO.File.WriteAllBytes(Path.Combine(serverConfig.BlackholeDir, fileName), downloadBytes);
+                }
+                catch (IOException)
+                {
+                    // Sometimes a torrent's name is very long which causes an exception when writing the file to disk.
+                    // In this specific case, use a GUID instead of the torrent's name.
+                    System.IO.File.WriteAllBytes(Path.Combine(serverConfig.BlackholeDir, Guid.NewGuid() + fileExtension), downloadBytes);
+                }
+
                 jsonReply["result"] = "success";
             }
             catch (Exception e)


### PR DESCRIPTION
Sometimes a torrent's name is very long which causes an exception when writing the blackhole file to disk.

**Only in that specific case**, this PR replaces the file name with a GUID (which still allows torrent clients to pick the files up and does not affect the name of the torrent once loaded in a client) instead of implementing somewhat arbitrary filename-shortening logic, which could possibly result in filename collisions and would require more code.

Open to discussion on the way the filename should be shortened if you're not OK with the GUID solution.