### PR TITLE
[feature] Performance Test Suite

### DIFF
--- a/src/Jackett.Common/Indexers/BaseIndexer.cs
+++ b/src/Jackett.Common/Indexers/BaseIndexer.cs
@@ -395,6 +395,7 @@ namespace Jackett.Common.Indexers
         }
 
         protected abstract Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query);
+        public override string ToString() => Id;
     }
 
     public abstract class BaseWebIndexer : BaseIndexer, IWebIndexer

--- a/src/Jackett.Common/Services/IndexerConfigurationService.cs
+++ b/src/Jackett.Common/Services/IndexerConfigurationService.cs
@@ -129,6 +129,32 @@ namespace Jackett.Common.Services
         public string GetIndexerConfigFilePath(string indexerId)
             => Path.Combine(configService.GetIndexerConfigDir(), indexerId + ".json");
 
+        public void RenameIndexer(string oldId, string newId)
+        {
+            var oldPath = GetIndexerConfigFilePath(oldId);
+            if (File.Exists(oldPath))
+            {
+                // if the old configuration exists, we rename it to be used by the renamed indexer
+                logger.Info($"Old configuration detected: {oldPath}");
+                var newPath = GetIndexerConfigFilePath(newId);
+                if (File.Exists(newPath))
+                    File.Delete(newPath);
+                File.Move(oldPath, newPath);
+                // backups
+                var oldPathBak = oldPath + ".bak";
+                var newPathBak = newPath + ".bak";
+                if (File.Exists(oldPathBak))
+                {
+                    if (File.Exists(newPathBak))
+                        File.Delete(newPathBak);
+                    File.Move(oldPathBak, newPathBak);
+                }
+
+                logger.Info($"Configuration renamed: {oldPath} => {newPath}");
+            }
+        }
+
+
         private readonly IConfigurationService configService;
         private readonly Logger logger;
 

--- a/src/Jackett.Common/Services/IndexerManagerService.cs
+++ b/src/Jackett.Common/Services/IndexerManagerService.cs
@@ -91,26 +91,8 @@ namespace Jackett.Common.Services
         {
             foreach (var oldId in renamedIndexers.Keys)
             {
-                var oldPath = configService.GetIndexerConfigFilePath(oldId);
-                if (File.Exists(oldPath))
-                {
-                    // if the old configuration exists, we rename it to be used by the renamed indexer
-                    logger.Info($"Old configuration detected: {oldPath}");
-                    var newPath = configService.GetIndexerConfigFilePath(renamedIndexers[oldId]);
-                    if (File.Exists(newPath))
-                        File.Delete(newPath);
-                    File.Move(oldPath, newPath);
-                    // backups
-                    var oldPathBak = oldPath + ".bak";
-                    var newPathBak = newPath + ".bak";
-                    if (File.Exists(oldPathBak))
-                    {
-                        if (File.Exists(newPathBak))
-                            File.Delete(newPathBak);
-                        File.Move(oldPathBak, newPathBak);
-                    }
-                    logger.Info($"Configuration renamed: {oldPath} => {newPath}");
-                }
+                var newId = renamedIndexers[oldId];
+                configService.RenameIndexer(oldId, newId);
             }
         }
 

--- a/src/Jackett.Common/Services/Interfaces/IIndexerConfigurationService.cs
+++ b/src/Jackett.Common/Services/Interfaces/IIndexerConfigurationService.cs
@@ -8,6 +8,6 @@ namespace Jackett.Common.Services.Interfaces
         void Load(IIndexer indexer);
         void Save(IIndexer indexer, JToken config);
         void Delete(IIndexer indexer);
-        string GetIndexerConfigFilePath(string indexerId);
+        void RenameIndexer(string oldId, string newId);
     }
 }

--- a/src/Jackett.Performance/IndexerBenchmarks.cs
+++ b/src/Jackett.Performance/IndexerBenchmarks.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using AutoMapper;
+using BenchmarkDotNet.Attributes;
+using Jackett.Common.Indexers;
+using Jackett.Common.Indexers.Meta;
+using Jackett.Common.Models;
+using Jackett.Common.Models.Config;
+using Jackett.Common.Services;
+using Jackett.Common.Services.Interfaces;
+using Jackett.Common.Utils.Clients;
+using Jackett.Performance.Services;
+using Jackett.Performance.Utils.Clients;
+using Jackett.Server.Services;
+
+using NLog;
+
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Jackett.Performance
+{
+    [ShortRunJob]
+    [MemoryDiagnoser]
+    public class IndexerBenchmarks
+    {
+        private IndexerManager indexerManager = new IndexerManager();
+        public IndexerBenchmarks()
+        {
+            var applicationFolder = Path.GetDirectoryName(typeof(IndexerBenchmarks).Assembly.Location);
+            indexerManager.Init();
+            var indexers = indexerManager.GetIndexers();
+            Indexers = indexers.ToArray();
+        }
+
+        public IIndexer[] Indexers { get; }
+
+        [GlobalSetup]
+        [ArgumentsSource(nameof(Indexers))]
+        public Task InitAsync(IIndexer indexer)
+        {
+            return indexerManager.SetupAsync(indexer);
+        }
+
+        [Benchmark(Description = "TestIndexer")]
+        [ArgumentsSource(nameof(Indexers))]
+        public async Task<IndexerResult> TestAsync(IIndexer indexer)
+        {
+            var query = new TorznabQuery { QueryType = "search", SearchTerm = "", IsTest = true };
+            return await indexer.ResultsForQuery(query);
+        }
+    }
+}

--- a/src/Jackett.Performance/IndexerManager.cs
+++ b/src/Jackett.Performance/IndexerManager.cs
@@ -1,0 +1,205 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using AutoMapper;
+
+using Jackett.Common.Indexers;
+using Jackett.Common.Indexers.Meta;
+using Jackett.Common.Models;
+using Jackett.Common.Models.Config;
+using Jackett.Common.Services;
+using Jackett.Common.Services.Interfaces;
+using Jackett.Common.Utils.Clients;
+using Jackett.Performance.Services;
+using Jackett.Performance.Utils.Clients;
+using Jackett.Server.Services;
+
+using NLog;
+using NLog.Targets;
+
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Jackett.Performance
+{
+    internal class IndexerManager
+    {
+        private readonly PerformanceIndexerConfigurationService configService;
+        private readonly PerformanceProtectionService protectionService;
+        private readonly PerformanceCacheService cacheService;
+        private readonly PerformanceProcessService processService;
+        private readonly PerformanceConfigurationService configurationService;
+        private readonly ServerConfig serverConfig;
+        private Logger logger;
+        private IIndexerManagerService indexerManager;
+        private IServerService server;
+
+        static IndexerManager()
+        {
+            Encoding.RegisterProvider(CodePagesEncodingProvider.Instance);
+        }
+
+        public IndexerManager()
+        {
+            protectionService = new PerformanceProtectionService();
+            configService = new PerformanceIndexerConfigurationService(protectionService);
+            cacheService = new PerformanceCacheService();
+            processService = new PerformanceProcessService();
+            configurationService = new PerformanceConfigurationService();
+            serverConfig = new ServerConfig(new RuntimeSettings());
+            logger = LogManager.CreateNullLogger();
+        }
+
+        public void Init()
+        {
+#pragma warning disable CS0618 // Type or member is obsolete
+            Mapper.Initialize(cfg => { cfg.CreateMap<WebResult, WebResult>(); });
+#pragma warning restore CS0618 // Type or member is obsolete
+
+            var config = new NLog.Config.LoggingConfiguration();
+            config.AddRule(LogLevel.Info, LogLevel.Fatal, new ConsoleTarget());
+            LogManager.Configuration = config;
+            logger = LogManager.GetCurrentClassLogger();
+
+            var webClient = CreateWebClient();
+            indexerManager = new IndexerManagerService(
+                configService, protectionService, webClient, logger, cacheService, processService,
+                configurationService, serverConfig);
+            server = new ServerService(
+                indexerManager, processService, new SerializeService(), configurationService, logger, webClient,
+                new NullUpdateService(), protectionService, serverConfig);
+
+            server.Initalize();
+        }
+
+        public List<IIndexer> GetIndexers()
+        {
+            return indexerManager.GetAllIndexers().Where(x => x.IsConfigured).ToList();
+        }
+
+        private void AddNativeIndexers(List<IIndexer> indexers)
+        {
+            var allTypes = typeof(IIndexer).Assembly.GetTypes();
+            var allIndexerTypes = allTypes.Where(p => typeof(IIndexer).IsAssignableFrom(p));
+            var allInstantiatableIndexerTypes = allIndexerTypes.Where(p => !p.IsInterface && !p.IsAbstract);
+            var allNonMetaInstantiatableIndexerTypes =
+                allInstantiatableIndexerTypes.Where(p => !typeof(BaseMetaIndexer).IsAssignableFrom(p));
+            var indexerTypes = allNonMetaInstantiatableIndexerTypes.Where(p => p.Name != "CardigannIndexer");
+            indexers.AddRange(indexerTypes.Select(
+                                  type =>
+                                  {
+                                      var constructorArgumentTypes = new[]
+                                      {
+                                          typeof(IIndexerConfigurationService),
+                                          typeof(WebClient),
+                                          typeof(Logger),
+                                          typeof(IProtectionService),
+                                          typeof(ICacheService)
+                                      };
+                                      var constructor = type.GetConstructor(constructorArgumentTypes);
+                                      if (constructor != null)
+                                      {
+                                          // create own webClient instance for each indexer (separate cookies stores, etc.)
+                                          var indexerWebClientInstance = CreateWebClient();
+                                          var arguments = new object[]
+                                          {
+                                              configService,
+                                              indexerWebClientInstance,
+                                              logger,
+                                              protectionService,
+                                              cacheService
+                                          };
+                                          var indexer = (IIndexer)constructor.Invoke(arguments);
+                                          return indexer;
+                                      }
+
+                                      logger.Error($"Cannot instantiate Native indexer: {type.Name}");
+                                      return null;
+                                  }).Where(indexer => indexer?.Type == "public"));
+        }
+
+        private void AddCardigannIndexers(List<IIndexer> indexers, string applicationFolder)
+        {
+            var deserializer = new DeserializerBuilder()
+                               .WithNamingConvention(CamelCaseNamingConvention.Instance)
+                               //.IgnoreUnmatchedProperties()
+                               .Build();
+            var path = new[] { Path.Combine(applicationFolder, "Definitions") };
+            var directoryInfos = path.Select(p => new DirectoryInfo(p));
+            var existingDirectories = directoryInfos.Where(d => d.Exists);
+            var files = existingDirectories.SelectMany(d => d.GetFiles("*.yml"));
+            var definitions = files.Select(file =>
+            {
+                logger.Debug("Loading Cardigann definition " + file.FullName);
+                try
+                {
+                    var definitionString = File.ReadAllText(file.FullName);
+                    var definition = deserializer.Deserialize<IndexerDefinition>(definitionString);
+                    return definition;
+                }
+                catch (Exception e)
+                {
+                    logger.Error($"Error while parsing Cardigann definition {file.FullName}\n{e}");
+                    return null;
+                }
+            }).Where(definition => definition != null);
+
+            var cardigannIndexers = definitions.Select(definition =>
+            {
+                try
+                {
+                    // create own webClient instance for each indexer (separate cookies stores, etc.)
+                    var indexerWebClientInstance = CreateWebClient();
+
+                    IIndexer indexer = new CardigannIndexer(configService, indexerWebClientInstance, logger, protectionService, cacheService, definition);
+                    return indexer;
+                }
+                catch (Exception e)
+                {
+                    logger.Error($"Error while creating Cardigann instance from definition ID={definition.Id}: {e}");
+                    return null;
+                }
+            }).Where(cardigannIndexer => cardigannIndexer?.Type == "public").ToList(); // Explicit conversion to list to avoid repeated resource loading
+
+            var cardigannCounter = 0;
+            var cardiganIds = new List<string>();
+            foreach (var indexer in cardigannIndexers)
+            {
+                if (indexers.Any(x => x.Id == indexer.Id))
+                {
+                    logger.Warn($"Ignoring definition ID={indexer.Id}: Indexer already exists");
+                    continue;
+                }
+                indexers.Add(indexer);
+
+                cardigannCounter++;
+                cardiganIds.Add(indexer.Id);
+            }
+
+            logger.Info($"Loaded {cardigannCounter} Cardigann indexers: {string.Join(", ", cardiganIds)}");
+        }
+
+        private PerformanceWebClient CreateWebClient() => new PerformanceWebClient(processService, logger, configurationService, serverConfig);
+
+        public async Task SetupAsync(IIndexer indexer)
+        {
+            var configData = await indexer.GetConfigurationForSetup();
+            indexer.LoadFromSavedConfiguration(configData.ToJson(protectionService));
+        }
+    }
+
+    internal class NullUpdateService : IUpdateService
+    {
+        public void StartUpdateChecker() { }
+
+        public void CheckForUpdatesNow() { }
+
+        public void CleanupTempDir() { }
+
+        public void CheckUpdaterLock() { }
+    }
+}

--- a/src/Jackett.Performance/Jackett.Performance.csproj
+++ b/src/Jackett.Performance/Jackett.Performance.csproj
@@ -1,0 +1,25 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net5.0;net461</TargetFrameworks>
+    <OutputType>Exe</OutputType>
+  </PropertyGroup>
+  <PropertyGroup>
+    <PlatformTarget>AnyCPU</PlatformTarget>
+    <DebugType>portable</DebugType>
+    <DebugSymbols>true</DebugSymbols>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <Optimize>true</Optimize>
+    <Configuration>Release</Configuration>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
+    <PackageReference Include="BenchmarkDotNet.Diagnostics.Windows" Version="0.12.1" />
+    <PackageReference Include="NLog" Version="4.7.5" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Jackett.Server\Jackett.Server.csproj" />
+  </ItemGroup>
+</Project>

--- a/src/Jackett.Performance/Program.cs
+++ b/src/Jackett.Performance/Program.cs
@@ -1,0 +1,30 @@
+using System.Globalization;
+using System.Linq;
+using AutoMapper;
+using BenchmarkDotNet.Configs;
+using BenchmarkDotNet.Exporters;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Parameters;
+using BenchmarkDotNet.Running;
+using Jackett.Common.Models;
+using Jackett.Common.Utils.Clients;
+
+namespace Jackett.Performance
+{
+    public class Program
+    {
+        public static void Main(string[] args)
+        {
+            BenchmarkSwitcher
+                .FromAssembly(typeof(Program).Assembly)
+                .Run(args, GetGlobalConfig());
+        }
+
+        private static IConfig GetGlobalConfig()
+        {
+            return DefaultConfig.Instance
+                    .WithCultureInfo(new CultureInfo("en-US"))
+                    .AddExporter(RPlotExporter.Default);
+        }
+    }
+}

--- a/src/Jackett.Performance/Services/PerformanceCacheService.cs
+++ b/src/Jackett.Performance/Services/PerformanceCacheService.cs
@@ -1,0 +1,21 @@
+using System;
+using System.Collections.Generic;
+using Jackett.Common.Indexers;
+using Jackett.Common.Models;
+using Jackett.Common.Services.Interfaces;
+
+namespace Jackett.Performance.Services
+{
+    public class PerformanceCacheService : ICacheService
+    {
+        public List<ReleaseInfo> Search(IIndexer indexer, TorznabQuery query) => null;
+
+        public void CacheResults(IIndexer indexer, TorznabQuery query, List<ReleaseInfo> releases) {}
+
+        public List<TrackerCacheResult> GetCachedResults() => throw new NotImplementedException();
+
+        public void CleanIndexerCache(IIndexer indexer) => throw new NotImplementedException();
+
+        public void CleanCache() => throw new NotImplementedException();
+    }
+}

--- a/src/Jackett.Performance/Services/PerformanceConfigurationService.cs
+++ b/src/Jackett.Performance/Services/PerformanceConfigurationService.cs
@@ -1,0 +1,36 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+using Jackett.Common.Models.Config;
+using Jackett.Common.Services.Interfaces;
+
+namespace Jackett.Performance.Services
+{
+    public class PerformanceConfigurationService : IConfigurationService
+    {
+        public string GetContentFolder() => throw new NotImplementedException();
+
+        public string GetVersion() => throw new NotImplementedException();
+
+        public string GetIndexerConfigDir() => Path.Combine(GetAppDataFolder(), "Indexers");
+
+        public string GetAppDataFolder() => Path.GetDirectoryName(typeof(Program).Assembly.Location);
+
+        public string GetSonarrConfigFile() => throw new NotImplementedException();
+
+        public T GetConfig<T>() => throw new NotImplementedException();
+
+        public void SaveConfig<T>(T config) => throw new NotImplementedException();
+
+        public string ApplicationFolder() => throw new NotImplementedException();
+
+        public List<string> GetCardigannDefinitionsFolders() => new List<string>() { Path.Combine(GetAppDataFolder(), "Definitions") };
+
+        public void CreateOrMigrateSettings() => throw new NotImplementedException();
+
+        public void PerformMigration(string oldDirectory) => throw new NotImplementedException();
+
+        public ServerConfig BuildServerConfig(RuntimeSettings runtimeSettings) => throw new NotImplementedException();
+    }
+}

--- a/src/Jackett.Performance/Services/PerformanceIndexerConfigurationService.cs
+++ b/src/Jackett.Performance/Services/PerformanceIndexerConfigurationService.cs
@@ -1,0 +1,34 @@
+using System;
+using Jackett.Common.Indexers;
+using Jackett.Common.Services.Interfaces;
+using Newtonsoft.Json.Linq;
+
+namespace Jackett.Performance.Services
+{
+    public class PerformanceIndexerConfigurationService : IIndexerConfigurationService
+    {
+        private IProtectionService protectionService;
+
+        public PerformanceIndexerConfigurationService(IProtectionService protectionService)
+        {
+            this.protectionService = protectionService;
+        }
+
+        public void Load(IIndexer indexer)
+        {
+            if (indexer.Type != "public")
+                return;
+
+            var configData = indexer.GetConfigurationForSetup().GetAwaiter().GetResult();
+            indexer.LoadFromSavedConfiguration(configData.ToJson(protectionService));
+        }
+
+        public void Delete(IIndexer indexer) => throw new NotImplementedException();
+
+        public void RenameIndexer(string oldId, string newId) {}
+
+        public string GetIndexerConfigFilePath(string indexerId) => throw new NotImplementedException();
+
+        public void Save(IIndexer indexer, JToken config) { }
+    }
+}

--- a/src/Jackett.Performance/Services/PerformanceProcessService.cs
+++ b/src/Jackett.Performance/Services/PerformanceProcessService.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using Jackett.Common.Services.Interfaces;
+
+namespace Jackett.Performance.Services
+{
+    public class PerformanceProcessService : IProcessService
+    {
+        public void StartProcessAndLog(string exe, string args, bool asAdmin = false) => throw new NotImplementedException();
+
+        public string StartProcessAndGetOutput(string exe, string args, bool keepnewlines = false, bool asAdmin = false) => throw new NotImplementedException();
+    }
+}

--- a/src/Jackett.Performance/Services/PerformanceProtectionService.cs
+++ b/src/Jackett.Performance/Services/PerformanceProtectionService.cs
@@ -1,0 +1,11 @@
+using Jackett.Common.Services.Interfaces;
+
+namespace Jackett.Performance.Services
+{
+    public class PerformanceProtectionService : IProtectionService
+    {
+        public string Protect(string plainText) => plainText;
+
+        public string UnProtect(string plainText) => plainText;
+    }
+}

--- a/src/Jackett.Performance/Services/PerformanceServerService.cs
+++ b/src/Jackett.Performance/Services/PerformanceServerService.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Jackett.Common.Models.Config;
+using Jackett.Common.Services.Interfaces;
+using Jackett.Common.Utils.Clients;
+using Jackett.Server.Services;
+using NLog;
+
+namespace Jackett.Performance.Services
+{
+}

--- a/src/Jackett.Performance/Utils/Clients/PerformanceWebClient.cs
+++ b/src/Jackett.Performance/Utils/Clients/PerformanceWebClient.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Collections.Concurrent;
+using System.Threading.Tasks;
+
+using Jackett.Common.Models.Config;
+using Jackett.Common.Services.Interfaces;
+using Jackett.Common.Utils.Clients;
+
+using NLog;
+
+namespace Jackett.Performance.Utils.Clients
+{
+    public class PerformanceWebClient : WebClient
+    {
+        private readonly WebClient webClient;
+        private readonly ConcurrentDictionary<WebRequest, Task<WebResult>> _cache = new ConcurrentDictionary<WebRequest, Task<WebResult>>(WebRequestEqualityComparer.Default);
+
+        public PerformanceWebClient(IProcessService p, Logger l, IConfigurationService c, ServerConfig sc) : base(p, l, c, sc)
+        {
+            webClient = new HttpWebClient2(p, l, c, sc);
+        }
+
+        public override void Init() => webClient.Init();
+
+        public override void AddTrustedCertificate(string host, string hash) => webClient.AddTrustedCertificate(host, hash);
+
+        public override async Task<WebResult> GetResultAsync(WebRequest request)
+        {
+            return await _cache.GetOrAdd(request, x =>
+            {
+                Console.WriteLine($"Caching WebRequest result: {x.Type} {x.Url}");
+                return webClient.GetResultAsync(x);
+            });
+        }
+
+        protected override void OnConfigChange() => throw new NotImplementedException();
+
+        protected override void PrepareRequest(WebRequest request) => throw new NotImplementedException();
+
+        protected override Task<WebResult> Run(WebRequest webRequest) => throw new NotImplementedException();
+
+        public override void OnCompleted() => throw new NotImplementedException();
+
+        public override void OnError(Exception error) => throw new NotImplementedException();
+
+        public override void OnNext(ServerConfig value) => throw new NotImplementedException();
+    }
+}

--- a/src/Jackett.Performance/Utils/WebRequestEqualityComparer.cs
+++ b/src/Jackett.Performance/Utils/WebRequestEqualityComparer.cs
@@ -1,0 +1,83 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Jackett.Common.Utils.Clients;
+
+namespace Jackett.Performance.Utils
+{
+    public sealed class WebRequestEqualityComparer : IEqualityComparer<WebRequest>
+    {
+        public static readonly WebRequestEqualityComparer Default = new WebRequestEqualityComparer();
+        private static readonly PostDataEqualityComparer _PostDataEqualityComparer = new PostDataEqualityComparer();
+
+        public bool Equals(WebRequest x, WebRequest y)
+        {
+            if (ReferenceEquals(x, y))
+                return true;
+            if (ReferenceEquals(x, null))
+                return false;
+            if (ReferenceEquals(y, null))
+                return false;
+            if (x.GetType() != y.GetType())
+                return false;
+            if (!string.Equals(x.Url, y.Url, StringComparison.InvariantCulture))
+                return false;
+            if (x.Type != y.Type)
+                return false;
+            if (!string.Equals(x.RawBody, y.RawBody, StringComparison.InvariantCulture))
+                return false;
+            return _PostDataEqualityComparer.Equals(x.PostData, y.PostData);
+        }
+
+        public int GetHashCode(WebRequest obj)
+        {
+            unchecked
+            {
+                var hashCode = (obj.Url != null ? StringComparer.InvariantCulture.GetHashCode(obj.Url) : 0);
+                hashCode = (hashCode * 397) ^ (int)obj.Type;
+                hashCode = (hashCode * 397) ^ (obj.RawBody != null ? StringComparer.InvariantCulture.GetHashCode(obj.RawBody) : 0);
+                hashCode = (hashCode * 397) ^ (obj.PostData != null ? _PostDataEqualityComparer.GetHashCode(obj.PostData) : 0);
+                return hashCode;
+            }
+        }
+        public class PostDataEqualityComparer : IEqualityComparer<IEnumerable<KeyValuePair<string, string>>>, IEqualityComparer<KeyValuePair<string, string>>
+        {
+            public bool Equals(IEnumerable<KeyValuePair<string, string>> x, IEnumerable<KeyValuePair<string, string>> y)
+            {
+                if (ReferenceEquals(x, y))
+                    return true;
+                if (ReferenceEquals(x, null))
+                    return false;
+                if (ReferenceEquals(y, null))
+                    return false;
+                if (x.GetType() != y.GetType())
+                    return false;
+                return Enumerable.SequenceEqual(x, y, this);
+            }
+
+            public int GetHashCode(IEnumerable<KeyValuePair<string, string>> obj)
+            {
+                unchecked
+                {
+                    return obj.Aggregate(17, (current, pair) => (current * 397) ^ _PostDataEqualityComparer.GetHashCode(pair));
+                }
+            }
+
+            public bool Equals(KeyValuePair<string, string> x, KeyValuePair<string, string> y)
+            {
+                return string.Equals(x.Key, y.Key, StringComparison.InvariantCulture) && string.Equals(x.Value, y.Value, StringComparison.InvariantCulture);
+            }
+
+            public int GetHashCode(KeyValuePair<string, string> obj)
+            {
+                unchecked
+                {
+                    var hashCode = StringComparer.InvariantCulture.GetHashCode(obj.Key);
+                    return (hashCode * 397) ^ StringComparer.InvariantCulture.GetHashCode(obj.Value);
+                }
+            }
+
+
+        }
+    }
+}

--- a/src/Jackett.sln
+++ b/src/Jackett.sln
@@ -27,6 +27,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jackett.Server", "Jackett.S
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jackett.IntegrationTests", "Jackett.IntegrationTests\Jackett.IntegrationTests.csproj", "{0250DEAA-ED2E-4F72-BE76-D92D80B40080}"
 EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Jackett.Performance", "Jackett.Performance\Jackett.Performance.csproj", "{70202B1F-6F30-402E-AAB9-72444C6A5092}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -65,6 +67,10 @@ Global
 		{0250DEAA-ED2E-4F72-BE76-D92D80B40080}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{0250DEAA-ED2E-4F72-BE76-D92D80B40080}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{0250DEAA-ED2E-4F72-BE76-D92D80B40080}.Release|Any CPU.Build.0 = Release|Any CPU
+		{70202B1F-6F30-402E-AAB9-72444C6A5092}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{70202B1F-6F30-402E-AAB9-72444C6A5092}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{70202B1F-6F30-402E-AAB9-72444C6A5092}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{70202B1F-6F30-402E-AAB9-72444C6A5092}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Performance is the goal, measurement is the key.

We can collect information using [BenchmarkDotNet](https://github.com/dotnet/BenchmarkDotNet)
and with some adjustment in the internal abstraction
test functionality without network latency or other external dependencies.

In the future, we can integrate the performance test in the main release pipeline, to verify improvements or criticalities.

Here below, an example of a report created using the example code in this draft pull request.
Currently, only the public indexers can be tested, and only the test action is checked.
During the warmup, all the remote request are cached in memory, to avoid any network interaction during the real test.

// * Summary *

BenchmarkDotNet=v0.12.1, OS=Windows 10.0.19042
Intel Core i7-7660U CPU 2.50GHz (Kaby Lake), 1 CPU, 4 logical and 2 physical cores
.NET Core SDK=5.0.202
  [Host]   : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT
  ShortRun : .NET Core 5.0.5 (CoreCLR 5.0.521.16609, CoreFX 5.0.521.16609), X64 RyuJIT

Job=ShortRun  IterationCount=3  LaunchCount=1  
WarmupCount=3  

|      Method |             indexer |             Mean |            Error |         StdDev |           Median |      Gen 0 |     Gen 1 | Gen 2 |   Allocated |
|------------ |-------------------- |-----------------:|-----------------:|---------------:|-----------------:|-----------:|----------:|------:|------------:|
| TestIndexer |               1337x |    92,205.233 μs |    81,074.148 μs |  4,443.9476 μs |    93,457.900 μs |  6000.0000 | 1000.0000 |     - |  26918080 B |
| TestIndexer |           7torrents |    17,271.267 μs |    63,787.394 μs |  3,496.4023 μs |    18,621.400 μs |          - |         - |     - |   3671504 B |
| TestIndexer |           AniLibria |    11,324.167 μs |    35,253.614 μs |  1,932.3696 μs |    12,065.500 μs |          - |         - |     - |   2804136 B |
| TestIndexer |            Animedia |    96,679.000 μs |    75,049.696 μs |  4,113.7271 μs |    94,772.500 μs |  5000.0000 | 1000.0000 |     - |  33357696 B |
| TestIndexer |              acgrip |    27,605.667 μs |    38,625.113 μs |  2,117.1728 μs |    28,504.300 μs |          - |         - |     - |   4306864 B |
| TestIndexer |              acgsou |    42,090.300 μs |    62,070.177 μs |  3,402.2758 μs |    40,497.500 μs |  1000.0000 |         - |     - |   7470480 B |
| TestIndexer |             aniRena |   112,347.300 μs |   140,956.713 μs |  7,726.3131 μs |   110,994.700 μs |  3000.0000 | 1000.0000 |     - |  17922752 B |
| TestIndexer |              anidex |               NA |               NA |             NA |               NA |          - |         - |     - |           - |
| TestIndexer |         animeclipse |   162,929.100 μs |   237,655.551 μs | 13,026.7027 μs |   169,257.300 μs |  9000.0000 |         - |     - |  31039784 B |
| TestIndexer |          animetosho |     8,355.933 μs |    57,709.473 μs |  3,163.2509 μs |     8,475.700 μs |          - |         - |     - |   1497344 B |
| TestIndexer |           anisource |    61,180.333 μs |    54,601.765 μs |  2,992.9070 μs |    61,484.400 μs |  3000.0000 | 1000.0000 |     - |  17486896 B |
| TestIndexer |        audiobookbay |    54,954.100 μs |   107,112.205 μs |  5,871.1814 μs |    52,828.200 μs |  2000.0000 | 1000.0000 |     - |  12550912 B |
| TestIndexer |         bigfangroup |   102,982.967 μs |    72,888.886 μs |  3,995.2858 μs |   104,919.000 μs |  8000.0000 | 1000.0000 |     - |  22490952 B |
| TestIndexer |               bitru |    91,231.033 μs |    13,446.842 μs |    737.0668 μs |    91,638.300 μs |  3000.0000 | 1000.0000 |     - |  16072312 B |
| TestIndexer |                bt4g |     8,561.667 μs |    39,059.984 μs |  2,141.0095 μs |     7,937.500 μs |          - |         - |     - |   2610184 B |
| TestIndexer |                btdb |   119,334.400 μs |   271,089.927 μs | 14,859.3536 μs |   112,184.600 μs |  3000.0000 | 1000.0000 |     - |  24789800 B |
| TestIndexer |              btdigg |     1,930.100 μs |     2,111.772 μs |    115.7534 μs |     1,873.100 μs |          - |         - |     - |    570656 B |
| TestIndexer |             btetree |    48,698.333 μs |   142,917.255 μs |  7,833.7770 μs |    47,151.900 μs |  1000.0000 |         - |     - |   8015672 B |
| TestIndexer |               btsow |    19,127.200 μs |    46,446.341 μs |  2,545.8807 μs |    20,460.100 μs |  1000.0000 |         - |     - |   5825104 B |
| TestIndexer |             byrutor |    13,946.200 μs |    36,183.136 μs |  1,983.3198 μs |    14,126.700 μs |          - |         - |     - |   3256000 B |
| TestIndexer |             cilipro |    12,553.267 μs |    45,207.226 μs |  2,477.9606 μs |    12,544.900 μs |  1000.0000 |         - |     - |   3637672 B |
| TestIndexer |         cinecalidad |     9,475.600 μs |     7,586.451 μs |    415.8390 μs |     9,666.400 μs |  1000.0000 |         - |     - |   2943720 B |
| TestIndexer |             comicat |    74,721.833 μs |    34,593.166 μs |  1,896.1682 μs |    73,691.500 μs |  2000.0000 | 1000.0000 |     - |  18709632 B |
| TestIndexer |              concen |    40,986.233 μs |    28,938.129 μs |  1,586.1965 μs |    40,589.300 μs |  2000.0000 | 1000.0000 |     - |   9994136 B |
| TestIndexer |       cpasbienclone |   189,087.133 μs |   384,785.948 μs | 21,091.4162 μs |   198,203.600 μs | 37000.0000 | 1000.0000 |     - |  83020144 B |
| TestIndexer |           divxtotal |    11,667.867 μs |    30,496.506 μs |  1,671.6164 μs |    11,793.000 μs |          - |         - |     - |   3263992 B |
| TestIndexer |                dmhy |               NA |               NA |             NA |               NA |          - |         - |     - |           - |
| TestIndexer |             ehentai |    57,977.900 μs |   167,827.873 μs |  9,199.2120 μs |    57,652.700 μs |  2000.0000 | 1000.0000 |     - |  13564520 B |
| TestIndexer |              emtrek |    48,157.633 μs |    47,545.334 μs |  2,606.1202 μs |    48,941.300 μs |  1000.0000 |         - |     - |   9673456 B |
| TestIndexer |           epublibre |               NA |               NA |             NA |               NA |          - |         - |     - |           - |
| TestIndexer |           erai-raws |    16,705.233 μs |    54,397.041 μs |  2,981.6854 μs |    15,439.400 μs |  1000.0000 |         - |     - |   4784112 B |
| TestIndexer |                ettv |     8,507.933 μs |    22,272.441 μs |  1,220.8276 μs |     7,967.500 μs |          - |         - |     - |   3206016 B |
| TestIndexer |     extratorrent-cd |    63,794.367 μs |    58,557.514 μs |  3,209.7350 μs |    62,089.400 μs |  5000.0000 |         - |     - |  19234952 B |
| TestIndexer |     extratorrent-it |   111,238.333 μs |   555,761.255 μs | 30,463.1497 μs |    96,904.300 μs |  4000.0000 | 1000.0000 |     - |  26734576 B |
| TestIndexer |         exttorrents |       631.033 μs |     3,275.068 μs |    179.5175 μs |       541.600 μs |          - |         - |     - |    105760 B |
| TestIndexer |                eztv |               NA |               NA |             NA |               NA |          - |         - |     - |           - |
| TestIndexer |            filebase |    64,424.233 μs |    29,960.004 μs |  1,642.2089 μs |    63,755.500 μs |  6000.0000 | 1000.0000 |     - |  21641008 B |
| TestIndexer |             firebit |    94,768.067 μs |   212,268.523 μs | 11,635.1540 μs |    96,811.400 μs | 11000.0000 | 1000.0000 |     - |  30131272 B |
| TestIndexer |              focusx |    40,005.433 μs |   183,607.302 μs | 10,064.1358 μs |    45,573.400 μs |  1000.0000 |         - |     - |   4933128 B |
| TestIndexer |         frozenlayer |    37,913.400 μs |    27,042.577 μs |  1,482.2949 μs |    37,074.200 μs |  4000.0000 | 1000.0000 |     - |  13028192 B |
| TestIndexer |       gamestorrents |    65,107.633 μs |    72,279.109 μs |  3,961.8619 μs |    63,046.000 μs |  4000.0000 | 1000.0000 |     - |  19057984 B |
| TestIndexer |           gktorrent |   147,556.767 μs |    66,005.935 μs |  3,618.0080 μs |   148,163.100 μs | 13000.0000 | 1000.0000 |     - |  40398176 B |
| TestIndexer |              glodls |   129,498.000 μs |   711,580.046 μs | 39,004.1034 μs |   117,033.800 μs | 17000.0000 | 1000.0000 |     - |  41083432 B |
| TestIndexer |            gtorrent |    36,293.667 μs |    49,432.188 μs |  2,709.5450 μs |    37,568.800 μs |  1000.0000 |         - |     - |  11095888 B |
| TestIndexer |         gtorrentpro |    17,437.167 μs |    74,638.876 μs |  4,091.2086 μs |    19,545.900 μs |  1000.0000 |         - |     - |   5921152 B |
| TestIndexer |             hdhouse |    17,161.900 μs |    50,034.526 μs |  2,742.5612 μs |    18,690.000 μs |  1000.0000 |         - |     - |   5885456 B |
| TestIndexer |                ibit |    23,654.167 μs |    31,530.508 μs |  1,728.2935 μs |    24,408.000 μs |  1000.0000 |         - |     - |   6897584 B |
| TestIndexer |               idope |    30,759.433 μs |    41,621.786 μs |  2,281.4305 μs |    29,634.100 μs |  1000.0000 |         - |     - |   8194064 B |
| TestIndexer |       ilcorsaronero |               NA |               NA |             NA |               NA |          - |         - |     - |           - |
| TestIndexer |     internetarchive |   246,524.233 μs |   310,333.308 μs | 17,010.4158 μs |   255,606.000 μs | 35000.0000 | 1000.0000 |     - |  91675272 B |
| TestIndexer |            isohunt2 |     2,002.667 μs |    12,438.333 μs |    681.7870 μs |     1,816.500 μs |          - |         - |     - |    413200 B |
| TestIndexer |            itorrent |    26,802.667 μs |    37,801.885 μs |  2,072.0489 μs |    25,637.200 μs |  1000.0000 |         - |     - |   7181496 B |
| TestIndexer |  kickasstorrents-to |    46,710.633 μs |    59,762.982 μs |  3,275.8107 μs |    45,266.300 μs |  2000.0000 | 1000.0000 |     - |   9284944 B |
| TestIndexer |  kickasstorrents-ws |   105,459.500 μs |   348,840.799 μs | 19,121.1413 μs |    96,416.500 μs |  2000.0000 | 1000.0000 |     - |  15489688 B |
| TestIndexer |       legittorrents |    70,849.767 μs |    94,613.964 μs |  5,186.1106 μs |    68,655.600 μs |  2000.0000 | 1000.0000 |     - |  12582824 B |
| TestIndexer |         lepornoinfo |    21,690.267 μs |    50,741.704 μs |  2,781.3240 μs |    21,894.400 μs |  1000.0000 |         - |     - |   3913264 B |
| TestIndexer |        limetorrents |    50,686.033 μs |    73,721.361 μs |  4,040.9166 μs |    52,383.900 μs |  1000.0000 |         - |     - |   7715984 B |
| TestIndexer |        linuxtracker |   164,844.200 μs |   179,179.571 μs |  9,821.4369 μs |   168,102.500 μs | 11000.0000 | 4000.0000 |     - |  27945816 B |
| TestIndexer |         mactorrents |    97,678.300 μs |   178,974.761 μs |  9,810.2106 μs |    92,779.800 μs |  3000.0000 | 1000.0000 |     - |  16711944 B |
| TestIndexer |          magnet4you |    54,248.967 μs |    33,792.675 μs |  1,852.2905 μs |    54,469.700 μs |  2000.0000 | 1000.0000 |     - |   9493728 B |
| TestIndexer |        mejortorrent |   122,158.367 μs |   218,800.041 μs | 11,993.1686 μs |   120,932.000 μs |  4000.0000 | 1000.0000 |     - |  18481624 B |
| TestIndexer |      mixtapetorrent |    24,007.467 μs |    64,886.207 μs |  3,556.6319 μs |    24,151.300 μs |  1000.0000 |         - |     - |   5490824 B |
| TestIndexer |          montorrent |    25,447.467 μs |    62,909.144 μs |  3,448.2625 μs |    26,655.600 μs |          - |         - |     - |   3375280 B |
| TestIndexer |          moviesdvdr |               NA |               NA |             NA |               NA |          - |         - |     - |           - |
| TestIndexer |        movietorrent |    29,482.333 μs |    51,186.817 μs |  2,805.7221 μs |    30,217.900 μs |  1000.0000 |         - |     - |   5808736 B |
| TestIndexer |          mypornclub |    88,792.233 μs |   426,071.104 μs | 23,354.3949 μs |    88,039.700 μs |  3000.0000 | 1000.0000 |     - |  18655024 B |
| TestIndexer |              newpct |    41,059.700 μs |   145,619.912 μs |  7,981.9187 μs |    37,481.800 μs |  1000.0000 |         - |     - |   7568880 B |
| TestIndexer |           newstudio |   289,112.833 μs |   417,895.589 μs | 22,906.2673 μs |   295,447.400 μs |  5000.0000 | 1000.0000 |     - |  40578840 B |
| TestIndexer |               nitro |   299,151.300 μs |   153,914.171 μs |  8,436.5551 μs |   297,307.100 μs | 29000.0000 | 1000.0000 |     - |  79086824 B |
| TestIndexer |                nntt |    96,409.333 μs |   126,887.363 μs |  6,955.1245 μs |    93,611.900 μs |  3000.0000 |         - |     - |  16639392 B |
| TestIndexer |         noname-club |    86,783.367 μs |    95,494.658 μs |  5,234.3844 μs |    84,949.200 μs |  8000.0000 |         - |     - |  25581968 B |
| TestIndexer |         nyaa-pantsu |   108,672.533 μs |    73,983.440 μs |  4,055.2820 μs |   107,820.900 μs |  6000.0000 | 1000.0000 |     - |  22520296 B |
| TestIndexer |              nyaasi |    70,729.600 μs |   112,984.517 μs |  6,193.0626 μs |    67,172.800 μs |  2000.0000 | 1000.0000 |     - |  13273112 B |
| TestIndexer |          oncesearch |    98,756.867 μs |   222,166.590 μs | 12,177.7005 μs |    92,098.500 μs |  2000.0000 | 1000.0000 |     - |  12668080 B |
| TestIndexer |              onejav |    39,961.867 μs |    99,465.580 μs |  5,452.0441 μs |    38,241.400 μs |  1000.0000 |         - |     - |   7398352 B |
| TestIndexer |           oxtorrent |    34,000.267 μs |    28,645.895 μs |  1,570.1781 μs |    33,904.800 μs |  1000.0000 |         - |     - |   9368896 B |
| TestIndexer |             parnuxi |   150,389.600 μs |   103,889.991 μs |  5,694.5610 μs |   148,670.700 μs | 17000.0000 |         - |     - |  42107440 B |
| TestIndexer |           pctorrent |   128,510.000 μs |    63,178.088 μs |  3,463.0042 μs |   130,234.900 μs |  2000.0000 | 1000.0000 |     - |  12683760 B |
| TestIndexer |            piratbit |    16,778.067 μs |    47,302.695 μs |  2,592.8203 μs |    18,234.400 μs |  1000.0000 |         - |     - |   4676800 B |
| TestIndexer |           pirateiro |    97,328.833 μs |   171,928.426 μs |  9,423.9772 μs |    94,373.800 μs |  2000.0000 | 1000.0000 |     - |  11307096 B |
| TestIndexer |          pornforall |               NA |               NA |             NA |               NA |          - |         - |     - |           - |
| TestIndexer |           pornleech |    48,871.000 μs |    80,492.255 μs |  4,412.0521 μs |    49,632.400 μs |  1000.0000 |         - |     - |   8681696 B |
| TestIndexer |           pornolive |    68,380.500 μs |    38,566.189 μs |  2,113.9429 μs |    67,637.200 μs |  2000.0000 | 1000.0000 |     - |  11569792 B |
| TestIndexer |            pornorip |    25,332.367 μs |    62,242.657 μs |  3,411.7301 μs |    24,624.800 μs |          - |         - |     - |   4508376 B |
| TestIndexer |            pornotor |    45,873.700 μs |    57,918.773 μs |  3,174.7234 μs |    45,798.200 μs |  2000.0000 | 1000.0000 |     - |   8892848 B |
| TestIndexer |            proporno |    23,508.600 μs |    68,329.383 μs |  3,745.3641 μs |    24,646.700 μs |  1000.0000 |         - |     - |   5761856 B |
| TestIndexer |           rapidzona |    33,510.367 μs |   139,523.806 μs |  7,647.7706 μs |    31,743.600 μs |          - |         - |     - |   4071624 B |
| TestIndexer |               rarbg |    24,014.033 μs |    41,412.393 μs |  2,269.9530 μs |    23,759.800 μs |          - |         - |     - |   4485416 B |
| TestIndexer |           rintornet |     4,034.900 μs |    10,127.646 μs |    555.1304 μs |     3,926.600 μs |          - |         - |     - |   1070720 B |
| TestIndexer |           rus-media |    32,101.000 μs |    56,191.150 μs |  3,080.0265 μs |    33,379.000 μs |  1000.0000 |         - |     - |   4788560 B |
| TestIndexer |               rutor |   114,830.367 μs |    94,229.225 μs |  5,165.0218 μs |   116,932.200 μs | 10000.0000 | 1000.0000 |     - |  31013312 B |
| TestIndexer |        rutracker-ru | 3,553,106.167 μs |   482,602.705 μs | 26,453.0827 μs | 3,563,829.500 μs | 68000.0000 | 4000.0000 |     - | 157342184 B |
| TestIndexer |            sexypics |   388,861.767 μs | 1,282,626.572 μs | 70,305.0905 μs |   363,563.600 μs |  8000.0000 | 1000.0000 |     - |  26980888 B |
| TestIndexer |             shokweb |    59,063.333 μs |    45,417.942 μs |  2,489.5107 μs |    59,243.800 μs |  2000.0000 | 1000.0000 |     - |  10598840 B |
| TestIndexer |             showrss |    75,567.033 μs |   139,620.720 μs |  7,653.0828 μs |    72,026.500 μs |  4000.0000 | 1000.0000 |     - |  17408528 B |
| TestIndexer |      skytorrents-to |     5,021.267 μs |    40,358.048 μs |  2,212.1608 μs |     3,794.300 μs |          - |         - |     - |   1499784 B |
| TestIndexer |       solidtorrents |               NA |               NA |             NA |               NA |          - |         - |     - |           - |
| TestIndexer |             sosulki |     2,311.067 μs |    11,023.251 μs |    604.2216 μs |     2,388.900 μs |          - |         - |     - |    435816 B |
| TestIndexer |          subsplease |    37,192.233 μs |    45,246.228 μs |  2,480.0984 μs |    36,222.400 μs |  1000.0000 |         - |     - |   4915760 B |
| TestIndexer |      sukebei-pantsu |     5,076.233 μs |    10,609.103 μs |    581.5207 μs |     4,905.900 μs |          - |         - |     - |    958680 B |
| TestIndexer |       sukebeinyaasi |    67,130.467 μs |   109,587.315 μs |  6,006.8505 μs |    65,416.200 μs |  3000.0000 | 1000.0000 |     - |  13685760 B |
| TestIndexer |        thepiratebay |    68,784.633 μs |    73,724.950 μs |  4,041.1133 μs |    68,987.300 μs |  2000.0000 |         - |     - |  11260000 B |
| TestIndexer |             tntfork |     1,106.367 μs |       546.878 μs |     29.9762 μs |     1,103.900 μs |          - |         - |     - |    180296 B |
| TestIndexer |          tokyotosho |   412,351.800 μs | 1,021,119.888 μs | 55,971.0267 μs |   427,922.400 μs | 20000.0000 | 1000.0000 |     - |  51613760 B |
| TestIndexer |             torlock |   359,739.900 μs |   256,535.530 μs | 14,061.5780 μs |   362,789.400 μs |  2000.0000 | 1000.0000 |     - |  11864200 B |
| TestIndexer |               toros |   229,633.700 μs |   590,849.117 μs | 32,386.4338 μs |   213,396.600 μs |  5000.0000 | 1000.0000 |     - |  20204896 B |
| TestIndexer | torrent-paradise-ml |   161,801.933 μs |   677,805.106 μs | 37,152.7850 μs |   182,486.300 μs |  2000.0000 |         - |     - |  14399400 B |
| TestIndexer |       torrent-pirat |     2,698.333 μs |     4,106.690 μs |    225.1015 μs |     2,736.200 μs |          - |         - |     - |    528432 B |
| TestIndexer |         torrent4you |    34,874.533 μs |     9,895.141 μs |    542.3860 μs |    35,032.500 μs |  1000.0000 |         - |     - |   7361720 B |
| TestIndexer |            torrent9 |   122,671.333 μs |   250,553.162 μs | 13,733.6643 μs |   125,571.800 μs |  5000.0000 | 1000.0000 |     - |  19788144 B |
| TestIndexer |       torrent9clone |   127,247.800 μs |   275,838.941 μs | 15,119.6632 μs |   123,382.500 μs | 13000.0000 | 1000.0000 |     - |  32211800 B |
| TestIndexer |    torrentdownloads |   102,225.667 μs |    68,065.473 μs |  3,730.8983 μs |   104,206.900 μs | 11000.0000 |         - |     - |  27387064 B |
| TestIndexer |         torrentfunk |   305,521.267 μs |   215,951.013 μs | 11,837.0037 μs |   309,651.100 μs | 29000.0000 | 3000.0000 |     - |  78703464 B |
| TestIndexer |       torrentgalaxy |    66,931.533 μs |   151,543.879 μs |  8,306.6314 μs |    66,023.200 μs |  2000.0000 | 1000.0000 |     - |   9301840 B |
| TestIndexer |        torrentkitty |   102,377.067 μs |   228,844.991 μs | 12,543.7662 μs |    95,194.000 μs |  3000.0000 | 1000.0000 |     - |  17217432 B |
| TestIndexer |        torrentmafya |               NA |               NA |             NA |               NA |          - |         - |     - |           - |
| TestIndexer |          torrentmax |     3,014.900 μs |    10,078.656 μs |    552.4451 μs |     2,968.000 μs |          - |         - |     - |    719656 B |
| TestIndexer |    torrentoyunindir |    97,974.500 μs |   280,420.913 μs | 15,370.8165 μs |    92,105.200 μs |  5000.0000 |         - |     - |  19322328 B |
| TestIndexer |     torrentparadise |     9,034.233 μs |    69,903.773 μs |  3,831.6617 μs |     7,288.400 μs |          - |         - |     - |   2348448 B |
| TestIndexer |      torrentproject |    90,794.233 μs |   490,783.985 μs | 26,901.5263 μs |   104,428.200 μs |  3000.0000 | 1000.0000 |     - |  12103752 B |
| TestIndexer |     torrentproject2 |               NA |               NA |             NA |               NA |          - |         - |     - |           - |
| TestIndexer |           torrentqq |    91,334.000 μs |   169,124.877 μs |  9,270.3052 μs |    93,451.600 μs |  5000.0000 | 1000.0000 |     - |  20694344 B |
| TestIndexer |         torrentscsv |               NA |               NA |             NA |               NA |          - |         - |     - |           - |
| TestIndexer |          torrentsir |         6.184 μs |        17.417 μs |      0.9547 μs |         6.449 μs |     1.2283 |         - |     - |      2576 B |
| TestIndexer |            torrentv |   104,257.233 μs |   279,505.267 μs | 15,320.6268 μs |    98,041.600 μs |  5000.0000 | 1000.0000 |     - |  20722984 B |
| TestIndexer |         torrentview |    27,762.167 μs |    34,249.192 μs |  1,877.3138 μs |    26,680.800 μs |  1000.0000 |         - |     - |   5820640 B |
| TestIndexer |         torrentwhiz |               NA |               NA |             NA |               NA |          - |         - |     - |           - |
| TestIndexer |        trupornolabs |               NA |               NA |             NA |               NA |          - |         - |     - |           - |
| TestIndexer |          underverse |   178,967.700 μs |   252,543.864 μs | 13,842.7814 μs |   185,483.100 μs | 15000.0000 | 1000.0000 |     - |  43159288 B |
| TestIndexer |            uniondht |   169,865.233 μs |   100,054.070 μs |  5,484.3012 μs |   170,682.400 μs |  4000.0000 | 1000.0000 |     - |  19289568 B |
| TestIndexer |            vsthouse |   325,495.967 μs | 1,642,545.871 μs | 90,033.4817 μs |   337,921.500 μs |  4000.0000 | 1000.0000 |     - |  17769432 B |
| TestIndexer |         vsttorrents |    79,932.100 μs |   197,008.135 μs | 10,798.6807 μs |    82,102.100 μs |  2000.0000 | 1000.0000 |     - |  14765864 B |
| TestIndexer |     xxxadulttorrent |    11,889.567 μs |    32,965.258 μs |  1,806.9370 μs |    12,393.000 μs |          - |         - |     - |   3437376 B |
| TestIndexer |              xxxtor |    41,936.900 μs |    26,985.241 μs |  1,479.1521 μs |    41,688.300 μs |  4000.0000 | 1000.0000 |     - |  19309408 B |
| TestIndexer |         xxxtorrents |    43,768.033 μs |    13,477.572 μs |    738.7512 μs |    43,494.700 μs |  6000.0000 | 1000.0000 |     - |  22647864 B |
| TestIndexer |      yourbittorrent |    48,360.800 μs |    63,251.337 μs |  3,467.0192 μs |    46,471.600 μs |  2000.0000 | 1000.0000 |     - |  14422024 B |
| TestIndexer |                 yts |    27,220.067 μs |    18,781.378 μs |  1,029.4707 μs |    26,955.500 μs |  3000.0000 | 1000.0000 |     - |  10630368 B |
| TestIndexer |          zetorrents |     3,424.600 μs |    23,446.525 μs |  1,285.1832 μs |     2,712.700 μs |          - |         - |     - |   1586536 B |
| TestIndexer |              zooqle |    57,945.567 μs |    27,878.365 μs |  1,528.1073 μs |    57,138.400 μs | 11000.0000 | 1000.0000 |     - |  28351792 B |