### PR TITLE
core: fixed category mapping for searchPaths

### DIFF
--- a/src/Jackett.Common/Definitions/torlock.yml
+++ b/src/Jackett.Common/Definitions/torlock.yml
@@ -78,7 +78,7 @@ search:
       categories: [MOVIES]
     - path: "{{ if .Keywords }}/music/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/music/1/added/desc.html{{end}}"
       categories: [MUSIC]
-    - path: "{{ if .Keywords }}/games/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/games/1/added/desc.html{{end}}"
+    - path: "{{ if .Keywords }}/game/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/games/1/added/desc.html{{end}}"
       categories: [GAMES]
     - path: "{{ if .Keywords }}/software/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/software/1/added/desc.html{{end}}"
       categories: [SOFTWARE]

--- a/src/Jackett.Common/Definitions/torlock.yml
+++ b/src/Jackett.Common/Definitions/torlock.yml
@@ -74,7 +74,7 @@ search:
       categories: ["!", TELEVISION, MOVIES, MUSIC, GAMES, SOFTWARE, ANIME, EBOOKS, OTHER, ADULT, AUDIOBOOK, IMAGES]
     - path: "{{ if .Keywords }}/television/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/television/1/added/desc.html{{end}}"
       categories: [TELEVISION]
-    - path: "{{ if .Keywords }}/movies/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/movies/1/added/desc.html{{end}}"
+    - path: "{{ if .Keywords }}/movie/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/movies/1/added/desc.html{{end}}"
       categories: [MOVIES]
     - path: "{{ if .Keywords }}/music/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/music/1/added/desc.html{{end}}"
       categories: [MUSIC]

--- a/src/Jackett.Common/Definitions/torlock.yml
+++ b/src/Jackett.Common/Definitions/torlock.yml
@@ -74,25 +74,25 @@ search:
       categories: ["!", TELEVISION, MOVIES, MUSIC, GAMES, SOFTWARE, ANIME, EBOOKS, OTHER, ADULT, AUDIOBOOK, IMAGES]
     - path: "{{ if .Keywords }}/television/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/television/1/{{ .Config.sort }}/{{ .Config.type }}.html{{end}}"
       categories: [TELEVISION]
-    - path: "{{ if .Keywords }}/movie/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/movies/1/added/desc.html{{end}}"
+    - path: "{{ if .Keywords }}/movie/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/movies/1/{{ .Config.sort }}/{{ .Config.type }}.html{{end}}"
       categories: [MOVIES]
-    - path: "{{ if .Keywords }}/music/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/music/1/added/desc.html{{end}}"
+    - path: "{{ if .Keywords }}/music/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/music/1/{{ .Config.sort }}/{{ .Config.type }}.html{{end}}"
       categories: [MUSIC]
-    - path: "{{ if .Keywords }}/game/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/games/1/added/desc.html{{end}}"
+    - path: "{{ if .Keywords }}/game/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/games/1/{{ .Config.sort }}/{{ .Config.type }}.html{{end}}"
       categories: [GAMES]
-    - path: "{{ if .Keywords }}/software/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/software/1/added/desc.html{{end}}"
+    - path: "{{ if .Keywords }}/software/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/software/1/{{ .Config.sort }}/{{ .Config.type }}.html{{end}}"
       categories: [SOFTWARE]
-    - path: "{{ if .Keywords }}/anime/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/anime/1/added/desc.html{{end}}"
+    - path: "{{ if .Keywords }}/anime/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/anime/1/{{ .Config.sort }}/{{ .Config.type }}.html{{end}}"
       categories: [ANIME]
-    - path: "{{ if .Keywords }}/ebook/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/ebooks/1/added/desc.html{{end}}"
+    - path: "{{ if .Keywords }}/ebook/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/ebooks/1/{{ .Config.sort }}/{{ .Config.type }}.html{{end}}"
       categories: [EBOOKS]
     - path: "{{ if .Keywords }}/unknown/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/unknown.html{{end}}" # sorting is broken for unknown
       categories: [OTHER]
-    - path: "{{ if .Keywords }}/adult/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/adult/1/added/desc.html{{end}}"
+    - path: "{{ if .Keywords }}/adult/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/adult/1/{{ .Config.sort }}/{{ .Config.type }}.html{{end}}"
       categories: [ADULT]
-    - path: "{{ if .Keywords }}/audiobook/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/audiobook/1/added/desc.html{{end}}"
+    - path: "{{ if .Keywords }}/audiobook/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/audiobook/1/{{ .Config.sort }}/{{ .Config.type }}.html{{end}}"
       categories: [AUDIOBOOK]
-    - path: "{{ if .Keywords }}/image/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/images/1/added/desc.html{{end}}"
+    - path: "{{ if .Keywords }}/image/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/images/1/{{ .Config.sort }}/{{ .Config.type }}.html{{end}}"
       categories: [IMAGES]
   keywordsfilters:
     - name: tolower

--- a/src/Jackett.Common/Definitions/torlock.yml
+++ b/src/Jackett.Common/Definitions/torlock.yml
@@ -72,7 +72,7 @@ search:
   paths:
     - path: "{{ if .Keywords }}/all/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{ else }}/fresh.html{{ end }}"
       categories: ["!", TELEVISION, MOVIES, MUSIC, GAMES, SOFTWARE, ANIME, EBOOKS, OTHER, ADULT, AUDIOBOOK, IMAGES]
-    - path: "{{ if .Keywords }}/television/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/television/1/added/desc.html{{end}}"
+    - path: "{{ if .Keywords }}/television/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/television/1/{{ .Config.sort }}/{{ .Config.type }}.html{{end}}"
       categories: [TELEVISION]
     - path: "{{ if .Keywords }}/movie/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/movies/1/added/desc.html{{end}}"
       categories: [MOVIES]
@@ -84,15 +84,15 @@ search:
       categories: [SOFTWARE]
     - path: "{{ if .Keywords }}/anime/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/anime/1/added/desc.html{{end}}"
       categories: [ANIME]
-    - path: "{{ if .Keywords }}/ebooks/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/ebooks/1/added/desc.html{{end}}"
+    - path: "{{ if .Keywords }}/ebook/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/ebooks/1/added/desc.html{{end}}"
       categories: [EBOOKS]
     - path: "{{ if .Keywords }}/unknown/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/unknown.html{{end}}" # sorting is broken for unknown
       categories: [OTHER]
     - path: "{{ if .Keywords }}/adult/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/adult/1/added/desc.html{{end}}"
       categories: [ADULT]
-    - path: "{{ if .Keywords }}/audiobooks/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/audiobooks/1/added/desc.html{{end}}"
+    - path: "{{ if .Keywords }}/audiobook/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/audiobook/1/added/desc.html{{end}}"
       categories: [AUDIOBOOK]
-    - path: "{{ if .Keywords }}/images/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/images/1/added/desc.html{{end}}"
+    - path: "{{ if .Keywords }}/image/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/images/1/added/desc.html{{end}}"
       categories: [IMAGES]
   keywordsfilters:
     - name: tolower

--- a/src/Jackett.Common/Definitions/torlock.yml
+++ b/src/Jackett.Common/Definitions/torlock.yml
@@ -71,6 +71,29 @@ settings:
 search:
   paths:
     - path: "{{ if .Keywords }}/all/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{ else }}/fresh.html{{ end }}"
+      categories: ["!", TELEVISION, MOVIES, MUSIC, GAMES, SOFTWARE, ANIME, EBOOKS, OTHER, ADULT, AUDIOBOOK, IMAGES]
+    - path: "{{ if .Keywords }}/television/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/television/1/added/desc.html{{end}}"
+      categories: [TELEVISION]
+    - path: "{{ if .Keywords }}/movies/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/movies/1/added/desc.html{{end}}"
+      categories: [MOVIES]
+    - path: "{{ if .Keywords }}/music/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/music/1/added/desc.html{{end}}"
+      categories: [MUSIC]
+    - path: "{{ if .Keywords }}/games/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/games/1/added/desc.html{{end}}"
+      categories: [GAMES]
+    - path: "{{ if .Keywords }}/software/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/software/1/added/desc.html{{end}}"
+      categories: [SOFTWARE]
+    - path: "{{ if .Keywords }}/anime/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/anime/1/added/desc.html{{end}}"
+      categories: [ANIME]
+    - path: "{{ if .Keywords }}/ebooks/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/ebooks/1/added/desc.html{{end}}"
+      categories: [EBOOKS]
+    - path: "{{ if .Keywords }}/unknown/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/unknown.html{{end}}" # sorting is broken for unknown
+      categories: [OTHER]
+    - path: "{{ if .Keywords }}/adult/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/adult/1/added/desc.html{{end}}"
+      categories: [ADULT]
+    - path: "{{ if .Keywords }}/audiobooks/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/audiobooks/1/added/desc.html{{end}}"
+      categories: [AUDIOBOOK]
+    - path: "{{ if .Keywords }}/images/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/images/1/added/desc.html{{end}}"
+      categories: [IMAGES]
   keywordsfilters:
     - name: tolower
     - name: re_replace

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -1262,7 +1262,7 @@ namespace Jackett.Common.Indexers
             foreach (var SearchPath in SearchPaths)
             {
                 // skip path if categories don't match
-                if (SearchPath.Categories != null && mappedCategories.Count > 0)
+                if (SearchPath.Categories.Count > 0)
                 {
                     var invertMatch = (SearchPath.Categories[0] == "!");
                     var hasIntersect = mappedCategories.Intersect(SearchPath.Categories).Any();

--- a/src/Jackett.Common/Models/IndexerDefinition.cs
+++ b/src/Jackett.Common/Models/IndexerDefinition.cs
@@ -152,7 +152,7 @@ namespace Jackett.Common.Models
 
     public class searchPathBlock : requestBlock
     {
-        public List<string> Categories { get; set; }
+        public List<string> Categories { get; set; } = new List<string>();
         public bool Inheritinputs { get; set; } = true;
         public bool Followredirect { get; set; } = false;
     }


### PR DESCRIPTION
This is an attempt to resolve https://github.com/Jackett/Jackett/issues/6256. Still needs more testing and feedback before merging.

You can test it out with the following indexer

<details><summary>test6256.yml</summary>

```yaml
---
id: test6256
name: test6256
description: "testing path category mappings"
language: en-us
type: public
encoding: UTF-8
links:
  - https://www.torlock.com/
  - https://www.torlock2.com/
legacylinks:
  - https://torlock.com/

caps:
  categorymappings:
    - {id: TELEVISION, cat: TV, desc: "TV Shows"}
    - {id: MOVIES, cat: Movies, desc: "Movies"}
    - {id: MUSIC, cat: Audio, desc: "Music"}
    - {id: GAMES, cat: PC/Games, desc: "Games"}
    - {id: SOFTWARE, cat: PC, desc: "Software"}
    - {id: ANIME, cat: TV/Anime, desc: "Anime"}
    - {id: EBOOKS, cat: Books/EBook, desc: "Books"}
    - {id: OTHER, cat: Other, desc: "Other"}
    - {id: ADULT, cat: XXX, desc: "Adult"}
    - {id: AUDIOBOOK, cat: Audio/Audiobook, desc: "Audiobook"}
    - {id: IMAGES, cat: Other/Misc, desc: "Images"}

  modes:
    search: [q]
    tv-search: [q, season, ep]
    movie-search: [q]

settings:
  - name: sort
    type: select
    label: Sort requested from site (only works for search with keywords)
    default: "added"
    options:
      "added": "created"
      "seeds": "seeders"
      "size": "size"
  - name: type
    type: select
    label: Order requested from site
    default: "desc"
    options:
      "desc": "desc"
      "asc": "asc"

search:
  paths:
    - path: "{{ if .Keywords }}/all/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/fresh.html{{end}}"
      categories: ["!", TELEVISION, MOVIES, MUSIC, GAMES, SOFTWARE, ANIME, EBOOKS, OTHER, ADULT, AUDIOBOOK, IMAGES]
    - path: "{{ if .Keywords }}/television/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/television/1/added/desc.html{{end}}"
      categories: [TELEVISION]
    - path: "{{ if .Keywords }}/movies/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/movies/1/added/desc.html{{end}}"
      categories: [MOVIES]
    - path: "{{ if .Keywords }}/music/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/music/1/added/desc.html{{end}}"
      categories: [MUSIC]
    - path: "{{ if .Keywords }}/games/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/games/1/added/desc.html{{end}}"
      categories: [GAMES]
    - path: "{{ if .Keywords }}/software/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/software/1/added/desc.html{{end}}"
      categories: [SOFTWARE]
    - path: "{{ if .Keywords }}/anime/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/anime/1/added/desc.html{{end}}"
      categories: [ANIME]
    - path: "{{ if .Keywords }}/ebooks/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/ebooks/1/added/desc.html{{end}}"
      categories: [EBOOKS]
    - path: "{{ if .Keywords }}/unknown/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/unknown.html{{end}}" # sorting is broken for unknown
      categories: [OTHER]
    - path: "{{ if .Keywords }}/adult/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/adult/1/added/desc.html{{end}}"
      categories: [ADULT]
    - path: "{{ if .Keywords }}/audiobooks/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/audiobooks/1/added/desc.html{{end}}"
      categories: [AUDIOBOOK]
    - path: "{{ if .Keywords }}/images/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/images/1/added/desc.html{{end}}"
      categories: [IMAGES]
  keywordsfilters:
    - name: tolower
    - name: re_replace
      args: ["[^a-zA-Z0-9]+", "-"]

  rows:
    selector: table > tbody > tr:has(td:has(div:has(a[href^="/torrent/"])))
    filters:
      - name: andmatch

  fields:
    category:
      selector: span[class^="tv"]
      attribute: class
      case:
        span.tv0: OTHER
        span.tv1: MOVIES
        span.tv2: MUSIC
        span.tv3: TELEVISION
        span.tv4: GAMES
        span.tv5: SOFTWARE
        span.tv6: ANIME
        span.tv7: ADULT
        span.tv8: EBOOKS
        span.tv9: IMAGES
        span.tv12: AUDIOBOOK
        "*": "" # some torrents have invalid categories
    title:
      selector: td:nth-child(1) > div > a
    details:
      selector: td:nth-child(1) > div > a[href^="/torrent/"]
      attribute: href
    download:
      selector: td:nth-child(1) > div > a[href^="/torrent/"]
      attribute: href
      filters:
        - name: replace
          args: ["/torrent/", "/tor/"]
        - name: regexp
          args: (^/tor/\d*)
        - name: append
          args: ".torrent"
    date:
      selector: td:nth-child(2):contains("/")
      optional: true
      filters:
        - name: dateparse
          args: "1/2/2006"
    date:
      selector: td:nth-child(2):contains("Today"), td:nth-child(2):contains("Yesterday")
      optional: true
      filters:
        - name: fuzzytime
    date:
      selector: td:nth-child(2):not(:contains("Today")):not(:contains("Yesterday")):not(:contains("/"))
      optional: true
      filters:
        - name: re_replace
          args: ["(min|mins)", "minutes"]
        - name: timeago
    size:
      selector: td:nth-child(3)
    seeders:
      selector: td:nth-child(4)
    leechers:
      selector: td:nth-child(5)
    downloadvolumefactor:
      text: 0
    uploadvolumefactor:
      text: 1
# Engine n/a
```

</details>


@garfield69 there's something that I am still not very clear. Previously, the following line was absent:

```yaml
- path: "{{ if .Keywords }}/all/torrents/{{ .Keywords }}.html?sort={{ .Config.sort }}&order={{ .Config.type }}{{else}}/fresh.html{{end}}"
  categories: ["!", TELEVISION, MOVIES, MUSIC, GAMES, SOFTWARE, ANIME, EBOOKS, OTHER, ADULT, AUDIOBOOK, IMAGES]
```

What are the expected results for this? In my test, there would be no results returned when categories are set to "Any".

Also, if I don't do the inverse for the categories, the search paths would always run no matter if the category filter is set or otherwise. If category filters are set, the result returned would be duplicated.