### PR TITLE
ncore: update domain *.pro . resolves #10956

### DIFF
--- a/src/Jackett.Common/Indexers/NCore.cs
+++ b/src/Jackett.Common/Indexers/NCore.cs
@@ -41,12 +41,16 @@ namespace Jackett.Common.Indexers
             "ebook"
         };
 
+        public override string[] LegacySiteLinks { get; protected set; } = {
+            "https://ncore.cc/"
+        };
+
         public NCore(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
             : base(id: "ncore",
                   name: "nCore",
                   description: "A Hungarian private torrent site.",
-                  link: "https://ncore.cc/",
+                  link: "https://ncore.pro/",
                   caps: new TorznabCapabilities
                   {
                       TvSearchParams = new List<TvSearchParam>


### PR DESCRIPTION
https://ncore.cc/ now returns a 301 to https://ncore.pro/