### PR TITLE
Add various musl libc targets to azure pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -78,6 +78,27 @@ stages:
               runtime: linux-arm64
               archiveType: tar
               artifactName: Jackett.Binaries.LinuxARM64.tar.gz
+            LinuxMuslAMDx64:
+              buildDescription: Linux musl AMD x64
+              imageName: ubuntu-20.04
+              framework: $(netCoreFramework)
+              runtime: linux-musl-x64
+              archiveType: tar
+              artifactName: Jackett.Binaries.LinuxMuslAMDx64.tar.gz
+            LinuxMuslARM32:
+              buildDescription: Linux musl ARM32
+              imageName: ubuntu-20.04
+              framework: $(netCoreFramework)
+              runtime: linux-musl-arm
+              archiveType: tar
+              artifactName: Jackett.Binaries.LinuxMuslARM32.tar.gz
+            LinuxMuslARM64:
+              buildDescription: Linux musl ARM64
+              imageName: ubuntu-20.04
+              framework: $(netCoreFramework)
+              runtime: linux-musl-arm64
+              archiveType: tar
+              artifactName: Jackett.Binaries.LinuxMuslARM64.tar.gz
         pool:
           vmImage: $(imageName)
         displayName: ${{ variables.buildDescription }}


### PR DESCRIPTION
## Needs
Currently there isn't a prebuilt release file for Alpine/Musl which makes it impossible to run the dotnet-core version of the application in an Alpine Linux container.

This simple addition to the pipeline generates those build files so that appropriate containers can be made by maintainers using Alpine containers.

## Alternative Solutions
The alternative solution would be to build a non-self-contained version of this for dotnet-core (and potentially drop the mono solution in the future) allowing it to be run a dotnet-alpine container.

This is less desirable as running self contained is generally better and much simpler from a container maintainer perspective, but would result in fewer platform specific images if that's a worry.