### PR TITLE
Fix cache collision for non ASCII characters

### DIFF
--- a/src/Jackett.Common/Services/CacheService.cs
+++ b/src/Jackett.Common/Services/CacheService.cs
@@ -241,7 +241,7 @@ namespace Jackett.Common.Services
         {
             var json = GetSerializedQuery(query);
             // Compute the hash
-            return BitConverter.ToString(_sha256.ComputeHash(Encoding.ASCII.GetBytes(json)));
+            return BitConverter.ToString(_sha256.ComputeHash(Encoding.UTF8.GetBytes(json)));
         }
 
         private static string GetSerializedQuery(TorznabQuery query)


### PR DESCRIPTION
`Encoding.ASCII` will replace all non ASCII characters with '?'
https://docs.microsoft.com/en-us/dotnet/api/system.text.encoding.ascii