### PR TITLE
Added new link to NewPCT indexer

### DIFF
--- a/src/Jackett.Common/Indexers/NewPCT.cs
+++ b/src/Jackett.Common/Indexers/NewPCT.cs
@@ -101,7 +101,8 @@ namespace Jackett.Common.Indexers
         public override string[] AlternativeSiteLinks { get; protected set; } = {
             "https://pctmix.com/",
             "https://pctmix1.com/",
-            "https://pctreload1.com/"
+            "https://pctreload1.com/",
+            "https://maxitorrent.com"
         };
 
         public override string[] LegacySiteLinks { get; protected set; } = {
@@ -115,7 +116,8 @@ namespace Jackett.Common.Indexers
             "http://pctnew.com/",
             "https://descargas2020.org/",
             "https://pctnew.org/",
-            "https://pctreload.com/"
+            "https://pctreload.com/",
+            "https://maxitorrent.com"
         };
 
         public NewPCT(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,

--- a/src/Jackett.Common/Indexers/NewPCT.cs
+++ b/src/Jackett.Common/Indexers/NewPCT.cs
@@ -116,8 +116,7 @@ namespace Jackett.Common.Indexers
             "http://pctnew.com/",
             "https://descargas2020.org/",
             "https://pctnew.org/",
-            "https://pctreload.com/",
-            "https://maxitorrent.com"
+            "https://pctreload.com/"
         };
 
         public NewPCT(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,


### PR DESCRIPTION
Some internet providers are blocking the connection to this indexer. With this new link the connection is allowed without the need for a proxy or vpn to the indexer