### PR TITLE
[Core] Enable multiple redirects

### DIFF
--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -1727,11 +1727,16 @@ namespace Jackett.Common.Indexers
             return response;
         }
 
-        protected async Task<WebResult> HandleRedirectableRequestAsync(string url, Dictionary<string, string> headers = null)
+        protected async Task<WebResult> HandleRedirectableRequestAsync(string url, Dictionary<string, string> headers = null, int maxRedirects = 5)
         {
             var response = await RequestWithCookiesAsync(url, headers: headers);
-            if (response.IsRedirect)
-                response = await RequestWithCookiesAsync(response.RedirectingTo, headers: headers);
+            for (var i = 0; i < maxRedirects; i++)
+            {
+                if (response.IsRedirect)
+                    response = await RequestWithCookiesAsync(response.RedirectingTo, headers: headers);
+                else
+                    break;
+            }
             return response;
         }
 


### PR DESCRIPTION
Fixes #12314.
As mentioned in the issue, there are multiple redirects which I also noticed in the network logs. However, traditionally the Cardigann indexer only takes care of one redirect. I've added an option to control it (from c# only, not yml) and have set a maximum of 5 redirects allowed. Again, I don't know how it could've been working earlier because from the start only 1 redirect was handled.