### PR TITLE
assorted: remove unrelated results

### DIFF
--- a/src/Jackett.Common/Definitions/arabp2p.yml
+++ b/src/Jackett.Common/Definitions/arabp2p.yml
@@ -126,6 +126,8 @@ search:
 
   rows:
     selector: table.torrent tr.torrent
+    filters:
+      - name: andmatch
 
   fields:
     category:

--- a/src/Jackett.Common/Definitions/bigfangroup.yml
+++ b/src/Jackett.Common/Definitions/bigfangroup.yml
@@ -101,6 +101,8 @@ search:
 
   rows:
     selector: table > tbody#highlighted > tr:has(a[href^="browse.php?cat="])
+    filters:
+      - name: andmatch
 
   fields:
     category:

--- a/src/Jackett.Common/Definitions/bitsexy.yml
+++ b/src/Jackett.Common/Definitions/bitsexy.yml
@@ -119,8 +119,14 @@ search:
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
 
+  keywordsfilters:
+    - name: re_replace
+      args: ["(\\w+)", " +$1"] # prepend + to each word
+
   rows:
     selector: div.torrentrow:has(a[href^="download.php?torrent="])
+    filters:
+      - name: andmatch
 
   fields:
     category:

--- a/src/Jackett.Common/Definitions/bluesbrothers.yml
+++ b/src/Jackett.Common/Definitions/bluesbrothers.yml
@@ -119,6 +119,8 @@ search:
 
   rows:
     selector: table.table-bordered tr:has(a[href^="download.php?torrent="])
+    filters:
+      - name: andmatch
 
   fields:
     category:

--- a/src/Jackett.Common/Definitions/eniahd.yml
+++ b/src/Jackett.Common/Definitions/eniahd.yml
@@ -155,6 +155,8 @@ search:
 
   rows:
     selector: tr[id^="tor_"]:has(a[href^="./dl.php?id="])
+    filters:
+      - name: andmatch
 
   fields:
     title:

--- a/src/Jackett.Common/Definitions/finelite.yml
+++ b/src/Jackett.Common/Definitions/finelite.yml
@@ -98,6 +98,8 @@ search:
 
   rows:
     selector: table.main > tbody >  tr:has(a[href^="/lataa.php/"])
+    filters:
+      - name: andmatch
 
   fields:
     category:

--- a/src/Jackett.Common/Definitions/hqsource.yml
+++ b/src/Jackett.Common/Definitions/hqsource.yml
@@ -68,7 +68,8 @@ search:
     search: "{{ .Keywords }}"
     incldead: 1
     polish: 0
-    blah: 0
+    # 0 both, 1 name, 2 desc
+    blah: 1
 
   rows:
     selector: table#line > tbody > tr:has(a[href^="details.php?id="])

--- a/src/Jackett.Common/Definitions/rintor.yml
+++ b/src/Jackett.Common/Definitions/rintor.yml
@@ -150,6 +150,8 @@ search:
 
   rows:
     selector: tr[id^="tor_"]
+    filters:
+      - name: andmatch
 
   fields:
     category:

--- a/src/Jackett.Common/Definitions/sktorrent-org.yml
+++ b/src/Jackett.Common/Definitions/sktorrent-org.yml
@@ -119,6 +119,8 @@ search:
 
   rows:
     selector: tr.t-row
+    filters:
+      - name: andmatch
 
   fields:
     category:

--- a/src/Jackett.Common/Definitions/theleachzone.yml
+++ b/src/Jackett.Common/Definitions/theleachzone.yml
@@ -111,6 +111,8 @@ search:
 
   rows:
     selector: table.table-bordered tr:has(a[href^="download.php?torrent="])
+    filters:
+      - name: andmatch
 
   fields:
     category:

--- a/src/Jackett.Common/Definitions/torlook.yml
+++ b/src/Jackett.Common/Definitions/torlook.yml
@@ -53,6 +53,8 @@ search:
 
   rows:
     selector: div.webResult:has(a.magneto[data-src])
+    filters:
+      - name: andmatch
 
   fields:
     category:

--- a/src/Jackett.Common/Definitions/torrentoyunindir.yml
+++ b/src/Jackett.Common/Definitions/torrentoyunindir.yml
@@ -28,6 +28,8 @@ search:
 
   rows:
     selector: div.moviefilm
+    filters:
+      - name: andmatch
 
   fields:
     category:

--- a/src/Jackett.Common/Definitions/wdt.yml
+++ b/src/Jackett.Common/Definitions/wdt.yml
@@ -123,8 +123,14 @@ search:
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
 
+  keywordsfilters:
+    - name: re_replace
+      args: ["(\\w+)", " +$1"] # prepend + to each word
+
   rows:
     selector: table.table-bordered tr:has(a[href^="download.php?torrent="])
+    filters:
+      - name: andmatch
 
   fields:
     category:

--- a/src/Jackett.Common/Definitions/zomb.yml
+++ b/src/Jackett.Common/Definitions/zomb.yml
@@ -81,6 +81,8 @@ search:
 
   rows:
     selector: "table[style=\"border: solid #000000 1px;\"] > tbody > tr:has(a[href^=\"takedownload.php?id=\"])"
+    filters:
+      - name: andmatch
 
   fields:
     category:


### PR DESCRIPTION
Looking a second pair of eyes because it's a bit of a mix of indexers and solutions, but all for the same problem. See if I've missed a better fix somewhere.

**arabp2p** - Site only uses 'any words' search, no way I can see to force 'all words' - no site setting, prepending words with `+` is ignored, surrounding words or whole phrase with `"` returns no results, replacing whitespaces with `.` is ignored.

**bigfangroup** - Site seems to ignore keywords with 3 characters or fewer, no way I can see to change it - no site setting, prepending words with `+` is ignored, surrounding words with `"` returns no results, surrounding whole phrase with `"` uses 'whole phrase' search, replacing whitespaces with `.` is ignored.

**bitsexy** - Site's 'search help' lies, prepending with `+` does not make a word required, only preferred (which is supposed to be the default search, but isn't). That's still useful to us, as it moves matches to the top of the first page, but andmatch is still required - surrounding words with `"` is ignored, surrounding whole phrase with `"` uses 'whole phrase' search, replacing whitespaces with `.` is ignored. Site searches both titles and descriptions, no option to change this.

**bluebrothers** - Prepending with `+` works but keywords with 3 characters or fewer are ignored.

**eniahd** - Site seems to ignore keywords with 3 characters or fewer.

**finelite** - Bit of a weird one. Despite being set to search 'name only', if no results would be returned then the site seems to instead use an 'all word' description search (whereas a normal 'description only' search is 'any word').

**hqsource** - Switch to site's name search.

**rintor** - Site seems to ignore keywords with 3 characters or fewer.

**sktorrent-org** - Site seems to ignore keywords with 3 characters or fewer and some common words.

**theleachzone** - Prepending with `+` works but keywords with 3 characters or fewer are ignored.

**torlook** - At least one of the trackers it uses (booktracker) ignores keywords with 3 characters or fewer.

**torrentoyunindir** - Site searches names and descriptions, no way to change it.

**wdt** - Needs to prepend `+` to perform 'all word' search, but ignores keywords with 3 characters or fewer.

**zomb** - Site searches names and descriptions, no way to change it.

---

**superbits** - also needs an andmatch filter, but is awaiting #12464