### PR TITLE
Standardized YML language on  `{ISO 639-1}-{ISO 3166-1 alpha-2}`

### DIFF
--- a/src/Jackett.Common/Definitions/0daykiev.yml
+++ b/src/Jackett.Common/Definitions/0daykiev.yml
@@ -2,7 +2,7 @@
 id: 0daykiev
 name: 0day.kiev
 description: "0day.kiev.ua is a RUSSIAN Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: ru-ru
+language: ru-RU
 type: private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -2,7 +2,7 @@
 id: 1337x
 name: 1337x
 description: "1337X is a Public torrent site that offers verified torrent downloads"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/1ptbar.yml
+++ b/src/Jackett.Common/Definitions/1ptbar.yml
@@ -2,7 +2,7 @@
 id: 1ptbar
 name: 1ptbar
 description: "1ptbar is a CHINESE Private Torrent Tracker for Movies, TV, and e-Learning"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/2fast4you.yml
+++ b/src/Jackett.Common/Definitions/2fast4you.yml
@@ -2,7 +2,7 @@
 id: 2fast4you
 name: 2 Fast 4 You
 description: "2 Fast 4 You is a FRENCH Private site for TV / MOVIES / GENERAL"
-language: fr-fr
+language: fr-FR
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/3changtrai.yml
+++ b/src/Jackett.Common/Definitions/3changtrai.yml
@@ -2,7 +2,7 @@
 id: 3changtrai
 name: 3ChangTrai
 description: "3ChangTrai (3CT) is a VIETNAMESE Private Torrent Tracker for HD MOVIES / TV"
-language: vi-vn
+language: vi-VN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/3dtorrents.yml
+++ b/src/Jackett.Common/Definitions/3dtorrents.yml
@@ -2,7 +2,7 @@
 id: 3dtorrents
 name: 3D Torrents
 description: "3D Torrents (3DT) is a Private Torrent Tracker for 3D HD / BLURAY MOVIES"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/4thd.yml
+++ b/src/Jackett.Common/Definitions/4thd.yml
@@ -2,7 +2,7 @@
 id: 4thd
 name: 4thD
 description: "4th Dimension is a Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 encoding: UTF-8
 type: private
 links:

--- a/src/Jackett.Common/Definitions/52pt.yml
+++ b/src/Jackett.Common/Definitions/52pt.yml
@@ -2,7 +2,7 @@
 id: 52pt
 name: 52PT
 description: "52PT is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/7torrents.yml
+++ b/src/Jackett.Common/Definitions/7torrents.yml
@@ -2,7 +2,7 @@
 id: 7torrents
 name: 7torrents
 description: "7torrents is a Public BitTorrent DHT search engine."
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/Bittorrentfiles.yml
+++ b/src/Jackett.Common/Definitions/Bittorrentfiles.yml
@@ -2,7 +2,7 @@
 id: Bittorrentfiles
 name: Bittorrentfiles
 description: "Bittorrentfiles is a Private GERMAN tracker"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/DasUnerwartete.yml
+++ b/src/Jackett.Common/Definitions/DasUnerwartete.yml
@@ -2,7 +2,7 @@
 id: Das-Unerwartete
 name: Das Unerwartete
 description: "Das Unerwartete is a Private GERMAN tracker"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/abtorrents.yml
+++ b/src/Jackett.Common/Definitions/abtorrents.yml
@@ -2,7 +2,7 @@
 id: abtorrents
 name: ABtorrents
 description: "ABtorrents (ABT) is a Private Torrent Tracker for AUDIOBOOKS"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/acgrip.yml
+++ b/src/Jackett.Common/Definitions/acgrip.yml
@@ -2,7 +2,7 @@
 id: acgrip
 name: ACG.RIP
 description: "ACG.RIP is a CHINESE Public torrent tracker for the latest anime and Japanese related torrents"
-language: zh-cn
+language: zh-CN
 type: public
 followredirect: true
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/acgsou.yml
+++ b/src/Jackett.Common/Definitions/acgsou.yml
@@ -2,7 +2,7 @@
 id: acgsou
 name: ACGsou
 description: "ACGsou (36DM) is a CHINESE Public torrent tracker for ANIME"
-language: zh-cn
+language: zh-CN
 type: public
 followredirect: true
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/acidlounge.yml
+++ b/src/Jackett.Common/Definitions/acidlounge.yml
@@ -2,7 +2,7 @@
 id: acidlounge
 name: Acid-Lounge
 description: "Acid Lounge (A-L) is a Private Torrent Tracker for 0DAY / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/acrossthetasman.yml
+++ b/src/Jackett.Common/Definitions/acrossthetasman.yml
@@ -2,7 +2,7 @@
 id: acrossthetasman
 name: Across The Tasman
 description: "ATT is a torrent site for Rugby and other sports played in Australia"
-language: en-US
+language: en-AU
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/acrossthetasman.yml
+++ b/src/Jackett.Common/Definitions/acrossthetasman.yml
@@ -2,7 +2,7 @@
 id: acrossthetasman
 name: Across The Tasman
 description: "ATT is a torrent site for Rugby and other sports played in Australia"
-language: en
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/aftershock.yml
+++ b/src/Jackett.Common/Definitions/aftershock.yml
@@ -2,7 +2,7 @@
 id: aftershock
 name: Aftershock
 description: "Aftershock is a HUNGARIAN Private Torrent Tracker for MOVIES / GENERAL"
-language: hu-hu
+language: hu-HU
 type: private
 encoding: iso-8859-1
 links:

--- a/src/Jackett.Common/Definitions/aidoruonline.yml
+++ b/src/Jackett.Common/Definitions/aidoruonline.yml
@@ -2,7 +2,7 @@
 id: aidoruonline
 name: Aidoru!Online
 description: "Aidoru!Online is a Private Torrent Tracker for Female Japanese Idol related files"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/aither.yml
+++ b/src/Jackett.Common/Definitions/aither.yml
@@ -2,7 +2,7 @@
 id: aither
 name: Aither
 description: "Aither is a Private Torrent Tracker for HD MOVIES / TV"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/amigosshare.yml
+++ b/src/Jackett.Common/Definitions/amigosshare.yml
@@ -2,7 +2,7 @@
 id: amigosshare
 name: Amigos Share Club
 description: "Amigos Share Club is a Brazilian Private site for TV / MOVIES / GENERAL"
-language: pt-br
+language: pt-BR
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/anaschcc.yml
+++ b/src/Jackett.Common/Definitions/anaschcc.yml
@@ -2,7 +2,7 @@
 id: anaschcc
 name: anasch.cc
 description: "anasch.cc is a Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: en
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/angietorrents.yml
+++ b/src/Jackett.Common/Definitions/angietorrents.yml
@@ -2,7 +2,7 @@
 id: angietorrents
 name: AngieTorrents
 description: "AngieTorrents is a Public Torrent Tracker for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/anime-free.yml
+++ b/src/Jackett.Common/Definitions/anime-free.yml
@@ -2,7 +2,7 @@
 id: anime-free
 name: Anime-Free
 description: "Anime-Free is a RUSSIAN Semi-Private Torrent Tracker for Hentai manga, eroge and flash porn games"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/animeclipse.yml
+++ b/src/Jackett.Common/Definitions/animeclipse.yml
@@ -2,7 +2,7 @@
 id: animeclipse
 name: AnimeClipse
 description: "AnimeClipse is a Public site for Hellenic Fansubs Anime."
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/animeworld.yml
+++ b/src/Jackett.Common/Definitions/animeworld.yml
@@ -2,7 +2,7 @@
 id: animeworld
 name: AnimeWorld
 description: "AnimeWorld (AW) is a GERMAN Private site for ANIME / MANGA / HENTAI"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/anirena.yml
+++ b/src/Jackett.Common/Definitions/anirena.yml
@@ -2,7 +2,7 @@
 id: aniRena
 name: AniRena
 description: "AniRena is a Public torrent tracker for the latest anime and Japanese related torrents"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/anisource.yml
+++ b/src/Jackett.Common/Definitions/anisource.yml
@@ -2,7 +2,7 @@
 id: anisource
 name: AniSource
 description: "AniSource is a Public site for HD Anime raws."
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/arabafenice.yml
+++ b/src/Jackett.Common/Definitions/arabafenice.yml
@@ -2,7 +2,7 @@
 id: arabafenice
 name: ArabaFenice
 description: "Araba Fenice (Phoenix) is an ITALIAN Private site for TV / MOVIES / GENERAL"
-language: it-it
+language: it-IT
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/arabp2p.yml
+++ b/src/Jackett.Common/Definitions/arabp2p.yml
@@ -2,7 +2,7 @@
 id: arabp2p
 name: ArabP2P
 description: "ArabP2P is an ARABIC Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: ar-ar
+language: ar-AR
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/asiancinema.yml
+++ b/src/Jackett.Common/Definitions/asiancinema.yml
@@ -2,7 +2,7 @@
 id: asiancinema
 name: AsianCinema
 description: "Tracker Movies/TV/Music"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/asiandvdclub.yml
+++ b/src/Jackett.Common/Definitions/asiandvdclub.yml
@@ -2,7 +2,7 @@
 id: asiandvdclub
 name: AsianDVDClub
 description: "AsianDVDClub (ADC) is a Private Torrent Tracker for Asian DVD and BluRay"
-language: en
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/audiobookbay.yml
+++ b/src/Jackett.Common/Definitions/audiobookbay.yml
@@ -2,7 +2,7 @@
 id: audiobookbay
 name: AudioBookBay
 description: "AudioBook Bay (ABB) is a public Torrent Tracker for AUDIOBOOKS"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/audionews.yml
+++ b/src/Jackett.Common/Definitions/audionews.yml
@@ -2,7 +2,7 @@
 id: audionews
 name: AudioNews
 description: "AudioNews (AN) is a Private Torrent Tracker for AUDIO SOFTWARE / SAMPLES / ETC"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/aussierules.yml
+++ b/src/Jackett.Common/Definitions/aussierules.yml
@@ -2,7 +2,7 @@
 id: aussierules
 name: Aussierul.es
 description: "Aussierul.es is a torrent site for Aussie Rules Football played in Australia"
-language: en-US
+language: en-AU
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/aussierules.yml
+++ b/src/Jackett.Common/Definitions/aussierules.yml
@@ -2,7 +2,7 @@
 id: aussierules
 name: Aussierul.es
 description: "Aussierul.es is a torrent site for Aussie Rules Football played in Australia"
-language: en
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/backups.yml
+++ b/src/Jackett.Common/Definitions/backups.yml
@@ -2,7 +2,7 @@
 id: backups
 name: Back-ups
 description: "Back-Ups is a Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/badasstorrents.yml
+++ b/src/Jackett.Common/Definitions/badasstorrents.yml
@@ -2,7 +2,7 @@
 id: badasstorrents
 name: Badass Torrents
 description: "Badass Torrents is a Public torrent site for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/baibako.yml
+++ b/src/Jackett.Common/Definitions/baibako.yml
@@ -2,7 +2,7 @@
 id: baibako
 name: BaibaKo
 description: "BaibaKo is a RUSSIAN Semi-Private Torrent Tracker for TV"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/beitai.yml
+++ b/src/Jackett.Common/Definitions/beitai.yml
@@ -2,7 +2,7 @@
 id: beitai
 name: BeiTai
 description: "BeiTai is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/beyond-hd-oneurl.yml
+++ b/src/Jackett.Common/Definitions/beyond-hd-oneurl.yml
@@ -2,7 +2,7 @@
 id: beyond-hd-oneurl
 name: Beyond-HD (OneURL)
 description: "This is BeyondHD using OneURL (for those that have enabled 2FA)"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/beyond-hd.yml
+++ b/src/Jackett.Common/Definitions/beyond-hd.yml
@@ -2,7 +2,7 @@
 id: beyond-hd
 name: Beyond-HD
 description: "Without BeyondHD, your HDTV is just a TV"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/bigfangroup.yml
+++ b/src/Jackett.Common/Definitions/bigfangroup.yml
@@ -2,7 +2,7 @@
 id: bigfangroup
 name: BigFANGroup
 description: "BigFANGroup is a RUSSIAN Public Torrent Tracker for MOVIES / TV"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/bigtorrent.yml
+++ b/src/Jackett.Common/Definitions/bigtorrent.yml
@@ -2,7 +2,7 @@
 id: bigtorrent
 name: BIGTorrent
 description: "BIGTorrent is a HUNGARIAN Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: hu
+language: hu-HU
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/bit-titan.yml
+++ b/src/Jackett.Common/Definitions/bit-titan.yml
@@ -2,7 +2,7 @@
 id: bit-titan
 name: BiT-TiTAN
 description: "BiT-TiTAN is a GERMAN Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: de-de
+language: de-DE
 type: private
 encoding: iso-8859-1
 links:

--- a/src/Jackett.Common/Definitions/bitded.yml
+++ b/src/Jackett.Common/Definitions/bitded.yml
@@ -2,7 +2,7 @@
 id: bitded
 name: Bitded
 description: "Bitded is a THAI Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: th-th
+language: th-TH
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/bithorlo.yml
+++ b/src/Jackett.Common/Definitions/bithorlo.yml
@@ -2,7 +2,7 @@
 id: bithorlo
 name: Bithorlo
 description: "Bithorlo (BHO) is a HUNGARIAN Private Torrent Tracker for MOVIES / GENERAL"
-language: hu-hu
+language: hu-HU
 type: private
 encoding: ISO-8859-2
 links:

--- a/src/Jackett.Common/Definitions/bithumen.yml
+++ b/src/Jackett.Common/Definitions/bithumen.yml
@@ -2,7 +2,7 @@
 id: bithumen
 name: BitHUmen
 description: "BitHUmen is a Hungarian Private site for TV / MOVIES / GENERAL"
-language: hu-hu
+language: hu-HU
 type: private
 encoding: ISO-8859-2
 links:

--- a/src/Jackett.Common/Definitions/bitru.yml
+++ b/src/Jackett.Common/Definitions/bitru.yml
@@ -2,7 +2,7 @@
 id: bitru
 name: BitRu
 description: "BitRu is a RUSSIAN Public Torrent Tracker for MOVIES / TV / GENERAL"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/bitsearch.yml
+++ b/src/Jackett.Common/Definitions/bitsearch.yml
@@ -2,7 +2,7 @@
 id: bitsearch
 name: BitSearch
 description: "BitSearch is a Public torrent meta-search engine"
-language: en
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/bitsexy.yml
+++ b/src/Jackett.Common/Definitions/bitsexy.yml
@@ -2,7 +2,7 @@
 id: bitsexy
 name: BitSexy
 description: "BitSexy is a Private Torrent Tracker for 3x"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/bitspyder.yml
+++ b/src/Jackett.Common/Definitions/bitspyder.yml
@@ -2,7 +2,7 @@
 id: bitspyder
 name: Bitspyder
 description: "Bitspyder is a Private site for Educational BOOKS / AUDIO"
-language: en-us
+language: en-US
 type: private
 encoding: windows-1252
 links:

--- a/src/Jackett.Common/Definitions/bitturk.yml
+++ b/src/Jackett.Common/Definitions/bitturk.yml
@@ -2,7 +2,7 @@
 id: bitturk
 name: BiTTuRK
 description: "BiTTuRK is a Turkish Private Torrent Tracker for HD MOVIES / TV / GENERAL. This Indexer is for English only."
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/bluebird.yml
+++ b/src/Jackett.Common/Definitions/bluebird.yml
@@ -2,7 +2,7 @@
 id: bluebirdhd
 name: BlueBird
 description: "BlueBird is a RUSSIAN Private Torrent Tracker for HD MOVIES"
-language: ru-ru
+language: ru-RU
 type: private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/blutopia.yml
+++ b/src/Jackett.Common/Definitions/blutopia.yml
@@ -2,7 +2,7 @@
 id: blutopia
 name: Blutopia
 description: "Blutopia (BLU) is a Private Torrent Tracker for HD MOVIES / TV"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/booktracker.yml
+++ b/src/Jackett.Common/Definitions/booktracker.yml
@@ -2,7 +2,7 @@
 id: booktracker
 name: BookTracker
 description: "BookTracker is a RUSSIAN Semi-Private Torrent Tracker for EBOOKS"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/bootytape.yml
+++ b/src/Jackett.Common/Definitions/bootytape.yml
@@ -1,8 +1,8 @@
 ---
 id: bootytape
 name: BootyTape
-language: en-US
 description: "BootyTape is a Semi-Private site for 3X"
+language: en-US
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/bootytape.yml
+++ b/src/Jackett.Common/Definitions/bootytape.yml
@@ -1,7 +1,7 @@
 ---
 id: bootytape
 name: BootyTape
-language: en-us
+language: en-US
 description: "BootyTape is a Semi-Private site for 3X"
 type: semi-private
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/borgzelle.yml
+++ b/src/Jackett.Common/Definitions/borgzelle.yml
@@ -2,7 +2,7 @@
 id: borgzelle
 name: Borgzelle
 description: "Borgzelle is a GERMAN Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/boxingtorrents.yml
+++ b/src/Jackett.Common/Definitions/boxingtorrents.yml
@@ -2,7 +2,7 @@
 id: boxingtorrents
 name: Boxing Torrents
 description: "Boxing Torrents is a Private Torrent Tracker for BOXING"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/brasiltracker.yml
+++ b/src/Jackett.Common/Definitions/brasiltracker.yml
@@ -2,7 +2,7 @@
 id: brasiltracker
 name: BrasilTracker
 description: "BrasilTracker is a BRAZILIAN Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: pt-br
+language: pt-BR
 encoding: UTF-8
 type: private
 links:

--- a/src/Jackett.Common/Definitions/brsociety.yml
+++ b/src/Jackett.Common/Definitions/brsociety.yml
@@ -2,7 +2,7 @@
 id: brsociety
 name: BrSociety
 description: "BrSociety (SemeandoCC) is a BRAZILIAN Private Torrent Tracker for E-LEARNING"
-language: pt-br
+language: pt-BR
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/bt4g.yml
+++ b/src/Jackett.Common/Definitions/bt4g.yml
@@ -2,7 +2,7 @@
 id: bt4g
 name: BT4G
 description: "BT4G is a Public metadata crawler for magnets"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/btdigg.yml
+++ b/src/Jackett.Common/Definitions/btdigg.yml
@@ -2,7 +2,7 @@
 id: btdigg
 name: BTDigg
 description: "BTDigg is a Public BitTorrent DHT search engine."
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/btetree.yml
+++ b/src/Jackett.Common/Definitions/btetree.yml
@@ -2,7 +2,7 @@
 id: btetree
 name: BT.etree
 description: "BT.etree is a Public Tracker dedicated to Bootleg FLAC MUSIC"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/btnext.yml
+++ b/src/Jackett.Common/Definitions/btnext.yml
@@ -2,7 +2,7 @@
 id: btnext
 name: BTNext
 description: "BTNext (BTNT) is a PORTUGUESE Private Torrent Tracker for 0DAY / GENERAL"
-language: pt-pt
+language: pt-PT
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/btschool.yml
+++ b/src/Jackett.Common/Definitions/btschool.yml
@@ -2,7 +2,7 @@
 id: btschool
 name: BTSCHOOL
 description: "BTSCHOOL is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/btsow.yml
+++ b/src/Jackett.Common/Definitions/btsow.yml
@@ -2,7 +2,7 @@
 id: btsow
 name: BTSOW
 description: "BTSOW is a Public torrent indexer"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/bwtorrents.yml
+++ b/src/Jackett.Common/Definitions/bwtorrents.yml
@@ -2,7 +2,7 @@
 id: bwtorrents
 name: BwTorrents
 description: "BwTorrents is a Private Torrent Tracker for BollyWood MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/byrutor.yml
+++ b/src/Jackett.Common/Definitions/byrutor.yml
@@ -2,7 +2,7 @@
 id: byrutor
 name: Byrutor
 description: "Byrutor is a RUSSIAN Public Torrent Tracker for GAMES"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/carpathians.yml
+++ b/src/Jackett.Common/Definitions/carpathians.yml
@@ -2,7 +2,7 @@
 id: carpathians
 name: Carpathians
 description: "Carpathians is a HUNGARIAN Private Torrent Tracker for 0DAY / GENERAL"
-language: hu-hu
+language: hu-HU
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/carphunter.yml
+++ b/src/Jackett.Common/Definitions/carphunter.yml
@@ -2,7 +2,7 @@
 id: carphunter
 name: Carp-Hunter
 description: "Carp-Hunter is a HUNGARIAN Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: hu-hu
+language: hu-HU
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/cartoonchaos.yml
+++ b/src/Jackett.Common/Definitions/cartoonchaos.yml
@@ -2,7 +2,7 @@
 id: cartoonchaos
 name: CartoonChaos
 description: "CartoonChaos (CC) is a Private Torrent Tracker for ANIMATED MOVIES / TV"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/casatorrent.yml
+++ b/src/Jackett.Common/Definitions/casatorrent.yml
@@ -2,7 +2,7 @@
 id: casatorrent
 name: Casa-Torrent
 description: "Casa-Torrent is a FRENCH Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: fr-fr
+language: fr-FR
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/cathoderaytube.yml
+++ b/src/Jackett.Common/Definitions/cathoderaytube.yml
@@ -2,7 +2,7 @@
 id: cathoderaytube
 name: Cathode-Ray.Tube
 description: "Cathode-Ray.Tube (CRT) is a Private Torrent Tracker for CLASSIC MOVIES / TV"
-language: en
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/cathoderaytube.yml
+++ b/src/Jackett.Common/Definitions/cathoderaytube.yml
@@ -2,7 +2,7 @@
 id: cathoderaytube
 name: Cathode-Ray.Tube
 description: "Cathode-Ray.Tube (CRT) is a Private Torrent Tracker for CLASSIC MOVIES / TV"
-language: en-US
+language: en-GB
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/catorrent.yml
+++ b/src/Jackett.Common/Definitions/catorrent.yml
@@ -2,7 +2,7 @@
 id: catorrent
 name: Catorrent
 description: "Catorrent is a RUSSIAN Semi-Private Torrent Tracker for GAMES"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/ccfbits.yml
+++ b/src/Jackett.Common/Definitions/ccfbits.yml
@@ -2,7 +2,7 @@
 id: ccfbits
 name: CCFBits
 description: "CCFBits is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/ceskeforum.yml
+++ b/src/Jackett.Common/Definitions/ceskeforum.yml
@@ -2,7 +2,7 @@
 id: ceskeforum
 name: CeskeForum
 description: "CeskeForum is a CZECH Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: cs-cz
+language: cs-CZ
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/chdbits.yml
+++ b/src/Jackett.Common/Definitions/chdbits.yml
@@ -2,7 +2,7 @@
 id: chdbits
 name: CHDBits
 description: "CHDBits is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/cinemageddon.yml
+++ b/src/Jackett.Common/Definitions/cinemageddon.yml
@@ -2,7 +2,7 @@
 id: cinemageddon
 name: Cinemageddon
 description: "B-movie tracker"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/cinemamovies.yml
+++ b/src/Jackett.Common/Definitions/cinemamovies.yml
@@ -2,7 +2,7 @@
 id: cinemamovies
 name: CinemaMovieS_ZT
 description: "CinemaMovieS_ZT is a POLISH Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: pl-pl
+language: pl-PL
 type: private
 encoding: ISO-8859-2
 links:

--- a/src/Jackett.Common/Definitions/cinematik.yml
+++ b/src/Jackett.Common/Definitions/cinematik.yml
@@ -2,7 +2,7 @@
 id: cinematik
 name: Cinematik
 description: "A tracker for full BD and DVD discs of non-mainstream movies, niche cinema and arthouse."
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/classix.yml
+++ b/src/Jackett.Common/Definitions/classix.yml
@@ -2,7 +2,7 @@
 id: classix
 name: Classix
 description: "Classic movie tracker"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/coastalcrew.yml
+++ b/src/Jackett.Common/Definitions/coastalcrew.yml
@@ -2,7 +2,7 @@
 id: coastalcrew
 name: Coastal-Crew
 description: "Coastal-Crew is a GERMAN Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/concen.yml
+++ b/src/Jackett.Common/Definitions/concen.yml
@@ -2,7 +2,7 @@
 id: concen
 name: ConCen
 description: "ConCen (Conspiracy Central) is a Public conspiracy related torrent index"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/concertos.yml
+++ b/src/Jackett.Common/Definitions/concertos.yml
@@ -2,7 +2,7 @@
 id: concertos
 name: Concertos
 description: "Concertos - Private site for Live Concerts with Strict Quality Control"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/cpabien.yml
+++ b/src/Jackett.Common/Definitions/cpabien.yml
@@ -2,7 +2,7 @@
 id: cpasbien
 name: cpasbien
 description: "cpasbien is a FRENCH Public site for TV / MOVIES / GENERAL"
-language: fr-fr
+language: fr-FR
 type: semi-private
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/cpasbienclone.yml
+++ b/src/Jackett.Common/Definitions/cpasbienclone.yml
@@ -2,7 +2,7 @@
 id: cpasbienclone
 name: cpasbien clone
 description: "cpasbien clone is a FRENCH Public site for TV / MOVIES / GENERAL"
-language: fr-fr
+language: fr-FR
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/crazyhd.yml
+++ b/src/Jackett.Common/Definitions/crazyhd.yml
@@ -2,7 +2,7 @@
 id: crazyhd
 name: CrazyHD
 description: "CrazyHD is a BANGLADESHI Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/crazyspirits.yml
+++ b/src/Jackett.Common/Definitions/crazyspirits.yml
@@ -2,7 +2,7 @@
 id: crazyspirits
 name: CrazySpirits
 description: "Crazy Spirits is a FRENCH Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: fr-fr
+language: fr-FR
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/crnaberza.yml
+++ b/src/Jackett.Common/Definitions/crnaberza.yml
@@ -2,7 +2,7 @@
 id: crnaberza
 name: CrnaBerza
 description: "Crna Berza is a BALKAN Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: sr-sp
+language: sr-SP
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/crt2fa.yml
+++ b/src/Jackett.Common/Definitions/crt2fa.yml
@@ -2,7 +2,7 @@
 id: crt2fa
 name: CRT2FA
 description: "This indexer uses a cookie login for Cathode-Ray.Tube for those that want to use 2FA"
-language: en-US
+language: en-GB
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/crt2fa.yml
+++ b/src/Jackett.Common/Definitions/crt2fa.yml
@@ -1,7 +1,7 @@
 ---
 id: crt2fa
 name: CRT2FA
-description: ""Cathode-Ray.Tube (CRT) is a Private Torrent Tracker for CLASSIC MOVIES / TV.  Cookie Login for 2FA use."
+description: "Cathode-Ray.Tube (CRT) is a Private Torrent Tracker for CLASSIC MOVIES / TV.  Cookie Login for 2FA use."
 language: en-GB
 type: private
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/crt2fa.yml
+++ b/src/Jackett.Common/Definitions/crt2fa.yml
@@ -2,7 +2,7 @@
 id: crt2fa
 name: CRT2FA
 description: "This indexer uses a cookie login for Cathode-Ray.Tube for those that want to use 2FA"
-language: en
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/crt2fa.yml
+++ b/src/Jackett.Common/Definitions/crt2fa.yml
@@ -1,7 +1,7 @@
 ---
 id: crt2fa
 name: CRT2FA
-description: "This indexer uses a cookie login for Cathode-Ray.Tube for those that want to use 2FA"
+description: ""Cathode-Ray.Tube (CRT) is a Private Torrent Tracker for CLASSIC MOVIES / TV.  Cookie Login for 2FA use."
 language: en-GB
 type: private
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/dariustracker.yml
+++ b/src/Jackett.Common/Definitions/dariustracker.yml
@@ -2,7 +2,7 @@
 id: dariustracker
 name: Darius Tracker
 description: "Darius Tracker is a HUNGARIAN Private Tracker for MOVIES / TV / GENERAL"
-language: hu
+language: hu-HU
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/dark-shadow.yml
+++ b/src/Jackett.Common/Definitions/dark-shadow.yml
@@ -2,7 +2,7 @@
 id: dark-shadow
 name: Dark-Shadow
 description: "Dark-Shadow is a German Private site for TV / MOVIES / GENERAL"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/darktracker.yml
+++ b/src/Jackett.Common/Definitions/darktracker.yml
@@ -2,7 +2,7 @@
 id: darktracker
 name: Dark Tracker
 description: "Dark Tracker is a RUSSIAN Semi-Private Torrent Tracker for 0DAY / GENERAL"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/deildu.yml
+++ b/src/Jackett.Common/Definitions/deildu.yml
@@ -2,7 +2,7 @@
 id: deildu
 name: Deildu
 description: "Deildu is an Icelandic Semi-Private site for TV / MOVIES / GENERAL"
-language: is-is
+language: is-IS
 type: semi-private
 encoding: iso-8859-1
 links:

--- a/src/Jackett.Common/Definitions/demonoid.yml
+++ b/src/Jackett.Common/Definitions/demonoid.yml
@@ -2,7 +2,7 @@
 id: demonoid
 name: Demonoid
 description: "Demonoid is a Public torrent site for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: semi-private
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/desireleasers.yml
+++ b/src/Jackett.Common/Definitions/desireleasers.yml
@@ -2,7 +2,7 @@
 id: desireleasers
 name: DesiReleasers
 description: "DesiReleasers is an INDIAN Private Torrent Tracker for INDIAN MOVIES"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/diablotorrent.yml
+++ b/src/Jackett.Common/Definitions/diablotorrent.yml
@@ -2,7 +2,7 @@
 id: diablotorrent
 name: Diablo Torrent
 description: " Diablo Torrent is a Hungarian Private site for TV / MOVIES / GENERAL"
-language: hu-hu
+language: hu-HU
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/dimeadozen.yml
+++ b/src/Jackett.Common/Definitions/dimeadozen.yml
@@ -2,7 +2,7 @@
 id: dimeadozen
 name: DimeADozen
 description: "DimeADozen (EzTorrent) is a Semi-Private Torrent Tracker for BOOTLEG MUSIC"
-language: en
+language: en-US
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/dimeadozen.yml
+++ b/src/Jackett.Common/Definitions/dimeadozen.yml
@@ -2,7 +2,7 @@
 id: dimeadozen
 name: DimeADozen
 description: "DimeADozen (EzTorrent) is a Semi-Private Torrent Tracker for BOOTLEG MUSIC"
-language: en-US
+language: en-GB
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/divteam.yml
+++ b/src/Jackett.Common/Definitions/divteam.yml
@@ -2,7 +2,7 @@
 id: divteam
 name: DivTeam
 description: "DivTeam is a SPANISH Private Torrent Tracker for MOVIES / GENERAL"
-language: es-es
+language: es-ES
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/dragonworldreloaded.yml
+++ b/src/Jackett.Common/Definitions/dragonworldreloaded.yml
@@ -2,7 +2,7 @@
 id: dragonworldreloaded
 name: Dragonworld Reloaded
 description: "Dragonworld Reloaded is a GERMAN Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/dxp.yml
+++ b/src/Jackett.Common/Definitions/dxp.yml
@@ -2,7 +2,7 @@
 id: dxp
 name: DXP
 description: "Deaf Experts (DXP) is a RUSSIAN Semi-Private Torrent Tracker for MOVIES / TV with Russian Subtitles."
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/ebooks-shares.yml
+++ b/src/Jackett.Common/Definitions/ebooks-shares.yml
@@ -2,7 +2,7 @@
 id: ebooks-shares
 name: Ebooks-Shares
 description: "Ebooks-Shares is a Private Torrent Tracker for EBOOKS / AUDIOBOOKS"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/efectodoppler.yml
+++ b/src/Jackett.Common/Definitions/efectodoppler.yml
@@ -2,7 +2,7 @@
 id: efectodoppler
 name: Efecto Doppler
 description: "Efecto Doppler is a SPANISH Private Torrent Tracker for MUSIC"
-language: es-es
+language: es-ES
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/ehentai.yml
+++ b/src/Jackett.Common/Definitions/ehentai.yml
@@ -2,7 +2,7 @@
 id: ehentai
 name: E-Hentai
 description: "E-Hentai is a Public site for Hentai doujinshi, manga."
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/elitetorrent-biz.yml
+++ b/src/Jackett.Common/Definitions/elitetorrent-biz.yml
@@ -2,7 +2,7 @@
 id: elitetorrent-biz
 name: EliteTorrent.biz
 description: "EliteTorrent.biz is a Public torrent site for TV, movies and documentaries"
-language: es-es
+language: es-ES
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/empornium.yml
+++ b/src/Jackett.Common/Definitions/empornium.yml
@@ -2,7 +2,7 @@
 id: empornium
 name: Empornium
 description: "Empornium (EMP) is a Private Torrent Tracker for XXX"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/empornium2fa.yml
+++ b/src/Jackett.Common/Definitions/empornium2fa.yml
@@ -2,7 +2,7 @@
 id: empornium2fa
 name: Empornium2FA
 description: "this indexer uses a cookie login for Empornium for those that want to use 2FA"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/eniahd.yml
+++ b/src/Jackett.Common/Definitions/eniahd.yml
@@ -2,7 +2,7 @@
 id: eniahd
 name: EniaHD
 description: "EniaHD is a RUSSIAN Semi-Private Torrent Tracker for MOVIES / TV"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/esharenet.yml
+++ b/src/Jackett.Common/Definitions/esharenet.yml
@@ -2,7 +2,7 @@
 id: esharenet
 name: eShareNet
 description: "eShareNet is a Private Tracker for Brittish MOVIE / TV"
-language: en-US
+language: en-GB
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/esharenet.yml
+++ b/src/Jackett.Common/Definitions/esharenet.yml
@@ -2,7 +2,7 @@
 id: esharenet
 name: eShareNet
 description: "eShareNet is a Private Tracker for Brittish MOVIE / TV"
-language: en
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/esharenet.yml
+++ b/src/Jackett.Common/Definitions/esharenet.yml
@@ -1,7 +1,7 @@
 ---
 id: esharenet
 name: eShareNet
-description: "eShareNet is a Private Tracker for Brittish MOVIE / TV"
+description: "eShareNet is a Private Tracker for British MOVIE / TV"
 language: en-GB
 type: private
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/estone.yml
+++ b/src/Jackett.Common/Definitions/estone.yml
@@ -2,7 +2,7 @@
 id: estone
 name: eStone
 description: "eStone (XiDER, BeLoad) is a HUNGARIAN Private Torrent Tracker for 0DAY / GENERAL"
-language: hu-hu
+language: hu-HU
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/ettv.yml
+++ b/src/Jackett.Common/Definitions/ettv.yml
@@ -2,7 +2,7 @@
 id: ettv
 name: ETTV
 description: "ETTV is a Public torrent site for TV / MOVIES, home of the  ETTV, ETHD and DTOne groups."
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/exkinoray.yml
+++ b/src/Jackett.Common/Definitions/exkinoray.yml
@@ -2,7 +2,7 @@
 id: exkinoray
 name: ExKinoRay
 description: "ExKinoRay is a RUSSIAN Semi-Private Torrent Tracker for MOVIES / TV"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/extratorrent-cd.yml
+++ b/src/Jackett.Common/Definitions/extratorrent-cd.yml
@@ -2,7 +2,7 @@
 id: extratorrent-cd
 name: ExtraTorrent.cd
 description: "ExtraTorrent.cd is a Public tracker for MOVIE / TV / GENERAL magnets"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/extremebits.yml
+++ b/src/Jackett.Common/Definitions/extremebits.yml
@@ -2,7 +2,7 @@
 id: extremebits
 name: ExtremeBits
 description: "ExtremeBits is a Private Torrent Tracker for EXTREME SPORTS"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/extremlymtorrents.yml
+++ b/src/Jackett.Common/Definitions/extremlymtorrents.yml
@@ -2,7 +2,7 @@
 id: extremlymtorrents
 name: ExtremlymTorrents
 description: "ExtremlymTorrents (XTR) is a Semi-Private tracker for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/exttorrents.yml
+++ b/src/Jackett.Common/Definitions/exttorrents.yml
@@ -2,7 +2,7 @@
 id: exttorrents
 name: EXT Torrents
 description: "EXT Torrents is a Public torrent site for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/eztv.yml
+++ b/src/Jackett.Common/Definitions/eztv.yml
@@ -2,7 +2,7 @@
 id: eztv
 name: EZTV
 description: "EZTV is a Public torrent site for TV shows"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/fanoin.yml
+++ b/src/Jackett.Common/Definitions/fanoin.yml
@@ -2,7 +2,7 @@
 id: fanoin
 name: FANO.IN
 description: "Fano.in is a LATVIAN Private Torrent Tracker for 0DAY / GENERAL"
-language: lv-lv
+language: lv-LV
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/fantasticheaven.yml
+++ b/src/Jackett.Common/Definitions/fantasticheaven.yml
@@ -2,7 +2,7 @@
 id: fantasticheaven
 name: Fantastic Heaven
 description: "Fantastic Heaven is a German Time based tracker"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/fantastiko.yml
+++ b/src/Jackett.Common/Definitions/fantastiko.yml
@@ -2,7 +2,7 @@
 id: fantastiko
 name: Fantastiko
 description: "Fantastiko is a GREEK Private Torrent Tracker for SCI-FI / FANTASY / HORROR MOVIES / TV / GENERAL"
-language: el-gr
+language: el-GR
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/feedurneed.yml
+++ b/src/Jackett.Common/Definitions/feedurneed.yml
@@ -2,7 +2,7 @@
 id: feedurneed
 name: FeedUrNeed
 description: "FeedUrNeed (FuN) is a Private Torrent Tracker for MOVIES / TV / General"
-language: en-us
+language: en-US
 type: private
 encoding: utf-8
 links:

--- a/src/Jackett.Common/Definitions/femdomcult.yml
+++ b/src/Jackett.Common/Definitions/femdomcult.yml
@@ -5,7 +5,7 @@
 id: femdomcult
 name: Femdomcult
 description: "Femdomcult is a Private Torrent Tracker for FETISH XXX"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/filebase.yml
+++ b/src/Jackett.Common/Definitions/filebase.yml
@@ -2,7 +2,7 @@
 id: filebase
 name: Filebase
 description: "Filebase is a RUSSIAN Public Torrent Tracker for MOVIES / TV / GENERAL"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/filelisting.yml
+++ b/src/Jackett.Common/Definitions/filelisting.yml
@@ -2,7 +2,7 @@
 id: filelisting
 name: FileListing
 description: "FileListing is a Public Torrent Search Engine"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/finelite.yml
+++ b/src/Jackett.Common/Definitions/finelite.yml
@@ -2,7 +2,7 @@
 id: finelite
 name: FinElite
 description: "FinElite (FE) is a FINNISH Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: fi-fi
+language: fi-FI
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/finvip.yml
+++ b/src/Jackett.Common/Definitions/finvip.yml
@@ -2,7 +2,7 @@
 id: finvip
 name: FinVip
 description: "FinVip is a FINNISH Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: fi-fi
+language: fi-FI
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/firebit.yml
+++ b/src/Jackett.Common/Definitions/firebit.yml
@@ -2,7 +2,7 @@
 id: firebit
 name: FireBit
 description: "FireBit is an UKRAINIAN / RUSSIAN Public Torrent Tracker for MOVIES / TV / GENERAL"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/fouducinema.yml
+++ b/src/Jackett.Common/Definitions/fouducinema.yml
@@ -2,7 +2,7 @@
 id: fouducinema
 name: Fou-Du-Cinema
 description: "Fou-Du-Cinema (FdC) is a FRENCH Semi-Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: fr-fr
+language: fr-FR
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/frozenlayer.yml
+++ b/src/Jackett.Common/Definitions/frozenlayer.yml
@@ -2,7 +2,7 @@
 id: frozenlayer
 name: Frozen Layer
 description: "Frozen Layer is a SPANISH Public torrent site focused on ANIME"
-language: es-es
+language: es-ES
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/funkytorrents.yml
+++ b/src/Jackett.Common/Definitions/funkytorrents.yml
@@ -2,7 +2,7 @@
 id: funkytorrents
 name: FunkyTorrents
 description: "FunkyTorrents (FT) is a Private Torrent Tracker for MUSIC"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/gamestorrents.yml
+++ b/src/Jackett.Common/Definitions/gamestorrents.yml
@@ -2,7 +2,7 @@
 id: gamestorrents
 name: GamesTorrents
 description: "GamesTorrents is a SPANISH Public tracker for GAMES"
-language: es-es
+language: es-ES
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/gay-torrents.yml
+++ b/src/Jackett.Common/Definitions/gay-torrents.yml
@@ -2,7 +2,7 @@
 id: gay-torrents
 name: Gay-Torrents.net
 description: "Gay-Torrents.net is a Private Torrent Tracker for GAY XXX"
-language: en-us
+language: en-US
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/gay-torrentsorg.yml
+++ b/src/Jackett.Common/Definitions/gay-torrentsorg.yml
@@ -2,7 +2,7 @@
 id: gay-torrentsorg
 name: gay-torrents.org
 description: "Gay-Torrents.org is a Private Torrent Tracker for GAY 3X"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/gaytorrentru.yml
+++ b/src/Jackett.Common/Definitions/gaytorrentru.yml
@@ -2,7 +2,7 @@
 id: gaytorrentru
 name: GAYtorrent.ru
 description: "GayTorrent.ru is a Private Torrent Tracker for GAY 3X"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/generationfree.yml
+++ b/src/Jackett.Common/Definitions/generationfree.yml
@@ -2,7 +2,7 @@
 id: generationfree
 name: Generation-Free
 description: "Generation-Free is a FRENCH Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: fr-fr
+language: fr-FR
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/genesismovement.yml
+++ b/src/Jackett.Common/Definitions/genesismovement.yml
@@ -2,7 +2,7 @@
 id: genesismovement
 name: Genesis-Movement
 description: "Genesis-Movement is a Semi-Private Torrent Tracker for GENESIS BOOTLEG MUSIC"
-language: en-us
+language: en-US
 type: semi-private
 encoding: iso-8859-1
 links:

--- a/src/Jackett.Common/Definitions/gfxpeers.yml
+++ b/src/Jackett.Common/Definitions/gfxpeers.yml
@@ -2,7 +2,7 @@
 id: gfxpeers
 name: GFXPeers
 description: "GFXPeers is a ratio-based torrent tracker for all things graphic design and visual effects"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/gigatorrents.yml
+++ b/src/Jackett.Common/Definitions/gigatorrents.yml
@@ -2,7 +2,7 @@
 id: gigatorrents
 name: GigaTorrents
 description: "Giga Torrents is a Hungarian Private site for TV / MOVIES / GENERAL"
-language: hu-hu
+language: hu-HU
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/girotorrent.yml
+++ b/src/Jackett.Common/Definitions/girotorrent.yml
@@ -2,7 +2,7 @@
 id: girotorrent
 name: Girotorrent
 description: "Girotorrent is an ITALIAN Private site for TV / MOVIES / GENERAL"
-language: it-it
+language: it-IT
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/gktorrent.yml
+++ b/src/Jackett.Common/Definitions/gktorrent.yml
@@ -2,7 +2,7 @@
 id: gktorrent
 name: GkTorrent
 description: "GkTorrent is a French Public site for TV / MOVIES / GENERAL"
-language: fr-fr
+language: fr-FR
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/glodls.yml
+++ b/src/Jackett.Common/Definitions/glodls.yml
@@ -2,7 +2,7 @@
 id: glodls
 name: GloDLS
 description: "GloDLS is a Public Torrent Tracker for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/greekdiamond.yml
+++ b/src/Jackett.Common/Definitions/greekdiamond.yml
@@ -2,7 +2,7 @@
 id: greekdiamond
 name: GreekDiamond
 description: "GreekDiamond is a GREEK Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: el-gr
+language: el-GR
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/greekteam.yml
+++ b/src/Jackett.Common/Definitions/greekteam.yml
@@ -1,7 +1,7 @@
 ---
 id: greekteam
 name: Greek Team
-language: el-gr
+language: el-GR
 description: "Greek Team is a GREEK Private site for TV / MOVIES / GENERAL"
 type: private
 encoding: windows-1253

--- a/src/Jackett.Common/Definitions/greekteam.yml
+++ b/src/Jackett.Common/Definitions/greekteam.yml
@@ -1,8 +1,8 @@
 ---
 id: greekteam
 name: Greek Team
-language: el-GR
 description: "Greek Team is a GREEK Private site for TV / MOVIES / GENERAL"
+language: el-GR
 type: private
 encoding: windows-1253
 links:

--- a/src/Jackett.Common/Definitions/gtorrentpro.yml
+++ b/src/Jackett.Common/Definitions/gtorrentpro.yml
@@ -2,7 +2,7 @@
 id: gtorrentpro
 name: GTorrent.pro
 description: "GTorrent.pro is a RUSSIAN Public Torrent Tracker for MOVIES / TV / GENERAL"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/haidan.yml
+++ b/src/Jackett.Common/Definitions/haidan.yml
@@ -2,7 +2,7 @@
 id: haidan
 name: HaiDan
 description: "HaiDan is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/haitang.yml
+++ b/src/Jackett.Common/Definitions/haitang.yml
@@ -2,7 +2,7 @@
 id: haitang
 name: Haitang
 description: "海棠PT (Hǎitáng PT) is a CHINESE Private Torrent Tracker for OPERA / CROSSTALK"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hamsterstudio.yml
+++ b/src/Jackett.Common/Definitions/hamsterstudio.yml
@@ -2,7 +2,7 @@
 id: hamsterstudio
 name: HamsterStudio
 description: "HamsterStudio is a RUSSIAN Semi-Private Torrent Tracker for TV"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/happyfappy.yml
+++ b/src/Jackett.Common/Definitions/happyfappy.yml
@@ -2,7 +2,7 @@
 id: happyfappy
 name: HappyFappy
 description: "HappyFappy is a Private Torrent Tracker for 3X"
-language: en
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hd4fans.yml
+++ b/src/Jackett.Common/Definitions/hd4fans.yml
@@ -2,7 +2,7 @@
 id: hd4fans
 name: HD4FANS
 description: "HD4FANS is a CHINESE Private Torrent Tracker for HD MOVIES / TV / GENERAL"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hdarea.yml
+++ b/src/Jackett.Common/Definitions/hdarea.yml
@@ -2,7 +2,7 @@
 id: hdarea
 name: HDArea
 description: "HDArea is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hdatmos.yml
+++ b/src/Jackett.Common/Definitions/hdatmos.yml
@@ -2,7 +2,7 @@
 id: hdatmos
 name: HDAtmos
 description: "HDAtmos is a CHINESE Private Torrent Tracker for HD MOVIES / TV / GENERAL"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hdbits.yml
+++ b/src/Jackett.Common/Definitions/hdbits.yml
@@ -2,7 +2,7 @@
 id: hdbits
 name: HDBits
 description: "Best HD Tracker"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hdbitscom.yml
+++ b/src/Jackett.Common/Definitions/hdbitscom.yml
@@ -2,7 +2,7 @@
 id: hdbitscom
 name: HD-Bits.com
 description: "HD tracker"
-language: en-us
+language: en-US
 encoding: UTF-8
 type: private
 links:

--- a/src/Jackett.Common/Definitions/hdbitscom.yml
+++ b/src/Jackett.Common/Definitions/hdbitscom.yml
@@ -3,8 +3,8 @@ id: hdbitscom
 name: HD-Bits.com
 description: "HD tracker"
 language: en-US
-encoding: UTF-8
 type: private
+encoding: UTF-8
 links:
   - https://www.hd-bits.com/
 

--- a/src/Jackett.Common/Definitions/hdc.yml
+++ b/src/Jackett.Common/Definitions/hdc.yml
@@ -2,7 +2,7 @@
 id: hdc
 name: HDC
 description: "HDC (HDCiTY) is a CHINESE Private Torrent Tracker for HD MOVIES / TV / GENERAL"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hdcenter.yml
+++ b/src/Jackett.Common/Definitions/hdcenter.yml
@@ -2,7 +2,7 @@
 id: hdcenter
 name: HDCenter
 description: "An German HD tracker"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hdchina.yml
+++ b/src/Jackett.Common/Definitions/hdchina.yml
@@ -2,7 +2,7 @@
 id: hdchina
 name: HDChina
 description: "HDChina (HDWing) is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hdcity.yml
+++ b/src/Jackett.Common/Definitions/hdcity.yml
@@ -2,7 +2,7 @@
 id: hdcity
 name: HDCity
 description: "HDCity is a SPANISH site for HD content"
-language: es-es
+language: es-ES
 type: private
 encoding: ISO-8859-1
 links:

--- a/src/Jackett.Common/Definitions/hdcztorrent.yml
+++ b/src/Jackett.Common/Definitions/hdcztorrent.yml
@@ -2,7 +2,7 @@
 id: hdcztorrent
 name: HD-CzTorrent
 description: "HD-CzTorrent is a CZECH semi private site for TV / MOVIES / GENERAL"
-language: cs-cz
+language: cs-CZ
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hddolby.yml
+++ b/src/Jackett.Common/Definitions/hddolby.yml
@@ -2,7 +2,7 @@
 id: hddolby
 name: HDDolby
 description: "HD Dolby is a CHINESE Private Torrent Tracker for HD MOVIES / TV / GENERAL"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hdforever.yml
+++ b/src/Jackett.Common/Definitions/hdforever.yml
@@ -2,7 +2,7 @@
 id: hdforever
 name: HD-Forever
 description: "HD-Forever (HD-F) is a FRENCH Private Torrent Tracker for HD MOVIES"
-language: fr-fr
+language: fr-FR
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hdhome.yml
+++ b/src/Jackett.Common/Definitions/hdhome.yml
@@ -2,7 +2,7 @@
 id: hdhome
 name: HDHome
 description: "HDHome (HDBiger) is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hdhouse.yml
+++ b/src/Jackett.Common/Definitions/hdhouse.yml
@@ -2,7 +2,7 @@
 id: hdhouse
 name: HDhouse
 description: "HDhouse (HDReactor) is a RUSSIAN Public Torrent Tracker for MOVIES / TV"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/hdme.yml
+++ b/src/Jackett.Common/Definitions/hdme.yml
@@ -2,7 +2,7 @@
 id: hdme
 name: HDME
 description: "HDME is a Private Torrent Tracker for HD MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: windows-1252
 links:

--- a/src/Jackett.Common/Definitions/hdolimpo.yml
+++ b/src/Jackett.Common/Definitions/hdolimpo.yml
@@ -2,7 +2,7 @@
 id: hdolimpo
 name: HD-Olimpo
 description: "HD-Olimpo is a SPANISH site for HD content"
-language: es-es
+language: es-ES
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hdonly.yml
+++ b/src/Jackett.Common/Definitions/hdonly.yml
@@ -2,7 +2,7 @@
 id: hdonly
 name: HD-Only
 description: "HD-Only (HD-O) is a FRENCH Private Torrent Tracker for HD MOVIES / TV"
-language: fr-fr
+language: fr-FR
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hdroute.yml
+++ b/src/Jackett.Common/Definitions/hdroute.yml
@@ -2,7 +2,7 @@
 id: hdroute
 name: HDRoute
 description: "HDRoute is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hdsky.yml
+++ b/src/Jackett.Common/Definitions/hdsky.yml
@@ -2,7 +2,7 @@
 id: hdsky
 name: HDSky
 description: "HDSky is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hdspain.yml
+++ b/src/Jackett.Common/Definitions/hdspain.yml
@@ -2,7 +2,7 @@
 id: hdspain
 name: HD-Spain
 description: "HD-Spain is a SPANISH site for HD content"
-language: es-es
+language: es-ES
 type: private
 encoding: ISO-8859-1
 links:

--- a/src/Jackett.Common/Definitions/hdtime.yml
+++ b/src/Jackett.Common/Definitions/hdtime.yml
@@ -2,7 +2,7 @@
 id: hdtime
 name: HDtime
 description: "HDtime is a CHINESE Private Torrent Tracker for HD MOVIES / TV / GENERAL"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hdtorrentsit.yml
+++ b/src/Jackett.Common/Definitions/hdtorrentsit.yml
@@ -2,7 +2,7 @@
 id: hdtorrentsit
 name: HDTorrents.it
 description: "HDTorrents.it is an ITALIAN Private site for TV / MOVIES"
-language: it-it
+language: it-IT
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hdu.yml
+++ b/src/Jackett.Common/Definitions/hdu.yml
@@ -2,7 +2,7 @@
 id: hdu
 name: HDU
 description: "HDU is a CHINESE Private Torrent Tracker for HD MOVIES / TV / GENERAL"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hdzone.yml
+++ b/src/Jackett.Common/Definitions/hdzone.yml
@@ -2,7 +2,7 @@
 id: hdzone
 name: HDZone
 description: "HDZone is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hellastz.yml
+++ b/src/Jackett.Common/Definitions/hellastz.yml
@@ -2,7 +2,7 @@
 id: hellastz
 name: HellasTZ
 description: "HellasTZ is an Greek Private site for TV / MOVIES / GENERAL"
-language: el-gr
+language: el-GR
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hqsource.yml
+++ b/src/Jackett.Common/Definitions/hqsource.yml
@@ -2,7 +2,7 @@
 id: hqsource
 name: HQSource
 description: "HQSource (HQS) is a POLISH Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: pl-pl
+language: pl-PL
 type: private
 encoding: ISO-8859-2
 links:

--- a/src/Jackett.Common/Definitions/huntorrent.yml
+++ b/src/Jackett.Common/Definitions/huntorrent.yml
@@ -2,7 +2,7 @@
 id: huntorrent
 name: HunTorrent
 description: "HunTorrent is a Hungarian Semi-Private site for MOVIES / TV / GENERAL"
-language: hu-hu
+language: hu-HU
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/hush.yml
+++ b/src/Jackett.Common/Definitions/hush.yml
@@ -2,7 +2,7 @@
 id: hush
 name: HuSh
 description: "HuSh is a community-built Movie/TV/FANRES database."
-language: fr-fr
+language: fr-FR
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/ibit.yml
+++ b/src/Jackett.Common/Definitions/ibit.yml
@@ -2,7 +2,7 @@
 id: ibit
 name: IBit
 description: "IBit is a Public Verified Torrent Search Engine"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/idope.yml
+++ b/src/Jackett.Common/Definitions/idope.yml
@@ -2,7 +2,7 @@
 id: idope
 name: Idope
 description: "iDope is a Public torrent search engine presenting direct magnet links"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/ilcorsaroblu.yml
+++ b/src/Jackett.Common/Definitions/ilcorsaroblu.yml
@@ -2,7 +2,7 @@
 id: ilcorsaroblu
 name: Il Corsaro Blu
 description: "il CorSaRo Blu is an ITALIAN Semi-Private site for TV / MOVIES / GENERAL"
-language: it-it
+language: it-IT
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/ilcorsaronero.yml
+++ b/src/Jackett.Common/Definitions/ilcorsaronero.yml
@@ -2,7 +2,7 @@
 id: ilcorsaronero
 name: Il Corsaro Nero
 description: "Il Corsaro Nero is an ITALIAN Public site for TV / MOVIES / GENERAL"
-language: it-it
+language: it-IT
 type: public
 encoding: Windows-1252
 followredirect: true

--- a/src/Jackett.Common/Definitions/immortuos.yml
+++ b/src/Jackett.Common/Definitions/immortuos.yml
@@ -2,7 +2,7 @@
 id: immortuos
 name: Immortuos
 description: "Immortuos is a GERMAN Private Tracker for MOVIES / TV"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/insanetracker.yml
+++ b/src/Jackett.Common/Definitions/insanetracker.yml
@@ -2,7 +2,7 @@
 id: insanetracker
 name: Insane Tracker
 description: "Insane Tracker is a HUNGARIAN Private Torrent Tracker for 0DAY / GENERAL"
-language: hu-hu
+language: hu-HU
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/isohunt2.yml
+++ b/src/Jackett.Common/Definitions/isohunt2.yml
@@ -2,7 +2,7 @@
 id: isohunt2
 name: Isohunt2
 description: "Isohunt2 is a Public torrent search engine for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/itorrent.yml
+++ b/src/Jackett.Common/Definitions/itorrent.yml
@@ -2,7 +2,7 @@
 id: itorrent
 name: iTorrent
 description: "iTorrent is a Public HUNGARIAN site"
-language: hu
+language: hu-HU
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/iv-torrents.yml
+++ b/src/Jackett.Common/Definitions/iv-torrents.yml
@@ -2,7 +2,7 @@
 id: iv-torrents
 name: IV-Torrents
 description: "IV-Torrents is a RUSSIAN Semi-Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/jpopsuki.yml
+++ b/src/Jackett.Common/Definitions/jpopsuki.yml
@@ -2,7 +2,7 @@
 id: jpopsuki
 name: JPopsuki
 description: "JPopSuki is a Private Torrent Tracker for ASIAN MUSIC"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/karagarga.yml
+++ b/src/Jackett.Common/Definitions/karagarga.yml
@@ -2,7 +2,7 @@
 id: karagarga
 name: Karagarga
 description: "Karagarga tracks non-hollywood, rare and obscure movies, music and literature."
-language: en-us
+language: en-US
 type: private
 encoding: iso-8859-1
 links:

--- a/src/Jackett.Common/Definitions/keepfriends.yml
+++ b/src/Jackett.Common/Definitions/keepfriends.yml
@@ -2,7 +2,7 @@
 id: keepfriends
 name: Keep Friends
 description: "Keep Friends is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/kickasstorrents-to.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrents-to.yml
@@ -2,7 +2,7 @@
 id: kickasstorrents-to
 name: kickasstorrents.to
 description: "kickasstorrents.to is a Public KickAssTorrent clone for TV / MOVIES / GENERAL"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/kickasstorrents-ws.yml
+++ b/src/Jackett.Common/Definitions/kickasstorrents-ws.yml
@@ -2,7 +2,7 @@
 id: kickasstorrents-ws
 name: kickasstorrents.ws
 description: "kickasstorrents.ws is a Public KickAssTorrent clone for TV / MOVIES / GENERAL"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/kinonavse100.yml
+++ b/src/Jackett.Common/Definitions/kinonavse100.yml
@@ -2,7 +2,7 @@
 id: kinonavse100
 name: KinoNaVse100
 description: "Кино на все 100 is a RUSSIAN Semi-Private Torrent Tracker for MOVIES / TV / MUSIC"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/kinorun.yml
+++ b/src/Jackett.Common/Definitions/kinorun.yml
@@ -2,7 +2,7 @@
 id: kinorun
 name: Kinorun
 description: "Kinorun is a RUSSIAN Semi-Private Torrent Tracker for 3X"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/kinozal.yml
+++ b/src/Jackett.Common/Definitions/kinozal.yml
@@ -2,7 +2,7 @@
 id: kinozal
 name: Kinozal
 description: "Kinozal is a RUSSIAN Semi-Private Torrent Tracker for MOVIES / TV / MUSIC"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/lastfiles.yml
+++ b/src/Jackett.Common/Definitions/lastfiles.yml
@@ -2,7 +2,7 @@
 id: lastfiles
 name: LastFiles
 description: "LastFiles (LF) is a ROMANIAN Private Torrent Tracker for 0DAY / GENERAL"
-language: ro-ro
+language: ro-RO
 type: private
 encoding: utf-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/learnbits.yml
+++ b/src/Jackett.Common/Definitions/learnbits.yml
@@ -2,7 +2,7 @@
 id: learnbits
 name: LearnBits
 description: "LearnBits is a Private Torrent Tracker for E-LEARNING"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/learnflakes.yml
+++ b/src/Jackett.Common/Definitions/learnflakes.yml
@@ -2,7 +2,7 @@
 id: learnflakes
 name: LearnFlakes
 description: "LearnFlakes is a Private Torrent Tracker for CERTIFICATE / TRAINING E-LEARNING"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/legacyhd.yml
+++ b/src/Jackett.Common/Definitions/legacyhd.yml
@@ -2,7 +2,7 @@
 id: legacyhd
 name: LegacyHD
 description: "LegacyHD (HD4Free) is a Private Torrent Tracker for HD MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/legittorrents.yml
+++ b/src/Jackett.Common/Definitions/legittorrents.yml
@@ -2,7 +2,7 @@
 id: legittorrents
 name: Legit Torrents
 description: "Legit Torrents is a Public site for free and legal torrents"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/lemonhd.yml
+++ b/src/Jackett.Common/Definitions/lemonhd.yml
@@ -2,7 +2,7 @@
 id: lemonhd
 name: LemonHD
 description: "LemonHD is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/lepornoinfo.yml
+++ b/src/Jackett.Common/Definitions/lepornoinfo.yml
@@ -2,7 +2,7 @@
 id: lepornoinfo
 name: LePorno.info
 description: "LePorno.info is a Public Tracker for 3X"
-language: en
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/lesaloon.yml
+++ b/src/Jackett.Common/Definitions/lesaloon.yml
@@ -2,7 +2,7 @@
 id: lesaloon
 name: LeSaloon
 description: "Le Saloon is a FRENCH Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: fr-fr
+language: fr-FR
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/libranet.yml
+++ b/src/Jackett.Common/Definitions/libranet.yml
@@ -2,7 +2,7 @@
 id: libranet
 name: LibraNet
 description: "LibraNet (LN) is a HUNGARIAN Private Torrent Tracker for EBOOKS / LOSSLESS MUSIC"
-language: hu
+language: hu-HU
 type: private
 encoding: ISO-8859-2
 links:

--- a/src/Jackett.Common/Definitions/limetorrents.yml
+++ b/src/Jackett.Common/Definitions/limetorrents.yml
@@ -2,7 +2,7 @@
 id: limetorrents
 name: LimeTorrents
 description: "LimeTorrents is a Public general torrent index with mostly verified torrents"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/linkomanija.yml
+++ b/src/Jackett.Common/Definitions/linkomanija.yml
@@ -2,7 +2,7 @@
 id: linkomanija
 name: LinkoManija
 description: "LinkoManija is an LITHUANIAN Private site for TV / MOVIES / GENERAL"
-language: lt-lt
+language: lt-LT
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/linuxtracker.yml
+++ b/src/Jackett.Common/Definitions/linuxtracker.yml
@@ -2,7 +2,7 @@
 id: linuxtracker
 name: LinuxTracker
 description: "LinuxTracker is a Public Linux ISO Torrent Repository"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/losslessclub.yml
+++ b/src/Jackett.Common/Definitions/losslessclub.yml
@@ -2,7 +2,7 @@
 id: losslessclub
 name: LosslessClub
 description: "LosslessClub is a Romanian Private site for High Quality Music"
-language: ru-ru
+language: ru-RU
 type: private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/mactorrents.yml
+++ b/src/Jackett.Common/Definitions/mactorrents.yml
@@ -2,7 +2,7 @@
 id: mactorrents
 name: MacTorrents
 description: "MacTorrents is a Public tracker for Mac software"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/madsrevolution.yml
+++ b/src/Jackett.Common/Definitions/madsrevolution.yml
@@ -2,7 +2,7 @@
 id: madsrevolution
 name: MaDs Revolution
 description: "MaDs Revolution is a Private GERMAN site for MOVIES / TV / GENERAL"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/magicheaven.yml
+++ b/src/Jackett.Common/Definitions/magicheaven.yml
@@ -2,7 +2,7 @@
 id: magicheaven
 name: magic-heaven
 description: "magic-heaven is a Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: en
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/magico.yml
+++ b/src/Jackett.Common/Definitions/magico.yml
@@ -2,7 +2,7 @@
 id: magico
 name: Magico
 description: "Magico (Trellas) is a GREEK Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: el-gr
+language: el-GR
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/majomparade.yml
+++ b/src/Jackett.Common/Definitions/majomparade.yml
@@ -2,7 +2,7 @@
 id: majomparade
 name: Majomparádé
 description: "Majomparádé (TurkDepo) is a HUNGARIAN Private Torrent Tracker for 0DAY / GENERAL"
-language: hu-hu
+language: hu-HU
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/marinetracker.yml
+++ b/src/Jackett.Common/Definitions/marinetracker.yml
@@ -2,7 +2,7 @@
 id: marinetracker
 name: Marine Tracker
 description: "Marine Tracker is a RUSSIAN Semi-Private Torrent Tracker for MARITIME E-LEARNING"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/mesevilag.yml
+++ b/src/Jackett.Common/Definitions/mesevilag.yml
@@ -2,7 +2,7 @@
 id: mesevilag
 name: MeseVilág
 description: "MeseVilág (Fairytale World) is a Hungarian Private site for fairy tales, family movies and comedies"
-language: hu-hu
+language: hu-HU
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/metaltracker.yml
+++ b/src/Jackett.Common/Definitions/metaltracker.yml
@@ -2,7 +2,7 @@
 id: metaltracker
 name: Metal Tracker
 description: "Metal Tracker is a Semi-Private site dedicated to HEAVY METAL MUSIC. This definition is for the English site."
-language: en-us
+language: en-US
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/microbit.yml
+++ b/src/Jackett.Common/Definitions/microbit.yml
@@ -2,7 +2,7 @@
 id: microbit
 name: MicroBit
 description: "MicroBit (µBit) is a HUNGARIAN Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: hu
+language: hu-HU
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/mircrew.yml
+++ b/src/Jackett.Common/Definitions/mircrew.yml
@@ -2,7 +2,7 @@
 id: mircrew
 name: MIRCrew
 description: "MIRCrew is an ITALIAN Private Torrent Tracker for MOVIES / TV / MUSIC"
-language: it-it
+language: it-IT
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/mixtapetorrent.yml
+++ b/src/Jackett.Common/Definitions/mixtapetorrent.yml
@@ -2,7 +2,7 @@
 id: mixtapetorrent
 name: MixtapeTorrent
 description: "MixtapeTorrent is a Public Music site for MixTapes"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/mma-torrents.yml
+++ b/src/Jackett.Common/Definitions/mma-torrents.yml
@@ -2,7 +2,7 @@
 id: mma-torrents
 name: MMA-torrents
 description: "MMA-Torrents is a Private Torrent Tracker for MMA (Mixed Martial Arts)"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/mnv.yml
+++ b/src/Jackett.Common/Definitions/mnv.yml
@@ -2,7 +2,7 @@
 id: mnv
 name: MNV
 description: "MNV (Max-New-Vision) is a Private GERMAN tracker"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/mononokebt.yml
+++ b/src/Jackett.Common/Definitions/mononokebt.yml
@@ -2,7 +2,7 @@
 id: mononokebt
 name: Mononoké-BT
 description: "Mononoke-BT is a FRENCH Private Torrent Tracker for ANIME"
-language: fr-fr
+language: fr-FR
 type: private
 encoding: iso-8859-15
 links:

--- a/src/Jackett.Common/Definitions/montorrent.yml
+++ b/src/Jackett.Common/Definitions/montorrent.yml
@@ -2,7 +2,7 @@
 id: montorrent
 name: MonTorrent
 description: "MonTorrent is a FRENCH Public Indexer"
-language: fr-fr
+language: fr-FR
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/mousebits.yml
+++ b/src/Jackett.Common/Definitions/mousebits.yml
@@ -2,7 +2,7 @@
 id: mousebits
 name: MouseBits
 description: "MouseBits is a Private Torrent Tracker for all things Disney"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/moviesdvdr.yml
+++ b/src/Jackett.Common/Definitions/moviesdvdr.yml
@@ -2,7 +2,7 @@
 id: moviesdvdr
 name: MoviesDVDR
 description: "MoviesDVDR is a SPANISH Public tracker for MOVIES"
-language: es-es
+language: es-ES
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/movietorrent.yml
+++ b/src/Jackett.Common/Definitions/movietorrent.yml
@@ -2,7 +2,7 @@
 id: movietorrent
 name: MovieTorrent
 description: "MovieTorrent is a Public site for Bollywood, Hollywood, Hindi Dubbed, Tamil , Punjabi, Pakistani MOVIES"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/mteamtp.yml
+++ b/src/Jackett.Common/Definitions/mteamtp.yml
@@ -2,7 +2,7 @@
 id: mteamtp
 name: M-Team - TP
 description: "M-Team TP (MTTP) is a CHINESE Private Torrent Tracker for HD MOVIES / TV / XXX"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/mteamtp2fa.yml
+++ b/src/Jackett.Common/Definitions/mteamtp2fa.yml
@@ -2,7 +2,7 @@
 id: mteamtp2fa
 name: MTeamTP2FA
 description: "this indexer uses a cookie login for MTeamTP for those that want to use 2FA"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/mvgroupforum.yml
+++ b/src/Jackett.Common/Definitions/mvgroupforum.yml
@@ -2,7 +2,7 @@
 id: mvgroupforum
 name: MVGroup Forum
 description: "MVGroup is a Semi-Private site dedicated to UK TV and DOCUMENTARIES. This definition is for the Forum Tracker site."
-language: en-us
+language: en-US
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/mvgroupmain.yml
+++ b/src/Jackett.Common/Definitions/mvgroupmain.yml
@@ -2,7 +2,7 @@
 id: mvgroupmain
 name: MVGroup Main
 description: "MVGroup is a Semi-Private site dedicated to UK TV and DOCUMENTARIES. This definition is for the Main Tracker site."
-language: en-us
+language: en-US
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/mypornclub.yml
+++ b/src/Jackett.Common/Definitions/mypornclub.yml
@@ -2,7 +2,7 @@
 id: mypornclub
 name: MyPornClub
 description: "MyPornClub is a Public Torrent Tracker for 3X"
-language: en
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/myspleen.yml
+++ b/src/Jackett.Common/Definitions/myspleen.yml
@@ -2,7 +2,7 @@
 id: myspleen
 name: MySpleen
 description: "MySpleen is a Private Torrent Tracker for TV / COMEDY / ANIMATION / 80-90’S VHS NOSTALGIA"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/nbtorrents.yml
+++ b/src/Jackett.Common/Definitions/nbtorrents.yml
@@ -2,7 +2,7 @@
 id: nbtorrents
 name: NBTorrents
 description: "NBTorrents is an INDIAN Private site for MOVIES / TV / MUSIC"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/nbytez.yml
+++ b/src/Jackett.Common/Definitions/nbytez.yml
@@ -2,7 +2,7 @@
 id: nbytez
 name: Nbytez
 description: "Nbytez is a Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/netcosmo.yml
+++ b/src/Jackett.Common/Definitions/netcosmo.yml
@@ -2,7 +2,7 @@
 id: netcosmo
 name: NetCosmo
 description: "NetCosmo is an ITALIAN Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: it-it
+language: it-IT
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/nethd.yml
+++ b/src/Jackett.Common/Definitions/nethd.yml
@@ -2,7 +2,7 @@
 id: nethd
 name: NetHD
 description: "NetHD (VietTorrent) is a VIETNAMESE Semi-Private Torrent Tracker for HD MOVIES / TV"
-language: vi-vn
+language: vi-VN
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/netlab.yml
+++ b/src/Jackett.Common/Definitions/netlab.yml
@@ -2,7 +2,7 @@
 id: netlab
 name: NetLab
 description: "NetLab is a RUSSIAN Private Torrent Tracker"
-language: ru-ru
+language: ru-RU
 type: private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/newretro.yml
+++ b/src/Jackett.Common/Definitions/newretro.yml
@@ -2,7 +2,7 @@
 id: newretro
 name: The New Retro
 description: "The New Retro is a GERMAN Private Torrent Tracker for MOVIES / GENERAL"
-language: de-de
+language: de-DE
 type: private
 encoding: windows-1252
 links:

--- a/src/Jackett.Common/Definitions/newstudio.yml
+++ b/src/Jackett.Common/Definitions/newstudio.yml
@@ -2,7 +2,7 @@
 id: newstudio
 name: Newstudio
 description: "Newstudio is a RUSSIAN Public site for TV"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/newstudiol.yml
+++ b/src/Jackett.Common/Definitions/newstudiol.yml
@@ -2,7 +2,7 @@
 id: newstudiol
 name: NewstudioL
 description: "this is the Newstudio indexer with Login enabled in the config."
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/nitro.yml
+++ b/src/Jackett.Common/Definitions/nitro.yml
@@ -2,7 +2,7 @@
 id: nitro
 name: Nitro
 description: "Nitro is a POLISH Public Torrent Tracker"
-language: pl-pl
+language: pl-PL
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/nntt.yml
+++ b/src/Jackett.Common/Definitions/nntt.yml
@@ -2,7 +2,7 @@
 id: nntt
 name: NNTT
 description: "NNTT is a RUSSIAN Public Torrent Tracker for MOVIES / TV / GENERAL"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/noname-club.yml
+++ b/src/Jackett.Common/Definitions/noname-club.yml
@@ -2,7 +2,7 @@
 id: noname-club
 name: NoNaMe Club
 description: "NoNaMe Club (NNM-Club) is a RUSSIAN Public Tracker for TV / MOVIES / MUSIC"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/noname-clubl.yml
+++ b/src/Jackett.Common/Definitions/noname-clubl.yml
@@ -2,7 +2,7 @@
 id: noname-clubl
 name: NoNaMe ClubL
 description: "This is the NoNaMe Club indexer with Login enabled in the config."
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/nyaa-pantsu.yml
+++ b/src/Jackett.Common/Definitions/nyaa-pantsu.yml
@@ -2,7 +2,7 @@
 id: nyaa-pantsu
 name: Nyaa-pantsu
 description: "Nyaa-pantsu is a Public site for dedicated to Asian ANIME"
-language: en-en
+language: en-EN
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/nyaasi.yml
+++ b/src/Jackett.Common/Definitions/nyaasi.yml
@@ -2,7 +2,7 @@
 id: nyaasi
 name: Nyaa.si
 description: "Nyaa is a Public torrent site focused on Eastern Asian media including anime, manga, literature and music"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/oasis.yml
+++ b/src/Jackett.Common/Definitions/oasis.yml
@@ -2,7 +2,7 @@
 id: oasis
 name: Oasis
 description: "Oasis is a FRENCH Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: fr-fr
+language: fr-FR
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/omgwtftrackr.yml
+++ b/src/Jackett.Common/Definitions/omgwtftrackr.yml
@@ -2,7 +2,7 @@
 id: omgwtftrackr
 name: oMg[WtF]trackr
 description: "oMg[WtF]trackr is a Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 encoding: UTF-8
 type: private
 links:

--- a/src/Jackett.Common/Definitions/omgwtftrackr.yml
+++ b/src/Jackett.Common/Definitions/omgwtftrackr.yml
@@ -3,8 +3,8 @@ id: omgwtftrackr
 name: oMg[WtF]trackr
 description: "oMg[WtF]trackr is a Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: en-US
-encoding: UTF-8
 type: private
+encoding: UTF-8
 links:
   - https://omg.wtftrackr.xyz/
 

--- a/src/Jackett.Common/Definitions/oncesearch.yml
+++ b/src/Jackett.Common/Definitions/oncesearch.yml
@@ -2,7 +2,7 @@
 id: oncesearch
 name: OnceSearch
 description: "OnceSearch is a Public Torrent Tracker for 3X"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/onejav.yml
+++ b/src/Jackett.Common/Definitions/onejav.yml
@@ -2,7 +2,7 @@
 id: onejav
 name: OneJAV
 description: "OneJAV is a Public tracker for Asian 3X (JAV)"
-language: en
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/opencd.yml
+++ b/src/Jackett.Common/Definitions/opencd.yml
@@ -2,7 +2,7 @@
 id: opencd
 name: OpenCD
 description: "OpenCD is a CHINESE Private Torrent Tracker for MUSIC"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/oshenpt.yml
+++ b/src/Jackett.Common/Definitions/oshenpt.yml
@@ -2,7 +2,7 @@
 id: oshenpt
 name: OshenPT
 description: "OshenPT is a CHINESE Private Torrent Tracker for HD Movies, TV, Music"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/ourbits.yml
+++ b/src/Jackett.Common/Definitions/ourbits.yml
@@ -2,7 +2,7 @@
 id: ourbits
 name: Ourbits
 description: "Ourbits (HDPter) is a CHINESE Private Torrent Tracker for HD MOVIES / TV / GENERAL"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/oxtorrent.yml
+++ b/src/Jackett.Common/Definitions/oxtorrent.yml
@@ -2,7 +2,7 @@
 id: oxtorrent
 name: OxTorrent
 description: "OxTorrent is a French Public site for TV / MOVIES / GENERAL"
-language: fr-fr
+language: fr-FR
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/p2pbg.yml
+++ b/src/Jackett.Common/Definitions/p2pbg.yml
@@ -2,7 +2,7 @@
 id: p2pbg
 name: P2PBG
 description: "P2PBG is a BULGARIAN Private Torrent Tracker for 0DAY / GENERAL"
-language: bg
+language: bg-BG
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/p2pelite.yml
+++ b/src/Jackett.Common/Definitions/p2pelite.yml
@@ -2,7 +2,7 @@
 id: p2pelite
 name: P2PElite
 description: "P2PElite is a Private Torrent Tracker for EBOOKS / AUDIOBOOKS"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/parnuxi.yml
+++ b/src/Jackett.Common/Definitions/parnuxi.yml
@@ -2,7 +2,7 @@
 id: parnuxi
 name: ParnuXi
 description: "ParnuXi is a RUSSIAN Public Torrent Tracker for 3X"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/pctorrent.yml
+++ b/src/Jackett.Common/Definitions/pctorrent.yml
@@ -2,7 +2,7 @@
 id: pctorrent
 name: PC-torrent
 description: "PC-torrent is a RUSSIAN Public Torrent Tracker for Games"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/peerjunkies.yml
+++ b/src/Jackett.Common/Definitions/peerjunkies.yml
@@ -2,7 +2,7 @@
 id: peerjunkies
 name: PeerJunkies
 description: "PeerJunkies is a Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/peersfm.yml
+++ b/src/Jackett.Common/Definitions/peersfm.yml
@@ -2,7 +2,7 @@
 id: peersfm
 name: Peers.FM
 description: "Peers.FM is a RUSSIAN Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: ru-ru
+language: ru-RU
 type: private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/pier720.yml
+++ b/src/Jackett.Common/Definitions/pier720.yml
@@ -2,7 +2,7 @@
 id: pier720
 name: 720pier
 description: "720pier is a RUSSIAN Private Torrent Tracker for HD SPORTS"
-language: ru-ru
+language: ru-RU
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/piratadigital.yml
+++ b/src/Jackett.Common/Definitions/piratadigital.yml
@@ -2,7 +2,7 @@
 id: piratadigital
 name: Pirata Digital
 description: "Pirata Digital (PD) is a Private Torrent Tracker for HD MOVIES / TV"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/piratbit.yml
+++ b/src/Jackett.Common/Definitions/piratbit.yml
@@ -2,7 +2,7 @@
 id: piratbit
 name: PiratBit
 description: "PirateBit is a RUSSIAN Public Torrent Tracker for MOVIES / TV / GENERAL"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/piratbitl.yml
+++ b/src/Jackett.Common/Definitions/piratbitl.yml
@@ -1,7 +1,7 @@
 ---
 id: piratbitl
 name: PiratBitL
-description: "this is the PiratBit indexer with Login enabled in the config."
+description: "PirateBit is a RUSSIAN Public Torrent Tracker for MOVIES / TV / GENERAL. This supports login."
 language: ru-RU
 type: semi-private
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/piratbitl.yml
+++ b/src/Jackett.Common/Definitions/piratbitl.yml
@@ -2,7 +2,7 @@
 id: piratbitl
 name: PiratBitL
 description: "this is the PiratBit indexer with Login enabled in the config."
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/pirateiro.yml
+++ b/src/Jackett.Common/Definitions/pirateiro.yml
@@ -2,7 +2,7 @@
 id: pirateiro
 name: Pirateiro
 description: "Pirateiro is a Public site for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/pixelcove.yml
+++ b/src/Jackett.Common/Definitions/pixelcove.yml
@@ -2,7 +2,7 @@
 id: pixelcove
 name: PixelCove
 description: "PixelCove (Ultimate Gamer) is a Private Torrent Tracker for GAMES"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/pleasuredome.yml
+++ b/src/Jackett.Common/Definitions/pleasuredome.yml
@@ -2,7 +2,7 @@
 id: pleasuredome
 name: PleasureDome
 description: "PleasureDome is a private site for Arcade / Console / PC Games"
-language: en
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/pleasuredome.yml
+++ b/src/Jackett.Common/Definitions/pleasuredome.yml
@@ -2,7 +2,7 @@
 id: pleasuredome
 name: PleasureDome
 description: "PleasureDome is a private site for Arcade / Console / PC Games"
-language: en-US
+language: en-GB
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/polishsource.yml
+++ b/src/Jackett.Common/Definitions/polishsource.yml
@@ -2,7 +2,7 @@
 id: polishsource
 name: PolishSource
 description: "PolishSource (PS) is a POLISH Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: pl-pl
+language: pl-PL
 type: private
 encoding: ISO-8859-2
 links:

--- a/src/Jackett.Common/Definitions/pornbay.yml
+++ b/src/Jackett.Common/Definitions/pornbay.yml
@@ -2,7 +2,7 @@
 id: pornbay
 name: Pornbay
 description: "Pornbay is a Private Torrent Tracker for 3X"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/pornbits.yml
+++ b/src/Jackett.Common/Definitions/pornbits.yml
@@ -2,7 +2,7 @@
 id: pornbits
 name: Pornbits
 description: "Pornbits (PB) is a Private Torrent Tracker for 3X"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/pornforall.yml
+++ b/src/Jackett.Common/Definitions/pornforall.yml
@@ -2,7 +2,7 @@
 id: pornforall
 name: Pornforall
 description: "Pornforall is a RUSSIAN Public tracker for 3X"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/pornleech.yml
+++ b/src/Jackett.Common/Definitions/pornleech.yml
@@ -2,7 +2,7 @@
 id: pornleech
 name: PornLeech
 description: "PornLeech is a Public Tracker for 3X"
-language: en
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/pornolive.yml
+++ b/src/Jackett.Common/Definitions/pornolive.yml
@@ -2,7 +2,7 @@
 id: pornolive
 name: PornoLive
 description: "PornoLive is a RUSSIAN Public Torrent Tracker for 3X"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/pornorip.yml
+++ b/src/Jackett.Common/Definitions/pornorip.yml
@@ -2,7 +2,7 @@
 id: pornorip
 name: PornoRip
 description: "PornoRip is a RUSSIAN Public Torrent Tracker for 3X"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/pornotor.yml
+++ b/src/Jackett.Common/Definitions/pornotor.yml
@@ -2,7 +2,7 @@
 id: pornotor
 name: Pornotor
 description: "Pornotor is a RUSSIAN Public Torrent Tracker for 3X"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/portugas.yml
+++ b/src/Jackett.Common/Definitions/portugas.yml
@@ -2,7 +2,7 @@
 id: portugas
 name: Portugas
 description: "Portugas is a Private Portoguese Tracker"
-language: pt-pt
+language: pt-PT
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/potuk.yml
+++ b/src/Jackett.Common/Definitions/potuk.yml
@@ -2,7 +2,7 @@
 id: potuk
 name: PotUK
 description: "PotUK - Private site for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/proaudiotorrents.yml
+++ b/src/Jackett.Common/Definitions/proaudiotorrents.yml
@@ -2,7 +2,7 @@
 id: proaudiotorrents
 name: ProAudioTorrents
 description: "ProAudioTorrents (PAT) is a Private Torrent Tracker for AUDIO SOFTWARE / SAMPLES / TUTORIALS / ETC"
-language: en
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/proporno.yml
+++ b/src/Jackett.Common/Definitions/proporno.yml
@@ -2,7 +2,7 @@
 id: proporno
 name: ProPorno
 description: "ProPorno is a RUSSIAN Public tracker for 3X"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/prostylex.yml
+++ b/src/Jackett.Common/Definitions/prostylex.yml
@@ -2,7 +2,7 @@
 id: prostylex
 name: ProStyleX
 description: "ProStyleX is a Semi-Private torrent site for 0Day and General"
-language: en-us
+language: en-US
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/pterclub.yml
+++ b/src/Jackett.Common/Definitions/pterclub.yml
@@ -2,7 +2,7 @@
 id: pterclub
 name: PTerClub
 description: "PTerClub is a CHINESE Private Torrent Tracker for HD MUSIC VIDEOS, MOVIES, TV & ANIME"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/ptfiles.yml
+++ b/src/Jackett.Common/Definitions/ptfiles.yml
@@ -2,7 +2,7 @@
 id: ptfiles
 name: PTFiles
 description: "PTFiles (PTF) is a Private site for TV / MOVIES / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: windows-1252
 links:

--- a/src/Jackett.Common/Definitions/ptmsg.yml
+++ b/src/Jackett.Common/Definitions/ptmsg.yml
@@ -2,7 +2,7 @@
 id: ptmsg
 name: PTMSG
 description: "PTMSG is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/pttime.yml
+++ b/src/Jackett.Common/Definitions/pttime.yml
@@ -2,7 +2,7 @@
 id: pttime
 name: PTTime
 description: "PTTime is a ratioless CHINESE Private Torrent Tracker for HD MOVIES / TV / GENERAL"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/puntotorrent.yml
+++ b/src/Jackett.Common/Definitions/puntotorrent.yml
@@ -2,7 +2,7 @@
 id: puntotorrent
 name: PuntoTorrent
 description: "PuntoTorrent is a SPANISH site for General content"
-language: es-es
+language: es-ES
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/pussytorrents.yml
+++ b/src/Jackett.Common/Definitions/pussytorrents.yml
@@ -2,7 +2,7 @@
 id: pussytorrents
 name: PussyTorrents
 description: "PussyTorrents is a Semi-Private Torrent Tracker for 3X"
-language: en-us
+language: en-US
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/pwtorrents.yml
+++ b/src/Jackett.Common/Definitions/pwtorrents.yml
@@ -2,7 +2,7 @@
 id: pwtorrents
 name: PWTorrents
 description: "PWTorrents (PWT) is a Private Torrent Tracker for PROFESSIONAL WRESTLING"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/r3vwtf.yml
+++ b/src/Jackett.Common/Definitions/r3vwtf.yml
@@ -2,7 +2,7 @@
 id: r3vwtf
 name: R3V WTF!
 description: "R3V WTF! is a Private site for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/racing4everyone.yml
+++ b/src/Jackett.Common/Definitions/racing4everyone.yml
@@ -2,7 +2,7 @@
 id: racing4everyone
 name: Racing4Everyone (R4E)
 description: "Racing4Everyone (R4E) is a Private Torrent Tracker for RACING"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/racingforme.yml
+++ b/src/Jackett.Common/Definitions/racingforme.yml
@@ -2,7 +2,7 @@
 id: racingforme
 name: RacingForMe
 description: "Racing For Me (RFM) is a Private Torrent Tracker for RACING"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/rainbowtracker.yml
+++ b/src/Jackett.Common/Definitions/rainbowtracker.yml
@@ -2,7 +2,7 @@
 id: rainbowtracker
 name: Rainbow Tracker
 description: "Rainbow Tracker is a RUSSIAN Semi-Private Torrent Tracker for LGBTQ MOVIES / TV"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/rapidzona.yml
+++ b/src/Jackett.Common/Definitions/rapidzona.yml
@@ -2,7 +2,7 @@
 id: rapidzona
 name: Rapidzona
 description: "Rapidzona is a RUSSIAN Public Torrent Tracker for 3X"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/redbits.yml
+++ b/src/Jackett.Common/Definitions/redbits.yml
@@ -2,7 +2,7 @@
 id: redbits
 name: RedBits
 description: "RedBits is a SPANISH site for classic content"
-language: es-es
+language: es-ES
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/redstartorrent.yml
+++ b/src/Jackett.Common/Definitions/redstartorrent.yml
@@ -2,7 +2,7 @@
 id: redstartorrent
 name: Red Star Torrent
 description: "Red Star Torrent (RST) is a POLISH Private Torrent Tracker for TV"
-language: pl-pl
+language: pl-PL
 type: private
 encoding: ISO-8859-2
 links:

--- a/src/Jackett.Common/Definitions/resurrectthenet.yml
+++ b/src/Jackett.Common/Definitions/resurrectthenet.yml
@@ -2,7 +2,7 @@
 id: resurrectthenet
 name: Resurrect The Net
 description: "Resurrect The Net (RTN) is a Private site for TV / MOVIES / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/rgfootball.yml
+++ b/src/Jackett.Common/Definitions/rgfootball.yml
@@ -2,7 +2,7 @@
 id: rgfootball
 name: RGFootball
 description: "RGFootball is a Russian Sports torrent tracker."
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/rintor.yml
+++ b/src/Jackett.Common/Definitions/rintor.yml
@@ -2,7 +2,7 @@
 id: rintor
 name: RinTor
 description: "RinTor is a Semi-Private Tracker for 3X"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/rintornet.yml
+++ b/src/Jackett.Common/Definitions/rintornet.yml
@@ -2,7 +2,7 @@
 id: rintornet
 name: RinTor.NeT
 description: "RinTor.NeT is a RUSSIAN Public tracker for 3X"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/riperam.yml
+++ b/src/Jackett.Common/Definitions/riperam.yml
@@ -2,7 +2,7 @@
 id: riperam
 name: RiperAM
 description: "RiperAM is a RUSSIAN Semi-Private Torrent Tracker for MOVIES / TV"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/rockbox.yml
+++ b/src/Jackett.Common/Definitions/rockbox.yml
@@ -2,7 +2,7 @@
 id: RockBox
 name: RockBox
 description: "RockBox Semi-Private site dedicated to HEAVY METAL/ROCK MUSIC. This definition is for the English site."
-language: en-us
+language: en-US
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/romanianmetaltorrents.yml
+++ b/src/Jackett.Common/Definitions/romanianmetaltorrents.yml
@@ -2,7 +2,7 @@
 id: romanianmetaltorrents
 name: Romanian Metal Torrents
 description: "Romanian Metal Torrents (RMT) is a Private site dedicated to METAL MUSIC. This definition is for the English site."
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/rptorrents.yml
+++ b/src/Jackett.Common/Definitions/rptorrents.yml
@@ -2,7 +2,7 @@
 id: rptorrents
 name: RPTorrents
 description: "RPTorrents is a Private tracker for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/rus-media.yml
+++ b/src/Jackett.Common/Definitions/rus-media.yml
@@ -2,7 +2,7 @@
 id: rus-media
 name: Rus-media
 description: "Rus-media is a RUSSIAN Public Torrent Tracker for MOVIES / TV / GENERAL"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/rustorka.yml
+++ b/src/Jackett.Common/Definitions/rustorka.yml
@@ -2,7 +2,7 @@
 id: rustorka
 name: Rustorka
 description: "Rustorka is a RUSSIAN Semi-Private Torrent Tracker for MOVIES / GENERAL"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/rutor.yml
+++ b/src/Jackett.Common/Definitions/rutor.yml
@@ -2,7 +2,7 @@
 id: rutor
 name: RuTor
 description: "RuTor is a RUSSIAN Public site for MOVIES / TV / GENERAL"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/rutracker-ru.yml
+++ b/src/Jackett.Common/Definitions/rutracker-ru.yml
@@ -2,7 +2,7 @@
 id: rutracker-ru
 name: RuTracker.RU
 description: "RuTracker.RU is a RUSSIAN Public Torrent Tracker for MOVIES / GENERAL"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/scenepalace.yml
+++ b/src/Jackett.Common/Definitions/scenepalace.yml
@@ -2,7 +2,7 @@
 id: scenepalace
 name: ScenePalace
 description: "ScenePalace (SP) is a Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/sdbits.yml
+++ b/src/Jackett.Common/Definitions/sdbits.yml
@@ -2,7 +2,7 @@
 id: sdbits
 name: SDBits
 description: "SDBits is a small tracker that focuses on SD movies and tv."
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/seedfile.yml
+++ b/src/Jackett.Common/Definitions/seedfile.yml
@@ -2,7 +2,7 @@
 id: seedfile
 name: SeedFile
 description: "SeedFile (SF) is a ROMANIAN Private Torrent Tracker for 0DAY / GENERAL"
-language: ro-ro
+language: ro-RO
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/selezen.yml
+++ b/src/Jackett.Common/Definitions/selezen.yml
@@ -2,7 +2,7 @@
 id: selezen
 name: seleZen
 description: "seleZen is a RUSSIAN Semi-Private Torrent Tracker for MOVIES"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/sexypics.yml
+++ b/src/Jackett.Common/Definitions/sexypics.yml
@@ -2,7 +2,7 @@
 id: sexypics
 name: Sexy-Pics
 description: "Sexy-Pics is a Public Magnet Links site for 3X MP4"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/sharefiles.yml
+++ b/src/Jackett.Common/Definitions/sharefiles.yml
@@ -2,7 +2,7 @@
 id: sharefiles
 name: ShareFiles
 description: "ShareFiles is a ROMANIAN Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: ro-ro
+language: ro-RO
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/shareisland.yml
+++ b/src/Jackett.Common/Definitions/shareisland.yml
@@ -2,7 +2,7 @@
 id: shareisland
 name: Shareisland
 description: "A general italian tracker"
-language: it-it
+language: it-IT
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/sharewood.yml
+++ b/src/Jackett.Common/Definitions/sharewood.yml
@@ -2,7 +2,7 @@
 id: sharewood
 name: Sharewood
 description: "sharewood is a Semi-Private FRENCH Torrent Tracker for GENERAL"
-language: fr-fr
+language: fr-FR
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/siambit.yml
+++ b/src/Jackett.Common/Definitions/siambit.yml
@@ -2,7 +2,7 @@
 id: siambit
 name: SiamBIT
 description: "SiamBIT is a THAI Private Torrent Tracker for GENERAL"
-language: th-th
+language: th-TH
 type: private
 encoding: tis-620
 links:

--- a/src/Jackett.Common/Definitions/sktorrent-org.yml
+++ b/src/Jackett.Common/Definitions/sktorrent-org.yml
@@ -2,7 +2,7 @@
 id: sktorrent-org
 name: SkTorrent-org
 description: "SkTorrent.org is a Semi-Private torrent site for MOVIES / TV/ GENERAL"
-language: en-us
+language: en-US
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/sktorrent.yml
+++ b/src/Jackett.Common/Definitions/sktorrent.yml
@@ -2,7 +2,7 @@
 id: sktorrent
 name: SkTorrent
 description: "SkTorrent is a CZECH/SLOVAK Semi-Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: cs-cz
+language: cs-CZ
 type: semi-private
 encoding: windows-1250
 links:

--- a/src/Jackett.Common/Definitions/snowpt.yml
+++ b/src/Jackett.Common/Definitions/snowpt.yml
@@ -2,7 +2,7 @@
 id: snowpt
 name: SnowPT
 description: "SnowPT (SSPT) is a CHINESE Private Torrent Tracker for ANIME"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/sosulki.yml
+++ b/src/Jackett.Common/Definitions/sosulki.yml
@@ -2,7 +2,7 @@
 id: sosulki
 name: sosulki
 description: "sosulki is a RUSSIAN Public Torrent Tracker for 3X"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/soulvoice.yml
+++ b/src/Jackett.Common/Definitions/soulvoice.yml
@@ -2,7 +2,7 @@
 id: soulvoice
 name: SoulVoice
 description: "SoulVoice is a CHINESE Private Torrent Tracker for Movies, TV, and e-Learning"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/speedmasterhd.yml
+++ b/src/Jackett.Common/Definitions/speedmasterhd.yml
@@ -2,7 +2,7 @@
 id: speedmasterhd
 name: Speedmaster HD
 description: "Speedmaster HD is a German Time based tracker for MOVIES / TV"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/speedtorrentreloaded.yml
+++ b/src/Jackett.Common/Definitions/speedtorrentreloaded.yml
@@ -2,7 +2,7 @@
 id: speedtorrentreloaded
 name: SpeedTorrent Reloaded
 description: "SpeedTorrent Reloaded is a GERMAN Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/spiritofrevolution.yml
+++ b/src/Jackett.Common/Definitions/spiritofrevolution.yml
@@ -2,7 +2,7 @@
 id: spiritofrevolution
 name: Spirit of Revolution
 description: "Spirit of Revolution is a German Time based tracker for 0DAY"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/sporthd.yml
+++ b/src/Jackett.Common/Definitions/sporthd.yml
@@ -2,7 +2,7 @@
 id: sporthd
 name: SportHD
 description: "SportHD is a Private Torrent Tracker for HD SPORTS"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/sportscult.yml
+++ b/src/Jackett.Common/Definitions/sportscult.yml
@@ -2,7 +2,7 @@
 id: sportscult
 name: SportsCult
 description: "SportsCult is a Private Torrent Tracker for SPORTS"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/springsunday.yml
+++ b/src/Jackett.Common/Definitions/springsunday.yml
@@ -2,7 +2,7 @@
 id: springsunday
 name: SpringSunday
 description: "SpringSunday (SSD) is a CHINESE Private Torrent Tracker for HD MOVIES / TV / GENERAL"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/sugoimusic.yml
+++ b/src/Jackett.Common/Definitions/sugoimusic.yml
@@ -2,7 +2,7 @@
 id: sugoimusic
 name: SugoiMusic
 description: "SugoiMusic is a Private Torrent Tracker for Asian MUSIC / TV"
-language: en
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/sukebei-pantsu.yml
+++ b/src/Jackett.Common/Definitions/sukebei-pantsu.yml
@@ -2,7 +2,7 @@
 id: sukebei-pantsu
 name: Sukebei-pantsu
 description: "Sukebei-pantsu is a Public site dedicated to Adult Asian content"
-language: en-en
+language: en-EN
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/sukebeinyaasi.yml
+++ b/src/Jackett.Common/Definitions/sukebeinyaasi.yml
@@ -2,7 +2,7 @@
 id: sukebeinyaasi
 name: sukebei.nyaa.si
 description: "sukebei.nyaa is a Public torrent site focused on adult Eastern Asian media including anime, manga, games and JAV"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/swarmazon.yml
+++ b/src/Jackett.Common/Definitions/swarmazon.yml
@@ -2,7 +2,7 @@
 id: swarmazon
 name: Swarmazon
 description: "Swarmazon is a Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: en
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/tapochek.yml
+++ b/src/Jackett.Common/Definitions/tapochek.yml
@@ -2,7 +2,7 @@
 id: tapochek
 name: Tapochek
 description: "Tapochek is a RUSSIAN Private Torrent Tracker for 0DAY / GENERAL"
-language: ru-ru
+language: ru-RU
 type: private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/tasmanit.yml
+++ b/src/Jackett.Common/Definitions/tasmanit.yml
@@ -2,7 +2,7 @@
 id: tasmanit
 name: Tasmanit
 description: "Tasmanit.es is a AUSTRALIAN / NEW ZEALAND Private Torrent Tracker for AUS / NZ TV"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/tasmanit.yml
+++ b/src/Jackett.Common/Definitions/tasmanit.yml
@@ -2,7 +2,7 @@
 id: tasmanit
 name: Tasmanit
 description: "Tasmanit.es is a AUSTRALIAN / NEW ZEALAND Private Torrent Tracker for AUS / NZ TV"
-language: en-US
+language: en-AU
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/teamhd.yml
+++ b/src/Jackett.Common/Definitions/teamhd.yml
@@ -2,7 +2,7 @@
 id: teamhd
 name: TeamHD
 description: "TeamHD is a RUSSIAN Private Torrent Tracker for HD MOVIES / TV"
-language: ru-ru
+language: ru-RU
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/teamos.yml
+++ b/src/Jackett.Common/Definitions/teamos.yml
@@ -2,7 +2,7 @@
 id: teamos
 name: TeamOS
 description: "Team OS is a Private Torrent Tracker for SOFTWARE"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/tekno3d.yml
+++ b/src/Jackett.Common/Definitions/tekno3d.yml
@@ -2,7 +2,7 @@
 id: tekno3d
 name: TEKNO3D
 description: "TEKNO3D is a Private Torrent Tracker for MOVIES / TV"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/tellytorrent.yml
+++ b/src/Jackett.Common/Definitions/tellytorrent.yml
@@ -2,7 +2,7 @@
 id: tellytorrent
 name: TellyTorrent
 description: "TellyTorrent is an INDIAN Private Tracker for MOVIES / TV"
-language: en
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/teracod.yml
+++ b/src/Jackett.Common/Definitions/teracod.yml
@@ -2,7 +2,7 @@
 id: teracod
 name: teracod
 description: "teracod (Movie Zone) is a HUNGARIAN Private Torrent Tracker for 0DAY / GENERAL"
-language: hu-hu
+language: hu-HU
 type: private
 encoding: iso-8859-2
 links:

--- a/src/Jackett.Common/Definitions/theaudioscene.yml
+++ b/src/Jackett.Common/Definitions/theaudioscene.yml
@@ -2,7 +2,7 @@
 id: theaudioscene
 name: TheAudioScene
 description: "TheAudioScene is a Private Torrent Tracker for AUDIO SOFTWARE / SAMPLES / ETC"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/theempire.yml
+++ b/src/Jackett.Common/Definitions/theempire.yml
@@ -2,7 +2,7 @@
 id: theempire
 name: The Empire
 description: "TheEmpire (TE) is a Private Torrent Tracker for COMMONWEALTH TV / RADIO"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/thefallingangels.yml
+++ b/src/Jackett.Common/Definitions/thefallingangels.yml
@@ -2,7 +2,7 @@
 id: thefallingangels
 name: The Falling Angels
 description: "The Falling Angels (TFA) is a German Private site for TV / MOVIES / GENERAL"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/thegeeks.yml
+++ b/src/Jackett.Common/Definitions/thegeeks.yml
@@ -2,7 +2,7 @@
 id: thegeeks
 name: The Geeks
 description: "Technology E-Learning"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/thehorrorcharnel.yml
+++ b/src/Jackett.Common/Definitions/thehorrorcharnel.yml
@@ -2,7 +2,7 @@
 id: thehorrorcharnel
 name: The Horror Charnel
 description: "The Horror Charnel (THC) is a Private Torrent Tracker for HORROR / CULT / SLEAZE / SCI FI MOVIES"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/theleachzone.yml
+++ b/src/Jackett.Common/Definitions/theleachzone.yml
@@ -2,7 +2,7 @@
 id: theleachzone
 name: TheLeachZone
 description: "The Leach Zone (TLZ) is a Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/themixingbowl.yml
+++ b/src/Jackett.Common/Definitions/themixingbowl.yml
@@ -2,7 +2,7 @@
 id: themixingbowl
 name: themixingbowl
 description: "themixingbowl (TMB) is a Semi-Private Torrent Tracker for DJ Music mixes"
-language: en-us
+language: en-US
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/theoccult.yml
+++ b/src/Jackett.Common/Definitions/theoccult.yml
@@ -2,7 +2,7 @@
 id: theoccult
 name: The Occult
 description: "Cult E-Learning"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/theplace.yml
+++ b/src/Jackett.Common/Definitions/theplace.yml
@@ -2,7 +2,7 @@
 id: theplace
 name: The Place
 description: "Self-improvement E-Learning"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/thesceneplace.yml
+++ b/src/Jackett.Common/Definitions/thesceneplace.yml
@@ -2,7 +2,7 @@
 id: thesceneplace
 name: TheScenePlace
 description: "TheScenePlace (TSP) is a Private site for TV / MOVIES / GENERAL"
-language: en
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/theshinning.yml
+++ b/src/Jackett.Common/Definitions/theshinning.yml
@@ -2,7 +2,7 @@
 id: theshinning
 name: The Shinning
 description: "The Shinning (TsH) is a GERMAN Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/theshow.yml
+++ b/src/Jackett.Common/Definitions/theshow.yml
@@ -2,7 +2,7 @@
 id: theshow
 name: The Show
 description: "Entertainment E-Learning"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/thevault.yml
+++ b/src/Jackett.Common/Definitions/thevault.yml
@@ -2,7 +2,7 @@
 id: thevault
 name: The Vault
 description: "Business/Marketing E-Learning"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/tjupt.yml
+++ b/src/Jackett.Common/Definitions/tjupt.yml
@@ -2,7 +2,7 @@
 id: tjupt
 name: TJUPT
 description: "TJUPT is a CHINESE Private Torrent Tracker for GENERAL"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/tlfbits.yml
+++ b/src/Jackett.Common/Definitions/tlfbits.yml
@@ -2,7 +2,7 @@
 id: tlfbits
 name: TLFBits
 description: "TLFBits is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/tntfork.yml
+++ b/src/Jackett.Common/Definitions/tntfork.yml
@@ -2,7 +2,7 @@
 id: tntfork
 name: TNTfork
 description: "TNTfork is a mirror for the archive published by tntvillage"
-language: it-it
+language: it-IT
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/tokyotosho.yml
+++ b/src/Jackett.Common/Definitions/tokyotosho.yml
@@ -2,7 +2,7 @@
 id: tokyotosho
 name: Tokyo Toshokan
 description: "A BitTorrent Library for Japanese Media"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/torlock.yml
+++ b/src/Jackett.Common/Definitions/torlock.yml
@@ -2,7 +2,7 @@
 id: torlock
 name: Torlock
 description: "Torlock is a torrent search site that lists verified torrents only for TV series and movies"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/toros.yml
+++ b/src/Jackett.Common/Definitions/toros.yml
@@ -2,7 +2,7 @@
 id: toros
 name: TOROS
 description: "TOROS is a Public torrent index"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/torrent-explosiv.yml
+++ b/src/Jackett.Common/Definitions/torrent-explosiv.yml
@@ -2,7 +2,7 @@
 id: torrent-explosiv
 name: Torrent-Explosiv
 description: "Torrent-Explosiv is a German Private site for TV / MOVIES / GENERAL"
-language: de-de
+language: de-DE
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/torrent-pirat.yml
+++ b/src/Jackett.Common/Definitions/torrent-pirat.yml
@@ -2,7 +2,7 @@
 id: torrent-pirat
 name: torrent-pirat
 description: "torrent-pirat is a RUSSIAN Public Torrent Tracker for 3X"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -2,7 +2,7 @@
 id: torrent9
 name: Torrent9
 description: "Torrent9 is a FRENCH Public site for TV / MOVIES / GENERAL"
-language: fr-fr
+language: fr-FR
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/torrent9clone.yml
+++ b/src/Jackett.Common/Definitions/torrent9clone.yml
@@ -2,7 +2,7 @@
 id: torrent9clone
 name: Torrent9 clone
 description: "Torrent9 clone is a FRENCH Public Torrent9 clone for TV / MOVIES / GENERAL"
-language: fr-fr
+language: fr-FR
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/torrentbd.yml
+++ b/src/Jackett.Common/Definitions/torrentbd.yml
@@ -2,7 +2,7 @@
 id: torrentbd
 name: TorrentBD
 description: "A general Bangladesh tracker"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/torrentccf.yml
+++ b/src/Jackett.Common/Definitions/torrentccf.yml
@@ -2,7 +2,7 @@
 id: torrentccf
 name: TorrentCCF
 description: "TorrentCCF (TCCF) is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/torrentdb.yml
+++ b/src/Jackett.Common/Definitions/torrentdb.yml
@@ -2,7 +2,7 @@
 id: torrentdb
 name: TorrentDB
 description: "TorrentDB - Private site for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/torrentdownload.yml
+++ b/src/Jackett.Common/Definitions/torrentdownload.yml
@@ -2,7 +2,7 @@
 id: torrentdownload
 name: TorrentDownload
 description: "TorrentDownload is a Public general torrent index"
-language: en-us
+language: en-US
 type: semi-private
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/torrentdownloads.yml
+++ b/src/Jackett.Common/Definitions/torrentdownloads.yml
@@ -2,7 +2,7 @@
 id: torrentdownloads
 name: Torrent Downloads
 description: "Torrent Downloads (TD) is a Public torrent site for all kinds of content"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/torrentfunk.yml
+++ b/src/Jackett.Common/Definitions/torrentfunk.yml
@@ -2,7 +2,7 @@
 id: torrentfunk
 name: TorrentFunk
 description: "TorrentFunk is a Public torrent index"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/torrentgalaxy.yml
+++ b/src/Jackett.Common/Definitions/torrentgalaxy.yml
@@ -2,7 +2,7 @@
 id: torrentgalaxy
 name: TorrentGalaxy
 description: "TorrentGalaxy (TGx) is a Public site for TV / MOVIES / GENERAL"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/torrenthr.yml
+++ b/src/Jackett.Common/Definitions/torrenthr.yml
@@ -2,7 +2,7 @@
 id: torrenthr
 name: TorrentHR
 description: "TorrentHR is a ratioless CROATIAN Private Torrent Tracker for 0DAY / GENERAL"
-language: hr-hr
+language: hr-HR
 type: private
 encoding: windows-1250
 links:

--- a/src/Jackett.Common/Definitions/torrenting.yml
+++ b/src/Jackett.Common/Definitions/torrenting.yml
@@ -2,7 +2,7 @@
 id: torrenting
 name: Torrenting
 description: "Torrenting (TT) is a Private site for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: windows-1252
 links:

--- a/src/Jackett.Common/Definitions/torrentkitty.yml
+++ b/src/Jackett.Common/Definitions/torrentkitty.yml
@@ -2,7 +2,7 @@
 id: torrentkitty
 name: TorrentKitty
 description: "TorrentKitty is a Public torrent indexer"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/torrentland.yml
+++ b/src/Jackett.Common/Definitions/torrentland.yml
@@ -2,7 +2,7 @@
 id: torrentland
 name: Torrentland
 description: "Torrentland is a SPANISH Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: es-es
+language: es-ES
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/torrentleech-pl.yml
+++ b/src/Jackett.Common/Definitions/torrentleech-pl.yml
@@ -2,7 +2,7 @@
 id: torrentleech-pl
 name: Torrentleech.pl
 description: "Torrentleech.pl is a POLISH Private Torrent Tracker for 0DAY / GENERAL"
-language: pl-pl
+language: pl-PL
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/torrentlt.yml
+++ b/src/Jackett.Common/Definitions/torrentlt.yml
@@ -2,7 +2,7 @@
 id: torrentlt
 name: Torrent.LT
 description: "Torrent.LT is a LITHUANIAN Private Torrent Tracker for 0DAY / GENERAL"
-language: lt-lt
+language: lt-LT
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/torrentoyunindir.yml
+++ b/src/Jackett.Common/Definitions/torrentoyunindir.yml
@@ -2,7 +2,7 @@
 id: torrentoyunindir
 name: Torrent Oyun indir
 description: "Torrent Oyun indir is a TURKISH Public torrent site for GAMES"
-language: tr
+language: tr-TR
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/torrentparadise.yml
+++ b/src/Jackett.Common/Definitions/torrentparadise.yml
@@ -2,7 +2,7 @@
 id: torrentparadise
 name: TorrentParadise
 description: "Torrent Paradise is a Public magnet indexer"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/torrentproject2.yml
+++ b/src/Jackett.Common/Definitions/torrentproject2.yml
@@ -2,7 +2,7 @@
 id: torrentproject2
 name: TorrentProject2
 description: "TorrentProject2 is a Public torrent meta-search engine"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/torrentsectorcrew.yml
+++ b/src/Jackett.Common/Definitions/torrentsectorcrew.yml
@@ -2,7 +2,7 @@
 id: torrentsectorcrew
 name: Torrent Sector Crew
 description: "Torrent Sector Crew (TSC) is a GERMAN Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: de-de
+language: de-DE
 type: private
 encoding: ISO-8859-1
 links:

--- a/src/Jackett.Common/Definitions/torrentslocal.yml
+++ b/src/Jackett.Common/Definitions/torrentslocal.yml
@@ -2,7 +2,7 @@
 id: torrentslocal
 name: Torrents-Local
 description: "Torrents-Local is a RUSSIAN Semi-Private Torrent Tracker"
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/torrentsurf.yml
+++ b/src/Jackett.Common/Definitions/torrentsurf.yml
@@ -2,7 +2,7 @@
 id: torrentsurf
 name: Torrent Surf
 description: "Torrent Surf is a Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/torrentv.yml
+++ b/src/Jackett.Common/Definitions/torrentv.yml
@@ -2,7 +2,7 @@
 id: torrentv
 name: Torrentv
 description: "Torrentv is a Public tracker for MOVIES"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/torrentz2eu.yml
+++ b/src/Jackett.Common/Definitions/torrentz2eu.yml
@@ -2,7 +2,7 @@
 id: torrentz2eu
 name: Torrentz2eu
 description: "Torrentz2eu is a Public torrent meta-search engine"
-language: en
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/totallykids.yml
+++ b/src/Jackett.Common/Definitions/totallykids.yml
@@ -2,7 +2,7 @@
 id: totallykids
 name: TotallyKids
 description: "TotallyKids (TK) is a Private Torrent Tracker for CHILDRENS MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/totheglory.yml
+++ b/src/Jackett.Common/Definitions/totheglory.yml
@@ -2,7 +2,7 @@
 id: totheglory
 name: ToTheGlory
 description: "ToTheGlory (TTG) A Chinese tracker"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/totheglorycookie.yml
+++ b/src/Jackett.Common/Definitions/totheglorycookie.yml
@@ -2,7 +2,7 @@
 id: totheglorycookie
 name: ToTheGloryCookie
 description: "this is an alternate to the ToTheGlory indexer using the cookie method for access"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/totheglorycookie.yml
+++ b/src/Jackett.Common/Definitions/totheglorycookie.yml
@@ -1,7 +1,7 @@
 ---
 id: totheglorycookie
 name: ToTheGloryCookie
-description: "this is an alternate to the ToTheGlory indexer using the cookie method for access"
+description: "ToTheGlory (TTG) A Chinese tracker. This uses the cookie method for access"
 language: zh-CN
 type: private
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/trackeros.yml
+++ b/src/Jackett.Common/Definitions/trackeros.yml
@@ -2,7 +2,7 @@
 id: trackeros
 name: Trackeros
 description: "Trackeros is a Private SPANISH Tracker for HD MOVIES / TV / GENERAL"
-language: es-es
+language: es-ES
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/trancetraffic.yml
+++ b/src/Jackett.Common/Definitions/trancetraffic.yml
@@ -2,7 +2,7 @@
 id: trancetraffic
 name: TranceTraffic
 description: "TranceTraffic is a Private site for MUSIC"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/trezzor.yml
+++ b/src/Jackett.Common/Definitions/trezzor.yml
@@ -2,7 +2,7 @@
 id: trezzor
 name: Trezzor
 description: "Trezzor is a CZECH Private site for TV / MOVIES / GENERAL"
-language: cs-cz
+language: cs-CZ
 type: private
 encoding: windows-1250
 links:

--- a/src/Jackett.Common/Definitions/tribalmixes.yml
+++ b/src/Jackett.Common/Definitions/tribalmixes.yml
@@ -2,7 +2,7 @@
 id: tribalmixes
 name: TribalMixes
 description: "TribalMixes is a ratioless Semi-Private Torrent Tracker for DJ MIXES"
-language: en
+language: en-US
 type: semi-private
 encoding: ISO-8859-1
 links:

--- a/src/Jackett.Common/Definitions/tribalmixes.yml
+++ b/src/Jackett.Common/Definitions/tribalmixes.yml
@@ -2,7 +2,7 @@
 id: tribalmixes
 name: TribalMixes
 description: "TribalMixes is a ratioless Semi-Private Torrent Tracker for DJ MIXES"
-language: en-US
+language: en-GB
 type: semi-private
 encoding: ISO-8859-1
 links:

--- a/src/Jackett.Common/Definitions/trupornolabs.yml
+++ b/src/Jackett.Common/Definitions/trupornolabs.yml
@@ -2,7 +2,7 @@
 id: trupornolabs
 name: truPornolabs
 description: "truPornolabs is a RUSSIAN Public tracker for 3X"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/ttsweb.yml
+++ b/src/Jackett.Common/Definitions/ttsweb.yml
@@ -2,7 +2,7 @@
 id: ttsweb
 name: TTsWeb
 description: "TTsWeb is a Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: en
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/tvchaosuk.yml
+++ b/src/Jackett.Common/Definitions/tvchaosuk.yml
@@ -2,7 +2,7 @@
 id: tvchaosuk
 name: TVChaosUK
 description: "TV Chaos UK (TVCUK) is a Private Torrent Tracker for UK TV"
-language: en-uk
+language: en-UK
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/twilight.yml
+++ b/src/Jackett.Common/Definitions/twilight.yml
@@ -2,7 +2,7 @@
 id: twilight
 name: Twilight Torrents
 description: "Twilight Torrents is a Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/twilightszoom.yml
+++ b/src/Jackett.Common/Definitions/twilightszoom.yml
@@ -2,7 +2,7 @@
 id: twilightszoom
 name: Twilights Zoom
 description: "Twilights Zoom is a Private Torrent Tracker for MUSIC"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/u2.yml
+++ b/src/Jackett.Common/Definitions/u2.yml
@@ -2,7 +2,7 @@
 id: u2
 name: U2
 description: "U2 (U2分享園@動漫花園) is a CHINESE Private Torrent Tracker for ANIME"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/uhdbits.yml
+++ b/src/Jackett.Common/Definitions/uhdbits.yml
@@ -2,7 +2,7 @@
 id: uhdbits
 name: UHDBits
 description: "A vietnamese general tracker"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/underverse.yml
+++ b/src/Jackett.Common/Definitions/underverse.yml
@@ -2,7 +2,7 @@
 id: underverse
 name: Underverse
 description: "Underverse is a RUSSIAN Public Torrent Tracker for MOVIES / TV / MUSIC / GENERAL"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/underversel.yml
+++ b/src/Jackett.Common/Definitions/underversel.yml
@@ -2,7 +2,7 @@
 id: underversel
 name: UnderverseL
 description: "this is the Underverse indexer with Login enabled in the config."
-language: ru-ru
+language: ru-RU
 type: semi-private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/uniondht.yml
+++ b/src/Jackett.Common/Definitions/uniondht.yml
@@ -2,7 +2,7 @@
 id: uniondht
 name: UnionDHT
 description: "UnionDHT is a RUSSIAN Public Torrent Tracker for MOVIES / TV / MUSIC / GENERAL"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/unionfansub.yml
+++ b/src/Jackett.Common/Definitions/unionfansub.yml
@@ -2,7 +2,7 @@
 id: unionfansub
 name: Union Fansub
 description: "Union Fansub is a SPANISH Semi private torrent site focused on ANIME"
-language: es-es
+language: es-ES
 type: semi-private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/uniongang.yml
+++ b/src/Jackett.Common/Definitions/uniongang.yml
@@ -2,7 +2,7 @@
 id: uniongang
 name: UnionGang
 description: "UnionGang is a RUSSIAN Private Torrent Tracker for MOVIES / GENERAL"
-language: ru-ru
+language: ru-RU
 type: private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/unlimitz.yml
+++ b/src/Jackett.Common/Definitions/unlimitz.yml
@@ -2,7 +2,7 @@
 id: unlimitz
 name: Unlimitz
 description: "Unlimitz is a THAI Private Torrent Tracker for GENERAL"
-language: th-th
+language: th-TH
 type: private
 encoding: windows-874
 links:

--- a/src/Jackett.Common/Definitions/vizuk.yml
+++ b/src/Jackett.Common/Definitions/vizuk.yml
@@ -2,7 +2,7 @@
 id: vizuk
 name: Vizuk
 description: "Vizuk is a SPANISH private site for HD content"
-language: es-es
+language: es-ES
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/vsthouse.yml
+++ b/src/Jackett.Common/Definitions/vsthouse.yml
@@ -2,7 +2,7 @@
 id: vsthouse
 name: VSTHouse
 description: "VSTHouse is a Public Russian site for AUDIO apps, plugins and samples"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/vsttorrents.yml
+++ b/src/Jackett.Common/Definitions/vsttorrents.yml
@@ -2,7 +2,7 @@
 id: vsttorrents
 name: VST Torrents
 description: "VST Torrents is a Public site for AUDIO apps, plugins and samples"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/wdt.yml
+++ b/src/Jackett.Common/Definitions/wdt.yml
@@ -2,7 +2,7 @@
 id: wdt
 name: WDT
 description: "Wrestling Desires Torrents (Ultimate Wrestling Torrents) is a Private Torrent Tracker for PROFESSIONAL WRESTLING / MMA"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/wihd.yml
+++ b/src/Jackett.Common/Definitions/wihd.yml
@@ -2,7 +2,7 @@
 id: wihd
 name: World-In-HD
 description: "Your world in HD"
-language: fr-fr
+language: fr-FR
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/woot.yml
+++ b/src/Jackett.Common/Definitions/woot.yml
@@ -2,7 +2,7 @@
 id: woot
 name: wOOt
 description: "wOOt is a Private GERMAN site for TV / MOVIES / GENERAL"
-language: de-de
+language: de-DE
 type: private
 encoding: iso-8859-1
 links:

--- a/src/Jackett.Common/Definitions/x-ite.me.yml
+++ b/src/Jackett.Common/Definitions/x-ite.me.yml
@@ -2,7 +2,7 @@
 id: xiteme
 name: x-ite.me
 description: "Tracker for LGBTQ movies, TV, books, magazines, anime, PC and XXX."
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/xbytes2.yml
+++ b/src/Jackett.Common/Definitions/xbytes2.yml
@@ -2,7 +2,7 @@
 id: xbytesv2
 name: XbytesV2
 description: "xbytesV2 is a SPANISH site for HD content"
-language: es-es
+language: es-ES
 type: private
 encoding: ISO-8859-1
 links:

--- a/src/Jackett.Common/Definitions/xwtclassics.yml
+++ b/src/Jackett.Common/Definitions/xwtclassics.yml
@@ -2,7 +2,7 @@
 id: xwtclassics
 name: XWT-Classics
 description: "XWT-Classics is a Private Torrent Tracker for CLASSIC PROFESSIONAL WRESTLING"
-language: en-us
+language: en-US
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/xwtorrents.yml
+++ b/src/Jackett.Common/Definitions/xwtorrents.yml
@@ -2,7 +2,7 @@
 id: xwtorrents
 name: XWtorrents
 description: "XtremeWrestlingTorrents (XWT) is a Private Torrent Tracker for PROFESSIONAL WRESTLING / MMA"
-language: en-us
+language: en-US
 type: private
 encoding: windows-1252
 links:

--- a/src/Jackett.Common/Definitions/xxxadulttorrent.yml
+++ b/src/Jackett.Common/Definitions/xxxadulttorrent.yml
@@ -2,7 +2,7 @@
 id: xxxadulttorrent
 name: xxxAdultTorrent
 description: "xxxAdultTorrent is a RUSSIAN Public tracker for 3X"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/xxxtor.yml
+++ b/src/Jackett.Common/Definitions/xxxtor.yml
@@ -2,7 +2,7 @@
 id: xxxtor
 name: xxxtor
 description: "xxxtor is a RUSSIAN Public Torrent Tracker for 3X"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/xxxtorrents.yml
+++ b/src/Jackett.Common/Definitions/xxxtorrents.yml
@@ -2,7 +2,7 @@
 id: xxxtorrents
 name: xxxtorrents
 description: "xxxtorrents is a RUSSIAN Public Torrent Tracker for 3X"
-language: ru-ru
+language: ru-RU
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/ydypt.yml
+++ b/src/Jackett.Common/Definitions/ydypt.yml
@@ -2,7 +2,7 @@
 id: ydypt
 name: YDYPT
 description: "YDYPT is a CHINESE Private Torrent Tracker for 3X"
-language: zh-cn
+language: zh-CN
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/yggcookie.yml
+++ b/src/Jackett.Common/Definitions/yggcookie.yml
@@ -2,7 +2,7 @@
 id: yggcookie
 name: YGGcookie
 description: "YGGTorrent is a FRENCH Semi-Private Torrent Tracker for 0DAY / GENERAL"
-language: fr-fr
+language: fr-FR
 type: semi-private
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/yggtorrent.yml
+++ b/src/Jackett.Common/Definitions/yggtorrent.yml
@@ -2,7 +2,7 @@
 id: yggtorrent
 name: YGGtorrent
 description: "YGGTorrent is a FRENCH Semi-Private Torrent Tracker for 0DAY / GENERAL"
-language: fr-fr
+language: fr-FR
 type: semi-private
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/yourbittorrent.yml
+++ b/src/Jackett.Common/Definitions/yourbittorrent.yml
@@ -2,7 +2,7 @@
 id: yourbittorrent
 name: YourBittorrent
 description: "YourBittorrent is a Public torrent index"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/zamundanet.yml
+++ b/src/Jackett.Common/Definitions/zamundanet.yml
@@ -2,7 +2,7 @@
 id: zamundanet
 name: Zamunda.net
 description: "Zamunda is a BULGARIAN Private Torrent Tracker for 0DAY / GENERAL"
-language: bg-bg
+language: bg-BG
 type: private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/zelkaorg.yml
+++ b/src/Jackett.Common/Definitions/zelkaorg.yml
@@ -2,7 +2,7 @@
 id: zelkaorg
 name: Zelka.org
 description: "Zelka (Zamunda) is a BULGARIAN Private Torrent Tracker for 0DAY / GENERAL"
-language: bg-bg
+language: bg-BG
 type: private
 encoding: windows-1251
 links:

--- a/src/Jackett.Common/Definitions/zetorrents.yml
+++ b/src/Jackett.Common/Definitions/zetorrents.yml
@@ -2,7 +2,7 @@
 id: zetorrents
 name: zetorrents
 description: "zetorrents is a FRENCH Public site for MOVIES / TV / GENERAL"
-language: fr-fr
+language: fr-FR
 type: public
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/zooqle.yml
+++ b/src/Jackett.Common/Definitions/zooqle.yml
@@ -2,7 +2,7 @@
 id: zooqle
 name: Zooqle
 description: "Zooqle is a Public torrent index providing a huge database of verified torrents"
-language: en-us
+language: en-US
 type: public
 encoding: UTF-8
 followredirect: true

--- a/src/Jackett.Common/Definitions/ztracker.yml
+++ b/src/Jackett.Common/Definitions/ztracker.yml
@@ -2,7 +2,7 @@
 id: ztracker
 name: Ztracker
 description: "Ztracker is a HUNGARIAN Private Torrent Tracker for 0DAY / GENERAL"
-language: hu-hu
+language: hu-HU
 type: semi-private
 encoding: ISO-8859-2
 links:


### PR DESCRIPTION
Language for the various YMLs was inconsistent.  
This standardizes everything using the format of  `{ISO 3166-1 alpha-2}-{ISO 639-1}` 

Completed w/ N++ and some regex