### PR TITLE
Update hdcztorrent.yml

### DIFF
--- a/src/Jackett.Common/Definitions/hdcztorrent.yml
+++ b/src/Jackett.Common/Definitions/hdcztorrent.yml
@@ -129,7 +129,7 @@ search:
     by: "{{ .Config.type }}"
 
   rows:
-    selector: table.lista > tbody > tr:has(a[href*=bookmark])
+    selector: td#mcol table.lista > tbody > tr:has(a[href*=bookmark])
 
   fields:
     category:


### PR DESCRIPTION
fixes double findings, this is improved from original which was doing preprocessing and regex