### PR TITLE
webui: fix baseurloverride

### DIFF
--- a/src/Jackett.Server/Controllers/ServerConfigurationController.cs
+++ b/src/Jackett.Server/Controllers/ServerConfigurationController.cs
@@ -93,12 +93,17 @@ namespace Jackett.Server.Controllers
             }
 
             var baseUrlOverride = config.baseurloverride;
-            if (baseUrlOverride != null)
+            if (baseUrlOverride != serverConfig.BaseUrlOverride)
             {
                 baseUrlOverride = baseUrlOverride.TrimEnd('/');
-                if (!Uri.TryCreate(config.baseurloverride, UriKind.Absolute, out var uri)
+                if (string.IsNullOrWhiteSpace(baseUrlOverride))
+                    baseUrlOverride = "";
+                else if (!Uri.TryCreate(baseUrlOverride, UriKind.Absolute, out var uri)
                     || !(uri.Scheme == Uri.UriSchemeHttp || uri.Scheme == Uri.UriSchemeHttps))
                     throw new Exception("Base URL Override is invalid. Example: http://jackett:9117");
+
+                serverConfig.BaseUrlOverride = baseUrlOverride;
+                configService.SaveConfig(serverConfig);
             }
 
             var cacheEnabled = config.cache_enabled;


### PR DESCRIPTION
https://github.com/Jackett/Jackett/pull/12882#issuecomment-1024712443

Tested, but worth a second look.

The original version of #12882 was tested and worked fine, but my last minute change to use `uri.Scheme` wasn't and didn't.