### PR TITLE
Update animeworld.cx to new source

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * anasch.cc
  * AnimeBytes (AB)
  * AnimeTorrents (AnT)
- * AnimeWorld (AST4u) [![(invite needed)][inviteneeded]](#)
+ * AnimeWorld [![(invite needed)][inviteneeded]](#)
  * Anthelion
  * Araba Fenice (Phoenix) [![(invite needed)][inviteneeded]](#)
  * ArabP2P

--- a/src/Jackett.Common/Definitions/animeworld.yml
+++ b/src/Jackett.Common/Definitions/animeworld.yml
@@ -27,7 +27,9 @@ caps:
     search: [q]
     tv-search: [q, season, ep, imdbid, tvdbid]
     movie-search: [q, imdbid, tmdbid]
-
+    music-search: [q]
+    book-search: [q]
+    
 settings:
   - name: username
     type: text

--- a/src/Jackett.Common/Definitions/animeworld.yml
+++ b/src/Jackett.Common/Definitions/animeworld.yml
@@ -1,49 +1,32 @@
 ---
 id: animeworld
-name: AnimeWorld
-description: "AnimeWorld (AST4u) is a GERMAN Private site for TV / MOVIES / ANIME / HENTAI"
+name: Animeworld
+description: "AnimeWorld (AW) is a GERMAN Private site for ANIME / MANGA / HENTAI"
 language: de-de
 type: private
-encoding: iso-8859-1
+encoding: UTF-8
 links:
   - https://animeworld.cx/
-legacylinks:
-  - https://www.ast4u.me/
 
 caps:
   categorymappings:
-    - {id: 35, cat: TV/Anime, desc: "Anime Movie"}
-    - {id: 36, cat: TV/Anime, desc: "Anime Serie"}
-    - {id: 37, cat: Audio/Foreign, desc: "Anime Musik"}
-    - {id: 41, cat: Books, desc: "Anime Pic & Manga"}
-    - {id: 42, cat: XXX, desc: "Hentai Movie & OVA"}
-    - {id: 43, cat: XXX, desc: "Hentai Serie"}
-    - {id: 44, cat: PC, desc: "Hentai Game"}
-    - {id: 45, cat: Movies, desc: "Cartoon Movie"}
-    - {id: 46, cat: TV, desc: "Cartoon Serie"}
-    - {id: 47, cat: TV, desc: "TV-Serie"}
-    - {id: 49, cat: TV/Documentary, desc: "Sonstiges Doku"}
-    - {id: 50, cat: Audio, desc: "Sonstiges Soundtrack"}
-    - {id: 52, cat: Movies/HD, desc: "Movie HD"}
-    - {id: 53, cat: Other, desc: "Sonstiges"}
-    - {id: 55, cat: Movies/Foreign, desc: "Movie Asia & MartialArts"}
-    - {id: 56, cat: TV/Anime, desc: "Anime OVA"}
-    - {id: 58, cat: Movies, desc: "Movie"}
-    - {id: 59, cat: Audio/Audiobook, desc: "Sonstiges Hoerspiele"}
-    - {id: 62, cat: Console, desc: "Sonstiges Game"}
-    - {id: 65, cat: Movies/BluRay, desc: "Movie BluRay"}
-    - {id: 66, cat: TV, desc: "TV-Serie BluRay"}
-    - {id: 67, cat: TV/HD, desc: "TV-Serie HD"}
-    - {id: 68, cat: TV/Anime, desc: "Anime Movie HD & BD"}
-    - {id: 69, cat: TV/Anime, desc: "Anime OVA HD & BD"}
-    - {id: 70, cat: TV/Anime, desc: "Anime Serie HD & BD"}
+    - {id: 1, cat: TV/Anime, desc: "Anime Movie"}
+    - {id: 2, cat: TV/Anime, desc: "Anime Serie"}
+    - {id: 3, cat: Audio, desc: "Anime Musik/OST"}
+    - {id: 4, cat: PC/Games, desc: "Anime Spiele"}
+    - {id: 5, cat: XXX, desc: "Hentai"}
+    - {id: 6, cat: PC, desc: "Spiele Linux"}
+    - {id: 7, cat: Other, desc: "Sonstiges"}
+    - {id: 8, cat: Movies, desc: "Filme"}
+    - {id: 9, cat: TV, desc: "Serien"}
+    - {id: 10, cat: PC/Games, desc: "Spiele"}
+    - {id: 11, cat: Audio, desc: "Musik"}
+    - {id: 12, cat: Books, desc: "Mangas"}
 
   modes:
     search: [q]
-    tv-search: [q, season, ep]
-    movie-search: [q]
-    music-search: [q]
-    book-search: [q]
+    tv-search: [q, season, ep, imdbid, tvdbid]
+    movie-search: [q, imdbid, tmdbid]
 
 settings:
   - name: username
@@ -52,83 +35,155 @@ settings:
   - name: password
     type: password
     label: Password
-  - name: info
-    type: info
-    label: Results Per Page
-    default: For best results, change the <b>Torrentliste</b> setting to <i>Platzsparendes Layout mit PopUp für zusätzliche Informationen</i> in your profile.
+  - name: freeleech
+    type: checkbox
+    label: Search freeleech only
+    default: false
+  - name: sort
+    type: select
+    label: Sort requested from site
+    default: created_at
+    options:
+      created_at: created
+      seeders: seeders
+      size: size
+      name: title
+  - name: type
+    type: select
+    label: Order requested from site
+    default: desc
+    options:
+      desc: desc
+      asc: asc
 
 login:
-  path: takelogin.php
-  method: post
+  path: login
+  method: form
+  form: form[action$="/login"]
   inputs:
     username: "{{ .Config.username }}"
     password: "{{ .Config.password }}"
-    returnto: "/index.php"
-  test:
-    path: browse.php
+    remember: on
+  selectorinputs:
+    _token:
+      selector: input[name="_token"]
+      attribute: value
+  error:
+    - selector: div#ERROR_COPY
+#    test:
+#      path: /
+#      selector: a[href$="/logout"]
 
 search:
   paths:
-    - path: browse.php
+    - path: torrents
   inputs:
-    $raw: "{{ range .Categories }}c{{.}}=1&{{end}}"
-    search: "{{ .Keywords }}"
-    incldead: 0
-    orderby: added
-    sort: desc
+    $raw: "{{ range .Categories }}categories[]={{.}}&{{end}}"
+    name: "{{ if .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}" # for dashboard imdbid search
+    description: ""
+    mediainfo: ""
+    keywords: ""
+    uploader: ""
+    tmdbId: "{{ .Query.TMDBID }}"
+    imdbId: "{{ .Query.IMDBIDShort }}"
+    tvdbId: "{{ .Query.TVDBID }}"
+    malId: ""
+    startYear: ""
+    endYear: ""
+    sortField: "{{ .Config.sort }}"
+    sortDirection: "{{ .Config.type }}"
+    perPage: 100
+    page: 1
+    freeleech: "{{ if .Config.freeleech }}1{{ else }}{{ end }}"
 
   rows:
-    selector: table.tableinborder > tbody > tr:has(a[href^="details.php"])
+    selector: table > tbody > tr
 
-  fields: # note: two alternative layouts available
-    title:
-      selector: a[href^="details.php"]
-    title:
-      optional: true
-      selector: a[href^="details.php"][title]
-      attribute: title
+  fields:
     category:
-      selector: a[href^="browse.php?cat="]
+      selector: a[href*="/categories/"]
       attribute: href
       filters:
-        - name: querystring
-          args: cat
-    details:
-      selector: a[href^="details.php"]
-      attribute: href
+        - name: regexp
+          args: "/categories/(\\d+)"
+    title:
+      selector: a.view-torrent
     download:
-      selector: a[href^=" /gettorrent/"]
+      selector: a[href*="/download/"]
       attribute: href
-    files:
-      selector: td:nth-child(2) > table > tbody > tr:nth-child(2) > td:nth-child(1) > b:nth-child(2), a[href*="&filelist=1"]
-    grabs:
-      selector: td:nth-child(2) > table > tbody > tr:nth-child(2) > td:nth-child(3) > b:nth-child(1), a[href*="&tosnatchers=1"]
+    details:
+      selector: a.view-torrent
+      attribute: href
+    poster:
+      selector: div.torrent-poster img
+      attribute: src
+      filters:
+        - name: replace
+          args: ["https://via.placeholder.com/90x135", ""]
     size:
-      selector: td:nth-child(2) > table > tbody > tr:nth-child(2) > td:nth-child(1) > b:nth-child(1), td:nth-child(7):has(br)
-      filters:
-        - name: replace
-          args: [".", ""]
-        - name: replace
-          args: [",", "."]
+      selector: td:nth-last-child(5)
     seeders:
-      selector: td:nth-child(2) > table > tbody > tr:nth-child(2) > td:nth-child(2) > b:nth-child(1), a[href*="&toseeders=1"]
+      selector: td:nth-last-child(4)
     leechers:
-      selector: td:nth-child(2) > table > tbody > tr:nth-child(2) > td:nth-child(2) > b:nth-child(3), a[href*="&todlers=1"]
+      selector: td:nth-last-child(3)
+    grabs:
+      selector: td:nth-last-child(2)
     date:
-      selector: td:nth-child(2) > table > tbody > tr:nth-child(2) > td:nth-child(5), td:nth-child(5):has(br)
+      selector: td:nth-last-child(1)
       filters:
-        - name: replace
-          args: [" ", ""]
-        - name: append
-          args: " +2:00" # EET
-        - name: replace
-          args: ["\xA0", ""]
-        - name: dateparse
-          args: "02.01.200615:04:05 -07:00"
+        # translations for Turkish|Estonian|Danish|Italian|Polish|Norwegian|Portuguese|Czech|Russian|Romanian|Spanish|French|German|Bulgarian|Dutch|Chinese|Japanese|Swedish
+        - name: re_replace
+          args: ["(?i)(önce|tagasi|geleden|fa|temu|siden|há|atrás|nazpět|назад|acum|în urmă|hace|il y a|vor|преди|前|sedan)", " ago"]
+        - name: re_replace
+          args: ["(?i)(saniye|sekundit|sekunder|secondi|sekund|segundos|sekundami|секунд|secunde|secondes|Sekunden|секунди|seconden|秒前)", "seconds"]
+        - name: re_replace
+          args: ["(?i)(minutit|minutter|minuti|minuty|minutos|минуты|минут|Minuten|минути|minuten|minuter)", "minutes"]
+        - name: re_replace
+          args: ["(?i)(dakika|minut|minuto|minuta|minutt|минута|Minute|minuut|分钟|分)", " minute"]
+        - name: re_replace
+          args: ["(?i)(tundi|timer|ore|godziny|horas|hodiny|hoden|часа|часов|ore|heures|Stunden|timmar)", "hours"]
+        - name: re_replace
+          args: ["(?i)(saat|tund|time|ora|godzina|hora|hodina|час|oră|heure|Stunde|uur|小时|時間|timme)", " hour"]
+        - name: re_replace
+          args: ["(?i)(päeva|dage|giorni|dni|dias|dny|дня|дней|zile|días|jours|Tagen|дни|dagen|dagar)", "days"]
+        - name: re_replace
+          args: ["(?i)(gün|päev|dag|giorno|dzień|dia|den|день|zi|día|jour|Tag|ден|天|日)", " day"]
+        - name: re_replace
+          args: ["(?i)(nädalat|uger|settimane|tygodnie|uker|semanas|týdny|недели|недель|săptămâni|semaines|Wochen|седмици|weken|veckor)", "weeks"]
+        - name: re_replace
+          args: ["(?i)(hafta|nädal|uge|settimana|tydzień|uke|semana|týden|неделю|săptămână|semaine|Woche|седмица|周|週間|vecka)", " week"]
+        - name: re_replace
+          args: ["(?i) (ay)", "month"]
+        - name: re_replace
+          args: ["(?i)(kuud|måneder|mesi|miesiące|meses|měsíce|месяца|месяцев|luni|meses|mois|Monaten|месеца|maanden|månader)", "months"]
+        - name: re_replace
+          args: ["(?i)(kuu|måned|mese|miesiąc|mês|měsíc|месяц|lună|mes|Monat|месец|maand|个月|ヶ月|månad)", " month"]
+        - name: re_replace
+          args: ["(?i)(aastat|anni|lata|anos|roky|года|ani|años|ans|Jahren|години)", " years"]
+        - name: re_replace
+          args: ["(?i)(yil|aasta|år|anno|rok|ano|год|año|Jahr|година|jaar|年)", " year"]
+        - name: re_replace
+          args: ["(?i) (an)", "year"]
+        - name: re_replace
+          args: ["(?i)(För |und)", ""] # Misc removals
+        - name: timeago
     downloadvolumefactor:
       case:
-        img[src="/pic/free.gif"]: 0
+        i[class*="fa-id-badge text-orange"]: 0 # 24 Hour FreeLeech From BON Store
+        i[class*="fa-trophy text-purple"]: 0 # Special FreeLeech For Certain User Groups
+        i[class*="fa-star text-bold"]: 0 # Freeleech From Token
+        i[class*="fa-coins text-bold"]: 0 # Freeleech From Token
+        i[class*="fa-globe text-blue"]: 0 # Global Freeleech
+        i[class*="fa-star text-gold"]: 0 # Freeleech
+        i[class*="fa-certificate text-pink"]: 0 # Featured Torrent
         "*": 1
     uploadvolumefactor:
-      text: 1
-# engine tbd
+      case:
+        i[class*="fa-gem text-green"]: 2 # Single Torrent Double Upload
+        i[class*="fa-globe text-green"]: 2 # Global Double Upload
+        i[class*="fa-certificate text-pink"]: 2 # Featured Torrent
+        "*": 1
+    minimumseedtime:
+      # 7 day (as seconds = 7 x 24 x 60 x 60)
+      text: 604800
+# UNIT3D 5.3.0

--- a/src/Jackett.Common/Definitions/animeworld.yml
+++ b/src/Jackett.Common/Definitions/animeworld.yml
@@ -1,6 +1,6 @@
 ---
 id: animeworld
-name: Animeworld
+name: AnimeWorld
 description: "AnimeWorld (AW) is a GERMAN Private site for ANIME / MANGA / HENTAI"
 language: de-de
 type: private

--- a/src/Jackett.Common/Definitions/animeworld.yml
+++ b/src/Jackett.Common/Definitions/animeworld.yml
@@ -29,7 +29,7 @@ caps:
     movie-search: [q, imdbid, tmdbid]
     music-search: [q]
     book-search: [q]
-    
+
 settings:
   - name: username
     type: text

--- a/src/Jackett.Common/Definitions/animeworld.yml
+++ b/src/Jackett.Common/Definitions/animeworld.yml
@@ -10,7 +10,7 @@ links:
 
 caps:
   categorymappings:
-    - {id: 1, cat: TV/Anime, desc: "Anime Movie"}
+    - {id: 1, cat: Movies/Other, desc: "Anime Movie"}
     - {id: 2, cat: TV/Anime, desc: "Anime Serie"}
     - {id: 3, cat: Audio, desc: "Anime Musik/OST"}
     - {id: 4, cat: PC/Games, desc: "Anime Spiele"}

--- a/src/Jackett.Common/Services/IndexerManagerService.cs
+++ b/src/Jackett.Common/Services/IndexerManagerService.cs
@@ -40,7 +40,6 @@ namespace Jackett.Common.Services
         // use: {"<old id>", "<new id>"}
         private readonly Dictionary<string, string> renamedIndexers = new Dictionary<string, string>
         {
-            {"ast4u", "animeworld"},
             {"audiobooktorrents", "abtorrents"},
             {"broadcastthenet", "broadcasthenet"},
             {"cili180", "cilipro"},


### PR DESCRIPTION
animeworld.cx changed their source to unit3d, with this commit the jackett integration is working again.

They also had ast4u as their old trackername, but i removed those references as they now require a new registration and old accounts are not working anymore

I have one question though, they have a categorie for Anime Movies, which I mapped to "TV/Anime" (as it was on the old animeworld.yml), but is this okay or should this be mapped to "Movies"?

Thanks