### PR TITLE
[Core] Add option to prevent torrent link check

### DIFF
--- a/src/Jackett.Common/Definitions/anime-free.yml
+++ b/src/Jackett.Common/Definitions/anime-free.yml
@@ -5,6 +5,7 @@ description: "Anime-Free is a RUSSIAN Semi-Private Torrent Tracker for Hentai ma
 language: ru-RU
 type: semi-private
 encoding: windows-1251
+testlinktorrent: false
 links:
   - https://anime-free.biz/
 legacylinks:

--- a/src/Jackett.Common/Definitions/hellastz.yml
+++ b/src/Jackett.Common/Definitions/hellastz.yml
@@ -5,6 +5,7 @@ description: "HellasTZ is an Greek Private site for TV / MOVIES / GENERAL"
 language: el-GR
 type: private
 encoding: UTF-8
+testlinktorrent: false
 links:
   - https://hellastz.com/
 certificates:

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -1859,7 +1859,7 @@ namespace Jackett.Common.Indexers
                                 continue;
 
                             var torrentLink = resolvePath(href, link);
-                            if (torrentLink.Scheme != "magnet")
+                            if (torrentLink.Scheme != "magnet" && Definition.Testlinktorrent)
                             {
                                 // Test link
                                 response = await HandleRedirectableRequestAsync(torrentLink.ToString(), headers);

--- a/src/Jackett.Common/Models/IndexerDefinition.cs
+++ b/src/Jackett.Common/Models/IndexerDefinition.cs
@@ -39,6 +39,7 @@ namespace Jackett.Common.Models
         public List<string> Links { get; set; }
         public List<string> Legacylinks { get; set; }
         public bool Followredirect { get; set; } = false;
+        public bool Testlinktorrent { get; set; } = true;
         public List<string> Certificates { get; set; }
         public capabilitiesBlock Caps { get; set; }
         public loginBlock Login { get; set; }


### PR DESCRIPTION
Adds on to the Fix of #11865.
There is a new option named "testlinktorrent" which is by default true. On setting it to false, it skips the check essentially preventing 2 GET requests to download a torrent file for the indexers which don't like that behaviour.
I've also made the necessary change to hellastz indexer but needs testing since I don't have creds. 
On approval, I'll add it to the wiki and merge changes