### PR TITLE
Remove TorrentLeech IMDB Tv Search

### DIFF
--- a/src/Jackett.Common/Definitions/torrentleech.yml
+++ b/src/Jackett.Common/Definitions/torrentleech.yml
@@ -67,7 +67,7 @@ caps:
 
   modes:
     search: [q]
-    tv-search: [q, season, ep, imdbid]
+    tv-search: [q, season, ep]
     movie-search: [q, imdbid]
     music-search: [q]
     book-search: [q]


### PR DESCRIPTION
no other parameters are allowed with IMDB id searched which causes garbage results