### PR TITLE
core: integration with FlareSolverr 2.0.0

### DIFF
--- a/src/Jackett.Common/Jackett.Common.csproj
+++ b/src/Jackett.Common/Jackett.Common.csproj
@@ -14,7 +14,7 @@
     <PackageReference Include="Autofac" Version="5.2.0" />
     <PackageReference Include="AutoMapper" Version="8.1.1" />
     <PackageReference Include="BencodeNET" Version="3.1.4" />
-    <PackageReference Include="FlareSolverrSharp" Version="1.2.1" />
+    <PackageReference Include="FlareSolverrSharp" Version="2.0.0" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="DotNet4.SocksProxy" Version="1.4.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
@@ -77,8 +77,8 @@ namespace Jackett.Common.Utils.Clients
 
             using (var clearanceHandlr = new ClearanceHandler(serverConfig.FlareSolverrUrl))
             {
-                clearanceHandlr.UserAgent = BrowserUtil.ChromeUserAgent;
-                clearanceHandlr.MaxTimeout = 50000;
+                clearanceHandlr.MaxTimeout = 55000;
+                clearanceHandlr.ProxyUrl = serverConfig.GetProxyUrl(false);
                 using (var clientHandlr = new HttpClientHandler
                 {
                     CookieContainer = cookies,

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
@@ -56,8 +56,8 @@ namespace Jackett.Common.Utils.Clients
         {
             clearanceHandlr = new ClearanceHandler(serverConfig.FlareSolverrUrl)
             {
-                UserAgent = BrowserUtil.ChromeUserAgent,
-                MaxTimeout = 50000
+                MaxTimeout = 55000,
+                ProxyUrl = serverConfig.GetProxyUrl(false)
             };
             clientHandlr = new HttpClientHandler
             {


### PR DESCRIPTION
FlareSolverr 2.0.0 includes some important changes:
* The User-Agent will be managed by FlareSolverr. It will use Jacket User-Agent unless Cloudflare is detected. In that case it will use the FlareSolverr User-Agent to avoid detection.
* The Proxy configured in Jackett is used in FlareSolverr too. This will fix the issue "The cookies provided by FlareSolverr are not valid".