### PR TITLE
Better Brazilian Portuguese support

### DIFF
--- a/src/Jackett.Common/Definitions/amigosshare.yml
+++ b/src/Jackett.Common/Definitions/amigosshare.yml
@@ -205,7 +205,7 @@ search:
         - name: append
           args: "{{ if .Result._language }} {{ .Result._language }}{{ else }}{{ end }}"
         - name: re_replace
-          args: ["(Dual-Audio|Dublado)", "Brazilian $1"]
+          args: ["(Dual|[Nn]acional|[Dd]ublado)", "Brazilian $1"]
     details:
       selector: a[href*="torrents-details.php?id="], a[href*="details-misc.php?id="]
       attribute: href

--- a/src/Jackett.Common/Indexers/BJShare.cs
+++ b/src/Jackett.Common/Indexers/BJShare.cs
@@ -394,6 +394,9 @@ namespace Jackett.Common.Indexers
                                              titleElements[2] + " " + titleElements[4] + " " + string.Join(
                                                  " ", titleElements.Skip(6));
 
+                        if (Regex.IsMatch(release.Description, "(Dual|[Nn]acional|[Dd]ublado)"))
+                            release.Title += " Brazilian";
+
                         // This tracker does not provide an publish date to search terms (only on last 24h page)
                         release.PublishDate = DateTime.Today;
 
@@ -511,6 +514,9 @@ namespace Jackett.Common.Indexers
                                     }
                             }
                         }
+
+                        if (Regex.IsMatch(extraInfo, "(Dual|[Nn]acional|[Dd]ublado)"))
+                            extraInfo += " Brazilian";
 
                         var catStr = qCatLink.GetAttribute("href").Split('=')[1].Split('&')[0];
 


### PR DESCRIPTION
I had already contributed for improve Brazilian Portuguese support of AmigosShare tracker.
Now this is to improve BJShare Tracker.
This code only adds "Brazilian" at title to support Sonarr/Radarr detect Brazilian Portuguese content.
I also changed AmigosShare a little.