### PR TITLE
Better Size Parsing for Cardigann Indexer

### DIFF
--- a/src/Jackett.Common/Models/ReleaseInfo.cs
+++ b/src/Jackett.Common/Models/ReleaseInfo.cs
@@ -80,6 +80,11 @@ namespace Jackett.Common.Models
         public static long GetBytes(string str)
         {
             var valStr = new string(str.Where(c => char.IsDigit(c) || c == '.').ToArray());
+            if (valStr.Count(c => c == '.') > 1)
+            {
+                var lastOcc = valStr.LastIndexOf('.');
+                valStr = valStr.Substring(0, lastOcc).Replace(".", string.Empty) + valStr.Substring(lastOcc);
+            }
             var unit = new string(str.Where(char.IsLetter).ToArray());
             var val = ParseUtil.CoerceFloat(valStr);
             return GetBytes(unit, val);


### PR DESCRIPTION
Fixes #12241.
As mentioned in the issue, except for the last instance of dot character, all are removed. 
I didn't go with my replace all commas with dots logic because of the following reason:
1,024 MB should be 1024 MB but with this, it could've become 1.024 MB which would be disastrous.

The first logic is working for the variation of the size mentioned in the issue but needs actual testing with all the indexers.