### PR TITLE
Switch Erai-Raws back to main site

### DIFF
--- a/src/Jackett.Common/Indexers/EraiRaws.cs
+++ b/src/Jackett.Common/Indexers/EraiRaws.cs
@@ -19,14 +19,8 @@ namespace Jackett.Common.Indexers
         const string RSS_PATH = "feed/?type=magnet";
 
         public override string[] AlternativeSiteLinks { get; protected set; } = {
-            // At some point the beta site will probably replace the current one
-            // At that point, these can probably be re-enabled.
-            // "https://www.erai-raws.info/",
-            // "https://erairaws.nocensor.space/"
-        };
-
-        public override string[] LegacySiteLinks { get; protected set; } = {
             "https://www.erai-raws.info/",
+            "https://beta.erai-raws.info/",
             "https://erairaws.nocensor.space/"
         };
 
@@ -35,8 +29,7 @@ namespace Jackett.Common.Indexers
             : base(id: "erai-raws",
                    name: "Erai-Raws",
                    description: "Erai-Raws is a team release site for Anime subtitles.",
-                   //link: "https://www.erai-raws.info/",
-                   link: "https://beta.erai-raws.info/",
+                   link: "https://www.erai-raws.info/",
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -111,6 +104,8 @@ namespace Jackett.Common.Indexers
         {
             // Retrieve RSS feed
             var result = await RequestWithCookiesAndRetryAsync(RssFeedUri);
+            if (result.IsRedirect)
+                await FollowIfRedirect(result);
 
             // Parse as XML document
             var xmlDocument = new XmlDocument();

--- a/src/Jackett.Common/Indexers/EraiRaws.cs
+++ b/src/Jackett.Common/Indexers/EraiRaws.cs
@@ -226,7 +226,7 @@ namespace Jackett.Common.Indexers
                 var publishDate = rssItem.SelectSingleNode("pubDate")?.InnerText;
                 var size = rssItem.SelectSingleNode("erai:size", nsm)?.InnerText;
                 var description = rssItem.SelectSingleNode("description")?.InnerText;
-                var quality = rssItem.SelectSingleNode("erai:res", nsm)?.InnerText;
+                var quality = rssItem.SelectSingleNode("erai:resolution", nsm)?.InnerText;
 
                 item = new RssFeedItem
                 {


### PR DESCRIPTION
Erai-Raws looks to have published the new RSS feed now. This re-adds the URLs for the main site. I've left the beta site as an option for now as it is still working but I'm happy to move to legacy links if preferred.

I also re-added the nocensor site link but was unable to test it due to cloudflare restrictions (I don't have flaresolver set up atm). It seems to be just a proxy though with identical content so should work. It required the `FollowIfRedirect` change but I'm not sure if this is a result of cloudflare or nocensor.