### PR TITLE
[Feature] Copy API key to clipboard button

### DIFF
--- a/src/Jackett.Common/Content/custom.js
+++ b/src/Jackett.Common/Content/custom.js
@@ -1367,6 +1367,13 @@ function bindUIButtons() {
         return false;
     });
 
+    $('#api-key-copy-button').click(function () {
+        var apiKey = api.key;
+        if (apiKey !== null || apiKey !== undefined) {
+            copyToClipboard(apiKey);
+        }
+    });
+
     $('#jackett-add-indexer').click(function () {
         $("#modals").empty();
         displayUnconfiguredIndexersList();

--- a/src/Jackett.Common/Content/index.html
+++ b/src/Jackett.Common/Content/index.html
@@ -43,6 +43,9 @@
         <div class="pull-right jackett-apikey">
             <span class="input-header">API Key: </span>
             <input id="api-key-input" class="form-control input-right" type="text" value="" placeholder="API Key" readonly="">
+            <button id="api-key-copy-button" title="Copy API Key to clipboard" class="btn btn-primary btn-xs">
+                <span class="glyphicon glyphicon-copy" aria-hidden="true"></span>
+            </button>
         </div>
         <hr />
 
@@ -743,6 +746,6 @@
     </script>
 
     <script type="text/javascript" src="../libs/api.js?changed=2017083001"></script>
-    <script type="text/javascript" src="../custom.js?changed=2022012301"></script>
+    <script type="text/javascript" src="../custom.js?changed=2022012602"></script>
 </body>
 </html>


### PR DESCRIPTION
Hello everyone,

This PR just adds a small _Copy API key to clipboard_ button right next to the API key.
This uses the function copyToClipboard that's already in custom.js and that triggers that nice green success notification.
If for some reason the API key is not set then it wont copy anything to the clipboard.

I also invalidated the cache for custom.js in index.html by putting today's date.

Please find below some screenshots:
![image](https://user-images.githubusercontent.com/21265300/151139788-65dced63-a2b1-4564-b525-81c330007c94.png)
![image](https://user-images.githubusercontent.com/21265300/151140501-fe9d9c39-be28-41f1-9d46-1189e8f636cd.png)
![image](https://user-images.githubusercontent.com/21265300/151140438-67eef6de-7462-4d51-9f22-c361844b181a.png)

