### PR TITLE
pipelines: fix whitespace

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -299,7 +299,7 @@ stages:
             inputs:
               workingDirectory: $(Build.SourcesDirectory)
               targetType: inline
-              failOnStderr: true
+              failOnStderr: false
               script: |
                 dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/DateTimeRoutines
                 dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/Jackett.Common

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -299,16 +299,16 @@ stages:
             inputs:
               workingDirectory: $(Build.SourcesDirectory)
               targetType: inline
-              failOnStderr: false
+              failOnStderr: true
               script: |
-                dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/DateTimeRoutines
-                dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/Jackett.Common
-                dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/Jackett.IntegrationTests
-                dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/Jackett.Server
-                dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/Jackett.Service
-                dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/Jackett.Test
-                dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/Jackett.Tray
-                dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/Jackett.Updater
+                dotnet-format --fix-whitespace --verbosity diagnostic --folder ./src/DateTimeRoutines
+                dotnet-format --fix-whitespace --verbosity diagnostic --folder ./src/Jackett.Common
+                dotnet-format --fix-whitespace --verbosity diagnostic --folder ./src/Jackett.IntegrationTests
+                dotnet-format --fix-whitespace --verbosity diagnostic --folder ./src/Jackett.Server
+                dotnet-format --fix-whitespace --verbosity diagnostic --folder ./src/Jackett.Service
+                dotnet-format --fix-whitespace --verbosity diagnostic --folder ./src/Jackett.Test
+                dotnet-format --fix-whitespace --verbosity diagnostic --folder ./src/Jackett.Tray
+                dotnet-format --fix-whitespace --verbosity diagnostic --folder ./src/Jackett.Updater
 
       - job: Linting_YAML
         displayName: Linting YAML

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -309,6 +309,14 @@ stages:
                 dotnet-format --fix-whitespace --verbosity diagnostic --folder ./src/Jackett.Test
                 dotnet-format --fix-whitespace --verbosity diagnostic --folder ./src/Jackett.Tray
                 dotnet-format --fix-whitespace --verbosity diagnostic --folder ./src/Jackett.Updater
+                dotnet-format --check --verbosity diagnostic --folder ./src/DateTimeRoutines
+                dotnet-format --check --verbosity diagnostic --folder ./src/Jackett.Common
+                dotnet-format --check --verbosity diagnostic --folder ./src/Jackett.IntegrationTests
+                dotnet-format --check --verbosity diagnostic --folder ./src/Jackett.Server
+                dotnet-format --check --verbosity diagnostic --folder ./src/Jackett.Service
+                dotnet-format --check --verbosity diagnostic --folder ./src/Jackett.Test
+                dotnet-format --check --verbosity diagnostic --folder ./src/Jackett.Tray
+                dotnet-format --check --verbosity diagnostic --folder ./src/Jackett.Updater
 
       - job: Linting_YAML
         displayName: Linting YAML

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -301,14 +301,14 @@ stages:
               targetType: inline
               failOnStderr: true
               script: |
-                dotnet-format --check --verbosity diagnostic --folder ./src/DateTimeRoutines
-                dotnet-format --check --verbosity diagnostic --folder ./src/Jackett.Common
-                dotnet-format --check --verbosity diagnostic --folder ./src/Jackett.IntegrationTests
-                dotnet-format --check --verbosity diagnostic --folder ./src/Jackett.Server
-                dotnet-format --check --verbosity diagnostic --folder ./src/Jackett.Service
-                dotnet-format --check --verbosity diagnostic --folder ./src/Jackett.Test
-                dotnet-format --check --verbosity diagnostic --folder ./src/Jackett.Tray
-                dotnet-format --check --verbosity diagnostic --folder ./src/Jackett.Updater
+                dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/DateTimeRoutines
+                dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/Jackett.Common
+                dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/Jackett.IntegrationTests
+                dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/Jackett.Server
+                dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/Jackett.Service
+                dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/Jackett.Test
+                dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/Jackett.Tray
+                dotnet-format --fix-whitespace --check --verbosity diagnostic --folder ./src/Jackett.Updater
 
       - job: Linting_YAML
         displayName: Linting YAML


### PR DESCRIPTION
dotnet format bumped to 5.1.225507 today - https://github.com/dotnet/format/blob/main/CHANGELOG.md

Changes include dotnet/format#982 which outputs warnings and errors to StdErr, and we use `failOnStderr`.

--fix-whitespace - https://github.com/dotnet/format/blob/main/README.md