### PR TITLE
Get 'current year' results for keywordless query in torrent-paradise-ml. Resolves #4598

### DIFF
--- a/src/Jackett.Common/Indexers/TorrentParadiseMl.cs
+++ b/src/Jackett.Common/Indexers/TorrentParadiseMl.cs
@@ -94,11 +94,7 @@ namespace Jackett.Common.Indexers
             var searchTerm = query.GetQueryString();
             if (string.IsNullOrWhiteSpace(searchTerm))
             {
-                if (query.IsTest)
-                {
-                    searchTerm = DateTime.Now.Year.ToString();
-                }
-                else return null;
+                searchTerm = DateTime.Now.Year.ToString();
             }
 
             var qc = new NameValueCollection


### PR DESCRIPTION
#4598 