### PR TITLE
Fix Partis login check

### DIFF
--- a/src/Jackett.Common/Indexers/Partis.cs
+++ b/src/Jackett.Common/Indexers/Partis.cs
@@ -132,11 +132,9 @@ namespace Jackett.Common.Indexers
             };
 
             var result = await RequestLoginAndFollowRedirect(LoginUrl, pairs, string.Empty, false, null, null, true);
-            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.ContentString.Contains("/user/logout"), () =>
+            await ConfigureIfOK(result.Cookies, result.ContentString != null && result.Cookies.Contains("udata"), () =>
             {
-                var parser = new HtmlParser();
-                var dom = parser.ParseDocument(result.ContentString);
-                var errorMessage = dom.QuerySelector("#errLogin").TextContent.Trim(); // Prijava ni uspela! obvestilo
+                var errorMessage = "Login failed. Invalid username or password.";
                 throw new ExceptionWithConfigData(errorMessage, configData);
             });
             return IndexerConfigurationStatus.RequiresTesting;


### PR DESCRIPTION
Partis.si has changed login response which caused ConfigureIfOK() to not detect successful logins. Instead of logout link we now check for udata cookie, which is only returned on successful login. Generic error is returned on failed login - same as on website.

Fixes #12558