### PR TITLE
issue template: minor edit

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,3 +1,5 @@
+### Read and complete in full before submitting your issue. Do not delete the template.
+
 **Please use the search bar** at the top of the page and make sure you are not creating an already submitted issue.
 Check closed issues as well, because your issue may have already been fixed.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -2,7 +2,7 @@
 ### Do not delete the template.
 
 **Please use the search bar** at the top of the page and make sure you are not creating an already submitted issue.
-Check closed issues as well, because your issue may have already been fixed.
+Check closed issues as well, because your issue may have already been fixed. Also check our [Troubleshooting](https://github.com/Jackett/Jackett/wiki/Troubleshooting) for steps to resolve common issues.
 
 Please read our [Contributing Guidelines](https://github.com/Jackett/Jackett/blob/master/CONTRIBUTING.md) before submitting your issue to ensure a prompt response to your bug.
 

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,5 @@
-### Read and complete in full before submitting your issue. Do not delete the template.
+### Read and complete in full with information about your setup and issue before submitting.
+### Do not delete the template.
 
 **Please use the search bar** at the top of the page and make sure you are not creating an already submitted issue.
 Check closed issues as well, because your issue may have already been fixed.


### PR DESCRIPTION
Will hopefully dissuade some people from deleting the template or submitting an empty one.

Added link to troubleshooting as well to prevent some issues from being opened in the first place.

We'll still get redundant issues, but maybe this will reduce the number.