### PR TITLE
core: added download selectors

### DIFF
--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -162,8 +162,9 @@ settings:
 
 download:
   # the .torrent url is on the on the details page
-  selector: ul li a[href^="{{ .Config.downloadlink }}"]
-  attribute: href
+  selectors:
+    - selector: ul li a[href^="{{ .Config.downloadlink }}"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/acgsou.yml
+++ b/src/Jackett.Common/Definitions/acgsou.yml
@@ -51,8 +51,9 @@ caps:
 settings: []
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/anime-free.yml
+++ b/src/Jackett.Common/Definitions/anime-free.yml
@@ -57,8 +57,9 @@ login:
     selector: a[href$="/index.php?action=logout"]
 
 download:
-  selector: a[href*="/engine/download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href*="/engine/download.php?id="]
+      attribute: href
 
 search:
   # https://anime-free.biz/index.php?do=search&subaction=search&search_start=0&full_search=1&result_from=1&story=slaves+to+passion&all_word_seach=1&titleonly=3&searchuser=&replyless=0&replylimit=0&searchdate=0&beforeafter=after&sortby=date&resorder=desc&showposts=0&catlist[]=0

--- a/src/Jackett.Common/Definitions/arabafenice.yml
+++ b/src/Jackett.Common/Definitions/arabafenice.yml
@@ -121,8 +121,9 @@ download:
       infohash: "{{ .DownloadUri.Query.id }}"
       thanks: 1
       rndval: "1487013827343"
-  selector: a[href^="download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/arenabg.yml
+++ b/src/Jackett.Common/Definitions/arenabg.yml
@@ -111,8 +111,9 @@ login:
     selector: a[href="/en/users/logout/"]
 
 download:
-  selector: a[href^="{{ .Config.downloadlink }}"]
-  attribute: href
+  selectors:
+    - selector: a[href^="{{ .Config.downloadlink }}"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/audiobookbay.yml
+++ b/src/Jackett.Common/Definitions/audiobookbay.yml
@@ -89,7 +89,8 @@ caps:
 settings: []
 
 download:
-  selector: td:contains("Info Hash:") ~ td
+  selectors:
+    - selector: td:contains("Info Hash:") ~ td
   filters:
     - name: prepend
       args: "magnet:?xt=urn:btih:"

--- a/src/Jackett.Common/Definitions/badasstorrents.yml
+++ b/src/Jackett.Common/Definitions/badasstorrents.yml
@@ -52,8 +52,9 @@ settings:
       asc: asc
 
 download:
-  selector: a[href*="{{ .Config.downloadlink }}"]
-  attribute: href
+  selectors:
+    - selector: a[href*="{{ .Config.downloadlink }}"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/bigtorrent.yml
+++ b/src/Jackett.Common/Definitions/bigtorrent.yml
@@ -60,8 +60,9 @@ login:
     path: index.php
 
 download:
-  selector: a[href^="download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/boxingtorrents.yml
+++ b/src/Jackett.Common/Definitions/boxingtorrents.yml
@@ -77,8 +77,9 @@ login:
     selector: a[href="logout.php"]
 
 download:
-  selector: a[href^="download.php"]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/btsow.yml
+++ b/src/Jackett.Common/Definitions/btsow.yml
@@ -44,8 +44,9 @@ settings:
     default: BTSOW does not return categories in its search results.</br>To add to your Apps' Torznab indexer, replace all categories with 8000(Other).
 
 download:
-  selector: a#magnetOpen
-  attribute: href
+  selectors:
+    - selector: a#magnetOpen
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/byrutor.yml
+++ b/src/Jackett.Common/Definitions/byrutor.yml
@@ -260,8 +260,9 @@ caps:
 settings: []
 
 download:
-  selector: a.itemtop_game
-  attribute: href
+  selectors:
+    - selector: a.itemtop_game
+      attribute: href
 
 search:
   # keywords (article titles only search)

--- a/src/Jackett.Common/Definitions/catorrent.yml
+++ b/src/Jackett.Common/Definitions/catorrent.yml
@@ -56,8 +56,9 @@ login:
     selector: a[href$="/index.php?action=logout"]
 
 download:
-  selector: a[href*="/index.php?do=download&id="]
-  attribute: href
+  selectors:
+    - selector: a[href*="/index.php?do=download&id="]
+      attribute: href
 
 search:
   # https://catorrent.org/index.php?do=search&subaction=search&story=lovelot

--- a/src/Jackett.Common/Definitions/classix.yml
+++ b/src/Jackett.Common/Definitions/classix.yml
@@ -28,8 +28,9 @@ login:
     path: index.php
 
 download:
-  selector: a[href^="download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/cpabien.yml
+++ b/src/Jackett.Common/Definitions/cpabien.yml
@@ -61,7 +61,6 @@ settings:
   - name: useragent
     type: text
     label: User-Agent
-    label: User-Agent
   - name: info_useragent
     type: info
     label: How to get the User-Agent
@@ -101,8 +100,9 @@ login:
     user-agent: "[ .Config.useragent ]"
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/cpasbienclone.yml
+++ b/src/Jackett.Common/Definitions/cpasbienclone.yml
@@ -68,8 +68,9 @@ settings:
       ?trie-nom-a: title asc
 
 download:
-  selector: a[href^="magnet:"]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/crazyspirits.yml
+++ b/src/Jackett.Common/Definitions/crazyspirits.yml
@@ -175,8 +175,9 @@ download:
       id: "{{ .DownloadUri.Query.id }}"
       to: give
       torrent: "{{ .DownloadUri.Query.id }}"
-  selector: "a[href^=\"/{{ .DownloadUri.Query.id }}/\"]"
-  attribute: href
+  selectors:
+    - selector: "a[href^=\"/{{ .DownloadUri.Query.id }}/\"]"
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/demonoid.yml
+++ b/src/Jackett.Common/Definitions/demonoid.yml
@@ -318,8 +318,9 @@ login:
     path: files/
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/dimeadozen.yml
+++ b/src/Jackett.Common/Definitions/dimeadozen.yml
@@ -100,8 +100,9 @@ login:
 
 download:
   # download.php/673256/Talk%20Talk%20-%201986-07-05%20Paris.torrent
-  selector: a[href^="download.php/"]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php/"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/dxp.yml
+++ b/src/Jackett.Common/Definitions/dxp.yml
@@ -79,8 +79,9 @@ login:
     selector: a[href="logout.php"]
 
 download:
-  selector: a[href^="download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
 
 search:
   # https://dxp.ru/torrents.php?search=&sort=4&type=desc

--- a/src/Jackett.Common/Definitions/ebookparadijs.yml
+++ b/src/Jackett.Common/Definitions/ebookparadijs.yml
@@ -79,8 +79,9 @@ download:
       tid: "{{ .DownloadUri.Query.id }}"
       text: "{{ .Config.thankyou }}"
       submit: Opslaan
-  selector: a[href^="download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/ebooks-shares.yml
+++ b/src/Jackett.Common/Definitions/ebooks-shares.yml
@@ -308,8 +308,9 @@ login:
     selector: a[href^="account-logout.php"]
 
 download:
-  selector: a[href^="download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/ehentai.yml
+++ b/src/Jackett.Common/Definitions/ehentai.yml
@@ -19,8 +19,9 @@ caps:
     tv-search: [q, season, ep]
 
 download:
-  selector: a[href*="/get/"]
-  attribute: href
+  selectors:
+    - selector: a[href*="/get/"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/ettv.yml
+++ b/src/Jackett.Common/Definitions/ettv.yml
@@ -124,8 +124,9 @@ settings:
       asc: asc
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   path: "{{ if .Keywords }}torrents-search.php{{ else }}torrents.php{{ end }}"

--- a/src/Jackett.Common/Definitions/extremetorrents.yml
+++ b/src/Jackett.Common/Definitions/extremetorrents.yml
@@ -78,8 +78,9 @@ download:
       tid: "{{ .DownloadUri.Query.id }}"
       text: "{{ .Config.thankyou }}"
       submit: Opslaan
-  selector: a[href^="download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/exttorrents.yml
+++ b/src/Jackett.Common/Definitions/exttorrents.yml
@@ -93,8 +93,9 @@ settings:
     default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/film-paleis.yml
+++ b/src/Jackett.Common/Definitions/film-paleis.yml
@@ -74,8 +74,9 @@ download:
       tid: "{{ .DownloadUri.Query.id }}"
       text: "{{ .Config.thankyou }}"
       submit: Opslaan
-  selector: a[href^="download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/finvip.yml
+++ b/src/Jackett.Common/Definitions/finvip.yml
@@ -96,8 +96,9 @@ login:
     selector: a[href="logout.php"]
 
 download:
-  selector: a[href^="download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/firebit.yml
+++ b/src/Jackett.Common/Definitions/firebit.yml
@@ -57,8 +57,9 @@ caps:
 settings: []
 
 download:
-  selector: a[href^="/download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="/download.php?id="]
+      attribute: href
 
 search:
   # http://firebit.net/index.php?do=search&type=simple&q=2019

--- a/src/Jackett.Common/Definitions/gamestorrents.yml
+++ b/src/Jackett.Common/Definitions/gamestorrents.yml
@@ -30,8 +30,9 @@ caps:
 settings: []
 
 download:
-  selector: a#download_torrent
-  attribute: href
+  selectors:
+    - selector: a#download_torrent
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/generationfree.yml
+++ b/src/Jackett.Common/Definitions/generationfree.yml
@@ -142,8 +142,9 @@ download:
       id: "{{ .DownloadUri.Query.id }}"
       to: give
       torrent: "{{ .DownloadUri.Query.id }}"
-  selector: a[href^="download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/girotorrent.yml
+++ b/src/Jackett.Common/Definitions/girotorrent.yml
@@ -136,8 +136,9 @@ download:
       infohash: "{{ .DownloadUri.Query.id }}"
       thanks: 1
       rndval: "1487013827343"
-  selector: a[href^="download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/gktorrent.yml
+++ b/src/Jackett.Common/Definitions/gktorrent.yml
@@ -73,8 +73,9 @@ settings:
     default: false
 
 download:
-  selector: a[href*="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href*="magnet:?xt="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/gtorrent.yml
+++ b/src/Jackett.Common/Definitions/gtorrent.yml
@@ -23,8 +23,9 @@ caps:
 settings: []
 
 download:
-  selector: a[href^="/uploads/torrents/"]
-  attribute: href
+  selectors:
+    - selector: a[href^="/uploads/torrents/"]
+      attribute: href
 
 search:
   # do=search&subaction=search&search_start=0&full_search=0&result_from=1&story=%D0%A6%D0%B5%D0%BB%D1%8C%D0%BD%D0%BE%D0%BC%D0%B5%D1%82%D0%B0%D0%BB%D0%BB%D0%B8%D1%87%D0%B5%D1%81%D0%BA%D0%B0%D1%8F+%D0%BE%D0%B1%D0%BE%D0%BB%D0%BE%D1%87%D0%BA%D0%B0+

--- a/src/Jackett.Common/Definitions/gtorrentpro.yml
+++ b/src/Jackett.Common/Definitions/gtorrentpro.yml
@@ -23,8 +23,9 @@ caps:
 settings: []
 
 download:
-  selector: a[href^="/engine/download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="/engine/download.php?id="]
+      attribute: href
 
 search:
   # do=search&subaction=search&search_start=0&full_search=0&result_from=1&story=%D0%A6%D0%B5%D0%BB%D1%8C%D0%BD%D0%BE%D0%BC%D0%B5%D1%82%D0%B0%D0%BB%D0%BB%D0%B8%D1%87%D0%B5%D1%81%D0%BA%D0%B0%D1%8F+%D0%BE%D0%B1%D0%BE%D0%BB%D0%BE%D1%87%D0%BA%D0%B0+

--- a/src/Jackett.Common/Definitions/hdhouse.yml
+++ b/src/Jackett.Common/Definitions/hdhouse.yml
@@ -52,8 +52,9 @@ settings:
       asc: asc
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   # https://hdreactor.net/index.php?do=search&subaction=search&showposts=1&story=2020&catlist[]=2001&catlist[]=2006

--- a/src/Jackett.Common/Definitions/hellastz.yml
+++ b/src/Jackett.Common/Definitions/hellastz.yml
@@ -92,8 +92,9 @@ download:
       infohash: "{{ .DownloadUri.Query.id }}"
       thanks: 1
       rndval: "1487013827343"
-  selector: a[href^="download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/ibit.yml
+++ b/src/Jackett.Common/Definitions/ibit.yml
@@ -49,7 +49,8 @@ settings:
       asc: asc
 
 download:
-  selector: script:contains("magnet:?xt=")
+  selectors:
+    - selector: script:contains("magnet:?xt=")
   filters:
     - name: regexp
       args: "play\\('(.+?)'"

--- a/src/Jackett.Common/Definitions/isohunt2.yml
+++ b/src/Jackett.Common/Definitions/isohunt2.yml
@@ -58,8 +58,9 @@ settings:
       size: size
 
 download:
-  selector: a.btn-magnet
-  attribute: href
+  selectors:
+    - selector: a.btn-magnet
+      attribute: href
   filters:
     - name: querystring
       args: url

--- a/src/Jackett.Common/Definitions/itorrent.yml
+++ b/src/Jackett.Common/Definitions/itorrent.yml
@@ -50,8 +50,9 @@ settings:
 
 
 download:
-  selector: a[href^="/torrentfiles/"]
-  attribute: href
+  selectors:
+    - selector: a[href^="/torrentfiles/"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/kickasstorrents-to.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrents-to.yml
@@ -51,8 +51,9 @@ settings:
       asc: asc
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/limetorrents.yml
+++ b/src/Jackett.Common/Definitions/limetorrents.yml
@@ -83,8 +83,9 @@ settings:
 
 download:
   # the .torrent url is on the on the details page
-  selector: a.csprite_dltorrent[href^="{{ .Config.downloadlink }}"]
-  attribute: href
+  selectors:
+    - selector: a.csprite_dltorrent[href^="{{ .Config.downloadlink }}"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/magicheaven.yml
+++ b/src/Jackett.Common/Definitions/magicheaven.yml
@@ -121,8 +121,9 @@ download:
     method: post
     inputs:
       torrentid: "{{ .DownloadUri.Query.id }}"
-  selector: a[href*="/download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href*="/download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/mixtapetorrent.yml
+++ b/src/Jackett.Common/Definitions/mixtapetorrent.yml
@@ -20,8 +20,9 @@ caps:
 settings: []
 
 download:
-  selector: table#attachments > tbody > tr.odd > td > a
-  attribute: href
+  selectors:
+    - selector: table#attachments > tbody > tr.odd > td > a
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/moviesdvdr.yml
+++ b/src/Jackett.Common/Definitions/moviesdvdr.yml
@@ -21,8 +21,9 @@ caps:
 settings: []
 
 download:
-  selector: a.torrent_download
-  attribute: href
+  selectors:
+    - selector: a.torrent_download
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/movietorrent.yml
+++ b/src/Jackett.Common/Definitions/movietorrent.yml
@@ -54,8 +54,9 @@ caps:
 settings: []
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
   filters:
     - name: append
       args: "&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fopen.stealth.si%3A80%2Fannounce&tr=udp%3A%2F%2Fexodus.desync.com%3A6969&tr=udp%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=udp%3A%2F%2Fexplodie.org%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.tiny-vps.com%3A6969%2Fannounce&tr=udp%3A%2F%2Fopen.demonii.si%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce&tr=udp%3A%2F%2Ftracker.pirateparty.gr%3A6969%2Fannounce&tr=udp%3A%2F%2Fipv4.tracker.harry.lu%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.cyberia.is%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Fdenis.stalker.upeer.me%3A6969%2Fannounce"

--- a/src/Jackett.Common/Definitions/muziekfabriek.yml
+++ b/src/Jackett.Common/Definitions/muziekfabriek.yml
@@ -57,8 +57,9 @@ login:
     selector: :has(a[href="logout.php"])
 
 download:
-  selector: a[href^="download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/mypornclub.yml
+++ b/src/Jackett.Common/Definitions/mypornclub.yml
@@ -24,8 +24,9 @@ settings:
     default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
   filters:
     - name: re_replace
       args: ["\\s+", " "]

--- a/src/Jackett.Common/Definitions/nitro.yml
+++ b/src/Jackett.Common/Definitions/nitro.yml
@@ -49,7 +49,8 @@ settings:
       asc: asc
 
 download:
-  selector: script:contains("magnet:")
+  selectors:
+    - selector: script:contains("magnet:")
   filters:
     - name: regexp
       args: "(magnet:[^\"]+)\""

--- a/src/Jackett.Common/Definitions/nntt.yml
+++ b/src/Jackett.Common/Definitions/nntt.yml
@@ -672,8 +672,9 @@ settings:
       a: asc
 
 download:
-  selector: a[href^="./download/file.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="./download/file.php?id="]
+      attribute: href
 
 search:
   # http://www.nntt.org/search.php?sr=topics&sf=titleonly&fp=1&tracker_search=torrent&keywords=2020&fid[]=154

--- a/src/Jackett.Common/Definitions/oasis.yml
+++ b/src/Jackett.Common/Definitions/oasis.yml
@@ -196,8 +196,9 @@ download:
     method: post
     inputs:
       torrent: "{{ re_replace .DownloadUri.PathAndQuery \"^(.+?)(\\d+)$\" \"$2\" }}"
-  selector: a[href*="/Telechargement/"]
-  attribute: href
+  selectors:
+    - selector: a[href*="/Telechargement/"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/oxtorrent.yml
+++ b/src/Jackett.Common/Definitions/oxtorrent.yml
@@ -71,8 +71,9 @@ settings:
     default: false
 
 download:
-  selector: a[href^="magnet:?"]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/pctorrent.yml
+++ b/src/Jackett.Common/Definitions/pctorrent.yml
@@ -21,8 +21,9 @@ caps:
 settings: []
 
 download:
-  selector: a[href*="/engine/download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href*="/engine/download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/pier720.yml
+++ b/src/Jackett.Common/Definitions/pier720.yml
@@ -108,8 +108,9 @@ login:
     selector: :has(a[href^="./ucp.php?mode=logout&"])
 
 download:
-  selector: a[href*="/download/torrent?id="]
-  attribute: href
+  selectors:
+    - selector: a[href*="/download/torrent?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/piratbit.yml
+++ b/src/Jackett.Common/Definitions/piratbit.yml
@@ -646,8 +646,9 @@ settings:
 
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/proporno.yml
+++ b/src/Jackett.Common/Definitions/proporno.yml
@@ -31,8 +31,9 @@ caps:
 settings: []
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/prostylex.yml
+++ b/src/Jackett.Common/Definitions/prostylex.yml
@@ -123,8 +123,9 @@ login:
     path: search.php
 
 download:
-  selector: a[href^="magnet:?"]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/puurhollands.yml
+++ b/src/Jackett.Common/Definitions/puurhollands.yml
@@ -55,8 +55,9 @@ download:
       action: add
       tid: "{{ .DownloadUri.Query.id }}"
       text: "{{ .Config.thankyou }}"
-  selector: a[href^="download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/rapidzona.yml
+++ b/src/Jackett.Common/Definitions/rapidzona.yml
@@ -77,8 +77,9 @@ settings:
 
 
 download:
-  selector: a[href*="/download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href*="/download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/rintornet.yml
+++ b/src/Jackett.Common/Definitions/rintornet.yml
@@ -37,8 +37,9 @@ caps:
 settings: []
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/rofd.yml
+++ b/src/Jackett.Common/Definitions/rofd.yml
@@ -100,8 +100,9 @@ login:
     selector: a[href="logout.php"]
 
 download:
-  selector: a[href^="download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/rus-media.yml
+++ b/src/Jackett.Common/Definitions/rus-media.yml
@@ -297,8 +297,9 @@ settings:
       a: asc
 
 download:
-  selector: a[href^="./download/file.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="./download/file.php?id="]
+      attribute: href
 
 search:
   # http://rus-media.org/search.php?tracker_search=torrent&sr=topics&keywords=2020&fid[]=54

--- a/src/Jackett.Common/Definitions/seedfile.yml
+++ b/src/Jackett.Common/Definitions/seedfile.yml
@@ -27,12 +27,12 @@ caps:
     - {id: 14, cat: PC/Games, desc: "Jocuri PC"}
     - {id: 15, cat: Audio, desc: "Muzică"}
     - {id: 16, cat: PC/Mobile-Other, desc: "Mobile"}
-    - {id: 17, cat: PC, desc: "Programe	"}
+    - {id: 17, cat: PC, desc: "Programe"}
     - {id: 18, cat: TV/HD, desc: "Seriale HD"}
-    - {id: 19, cat: TV/HD, desc: "Seriale HD-RO	"}
+    - {id: 19, cat: TV/HD, desc: "Seriale HD-RO"}
     - {id: 20, cat: TV/SD, desc: "Seriale TV"}
-    - {id: 21, cat: TV/SD, desc: "Seriale TV-RO "}
-    - {id: 22, cat: TV/Sport, desc: "Sport "}
+    - {id: 21, cat: TV/SD, desc: "Seriale TV-RO"}
+    - {id: 22, cat: TV/Sport, desc: "Sport"}
     - {id: 23, cat: Audio/Video, desc: "Video Clip"}
     - {id: 24, cat: XXX, desc: "Adult 18+"}
     - {id: 36, cat: Movies/3D, desc: "Video 3D"}
@@ -69,8 +69,9 @@ login:
     path: profile.php
 
 download:
-  selector: a[href^="download.php/"]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php/"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/selezen.yml
+++ b/src/Jackett.Common/Definitions/selezen.yml
@@ -80,8 +80,9 @@ login:
     selector: a[href$="/index.php?action=logout"]
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   # do=search&subaction=search&story=greyhound&titleonly=0&sortby=date&resorder=desc&showposts=0&catlist[]=45&catlist[]=46&catlist[]=47

--- a/src/Jackett.Common/Definitions/siambit.yml
+++ b/src/Jackett.Common/Definitions/siambit.yml
@@ -112,8 +112,9 @@ download:
     inputs:
       _action: "say_thank"
       id: "{{ .DownloadUri.Query.id }}"
-  selector: a[href^="downloadnew.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="downloadnew.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/sktorrent.yml
+++ b/src/Jackett.Common/Definitions/sktorrent.yml
@@ -65,8 +65,9 @@ login:
     selector: a[href^="usercp.php"]
 
 download:
-  selector: a[href^="download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/sosulki.yml
+++ b/src/Jackett.Common/Definitions/sosulki.yml
@@ -35,8 +35,9 @@ caps:
 settings: []
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/sporthd.yml
+++ b/src/Jackett.Common/Definitions/sporthd.yml
@@ -145,8 +145,9 @@ login:
     path: index.php
 
 download:
-  selector: a[href^="download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/toros.yml
+++ b/src/Jackett.Common/Definitions/toros.yml
@@ -49,8 +49,9 @@ settings:
       asc: asc
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/torrent4you.yml
+++ b/src/Jackett.Common/Definitions/torrent4you.yml
@@ -36,8 +36,9 @@ settings:
       title: name
 
 download:
-  selector: form[action^="../torrents/"]
-  attribute: action
+  selectors:
+    - selector: form[action^="../torrents/"]
+      attribute: action
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -101,8 +101,9 @@ settings:
     default: Torrent9 only returns category <b>Movies</b> in its <i>Keywordless</i> search results page.</br>To pass your apps' indexer TEST you will need to include the 131681(Movies) category.
 
 download:
-  selector: a[href^="magnet:?"]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/torrent9clone.yml
+++ b/src/Jackett.Common/Definitions/torrent9clone.yml
@@ -104,8 +104,9 @@ settings:
     default: Torrent9clone only returns category <b>Movies</b> in its <i>Keywordless</i> search results page.</br>To pass your apps' indexer TEST you will need to include the 145469(Movies) category.
 
 download:
-  selector: a[href^="magnet:?"]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/torrentdownload.yml
+++ b/src/Jackett.Common/Definitions/torrentdownload.yml
@@ -114,8 +114,9 @@ settings:
       _: size
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 login:
   method: cookie

--- a/src/Jackett.Common/Definitions/torrentdownloads.yml
+++ b/src/Jackett.Common/Definitions/torrentdownloads.yml
@@ -68,8 +68,9 @@ settings:
       "magnet:": "magnet"
 
 download:
-  selector: a[href^="{{ .Config.downloadlink }}"]
-  attribute: href
+  selectors:
+    - selector: a[href^="{{ .Config.downloadlink }}"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/torrentmax.yml
+++ b/src/Jackett.Common/Definitions/torrentmax.yml
@@ -45,8 +45,9 @@ settings:
     default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
 
 download:
-  selector: a[href*="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href*="magnet:?xt="]
+      attribute: href
   filters:
     - name: append
       args: "&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fopen.stealth.si%3A80%2Fannounce&tr=udp%3A%2F%2Fexodus.desync.com%3A6969&tr=udp%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=udp%3A%2F%2Fexplodie.org%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.tiny-vps.com%3A6969%2Fannounce&tr=udp%3A%2F%2Fopen.demonii.si%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce&tr=udp%3A%2F%2Ftracker.pirateparty.gr%3A6969%2Fannounce&tr=udp%3A%2F%2Fipv4.tracker.harry.lu%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.cyberia.is%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Fdenis.stalker.upeer.me%3A6969%2Fannounce"

--- a/src/Jackett.Common/Definitions/torrentoyunindir.yml
+++ b/src/Jackett.Common/Definitions/torrentoyunindir.yml
@@ -18,8 +18,9 @@ caps:
 settings: []
 
 download:
-  selector: div.facepaylas a
-  attribute: href
+  selectors:
+    - selector: div.facepaylas a
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/torrentparadise.yml
+++ b/src/Jackett.Common/Definitions/torrentparadise.yml
@@ -204,8 +204,9 @@ caps:
 settings: []
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   # https://torrentparadise.org/search.php?f=monday+night

--- a/src/Jackett.Common/Definitions/torrentproject2.yml
+++ b/src/Jackett.Common/Definitions/torrentproject2.yml
@@ -51,8 +51,9 @@ settings:
       size: size
 
 download:
-  selector: "#download > div:nth-child(2) > div:nth-child(1) > a"
-  attribute: href
+  selectors:
+    - selector: "#download > div:nth-child(2) > div:nth-child(1) > a"
+      attribute: href
   filters:
     - name: replace
       args: ["https://mylink.me.uk/?url=", ""]

--- a/src/Jackett.Common/Definitions/torrentqq.yml
+++ b/src/Jackett.Common/Definitions/torrentqq.yml
@@ -55,8 +55,9 @@ settings:
     default: Some download links on this site use a link to a direct file download service, instead of a .torrent link. Jackett does not support direct file downloads, so you will get a page-cannot-be-found error when you try them.
 
 download:
-  selector: a[href^="/torrent/download/"]
-  attribute: href
+  selectors:
+    - selector: a[href^="/torrent/download/"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/torrentsir.yml
+++ b/src/Jackett.Common/Definitions/torrentsir.yml
@@ -38,8 +38,9 @@ settings:
     default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
 
 download:
-  selector: a[href*="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href*="magnet:?xt="]
+      attribute: href
   filters:
     - name: append
       args: "&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fopen.stealth.si%3A80%2Fannounce&tr=udp%3A%2F%2Fexodus.desync.com%3A6969&tr=udp%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=udp%3A%2F%2Fexplodie.org%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.tiny-vps.com%3A6969%2Fannounce&tr=udp%3A%2F%2Fopen.demonii.si%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce&tr=udp%3A%2F%2Ftracker.pirateparty.gr%3A6969%2Fannounce&tr=udp%3A%2F%2Fipv4.tracker.harry.lu%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.cyberia.is%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Fdenis.stalker.upeer.me%3A6969%2Fannounce"

--- a/src/Jackett.Common/Definitions/torrentv.yml
+++ b/src/Jackett.Common/Definitions/torrentv.yml
@@ -29,8 +29,9 @@ settings:
       na-1: title
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/torrentview.yml
+++ b/src/Jackett.Common/Definitions/torrentview.yml
@@ -63,8 +63,9 @@ caps:
 settings: []
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/torrentwhiz.yml
+++ b/src/Jackett.Common/Definitions/torrentwhiz.yml
@@ -37,8 +37,9 @@ settings:
     default: This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href="https://github.com/Jackett/Jackett#configuring-flaresolverr" target="_blank">FlareSolver</a> to access it.
 
 download:
-  selector: a[href*="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href*="magnet:?xt="]
+      attribute: href
   filters:
     - name: append
       args: "&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fopen.stealth.si%3A80%2Fannounce&tr=udp%3A%2F%2Fexodus.desync.com%3A6969&tr=udp%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=udp%3A%2F%2Fexplodie.org%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.tiny-vps.com%3A6969%2Fannounce&tr=udp%3A%2F%2Fopen.demonii.si%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce&tr=udp%3A%2F%2Ftracker.pirateparty.gr%3A6969%2Fannounce&tr=udp%3A%2F%2Fipv4.tracker.harry.lu%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.cyberia.is%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Fdenis.stalker.upeer.me%3A6969%2Fannounce"

--- a/src/Jackett.Common/Definitions/turkseed.yml
+++ b/src/Jackett.Common/Definitions/turkseed.yml
@@ -89,8 +89,9 @@ download:
     method: post
     inputs:
       torrentid: "{{ .DownloadUri.Query.id }}"
-  selector: a[href*="/download.php?id="]
-  attribute: href
+  selectors:
+    - selector: a[href*="/download.php?id="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/uniondht.yml
+++ b/src/Jackett.Common/Definitions/uniondht.yml
@@ -1,4 +1,4 @@
-﻿---
+---
 id: uniondht
 name: UnionDHT
 description: "UnionDHT is a RUSSIAN Public Torrent Tracker for MOVIES / TV / MUSIC / GENERAL"
@@ -528,8 +528,9 @@ settings:
       1: asc
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/unlimitz.yml
+++ b/src/Jackett.Common/Definitions/unlimitz.yml
@@ -104,8 +104,9 @@ login:
     selector: a[href="logout.php"]
 
 download:
-  selector: a[href^="d.php?keyalert1="]
-  attribute: href
+  selectors:
+    - selector: a[href^="d.php?keyalert1="]
+      attribute: href
   filters:
     - name: replace
       args: ["d.php?keyalert1=", "/dI.php/"]

--- a/src/Jackett.Common/Definitions/vsthouse.yml
+++ b/src/Jackett.Common/Definitions/vsthouse.yml
@@ -19,8 +19,9 @@ caps:
 settings: []
 
 download:
-  selector: a[title^="Скачать:"]
-  attribute: href
+  selectors:
+    - selector: a[title^="Скачать:"]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/vsttorrents.yml
+++ b/src/Jackett.Common/Definitions/vsttorrents.yml
@@ -21,8 +21,9 @@ caps:
 settings: []
 
 download:
-  selector: div.wp-block-file a
-  attribute: href
+  selectors:
+    - selector: div.wp-block-file a
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/xxxadulttorrent.yml
+++ b/src/Jackett.Common/Definitions/xxxadulttorrent.yml
@@ -18,8 +18,9 @@ caps:
 settings: []
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/zetorrents.yml
+++ b/src/Jackett.Common/Definitions/zetorrents.yml
@@ -51,8 +51,9 @@ settings:
     default: false
 
 download:
-  selector: a[href^="magnet:?xt="]
-  attribute: href
+  selectors:
+    - selector: a[href^="magnet:?xt="]
+      attribute: href
 
 search:
   paths:

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -1757,39 +1757,78 @@ namespace Jackett.Common.Indexers
                 if (Download.Method == "post")
                     method = RequestType.POST;
 
-                if (Download.Selector != null)
+                if (Download.Selectors != null)
                 {
-                    var selector = applyGoTemplateText(Download.Selector, variables);
                     var headers = ParseCustomHeaders(Definition.Search?.Headers, variables);
-                    var response = await RequestWithCookiesAsync(link.ToString(), headers: headers);
-                    if (response.IsRedirect)
-                        response = await RequestWithCookiesAsync(response.RedirectingTo, headers: headers);
-                    var results = response.ContentString;
+                    var results = "";
                     var searchResultParser = new HtmlParser();
-                    var searchResultDocument = searchResultParser.ParseDocument(results);
-                    var downloadElement = searchResultDocument.QuerySelector(selector);
-                    if (downloadElement != null)
+
+                    foreach (var selector in Download.Selectors)
                     {
-                        logger.Debug(string.Format("CardigannIndexer ({0}): Download selector {1} matched:{2}", Id, selector, downloadElement.ToHtmlPretty()));
-                        var href = "";
-                        if (Download.Attribute != null)
+                        var querySelector = applyGoTemplateText(selector.Selector, variables);
+                        try
                         {
-                            href = downloadElement.GetAttribute(Download.Attribute);
-                            if (href == null)
-                                throw new Exception(string.Format("Attribute \"{0}\" is not set for element {1}", Download.Attribute, downloadElement.ToHtmlPretty()));
+
+                            var response = await RequestWithCookiesAsync(link.ToString(), headers: headers);
+                            if (response.IsRedirect)
+                                response = await RequestWithCookiesAsync(response.RedirectingTo, headers: headers);
+                            results = response.ContentString;
+                            var searchResultDocument = searchResultParser.ParseDocument(results);
+                            var downloadElement = searchResultDocument.QuerySelector(querySelector);
+                            if (downloadElement == null)
+                            {
+                                logger.Debug(
+                                    $"CardigannIndexer ({Id}): Download selector {querySelector} could not match any elements, retrying with next available selector.");
+                                continue;
+                            }
+
+                            logger.Debug(
+                                $"CardigannIndexer ({Id}): Download selector {querySelector} matched:{downloadElement.ToHtmlPretty()}");
+                            var href = "";
+                            if (selector.Attribute != null)
+                            {
+                                href = downloadElement.GetAttribute(selector.Attribute);
+                                if (href == null)
+                                    throw new Exception(
+                                        $"Attribute \"{selector.Attribute}\" is not set for element {downloadElement.ToHtmlPretty()}");
+                            }
+                            else
+                            {
+                                href = downloadElement.TextContent;
+                            }
+
+                            href = applyFilters(href, Download.Filters, variables);
+                            var torrentLink = resolvePath(href, link);
+                            if (torrentLink.Scheme != "magnet")
+                            {
+                                // Test link
+                                response = await base.RequestWithCookiesAsync(
+                                    torrentLink.ToString(), null, RequestType.GET, headers: headers);
+                                if (response.IsRedirect)
+                                    await FollowIfRedirect(response);
+                                var content = response.ContentBytes;
+                                if (content.Length >= 1 && content[0] != 'd')
+                                {
+                                    logger.Debug(
+                                        $"CardigannIndexer ({Id}): Download selector {querySelector}'s torrent file is invalid, retrying with next available selector");
+                                    continue;
+                                }
+                            }
+
+                            link = torrentLink;
+                            return await base.Download(link, method, link.ToString());
                         }
-                        else
+                        catch (Exception e)
                         {
-                            href = downloadElement.TextContent;
+                            logger.Error(e,
+                                $"CardigannIndexer ({Id}): An exception occurred while trying selector {querySelector}, retrying with next available selector"
+                                );
                         }
-                        href = applyFilters(href, Download.Filters, variables);
-                        link = resolvePath(href, link);
                     }
-                    else
-                    {
-                        logger.Error(string.Format("CardigannIndexer ({0}): Download selector {1} didn't match:\n{2}", Id, Download.Selector, results));
-                        throw new Exception(string.Format("Download selector {0} didn't match", Download.Selector));
-                    }
+
+                    logger.Error(
+                        $"CardigannIndexer ({Id}): Download selectors didn't match:\n{results}");
+                    throw new Exception($"Download selectors didn't match");
                 }
             }
             return await base.Download(link, method, link.ToString());

--- a/src/Jackett.Common/Models/IndexerDefinition.cs
+++ b/src/Jackett.Common/Models/IndexerDefinition.cs
@@ -167,10 +167,15 @@ namespace Jackett.Common.Models
 
     public class downloadBlock
     {
-        public string Selector { get; set; }
-        public string Attribute { get; set; }
+        public List<downloadsField> Selectors { get; set; }
         public List<filterBlock> Filters { get; set; }
         public string Method { get; set; }
         public requestBlock Before { get; set; }
+    }
+
+    public class downloadsField
+    {
+        public string Selector { get; set; }
+        public string Attribute { get; set; }
     }
 }


### PR DESCRIPTION
This PR adds the ability to handle multiple download selectors, allowing for fallbacks in cases where sites offer multiple types of downloads. The download selectors are performed in order, so order is important

For example, the following code:

```yaml
download:
  selectors:
    - selector: ul li a[href^="{{ .Config.downloadlink }}"]
      attribute: href
    - selector: ul li a[href^="magnet:"]
      attribute: href
```

will first try the first selector, configured by the user, and fall back to the magnet if all else fails. It may be good practice to include this fallback notice in the footnotes of supported trackers.

Resolves https://github.com/Jackett/Jackett/issues/11865

Note: I've only done a limited number of tests, it may require a couple more tests to ensure stability.