### PR TITLE
[New Tracker] Fix Partis indexer to work with new website

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * OpenSharing
  * OxTorrent
  * ParnuXi
+ * Partis
  * PC-torrent
  * PiratBit
  * Pirateiro

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * OpenSharing
  * OxTorrent
  * ParnuXi
- * Partis
  * PC-torrent
  * PiratBit
  * Pirateiro
@@ -457,6 +456,7 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * Ourbits (HDPter)
  * P2PBG
  * P2PElite
+ * Partis
  * PassThePopcorn (PTP)
  * PeerJunkies
  * Peers.FM

--- a/src/Jackett.Common/Indexers/Partis.cs
+++ b/src/Jackett.Common/Indexers/Partis.cs
@@ -65,41 +65,44 @@ namespace Jackett.Common.Indexers
             Language = "sl-SL";
             Type = "private";
 
-            // Blu Ray
+            // Movies
             AddCategoryMapping(40, TorznabCatType.MoviesBluRay, "Blu-Ray 1080p/i");
             AddCategoryMapping(42, TorznabCatType.MoviesBluRay, "Blu-Ray 720p/i");
             AddCategoryMapping(43, TorznabCatType.MoviesBluRay, "Blu-Ray B-Disc");
             AddCategoryMapping(41, TorznabCatType.MoviesBluRay, "Blu-Ray 3D");
             AddCategoryMapping(44, TorznabCatType.MoviesBluRay, "Blu-Ray Remux");
             AddCategoryMapping(45, TorznabCatType.MoviesBluRay, "Blu-Ray Remux/Disc");
-
-            // UHD
             AddCategoryMapping(32, TorznabCatType.MoviesUHD, "UHD 4K Disc");
             AddCategoryMapping(55, TorznabCatType.MoviesUHD, "UHD 4K Remux");
-
-            // HD
             AddCategoryMapping(20, TorznabCatType.MoviesHD, "HD");
             AddCategoryMapping(4, TorznabCatType.MoviesSD, "DVD-R");
             AddCategoryMapping(7, TorznabCatType.MoviesSD, "XviD");
-            AddCategoryMapping(12, TorznabCatType.MoviesSD, "Anime");
             AddCategoryMapping(30, TorznabCatType.MoviesSD, "Risanke");
-            AddCategoryMapping(15, TorznabCatType.MoviesSD, "Sport");
+            AddCategoryMapping(54, TorznabCatType.MoviesSD, "WEBRip");
+            AddCategoryMapping(59, TorznabCatType.MoviesWEBDL, "WEB-DL");
 
-            // TV Show
+            // TV
             AddCategoryMapping(53, TorznabCatType.TVWEBDL, "TV WEB-DL");
             AddCategoryMapping(60, TorznabCatType.TVSD, "TV-XviD");
             AddCategoryMapping(38, TorznabCatType.TVSD, "SD-TV");
             AddCategoryMapping(51, TorznabCatType.TVHD, "TV 1080p/i");
             AddCategoryMapping(52, TorznabCatType.TVHD, "TV 720p/i");
-
-            AddCategoryMapping(54, TorznabCatType.MoviesSD, "WEBRip");
-            AddCategoryMapping(59, TorznabCatType.MoviesWEBDL, "WEB-DL");
+            AddCategoryMapping(5, TorznabCatType.TVSport, "Sport");
+            AddCategoryMapping(2, TorznabCatType.TVAnime, "Anime");
             AddCategoryMapping(24, TorznabCatType.TVDocumentary, "Dokumentarci");
-
+            
             // Games
             AddCategoryMapping(10, TorznabCatType.PCGames, "PC igre/ISO");
             AddCategoryMapping(11, TorznabCatType.PCGames, "PC igre/Rips/Repack");
             AddCategoryMapping(64, TorznabCatType.PCGames, "PC igre/Update & Patch");
+            AddCategoryMapping(13, TorznabCatType.ConsolePSP, "PSP");
+            AddCategoryMapping(12, TorznabCatType.ConsoleOther, "PS2");
+            AddCategoryMapping(28, TorznabCatType.ConsolePS3, "PS3");
+            AddCategoryMapping(63, TorznabCatType.ConsolePS4, "PS4");
+            AddCategoryMapping(27, TorznabCatType.ConsoleWii, "Wii");
+            AddCategoryMapping(14, TorznabCatType.ConsoleXBox, "XboX");
+            AddCategoryMapping(49, TorznabCatType.PCGames, "Mac Igre");
+            AddCategoryMapping(48, TorznabCatType.PCGames, "Linux Igre");
 
             // Music
             AddCategoryMapping(46, TorznabCatType.AudioLossless, "Glasba/Flac");
@@ -107,6 +110,13 @@ namespace Jackett.Common.Indexers
             AddCategoryMapping(47, TorznabCatType.AudioMP3, "Glasba/Mp3");
             AddCategoryMapping(8, TorznabCatType.AudioVideo, "Music DVD");
             AddCategoryMapping(8, TorznabCatType.AudioVideo, "Videospoti");
+            
+            // Programs
+            AddCategoryMapping(15, TorznabCatType.PC, "PC programi/drugo");
+            AddCategoryMapping(15, TorznabCatType.PCMac, "Mac Programi");
+            AddCategoryMapping(16, TorznabCatType.PCISO, "PC programi/ISO");
+
+            // Other
             AddCategoryMapping(21, TorznabCatType.AudioAudiobook, "AudioBook");
             AddCategoryMapping(3, TorznabCatType.BooksEBook, "eKnjige");
         }
@@ -192,15 +202,15 @@ namespace Jackett.Common.Indexers
                 600934, -- id
                 4571,   -- ?
                 1636450141, -- added timestamp
-                "No.Time.To.Die.2021.ENGSubs.REPACK.HDRip.",  --title
+                "No.Time.To.Die.2021.ENGSubs.REPACK.HDRip.",  -- title (max 41 chars)
                 677, -- leechers
                 30, -- seeders
-                "NI ČAS ZA SMRT/ NOVI JAMES BOND | Akcijski | HDRip...", --description 
+                "NI ČAS ZA SMRT/ NOVI JAMES BOND | Akcijski | HDRip...", -- description 
                 7, -- category
-                54.9014462385559, --downloads? scaled 0-100
+                54.9014462385559, -- health? scaled 0-100
                 "1.7 GB", -- size
-                "/img/ics/xvid.gif", --icon
-                "/torrent/image/600/600934/coverflow/james-bond.jpg" --thumbnail
+                "/img/ics/xvid.gif", -- icon
+                "/torrent/image/600/600934/coverflow/james-bond.jpg" -- thumbnail
             ]
             */
             try
@@ -215,8 +225,9 @@ namespace Jackett.Common.Indexers
                 // Get Category
                 release.Category = MapTrackerCatToNewznab(torrent[7].ToString());
 
-                // Title and torrent link
+                // Title, description and details link
                 release.Title = torrent[3].ToString();
+                release.Description = torrent[6].ToString();
                 release.Details = new Uri($"{SiteLink}index.html#torrent/{torrent[0]}");
                 release.Guid = release.Details;
 
@@ -224,13 +235,15 @@ namespace Jackett.Common.Indexers
                 release.PublishDate = DateTimeUtil.UnixTimestampToDateTime((long)torrent[2]);
 
                 // Download link
-                release.Link = new Uri(($"{SiteLink}torrent/download/{torrent[0]}"));
+                release.Link = new Uri($"{SiteLink}torrent/download/{torrent[0]}");
 
                 // Various data - size, seeders, leechers, download count
                 release.Size = ReleaseInfo.GetBytes(torrent[9].ToString());
                 release.Seeders = ParseUtil.CoerceInt(torrent[4].ToString());
                 release.Peers = ParseUtil.CoerceInt(torrent[5].ToString()) + release.Seeders;
-                release.Grabs = (long)torrent[8];
+
+                // Poster
+                release.Poster = new Uri($"{SiteLink}{torrent[11]}");
 
                 // // Set download/upload factor
                 release.DownloadVolumeFactor = 1; //No way to determine if torrent is freeleech from single request.

--- a/src/Jackett.Common/Indexers/Partis.cs
+++ b/src/Jackett.Common/Indexers/Partis.cs
@@ -90,7 +90,7 @@ namespace Jackett.Common.Indexers
             AddCategoryMapping(5, TorznabCatType.TVSport, "Sport");
             AddCategoryMapping(2, TorznabCatType.TVAnime, "Anime");
             AddCategoryMapping(24, TorznabCatType.TVDocumentary, "Dokumentarci");
-            
+
             // Games
             AddCategoryMapping(10, TorznabCatType.PCGames, "PC igre/ISO");
             AddCategoryMapping(11, TorznabCatType.PCGames, "PC igre/Rips/Repack");
@@ -110,7 +110,7 @@ namespace Jackett.Common.Indexers
             AddCategoryMapping(47, TorznabCatType.AudioMP3, "Glasba/Mp3");
             AddCategoryMapping(8, TorznabCatType.AudioVideo, "Music DVD");
             AddCategoryMapping(8, TorznabCatType.AudioVideo, "Videospoti");
-            
+
             // Programs
             AddCategoryMapping(15, TorznabCatType.PC, "PC programi/drugo");
             AddCategoryMapping(15, TorznabCatType.PCMac, "Mac Programi");

--- a/src/Jackett.Common/Indexers/Partis.cs
+++ b/src/Jackett.Common/Indexers/Partis.cs
@@ -1,0 +1,248 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics.CodeAnalysis;
+using System.Text;
+using System.Text.RegularExpressions;
+using System.Threading.Tasks;
+using AngleSharp.Html.Parser;
+using Jackett.Common.Models;
+using Jackett.Common.Models.IndexerConfig;
+using Jackett.Common.Services.Interfaces;
+using Jackett.Common.Utils;
+using Jackett.Common.Utils.Clients;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using NLog;
+
+namespace Jackett.Common.Indexers
+{
+    [ExcludeFromCodeCoverage]
+    public class Partis : BaseWebIndexer
+    {
+        private string LoginUrl => SiteLink + "user/login/";
+        private string SearchUrl => SiteLink + "torrent/search/";
+
+        private new ConfigurationDataBasicLogin configData
+        {
+            get => (ConfigurationDataBasicLogin)base.configData;
+            set => base.configData = value;
+        }
+
+        public Partis(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
+            ICacheService cs)
+            : base(id: "partis",
+                   name: "Partis",
+                   description: "Partis is a SLOVENIAN Private Torrent Tracker",
+                   link: "https://www.partis.si/",
+                   caps: new TorznabCapabilities
+                   {
+                       TvSearchParams = new List<TvSearchParam>
+                       {
+                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep
+                       },
+                       MovieSearchParams = new List<MovieSearchParam>
+                       {
+                           MovieSearchParam.Q
+                       },
+                       MusicSearchParams = new List<MusicSearchParam>
+                       {
+                           MusicSearchParam.Q
+                       },
+                       BookSearchParams = new List<BookSearchParam>
+                       {
+                           BookSearchParam.Q
+                       }
+                   },
+                   configService: configService,
+                   client: wc,
+                   logger: l,
+                   p: ps,
+                   cacheService: cs,
+                   configData: new ConfigurationDataBasicLogin())
+        {
+            Encoding = Encoding.UTF8;
+            Language = "sl-sl";
+            Type = "private";
+
+            // Blu Ray
+            AddCategoryMapping(40, TorznabCatType.MoviesBluRay, "Blu-Ray 1080p/i");
+            AddCategoryMapping(42, TorznabCatType.MoviesBluRay, "Blu-Ray 720p/i");
+            AddCategoryMapping(43, TorznabCatType.MoviesBluRay, "Blu-Ray B-Disc");
+            AddCategoryMapping(41, TorznabCatType.MoviesBluRay, "Blu-Ray 3D");
+            AddCategoryMapping(44, TorznabCatType.MoviesBluRay, "Blu-Ray Remux");
+            AddCategoryMapping(45, TorznabCatType.MoviesBluRay, "Blu-Ray Remux/Disc");
+
+            // UHD
+            AddCategoryMapping(32, TorznabCatType.MoviesUHD, "UHD 4K Disc");
+            AddCategoryMapping(55, TorznabCatType.MoviesUHD, "UHD 4K Remux");
+
+            // HD
+            AddCategoryMapping(20, TorznabCatType.MoviesHD, "HD");
+            AddCategoryMapping(4, TorznabCatType.MoviesSD, "DVD-R");
+            AddCategoryMapping(7, TorznabCatType.MoviesSD, "XviD");
+            AddCategoryMapping(12, TorznabCatType.MoviesSD, "Anime");
+            AddCategoryMapping(30, TorznabCatType.MoviesSD, "Risanke");
+            AddCategoryMapping(15, TorznabCatType.MoviesSD, "Sport");
+
+            // TV Show
+            AddCategoryMapping(53, TorznabCatType.TVWEBDL, "TV WEB-DL");
+            AddCategoryMapping(60, TorznabCatType.TVSD, "TV-XviD");
+            AddCategoryMapping(38, TorznabCatType.TVSD, "SD-TV");
+            AddCategoryMapping(51, TorznabCatType.TVHD, "TV 1080p/i");
+            AddCategoryMapping(52, TorznabCatType.TVHD, "TV 720p/i");
+
+            AddCategoryMapping(54, TorznabCatType.MoviesSD, "WEBRip");
+            AddCategoryMapping(59, TorznabCatType.MoviesWEBDL, "WEB-DL");
+            AddCategoryMapping(24, TorznabCatType.TVDocumentary, "Dokumentarci");
+
+            // Games
+            AddCategoryMapping(10, TorznabCatType.PCGames, "PC igre/ISO");
+            AddCategoryMapping(11, TorznabCatType.PCGames, "PC igre/Rips/Repack");
+            AddCategoryMapping(64, TorznabCatType.PCGames, "PC igre/Update & Patch");
+
+            // Music
+            AddCategoryMapping(46, TorznabCatType.AudioLossless, "Glasba/Flac");
+            AddCategoryMapping(8, TorznabCatType.AudioOther, "Glasba/Ostalo");
+            AddCategoryMapping(47, TorznabCatType.AudioMP3, "Glasba/Mp3");
+            AddCategoryMapping(8, TorznabCatType.AudioVideo, "Music DVD");
+            AddCategoryMapping(8, TorznabCatType.AudioVideo, "Videospoti");
+            AddCategoryMapping(21, TorznabCatType.AudioAudiobook, "AudioBook");
+            AddCategoryMapping(3, TorznabCatType.BooksEBook, "eKnjige");
+        }
+
+        public override async Task<IndexerConfigurationStatus> ApplyConfiguration(JToken configJson)
+        {
+            LoadValuesFromJson(configJson);
+
+            var pairs = new Dictionary<string, string>
+            {
+                { "user", configData.Username.Value },
+                { "pass", configData.Password.Value }
+            };
+
+            var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, string.Empty, false, null, null, true);
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("/user/logout"), () =>
+            {
+                var parser = new HtmlParser();
+                var dom = parser.ParseDocument(result.ContentString);
+                var errorMessage = dom.QuerySelector("#errLogin").TextContent.Trim(); // Prijava ni uspela! obvestilo
+                throw new ExceptionWithConfigData(errorMessage, configData);
+            });
+            return IndexerConfigurationStatus.RequiresTesting;
+        }
+
+        protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
+        {
+            var releases = new List<ReleaseInfo>();     //List of releases initialization
+            var searchString = query.GetQueryString();  //get search string from query
+
+            WebResult results = null;
+            var queryCollection = new NameValueCollection();
+            var catList = MapTorznabCapsToTrackers(query);     // map categories from query to indexer specific
+            var categ = string.Join(",", catList);
+
+            //create GET request - search URI
+            queryCollection.Add("q", searchString);
+            queryCollection.Add("cat", categ.TrimStart(','));
+
+            //c oncatenate base search url with query
+            var searchUrl = $"{SearchUrl}?{queryCollection.GetQueryString()}";
+
+            // log search URL
+            logger.Info(string.Format("Searh URL Partis_: {0}", searchUrl));
+
+            // add necessary headers
+            var header = new Dictionary<string, string>
+            {
+                { "X-requested-with", "XMLHttpRequest" }
+            };
+
+            // get results and follow redirect
+            results = await RequestWithCookiesAsync(searchUrl, referer: SearchUrl, headers: header);
+
+            // parse results
+            try
+            {
+                // successful search returns javascript code containing 'data' variable with actual torrent descriptions. 
+                // find this variable and extract its value
+                var resultDataJson = Regex.Match(results.ContentString, @"data( |=)*(?<json>\{.*\})").Groups["json"];
+
+                var resultsData = JsonConvert.DeserializeObject<dynamic>(resultDataJson.Value);
+
+                foreach (var torrent in resultsData.sets.torrent_list.data)
+                {
+                    var release = ParseRelease(torrent);
+                    if (release != null)
+                        releases.Add(release);
+                }
+            }
+            catch (Exception ex)
+            {
+                OnParseError(results.ContentString, ex);
+            }
+
+            return releases;
+        }
+
+        private ReleaseInfo ParseRelease(dynamic torrent)
+        {
+            /* Single torrent is represented with array:
+            [
+                600934, -- id
+                4571,   -- ?
+                1636450141, -- added timestamp
+                "No.Time.To.Die.2021.ENGSubs.REPACK.HDRip.",  --title
+                677, -- leechers
+                30, -- seeders
+                "NI ČAS ZA SMRT/ NOVI JAMES BOND | Akcijski | HDRip...", --description 
+                7, -- category
+                54.9014462385559, --downloads? scaled 0-100
+                "1.7 GB", -- size
+                "/img/ics/xvid.gif", --icon
+                "/torrent/image/600/600934/coverflow/james-bond.jpg" --thumbnail
+            ]
+            */
+            try
+            {
+                // initialize ReleaseInfo
+                var release = new ReleaseInfo
+                {
+                    MinimumRatio = 1,
+                    MinimumSeedTime = 0
+                };
+
+                // Get Category
+                release.Category = MapTrackerCatToNewznab(torrent[7].ToString());
+
+                // Title and torrent link
+                release.Title = torrent[3].ToString();
+                release.Details = new Uri($"{SiteLink}index.html#torrent/{torrent[0]}");
+                release.Guid = release.Details;
+
+                // Date of torrent creation                   
+                release.PublishDate = DateTimeUtil.UnixTimestampToDateTime((long)torrent[2]);
+
+                // Download link
+                release.Link = new Uri(($"{SiteLink}torrent/download/{torrent[0]}"));
+
+                // Various data - size, seeders, leechers, download count
+                release.Size = ReleaseInfo.GetBytes(torrent[9].ToString());
+                release.Seeders = ParseUtil.CoerceInt(torrent[4].ToString());
+                release.Peers = ParseUtil.CoerceInt(torrent[5].ToString()) + release.Seeders;
+                release.Grabs = (long)torrent[8];
+
+                // // Set download/upload factor
+                release.DownloadVolumeFactor = 1; //No way to determine if torrent is freeleech from single request.
+                release.UploadVolumeFactor = 1;
+
+                return release;
+            }
+            catch (Exception ex)
+            {
+                logger.Error(string.Format("{0}: Error while parsing torrent '{1}':\n\n{2}", Id, torrent, ex));
+                return null;
+            }
+        }
+    }
+}

--- a/src/Jackett.Common/Indexers/Partis.cs
+++ b/src/Jackett.Common/Indexers/Partis.cs
@@ -62,7 +62,7 @@ namespace Jackett.Common.Indexers
                    configData: new ConfigurationDataBasicLogin())
         {
             Encoding = Encoding.UTF8;
-            Language = "sl-sl";
+            Language = "sl-SL";
             Type = "private";
 
             // Blu Ray


### PR DESCRIPTION
Partis.si indexer was removed in https://github.com/Jackett/Jackett/commit/e86eda9ea3dfee9e078296ca08f9a7ef818566fa because tracker was unavailable since March 2021. Website has now been rebuilt and I have managed to reuse the majority of previous indexer implementation. 

Changes:

- Urls for login, logout, search and torrent download
- Username and password fields in login request
- Json is now returned and HTML parsing is not needed anymore

There are also some issues with the new indexer:

- No way to identify freeleech torrents from a single request. Indexer would have to make another request for each hit in search results
- Number of grabs is currently displayed on a 0-100 scale. I could not find a way to get the total number

This PR fixes https://github.com/Jackett/Jackett/issues/1596