### PR TITLE
orpheus: added api token support

### DIFF
--- a/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
@@ -26,6 +26,8 @@ namespace Jackett.Common.Indexers.Abstract
         protected virtual string APIUrl => SiteLink + "ajax.php";
         protected virtual string DownloadUrl => SiteLink + "torrents.php?action=download&usetoken=" + (useTokens ? "1" : "0") + "&id=";
         protected virtual string DetailsUrl => SiteLink + "torrents.php?torrentid=";
+        protected virtual string AuthorizationFormat => "{0}";
+        protected virtual int ApiKeyLength => 41;
 
         protected bool useTokens;
         protected string cookie = "";
@@ -81,8 +83,8 @@ namespace Jackett.Common.Indexers.Abstract
                 var apiKey = configData.ApiKey;
                 if (apiKey?.Value == null)
                     throw new Exception("Invalid API Key configured");
-                if (apiKey.Value.Length != 41)
-                    throw new Exception($"Invalid API Key configured: expected length: 41, got {apiKey.Value.Length}");
+                if (apiKey.Value.Length != ApiKeyLength)
+                    throw new Exception($"Invalid API Key configured: expected length: {ApiKeyLength}, got {apiKey.Value.Length}");
 
                 try
                 {
@@ -189,7 +191,7 @@ namespace Jackett.Common.Indexers.Abstract
             searchUrl += "?" + queryCollection.GetQueryString();
 
             var apiKey = configData.ApiKey;
-            var headers = apiKey != null ? new Dictionary<string, string> { ["Authorization"] = apiKey.Value } : null;
+            var headers = apiKey != null ? new Dictionary<string, string> { ["Authorization"] = String.Format(AuthorizationFormat, apiKey.Value) } : null;
 
             var response = await RequestWithCookiesAndRetryAsync(searchUrl, headers: headers);
             // we get a redirect in html pages and an error message in json response (api)
@@ -368,7 +370,7 @@ namespace Jackett.Common.Indexers.Abstract
         public override async Task<byte[]> Download(Uri link)
         {
             var apiKey = configData.ApiKey;
-            var headers = apiKey != null ? new Dictionary<string, string> { ["Authorization"] = apiKey.Value } : null;
+            var headers = apiKey != null ? new Dictionary<string, string> { ["Authorization"] = String.Format(AuthorizationFormat, apiKey.Value) } : null;
             var response = await base.RequestWithCookiesAsync(link.ToString(), null, RequestType.GET, headers: headers);
             var content = response.ContentBytes;
 
@@ -381,7 +383,7 @@ namespace Jackett.Common.Indexers.Abstract
             {
                 var html = Encoding.GetString(content);
                 if (html.Contains("You do not have any freeleech tokens left.")
-                    || html.Contains("You do not have enough freeleech tokens left.")
+                    || html.Contains("You do not have enough freeleech tokens")
                     || html.Contains("This torrent is too large."))
                 {
                     // download again with usetoken=0

--- a/src/Jackett.Common/Indexers/Orpheus.cs
+++ b/src/Jackett.Common/Indexers/Orpheus.cs
@@ -11,6 +11,10 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class Orpheus : GazelleTracker
     {
+        // API Reference: https://github.com/OPSnet/Gazelle/wiki/JSON-API-Documentation
+        protected override string DownloadUrl => SiteLink + "ajax.php?action=download&usetoken=" + (useTokens ? "1" : "0") + "&id=";
+        protected override string AuthorizationFormat => "token {0}";
+        protected override int ApiKeyLength => 118;
         public Orpheus(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
             : base(id: "orpheus",
@@ -42,7 +46,8 @@ namespace Jackett.Common.Indexers
                    p: ps,
                    cs: cs,
                    supportsFreeleechTokens: true,
-                   has2Fa: true)
+                   has2Fa: false,
+                   useApiKey: true)
         {
             Language = "en-us";
             Type = "private";

--- a/src/Jackett.Common/Indexers/Orpheus.cs
+++ b/src/Jackett.Common/Indexers/Orpheus.cs
@@ -47,7 +47,7 @@ namespace Jackett.Common.Indexers
                    cs: cs,
                    supportsFreeleechTokens: true,
 
-                   has2Fa: true,
+                   has2Fa: false,
                    usePassKey: true)
         {
             Language = "en-us";


### PR DESCRIPTION
Resolves https://github.com/Jackett/Jackett/issues/9860
Resolves https://github.com/Jackett/Jackett/issues/11543
Resolves https://github.com/Jackett/Jackett/issues/11728

This PR supports Orpheus long-standing issue of supporting API token, which I was supposed to implement last year.
It should resolve most issues related to using cookies.

**Note**: `usePassKey` and 2FA is not required when using API Tokens to download torrents, but you might want to merge https://github.com/Jackett/Jackett/pull/11815 first as it supports `usePassKey` for future trackers that may encounter a similar scenario. I will rebase once when the PR has been merged.