### PR TITLE
NewPCT: Show the year between parentheses on the title

### DIFF
--- a/src/Jackett.Common/Indexers/NewPCT.cs
+++ b/src/Jackett.Common/Indexers/NewPCT.cs
@@ -625,7 +625,7 @@ namespace Jackett.Common.Indexers
             };
 
             //Sanitize
-            title = title.Replace("-", "").Replace("(", "").Replace(")", "");
+            title = title.Replace("-", "");
             title = Regex.Replace(title, @"\s+", " ");
 
             if (releaseType == ReleaseType.Tv)


### PR DESCRIPTION
Resolving   #11113 

This updates NewPCT to show the year between parentheses on the title.