### PR TITLE
[Performance] Convert Parse/Catch to TryParse

### DIFF
--- a/src/Jackett.Common/Utils/DateTimeUtil.cs
+++ b/src/Jackett.Common/Utils/DateTimeUtil.cs
@@ -176,16 +176,12 @@ namespace Jackett.Common.Utils
                     return dt;
                 }
 
-                try
+                // try parsing the str as an unix timestamp
+                if (long.TryParse(str, out var unixTimeStamp))
                 {
-                    // try parsing the str as an unix timestamp
-                    var unixTimeStamp = long.Parse(str);
                     return UnixTimestampToDateTime(unixTimeStamp);
                 }
-                catch (FormatException)
-                {
-                    // it wasn't a timestamp, continue....
-                }
+                // it wasn't a timestamp, continue....
 
                 // add missing year
                 match = _MissingYearRegexp.Match(str);


### PR DESCRIPTION
Exceptions have a huge impact on performance.
When it's possible and meaningful, use Try method version instead of catch and exception.
DateTimeUtil.FromUnkown is used in 26 different points and many times during the results parsing.
Reducing the cost of it should help to improve performance.