### PR TITLE
[ExtremeTorrents] Replace dutch title keywords

### DIFF
--- a/src/Jackett.Common/Definitions/extremetorrents.yml
+++ b/src/Jackett.Common/Definitions/extremetorrents.yml
@@ -36,7 +36,7 @@ caps:
 
   modes:
     search: [q]
-    tv-search: [q, season, ep]
+    tv-search: [q]
     movie-search: [q]
     music-search: [q]
     book-search: [q]

--- a/src/Jackett.Common/Definitions/extremetorrents.yml
+++ b/src/Jackett.Common/Definitions/extremetorrents.yml
@@ -104,6 +104,15 @@ search:
           args: cat
     title:
       selector: a[href^="details.php?id="]
+      filters:
+        - name: re_replace
+          args: ["(?i)seizoen\\s*(\\d{1,2})\\s*(tot|t\/m)\\s*(\\d{1,2})", "S$1-$3"]
+        - name: re_replace
+          args: ["(?i)(seizoen\\s*)(\\d{1,2})", "S$2"]
+        - name: re_replace
+          args: ["(?i)(afl.\\s*|aflevering\\s*)(\\d{1,2})", "E$2"]
+        - name: re_replace
+          args: ["(?i)compleet", "Complete"]
     details:
       selector: a[href^="details.php?id="]
       attribute: href


### PR DESCRIPTION
This replaces dutch keywords so radarr/sonarr understands it.

I've copied it from: https://github.com/Jackett/Jackett/blob/master/src/Jackett.Common/Definitions/film-paleis.yml#L97-L105

Checked locally and it's working as intended.