### PR TITLE
orpheus: fixed api toggle

### DIFF
--- a/src/Jackett.Common/Indexers/Orpheus.cs
+++ b/src/Jackett.Common/Indexers/Orpheus.cs
@@ -46,9 +46,10 @@ namespace Jackett.Common.Indexers
                    p: ps,
                    cs: cs,
                    supportsFreeleechTokens: true,
-
-                   has2Fa: true,
-                   usePassKey: true)
+                   has2Fa: false,
+                   useApiKey: true,
+                   usePassKey: false,
+                   instructionMessageOptional: "<ol><li>Go to Orpheus's site and open your account settings.</li><li>Under <b>Access Settings</b> click on 'Create a new token'</li><li>Give it a name you like and click <b>Generate</b>.</li><li>Copy the generated API Key and paste it in the above text field.</li></ol>")
         {
             Language = "en-us";
             Type = "private";


### PR DESCRIPTION
@garfield69 @ilike2burnthing 

https://github.com/Jackett/Jackett/pull/11868 was merged before I had completed the rebase. This includes the rebase that I was supposed to include in the previous PR.

note that `has2Fa` is ineffective when `useApiKey` toggle is turned on, so we will leave it as `false`.