### PR TITLE
Fix search yggtorrent when anime ending by number without 'e'

### DIFF
--- a/src/Jackett.Common/Definitions/yggcookie.yml
+++ b/src/Jackett.Common/Definitions/yggcookie.yml
@@ -204,6 +204,8 @@ search:
       args: ["(?i)(.*)s([1-9])$", "$1 S0$2"]
     - name: re_replace # Full season S >= 10
       args: ["(?i)(.*)s([1-9][0-9])$", "$1 S$2"]
+    - name: re_replace # episode number at the end "123" to "E123"
+      args: ["(.*)(\\.| |\\-)(\\d{2,3})(.*)", "$1 E$3 $4"]
     # END ANIME HACK
     - name: replace
       args: ["\"", ""]

--- a/src/Jackett.Common/Definitions/yggtorrent.yml
+++ b/src/Jackett.Common/Definitions/yggtorrent.yml
@@ -212,6 +212,8 @@ search:
       args: ["(?i)(.*)s([1-9])$", "$1 S0$2"]
     - name: re_replace # Full season S >= 10
       args: ["(?i)(.*)s([1-9][0-9])$", "$1 S$2"]
+    - name: re_replace # episode number at the end "123" to "E123"
+      args: ["(.*)(\\.| |\\-)(\\d{2,3})(.*)", "$1 E$3 $4"]
     # END ANIME HACK
     - name: replace
       args: ["\"", ""]


### PR DESCRIPTION
Hello,
I made a change into the config file of Yggtorrent indexer. When we make a search for example "Boruto Naruto next generations 196", it find nothing but if we search "Boruto Naruto next generations E196", it shows results. So i made simple replace into keywords before searching.