### PR TITLE
Don't migrate UNIX configs if the input and output directories are the same

### DIFF
--- a/src/Jackett.Common/Services/ConfigurationService.cs
+++ b/src/Jackett.Common/Services/ConfigurationService.cs
@@ -89,7 +89,12 @@ namespace Jackett.Common.Services
             // Perform a migration in case of https://github.com/Jackett/Jackett/pull/11173#issuecomment-787520128
             if (Environment.OSVersion.Platform == PlatformID.Unix)
             {
-                PerformMigration("Jackett");
+                // In cases where the app data folder is the same as "$(cwd)/Jackett" we don't need to perform a migration
+                var fullConfigPath = Path.GetFullPath("Jackett");
+                if (GetAppDataFolder() != fullConfigPath)
+                {
+                    PerformMigration(fullConfigPath);
+                }
             }
         }
 
@@ -128,7 +133,11 @@ namespace Jackett.Common.Services
                     }
                 }
             }
-            Directory.Delete(oldDirectory, true);
+
+            // Don't remove configs that have been migrated to the same folder
+            if (GetAppDataFolder() != oldDirectory) {
+                Directory.Delete(oldDirectory, true);
+            }
         }
 
         public T GetConfig<T>()


### PR DESCRIPTION
This is to address the DietPi issues where they don't use the expected default location, and instead use `$HOME/Jackett` as the config directory. This causes the migrator to copy files to themselves, then remove the config directly entirely.

This change addresses this condition by checking the AppData folder against the assumed #11313 bugged folder on UNIX systems, and if they differ the migration will occur *. In addition, it adds a guard around the deletion portion of the migration function so we don't remove folders we've just migrated to.

\* The reason this change was added only to UNIX is the original migration function was made to copy files onto themselves with an updates security policy on Windows devices only, I didn't want to affect this behaviour.