### PR TITLE
anidex: fix search by language. resolves #10930

### DIFF
--- a/src/Jackett.Common/Indexers/Anidex.cs
+++ b/src/Jackett.Common/Indexers/Anidex.cs
@@ -68,7 +68,6 @@ namespace Jackett.Common.Indexers
             // Configure the language select option
             var languageSelect = new SelectItem(new Dictionary<string, string>
                 {
-                {"", "All langs"},
                 {"1", "English"},
                 {"2", "Japanese"},
                 {"3", "Polish"},
@@ -101,7 +100,7 @@ namespace Jackett.Common.Indexers
                 {"30", "Persian"},
                 {"31", "Malaysian"}
             })
-            { Name = "Language", Value = "" };
+            { Name = "Language", Value = "1" };
             configData.AddDynamic("languageid", languageSelect);
 
             // Configure the sort selects

--- a/src/Jackett.Common/Indexers/Anidex.cs
+++ b/src/Jackett.Common/Indexers/Anidex.cs
@@ -68,6 +68,7 @@ namespace Jackett.Common.Indexers
             // Configure the language select option
             var languageSelect = new SelectItem(new Dictionary<string, string>
                 {
+                {"", "All langs"},
                 {"1", "English"},
                 {"2", "Japanese"},
                 {"3", "Polish"},
@@ -100,7 +101,7 @@ namespace Jackett.Common.Indexers
                 {"30", "Persian"},
                 {"31", "Malaysian"}
             })
-            { Name = "Language", Value = "1" };
+            { Name = "Language", Value = "" };
             configData.AddDynamic("languageid", languageSelect);
 
             // Configure the sort selects
@@ -123,6 +124,8 @@ namespace Jackett.Common.Indexers
             configData.AddDynamic("orderrequestedfromsite", orderSelect);
         }
 
+        private string GetLang => ((SelectItem)configData.GetDynamic("languageid")).Value;
+        
         private string GetSortBy => ((SelectItem)configData.GetDynamic("sortrequestedfromsite")).Value;
 
         private string GetOrder => ((SelectItem)configData.GetDynamic("orderrequestedfromsite")).Value;
@@ -148,7 +151,8 @@ namespace Jackett.Common.Indexers
                 { "q", query.SearchTerm ?? string.Empty },
                 { "s", GetSortBy },
                 { "o", GetOrder },
-                { "group", "0" } // No group
+                { "lang_id", GetLang },
+                { "group_id", "0" } // No group
             };
 
             // Get specified categories


### PR DESCRIPTION
Also:
- ~added `all languages` option (not sure if that will work)~ (nope, didn't work)
- updated `group_id`