### PR TITLE
ci/cd: fix base images in azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -31,42 +31,42 @@ stages:
           matrix:
             Mono:
               buildDescription: Mono
-              imageName: ubuntu-latest
+              imageName: ubuntu-20.04
               framework: net461
               runtime: linux-x64
               archiveType: tar
               artifactName: Jackett.Binaries.Mono.tar.gz
             Windows:
               buildDescription: Windows
-              imageName: windows-latest
+              imageName: windows-2019
               framework: $(netCoreFramework)
               runtime: win-x86
               archiveType: zip
               artifactName: Jackett.Binaries.Windows.zip
             macOS:
               buildDescription: macOS
-              imageName: macOS-latest
+              imageName: macOS-10.15
               framework: $(netCoreFramework)
               runtime: osx-x64
               archiveType: tar
               artifactName: Jackett.Binaries.macOS.tar.gz
             LinuxAMDx64:
               buildDescription: Linux AMD x64
-              imageName: ubuntu-latest
+              imageName: ubuntu-20.04
               framework: $(netCoreFramework)
               runtime: linux-x64
               archiveType: tar
               artifactName: Jackett.Binaries.LinuxAMDx64.tar.gz
             LinuxARM32:
               buildDescription: Linux ARM32
-              imageName: ubuntu-latest
+              imageName: ubuntu-20.04
               framework: $(netCoreFramework)
               runtime: linux-arm
               archiveType: tar
               artifactName: Jackett.Binaries.LinuxARM32.tar.gz
             LinuxARM64:
               buildDescription: Linux ARM64
-              imageName: ubuntu-latest
+              imageName: ubuntu-20.04
               framework: $(netCoreFramework)
               runtime: linux-arm64
               archiveType: tar
@@ -274,7 +274,7 @@ stages:
       - job: Linting_Dotnet
         displayName: Linting Dotnet
         pool:
-          vmImage: ubuntu-latest
+          vmImage: ubuntu-20.04
         workspace:
           clean: all
         steps:
@@ -307,7 +307,7 @@ stages:
       - job: Linting_YAML
         displayName: Linting YAML
         pool:
-          vmImage: ubuntu-latest
+          vmImage: ubuntu-20.04
         workspace:
           clean: all
         steps:
@@ -335,27 +335,27 @@ stages:
           matrix:
             Mono:
               buildDescription: Mono
-              imageName: ubuntu-latest
+              imageName: ubuntu-20.04
               framework: net461
               runtime: linux-x64
             Windows:
               buildDescription: Windows
-              imageName: windows-latest
+              imageName: windows-2019
               framework: $(netCoreFramework)
               runtime: win-x86
             macOS:
               buildDescription: macOS
-              imageName: macOS-latest
+              imageName: macOS-10.15
               framework: $(netCoreFramework)
               runtime: osx-x64
             LinuxAMDx64:
               buildDescription: Linux AMD x64
-              imageName: ubuntu-latest
+              imageName: ubuntu-20.04
               framework: $(netCoreFramework)
               runtime: linux-x64
             LinuxARM:
               buildDescription: Linux ARM
-              imageName: ubuntu-latest
+              imageName: ubuntu-20.04
               framework: $(netCoreFramework)
               runtime: linux-arm
         pool:
@@ -440,19 +440,19 @@ stages:
           matrix:
             Mono:
               buildDescription: Mono
-              imageName: ubuntu-latest
+              imageName: ubuntu-20.04
               artifactName: Jackett.Binaries.Mono.tar.gz
             Windows:
               buildDescription: Windows
-              imageName: windows-latest
+              imageName: windows-2019
               artifactName: Jackett.Binaries.Windows.zip
             macOS:
               buildDescription: macOS
-              imageName: macOS-latest
+              imageName: macOS-10.15
               artifactName: Jackett.Binaries.macOS.tar.gz
             LinuxAMDx64:
               buildDescription: Linux AMD x64
-              imageName: ubuntu-latest
+              imageName: ubuntu-20.04
               artifactName: Jackett.Binaries.LinuxAMDx64.tar.gz
         pool:
           vmImage: $(imageName)
@@ -513,7 +513,7 @@ stages:
         workspace:
           clean: all
         pool:
-          vmImage: ubuntu-latest
+          vmImage: ubuntu-20.04
         steps:
           - checkout: self
 


### PR DESCRIPTION
To avoid this kind of issues in the future it's better to have fixed versions. they update the latest versions from time to time and things could stop working => https://github.com/Jackett/Jackett/pull/12394

Available images => https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/hosted?view=azure-devops&tabs=yaml

@ilike2burnthing @garfield69 FYI. We are still using `macOS-10.15` image but `macOS-11` is available. I think we can keep  `macOS-10.15` for now, but this could be useful in the future.