### PR TITLE
assorted: add fallback DL

### DIFF
--- a/src/Jackett.Common/Definitions/arenabg.yml
+++ b/src/Jackett.Common/Definitions/arenabg.yml
@@ -92,6 +92,17 @@ settings:
     options:
       "/en/torrents/download/?key=": ".torrent"
       "magnet:?xt=": "magnet"
+  - name: downloadlink2
+    type: select
+    label: Download link (fallback)
+    default: "/en/torrents/download/?key="
+    options:
+      "/en/torrents/download/?key=": ".torrent"
+      "magnet:?xt=": "magnet"
+  - name: info_download
+    type: info
+    label: About the Download links
+    default: You can optionally set as a fallback an automatic alternate link, so if the .torrent download link fails your download will still be successful.
 
 login:
   path: en/users/signin/
@@ -113,6 +124,8 @@ login:
 download:
   selectors:
     - selector: a[href^="{{ .Config.downloadlink }}"]
+      attribute: href
+    - selector: a[href^="{{ .Config.downloadlink2 }}"]
       attribute: href
 
 search:

--- a/src/Jackett.Common/Definitions/badasstorrents.yml
+++ b/src/Jackett.Common/Definitions/badasstorrents.yml
@@ -34,6 +34,17 @@ settings:
     options:
       "/download/": ".torrent"
       "magnet:?xt=": "magnet"
+  - name: downloadlink2
+    type: select
+    label: Download link (fallback)
+    default: "/download/"
+    options:
+      "/download/": ".torrent"
+      "magnet:?xt=": "magnet"
+  - name: info_download
+    type: info
+    label: About the Download links
+    default: You can optionally set as a fallback an automatic alternate link, so if the .torrent download link fails your download will still be successful.
   - name: sort
     type: select
     label: Sort requested from site
@@ -54,6 +65,8 @@ settings:
 download:
   selectors:
     - selector: a[href*="{{ .Config.downloadlink }}"]
+      attribute: href
+    - selector: a[href*="{{ .Config.downloadlink2 }}"]
       attribute: href
 
 search:

--- a/src/Jackett.Common/Definitions/limetorrents.yml
+++ b/src/Jackett.Common/Definitions/limetorrents.yml
@@ -68,6 +68,17 @@ settings:
     options:
       "http://itorrents.org/": iTorrents.org
       "magnet:": magnet
+  - name: downloadlink2
+    type: select
+    label: Download link (fallback)
+    default: "http://itorrents.org/"
+    options:
+      "http://itorrents.org/": iTorrents.org
+      "magnet:": magnet
+  - name: info_download
+    type: info
+    label: About the Download links
+    default: As the .torrent download links on this site are known to fail from time to time, you can optionally set as a fallback an automatic alternate link.
   - name: sort
     type: select
     label: Sort requested from site
@@ -85,6 +96,8 @@ download:
   # the .torrent url is on the on the details page
   selectors:
     - selector: a.csprite_dltorrent[href^="{{ .Config.downloadlink }}"]
+      attribute: href
+    - selector: a.csprite_dltorrent[href^="{{ .Config.downloadlink2 }}"]
       attribute: href
 
 search:

--- a/src/Jackett.Common/Definitions/torrentdownloads.yml
+++ b/src/Jackett.Common/Definitions/torrentdownloads.yml
@@ -66,10 +66,23 @@ settings:
     options:
       "http://itorrents.org/": "iTorrents.org"
       "magnet:": "magnet"
+  - name: downloadlink2
+    type: select
+    label: Download link (fallback)
+    default: "http://itorrents.org/"
+    options:
+      "http://itorrents.org/": "iTorrents.org"
+      "magnet:": "magnet"
+  - name: info_download
+    type: info
+    label: About the Download links
+    default: As the .torrent download links on this site are known to fail from time to time, you can optionally set as a fallback an automatic alternate link.
 
 download:
   selectors:
     - selector: a[href^="{{ .Config.downloadlink }}"]
+      attribute: href
+    - selector: a[href^="{{ .Config.downloadlink2 }}"]
       attribute: href
 
 search:


### PR DESCRIPTION
Follow up to https://github.com/Jackett/Jackett/issues/11865 and https://github.com/Jackett/Jackett/pull/11907

limetorrents and torrentsdownload only have itorrents.org and magnet, so removed `We suggest using the magnet link as a fallback.` as it's redundant.

arenabg and badasstorrents use their own torrents and are unlikely to fail with any regularity, so reworded the info section to work with this.