### PR TITLE
Don't delete $(cwd)/Jackett if it has jackett

### DIFF
--- a/src/Jackett.Common/Services/ConfigurationService.cs
+++ b/src/Jackett.Common/Services/ConfigurationService.cs
@@ -91,7 +91,7 @@ namespace Jackett.Common.Services
             {
                 // In cases where the app data folder is the same as "$(cwd)/Jackett" we don't need to perform a migration
                 var fullConfigPath = Path.GetFullPath("Jackett");
-                if (GetAppDataFolder() != fullConfigPath)
+                if (GetAppDataFolder() != fullConfigPath && ! File.Exists(Path.Combine(fullConfigPath, "jackett")))
                 {
                     PerformMigration(fullConfigPath);
                 }


### PR DESCRIPTION
Basically checks to see if we're looking at the installation directory.
If we're not, do the migrations, otherwise we don't want to be deleting
or copying the install directory to the user config directory.

Fixes #11463