### PR TITLE
bitcityreloaded: update indexer

### DIFF
--- a/src/Jackett.Common/Indexers/BitCityReloaded.cs
+++ b/src/Jackett.Common/Indexers/BitCityReloaded.cs
@@ -14,6 +14,7 @@ using Jackett.Common.Utils;
 using Jackett.Common.Utils.Clients;
 using Newtonsoft.Json.Linq;
 using NLog;
+using static Jackett.Common.Models.IndexerConfig.ConfigurationData;
 
 namespace Jackett.Common.Indexers
 {

--- a/src/Jackett.Common/Indexers/BitCityReloaded.cs
+++ b/src/Jackett.Common/Indexers/BitCityReloaded.cs
@@ -34,7 +34,7 @@ namespace Jackett.Common.Indexers
             IProtectionService ps, ICacheService cs)
             : base(id: "bitcityreloaded",
                    name: "Bit-City Reloaded",
-                   description: "A German general tracker.",
+                   description: "Bit-City Reloaded is a GERMAN Private Torrent Tracker for MOVIES / TV / GENERAL",
                    link: "https://bc-reloaded.net/",
                    caps: new TorznabCapabilities
                    {
@@ -60,47 +60,58 @@ namespace Jackett.Common.Indexers
                    logger: l,
                    p: ps,
                    cacheService: cs,
-                   configData: new ConfigurationDataBasicLoginWithRSSAndDisplay("Only the results from the first search result page are shown, adjust your profile settings to show a reasonable amount (it looks like there's no maximum)."))
+                   configData: new ConfigurationDataBasicLoginWithRSSAndDisplay("For best results, change the <b>Anzahl der Torrents beim Durchsuchen:</b> setting to <b>100</b> on your account profile."))
         {
             Encoding = Encoding.GetEncoding("iso-8859-1");
             Language = "de-DE";
             Type = "private";
 
-            AddCategoryMapping(1, TorznabCatType.Other, "Other/Anderes");
-            AddCategoryMapping(2, TorznabCatType.TVAnime, "TV/Anime");
+            var sort = new ConfigurationData.SingleSelectConfigurationItem("Sort requested from site", new Dictionary<string, string>
+                {
+                    {"added", "created"},
+                    {"size", "size"},
+                    {"seeders", "seeders"},
+                    {"name", "title"}
+                })
+            { Value = "added" };
+            configData.AddDynamic("sort", sort);
+
+            var order = new ConfigurationData.SingleSelectConfigurationItem("Order requested from site", new Dictionary<string, string>
+                {
+                    {"desc", "desc"},
+                    {"asc", "asc"},
+                })
+            { Value = "desc" };
+            configData.AddDynamic("order", order);
+
+            AddCategoryMapping(1, TorznabCatType.Other, "Anderes");
             AddCategoryMapping(34, TorznabCatType.PC, "Appz/Linux");
             AddCategoryMapping(35, TorznabCatType.PCMac, "Appz/Mac");
             AddCategoryMapping(36, TorznabCatType.PC, "Appz/Other");
-            AddCategoryMapping(20, TorznabCatType.PC, "Appz/Win");
-            AddCategoryMapping(3, TorznabCatType.TVDocumentary, "TV/Doku/Alle Formate");
-            AddCategoryMapping(4, TorznabCatType.Books, "EBooks");
-            AddCategoryMapping(12, TorznabCatType.ConsolePS4, "Games/PS & PSx");
-            AddCategoryMapping(11, TorznabCatType.ConsoleNDS, "Games/Nintendo DS");
+            AddCategoryMapping(20, TorznabCatType.PC0day, "Appz/Win");
+            AddCategoryMapping(4, TorznabCatType.BooksEBook, "EBooks");
             AddCategoryMapping(10, TorznabCatType.PCGames, "Games/PC");
-            AddCategoryMapping(13, TorznabCatType.ConsoleWii, "Games/Wii");
-            AddCategoryMapping(14, TorznabCatType.ConsoleXBox, "Games/Xbox & 360");
-            AddCategoryMapping(15, TorznabCatType.PCMobileOther, "Handy & PDA");
+            AddCategoryMapping(15, TorznabCatType.PCMobileAndroid, "Handy & PDA");
             AddCategoryMapping(16, TorznabCatType.AudioAudiobook, "Hörspiel/Hörbuch");
-            AddCategoryMapping(30, TorznabCatType.Other, "Other/International");
-            AddCategoryMapping(17, TorznabCatType.Other, "Other/MegaPack");
+            AddCategoryMapping(30, TorznabCatType.MoviesForeign, "International");
             AddCategoryMapping(43, TorznabCatType.Movies3D, "Movie/3D");
-            AddCategoryMapping(5, TorznabCatType.MoviesDVD, "Movie/DVD/R");
             AddCategoryMapping(6, TorznabCatType.MoviesHD, "Movie/HD 1080p");
             AddCategoryMapping(7, TorznabCatType.MoviesHD, "Movie/HD 720p");
-            AddCategoryMapping(32, TorznabCatType.MoviesOther, "Movie/TVRip");
-            AddCategoryMapping(9, TorznabCatType.MoviesOther, "Movie/XviD,DivX,h264");
-            AddCategoryMapping(26, TorznabCatType.XXX, "XXX/Movie");
-            AddCategoryMapping(41, TorznabCatType.XXXOther, "XXX/Movie/Other");
-            AddCategoryMapping(42, TorznabCatType.XXXPack, "XXX/Movie/Pack");
-            AddCategoryMapping(45, TorznabCatType.MoviesHD, "Movies/4K");
+            AddCategoryMapping(17, TorznabCatType.MoviesOther, "Movie/MegaPack");
+            AddCategoryMapping(9, TorznabCatType.MoviesSD, "Movie/SD");
+            AddCategoryMapping(26, TorznabCatType.XXX, "Movie/XXX");
+            AddCategoryMapping(41, TorznabCatType.XXXOther, "Movie/XXX/Other");
+            AddCategoryMapping(42, TorznabCatType.XXXPack, "Movie/XXX/Pack");
+            AddCategoryMapping(45, TorznabCatType.MoviesUHD, "Movies/4K");
             AddCategoryMapping(33, TorznabCatType.MoviesBluRay, "Movies/BluRay");
-            AddCategoryMapping(18, TorznabCatType.Audio, "Musik");
             AddCategoryMapping(19, TorznabCatType.AudioVideo, "Musik Videos");
-            AddCategoryMapping(44, TorznabCatType.TVOther, "Serie/DVD/R");
-            AddCategoryMapping(22, TorznabCatType.TVHD, "Serie/HDTV");
+            AddCategoryMapping(18, TorznabCatType.Audio, "Musik/MP3/Flac");
+            AddCategoryMapping(13, TorznabCatType.ConsoleWiiU, "Nintendo");
+            AddCategoryMapping(12, TorznabCatType.ConsolePS4, "Playstation");
+            AddCategoryMapping(22, TorznabCatType.TVHD, "Serie/HD");
             AddCategoryMapping(38, TorznabCatType.TV, "Serie/Pack");
-            AddCategoryMapping(23, TorznabCatType.TVOther, "Serie/XviD,DivX,h264");
-            AddCategoryMapping(25, TorznabCatType.TVSport, "TV/Sport");
+            AddCategoryMapping(23, TorznabCatType.TVSD, "Serie/SD");
+            AddCategoryMapping(25, TorznabCatType.TVSport, "Sport");
         }
 
         public override async Task<IndexerConfigurationStatus> ApplyConfiguration(JToken configJson)
@@ -132,12 +143,9 @@ namespace Jackett.Common.Indexers
             var searchUrl = BrowseUrl;
             var queryCollection = new NameValueCollection
             {
-                { "showsearch", "0" },
+                { "showsearch", "1" },
                 { "incldead", "1" },
-                { "blah", "0" },
-                { "team", "0" },
-                { "orderby", "added" },
-                { "sort", "desc" }
+                { "blah", "0" }
             };
 
             if (!string.IsNullOrWhiteSpace(searchString))
@@ -145,6 +153,10 @@ namespace Jackett.Common.Indexers
 
             foreach (var cat in MapTorznabCapsToTrackers(query))
                 queryCollection.Add("c" + cat, "1");
+
+            queryCollection.Add("orderby", ((SingleSelectConfigurationItem)configData.GetDynamic("sort")).Value);
+
+            queryCollection.Add("sort", ((SingleSelectConfigurationItem)configData.GetDynamic("order")).Value);
 
             searchUrl += "?" + queryCollection.GetQueryString();
 
@@ -173,6 +185,8 @@ namespace Jackett.Common.Indexers
                         var flag = flagImg.GetAttribute("src").Replace("pic/torrent_", "").Replace(".gif", "").ToUpper();
                         if (flag == "OU")
                             release.DownloadVolumeFactor = 0;
+                        if (flag == "2U")
+                            release.UploadVolumeFactor = 2;
                         else
                             flags.Add(flag);
                     }
@@ -221,4 +235,3 @@ namespace Jackett.Common.Indexers
         }
     }
 }
-


### PR DESCRIPTION
I had tried to convert this to yaml, but dates would fail for most but not all results, for no reason I could see:

> Error while parsing DateTime "15.04.2021 16:08:21 +01:00", using layout "02.01.2006 15:04:05 -07:00" (dd.MM.yyyy HH:mm:ss zzz): String '15.04.2021 16:08:21 +01:00' was not recognized as a valid DateTime.

Size and leechers would also seemingly randomly not work for individual results, and a selector which should have worked for leechers just wouldn't. No idea what was going on, but the C# indexer was fine.

In case anyone wants to give it a shot:

<details>
<summary>bitcityreloaded.yml</summary>

```yml
---
id: bitcityreloaded
name: Bit-City Reloaded
description: "Bit-City Reloaded is a GERMAN Private Torrent Tracker for MOVIES / TV / GENERAL"
language: de-DE
type: private
encoding: ISO-8859-1
links:
  - https://bc-reloaded.net/

caps:
  categorymappings:
    - {id: 1, cat: Other, desc: "Anderes"}
    - {id: 34, cat: PC, desc: "Appz/Linux"}
    - {id: 35, cat: PC/Mac, desc: "Appz/Mac"}
    - {id: 36, cat: PC, desc: "Appz/Other"}
    - {id: 20, cat: PC/0day, desc: "Appz/Win"}
    - {id: 4, cat: Books/EBook, desc: "EBooks"}
    - {id: 10, cat: PC/Games, desc: "Games/PC"}
    - {id: 15, cat: PC/Mobile-Android, desc: "Handy & PDA"}
    - {id: 16, cat: Audio/Audiobook, desc: "Hörspiel/Hörbuch"}
    - {id: 30, cat: Movies/Foreign, desc: "International"}
    - {id: 43, cat: Movies/3D, desc: "Movie/3D"}
    - {id: 6, cat: Movies/HD, desc: "Movie/HD 1080p"}
    - {id: 7, cat: Movies/HD, desc: "Movie/HD 720p"}
    - {id: 17, cat: Movies/Other, desc: "Movie/MegaPack"}
    - {id: 9, cat: Movies/SD, desc: "Movie/SD"}
    - {id: 26, cat: XXX, desc: "Movie/XXX"}
    - {id: 41, cat: XXX/Other, desc: "Movie/XXX/Other"}
    - {id: 42, cat: XXX/Pack, desc: "Movie/XXX/Pack"}
    - {id: 45, cat: Movies/UHD, desc: "Movies/4K"}
    - {id: 33, cat: Movies/BluRay, desc: "Movies/BluRay"}
    - {id: 19, cat: Audio/Video, desc: "Musik Videos"}
    - {id: 18, cat: Audio, desc: "Musik/MP3/Flac"}
    - {id: 13, cat: Console/WiiU, desc: "Nintendo"}
    - {id: 12, cat: Console/PS4, desc: "Playstation"}
    - {id: 22, cat: TV/HD, desc: "Serie/HD"}
    - {id: 38, cat: TV, desc: "Serie/Pack"}
    - {id: 23, cat: TV/SD, desc: "Serie/SD"}
    - {id: 25, cat: TV/Sport, desc: "Sport"}

  modes:
    search: [q]
    tv-search: [q, season, ep]
    movie-search: [q]
    music-search: [q]
    book-search: [q]

settings:
  - name: username
    type: text
    label: Username
  - name: password
    type: password
    label: Password
  - name: freeleech
    type: checkbox
    label: Filter freeleech only
    default: false
  - name: sort
    type: select
    label: Sort requested from site
    default: added
    options:
      added: created
      seeds: seeders
      size: size
      name: title
  - name: type
    type: select
    label: Order requested from site
    default: desc
    options:
      desc: desc
      asc: asc
  - name: info_tpp
    type: info
    label: Results Per Page
    default: For best results, change the <b>Anzahl der Torrents beim Durchsuchen</b> setting to <b>100</b> on your account profile.

login:
  path: login/
  method: form
  form: form[action="/login/index.php"]
  inputs:
    username: "{{ .Config.username }}"
    password: "{{ .Config.password }}"
  error:
    - selector: div[id="login_error"]
  test:
    path: index.php
    selector: a[href="logout.php"]

search:
  paths:
    # https://bc-reloaded.net/uebersicht.php?c7=1&c17=1&showsearch=1&search=2021+720p&blah=0&incldead=1&orderby=added&sort=desc
    - path: uebersicht.php
  inputs:
    $raw: "{{ range .Categories }}c{{.}}=1&{{end}}"
    showsearch: 1
    search: "{{ .Keywords }}"
    # 0 name, 1 descr, 2 both
    blah: 0
    # 0 active, 1 incldead, 2 onlydead
    incldead: 1
    orderby: "{{ .Config.sort }}"
    sort: "{{ .Config.type }}"
    # site does not support imdbid searching or display imdb links in results.

  rows:
    selector: "table.tableinborder tbody tr:has(a[href^=\"download.php\"]){{ if .Config.freeleech }}:has(img[src$=\"torrent_ou.gif\"]){{ else }}{{ end }}"

  fields:
    category:
      selector: a[href^="uebersicht.php?cat="]
      attribute: href
      filters:
        - name: querystring
          args: cat
    title:
      selector: a[href^="details.php?id="]
    details:
      selector: a[href^="details.php?id="]
      attribute: href
    download:
      selector: a[href^="download.php"]
      attribute: href
    date:
      selector: tr:nth-child(2) td:nth-child(5)
      filters:
        - name: append
          args: " +01:00" # CET
        - name: dateparse
          args: "02.01.2006 15:04:05 -07:00"
    size:
      selector: tr:nth-child(2) td:nth-child(1) b:nth-child(1)
#      filters:
#        - name: regexp
#          args: "(.+?) in"
    files:
      selector: tr:nth-child(2) td:nth-child(1) b:nth-child(2)
    grabs:
      selector: tr:nth-child(2) td:nth-child(3) b:nth-child(1)
    seeders:
      selector: tr:nth-child(2) td:nth-child(2) b:nth-child(1)
#      filters:
#        - name: regexp
#          args: "(\\d+) Seeder"
    leechers:
      selector: tr:nth-child(2) td:nth-child(2) # b:nth-child(2)
      filters:
        - name: regexp
          args: "(\\d+) Leecher"
    downloadvolumefactor:
      case:
        img[src$="torrent_ou.gif"]: 0
        "*": 1
    uploadvolumefactor:
      case:
        img[src$="torrent_2u.gif"]: 0
        "*": 1
    minimumratio:
      text: 0.7
    minimumseedtime:
      # 2 days (as seconds = 2 x 24 x 60 x 60)
      text: 172800
# engine n/a
```
</details>