### PR TITLE
newpct: fixed 404 torrent download url. resolves: #11841

### DIFF
--- a/src/Jackett.Common/Indexers/NewPCT.cs
+++ b/src/Jackett.Common/Indexers/NewPCT.cs
@@ -180,9 +180,9 @@ namespace Jackett.Common.Indexers
 
         public override async Task<byte[]> Download(Uri linkParam)
         {
-            var results = await RequestWithCookiesAndRetryAsync(linkParam.AbsoluteUri);
-
-            var uriLink = ExtractDownloadUri(results.ContentString, linkParam.AbsoluteUri);
+            var downloadLink = linkParam.AbsoluteUri.Replace("/descargar/", "/descargar/torrent/");
+            var results = await RequestWithCookiesAndRetryAsync(downloadLink);
+            var uriLink = ExtractDownloadUri(results.ContentString, downloadLink);
             if (uriLink == null)
                 throw new Exception("Download link not found!");
 

--- a/src/Jackett.Common/Indexers/NewPCT.cs
+++ b/src/Jackett.Common/Indexers/NewPCT.cs
@@ -116,8 +116,7 @@ namespace Jackett.Common.Indexers
             "http://pctnew.com/",
             "https://descargas2020.org/",
             "https://pctnew.org/",
-            "https://pctreload.com/",
-            "https://maxitorrent.com"
+            "https://pctreload.com/"
         };
 
         public NewPCT(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,

--- a/src/Jackett.Common/Indexers/NewPCT.cs
+++ b/src/Jackett.Common/Indexers/NewPCT.cs
@@ -101,7 +101,8 @@ namespace Jackett.Common.Indexers
         public override string[] AlternativeSiteLinks { get; protected set; } = {
             "https://pctmix.com/",
             "https://pctmix1.com/",
-            "https://pctreload1.com/"
+            "https://pctreload1.com/",
+            "https://maxitorrent.com"
         };
 
         public override string[] LegacySiteLinks { get; protected set; } = {
@@ -180,7 +181,10 @@ namespace Jackett.Common.Indexers
 
         public override async Task<byte[]> Download(Uri linkParam)
         {
-            var downloadLink = linkParam.AbsoluteUri.Replace("/descargar/", "/descargar/torrent/");
+            var downloadLink = new Regex("maxitorrent.com").Match(linkParam.AbsoluteUri).Success
+                ? linkParam.AbsoluteUri.Replace("/descargar/", "/descargar/torrent/")
+                : linkParam.AbsoluteUri;
+
             var results = await RequestWithCookiesAndRetryAsync(downloadLink);
             var uriLink = ExtractDownloadUri(results.ContentString, downloadLink);
             if (uriLink == null)


### PR DESCRIPTION
Fix for #11841

The download url page does not include js function with download link:
https://maxitorrent.com/descargar/serie/fbi/temporada-3/capitulo-11/hdtv/
The torrent download url has to be extracted from https://maxitorrent.com/descargar/torrent/serie/fbi/temporada-3/capitulo-11/hdtv/