### PR TITLE
IPTorrents fixes for Cloudflare

### DIFF
--- a/src/Jackett.Common/Indexers/IPTorrents.cs
+++ b/src/Jackett.Common/Indexers/IPTorrents.cs
@@ -49,7 +49,7 @@ namespace Jackett.Common.Indexers
             "https://iptorrents.eu/"
         };
 
-        private new ConfigurationDataCookie configData => (ConfigurationDataCookie)base.configData;
+        private new ConfigurationDataCookieCaptcha configData => (ConfigurationDataCookieCaptcha)base.configData;
 
         public IPTorrents(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
@@ -81,7 +81,7 @@ namespace Jackett.Common.Indexers
                    logger: l,
                    p: ps,
                    cacheService: cs,
-                   configData: new ConfigurationDataCookie("For best results, change the 'Torrents per page' option to 100 and check the 'Torrents - Show files count' option in the website Settings."))
+                   configData: new ConfigurationDataCookieCaptcha("For best results, change the 'Torrents per page' option to 100 and check the 'Torrents - Show files count' option in the website Settings."))
         {
             Encoding = Encoding.UTF8;
             Language = "en-US";
@@ -177,6 +177,7 @@ namespace Jackett.Common.Indexers
             LoadValuesFromJson(configJson);
 
             CookieHeader = configData.Cookie.Value;
+            
             try
             {
                 var results = await PerformQuery(new TorznabQuery());
@@ -190,7 +191,7 @@ namespace Jackett.Common.Indexers
             catch (Exception e)
             {
                 IsConfigured = false;
-                throw new Exception("Your cookie did not work: " + e.Message);
+                throw new Exception("Your cookie did not work, make sure the user agent matches your computer: " + e.Message);
             }
         }
 
@@ -199,6 +200,15 @@ namespace Jackett.Common.Indexers
             var releases = new List<ReleaseInfo>();
 
             var qc = new NameValueCollection();
+
+
+            Dictionary<string,string> headers = null;
+
+            if (!string.IsNullOrEmpty(configData.UserAgent.Value)) 
+            {
+                headers = new Dictionary<string, string>();
+                headers.Add("User-Agent", configData.UserAgent.Value);
+            }
 
             if (query.IsImdbQuery)
                 qc.Add("q", query.ImdbID);
@@ -214,7 +224,7 @@ namespace Jackett.Common.Indexers
             qc.Add("o", ((SingleSelectConfigurationItem)configData.GetDynamic("sort")).Value);
 
             var searchUrl = SearchUrl + "?" + qc.GetQueryString();
-            var response = await RequestWithCookiesAndRetryAsync(searchUrl, referer: SearchUrl);
+            var response = await RequestWithCookiesAndRetryAsync(searchUrl, referer: SearchUrl, headers: headers);
             var results = response.ContentString;
 
             if (results == null || !results.Contains("/lout.php"))

--- a/src/Jackett.Common/Indexers/IPTorrents.cs
+++ b/src/Jackett.Common/Indexers/IPTorrents.cs
@@ -49,7 +49,7 @@ namespace Jackett.Common.Indexers
             "https://iptorrents.eu/"
         };
 
-        private new ConfigurationDataCookieCaptcha configData => (ConfigurationDataCookieCaptcha)base.configData;
+        private new ConfigurationDataCookieUA configData => (ConfigurationDataCookieUA)base.configData;
 
         public IPTorrents(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
@@ -81,7 +81,7 @@ namespace Jackett.Common.Indexers
                    logger: l,
                    p: ps,
                    cacheService: cs,
-                   configData: new ConfigurationDataCookieCaptcha("For best results, change the 'Torrents per page' option to 100 and check the 'Torrents - Show files count' option in the website Settings."))
+                   configData: new ConfigurationDataCookieUA("For best results, change the 'Torrents per page' option to 100 and check the 'Torrents - Show files count' option in the website Settings."))
         {
             Encoding = Encoding.UTF8;
             Language = "en-US";

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataCookieCaptcha.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataCookieCaptcha.cs
@@ -1,0 +1,24 @@
+namespace Jackett.Common.Models.IndexerConfig
+{
+    public class ConfigurationDataCookieCaptcha : ConfigurationData
+    {
+        public StringConfigurationItem Cookie { get; private set; }
+        public DisplayInfoConfigurationItem CookieInstructions { get; private set; }
+        public StringConfigurationItem UserAgent { get; private set; }
+        public DisplayInfoConfigurationItem UserAgentInstructions { get; private set; }
+        public DisplayInfoConfigurationItem Instructions { get; private set; }
+
+        public ConfigurationDataCookieCaptcha(string instructionMessageOptional = null)
+        {
+            Cookie = new StringConfigurationItem("Cookie");
+            CookieInstructions = new DisplayInfoConfigurationItem("Cookie Instructions",
+            "Please enter the cookie for the site manually. <a href=\"https://github.com/Jackett/Jackett/wiki/Finding-cookies\" target=\"_blank\">See here</a> on how get the cookies." +
+            "<br>Example cookie header (usually longer than this):<br><code>PHPSESSID=8rk27odm; ipsconnect_63ad9c=1; more_stuff=etc;</code>");
+            UserAgent = new StringConfigurationItem("User-Agent");
+            UserAgentInstructions = new DisplayInfoConfigurationItem("User Agent Instructions", 
+            "<ol><li>From the same place you fetched the cookie,<li>Find <b>'user-agent:'</b> in the <b>Request Headers</b> section<li><b>Select</b>" + 
+            "and <b>Copy</b> the whole user-agent string <i>(everything after 'user-agent: ')</i> and <b>Paste</b> here.</ol>");
+            Instructions = new DisplayInfoConfigurationItem("", instructionMessageOptional);
+        }
+    }
+}

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataCookieUA.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataCookieUA.cs
@@ -1,6 +1,6 @@
 namespace Jackett.Common.Models.IndexerConfig
 {
-    public class ConfigurationDataCookieCaptcha : ConfigurationData
+    public class ConfigurationDataCookieUA : ConfigurationData
     {
         public StringConfigurationItem Cookie { get; private set; }
         public DisplayInfoConfigurationItem CookieInstructions { get; private set; }
@@ -8,7 +8,7 @@ namespace Jackett.Common.Models.IndexerConfig
         public DisplayInfoConfigurationItem UserAgentInstructions { get; private set; }
         public DisplayInfoConfigurationItem Instructions { get; private set; }
 
-        public ConfigurationDataCookieCaptcha(string instructionMessageOptional = null)
+        public ConfigurationDataCookieUA(string instructionMessageOptional = null)
         {
             Cookie = new StringConfigurationItem("Cookie");
             CookieInstructions = new DisplayInfoConfigurationItem("Cookie Instructions",


### PR DESCRIPTION
Recently I noticed that Jackett had stopped working for me.  After some research I noticed that it was simply from a security measure that had been put in place.  This added a field to the cookie and required the user agent to be the same.  Many other sites have been doing the same so I updated the code for IPTorrents to simply do the same.