### PR TITLE
[Cardigann] Add path selector in before block and few fixes

### DIFF
--- a/src/Jackett.Common/Models/IndexerDefinition.cs
+++ b/src/Jackett.Common/Models/IndexerDefinition.cs
@@ -165,22 +165,27 @@ namespace Jackett.Common.Models
         public string Queryseparator { get; set; } = "&";
     }
 
+    public class beforeBlock: requestBlock
+    {
+        public selectorField Pathselector { get; set; }
+    }
+
     public class infohashBlock
     {
-        public downloadsField Hash { get; set; }
-        public downloadsField Title { get; set; }
+        public selectorField Hash { get; set; }
+        public selectorField Title { get; set; }
         public bool Before { get; set; } = false;
     }
 
     public class downloadBlock
     {
-        public List<downloadsField> Selectors { get; set; }
+        public List<selectorField> Selectors { get; set; }
         public string Method { get; set; }
-        public requestBlock Before { get; set; }
+        public beforeBlock Before { get; set; }
         public infohashBlock Infohash { get; set; }
     }
 
-    public class downloadsField
+    public class selectorField
     {
         public string Selector { get; set; }
         public string Attribute { get; set; }

--- a/src/Jackett.Common/Models/IndexerDefinition.cs
+++ b/src/Jackett.Common/Models/IndexerDefinition.cs
@@ -165,7 +165,7 @@ namespace Jackett.Common.Models
         public string Queryseparator { get; set; } = "&";
     }
 
-    public class beforeBlock: requestBlock
+    public class beforeBlock : requestBlock
     {
         public selectorField Pathselector { get; set; }
     }


### PR DESCRIPTION
Fixes #12273.

1. I've added a pathselector field in the before block with all the parameters. This fixes the mircrew indexer which I'll create a separate pull. Following is the excerpt taken from it:
```yml
download:
  before:
    # thankyou link: ./viewtopic.php?f=52&p=65417&thanks=65417&to_id=54&from_id=3950
    pathselector:
      selector: a[id^="lnk_thanks_post"]
      attribute: href
  selectors:
    - selector: a[href^="magnet:?xt="]
      attribute: href
      filters:
        - name: trim
```
2. I've made some appropriate naming changes in the IndexerDefinition.
3. I've fixed a bug where the before block would cause trouble when Inputs field is not present (like in the case of mircrew).