### PR TITLE
Update LostFilm.tv URL

### DIFF
--- a/src/Jackett.Common/Indexers/LostFilm.cs
+++ b/src/Jackett.Common/Indexers/LostFilm.cs
@@ -98,7 +98,7 @@ namespace Jackett.Common.Indexers
             : base(id: "lostfilm",
                    name: "LostFilm.tv",
                    description: "Unique portal about foreign series",
-                   link: "https://www.lostfilm.run/",
+                   link: "https://www.lostfilm.uno/",
                    caps: new TorznabCapabilities {
                        TvSearchParams = new List<TvSearchParam>
                        {

--- a/src/Jackett.Common/Indexers/LostFilm.cs
+++ b/src/Jackett.Common/Indexers/LostFilm.cs
@@ -26,6 +26,10 @@ namespace Jackett.Common.Indexers
             "https://www.lostfilm.tv/"
         };
 
+        public override string[] AlternativeSiteLinks { get; protected set; } = {
+            "https://www.lostfilm.run/",
+            "https://www.lostfilm.uno/"
+ };
         private static readonly Regex parsePlayEpisodeRegex = new Regex("PlayEpisode\\('(?<id>\\d{1,3})(?<season>\\d{3})(?<episode>\\d{3})'\\)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex parseReleaseDetailsRegex = new Regex("Видео:\\ (?<quality>.+).\\ Размер:\\ (?<size>.+).\\ Перевод", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
@@ -98,7 +102,7 @@ namespace Jackett.Common.Indexers
             : base(id: "lostfilm",
                    name: "LostFilm.tv",
                    description: "Unique portal about foreign series",
-                   link: "https://www.lostfilm.uno/",
+                   link: "https://www.lostfilm.run/",
                    caps: new TorznabCapabilities {
                        TvSearchParams = new List<TvSearchParam>
                        {


### PR DESCRIPTION
The current Lostfilm url (https://www.lostfilm.run) is blocked 
```
Доступ к информационному ресурсу ограничен на основании Федерального закона от 27 июля 2006 г. N 149-ФЗ "Об информации, информационных технологиях и о защите информации"
```

Updated to use the correct one https://www.lostfilm.uno