### PR TITLE
Add certificate hash for tasmanit.es

### DIFF
--- a/src/Jackett.Common/Definitions/tasmanit.yml
+++ b/src/Jackett.Common/Definitions/tasmanit.yml
@@ -7,6 +7,8 @@ type: private
 encoding: UTF-8
 links:
   - https://tasmanit.es/
+certificates:
+  - 4325e8f1f13f6074f2bed6a6186fe183791ab32d # expired 24 Jan 2022
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/tasmanit.yml
+++ b/src/Jackett.Common/Definitions/tasmanit.yml
@@ -8,7 +8,7 @@ encoding: UTF-8
 links:
   - https://tasmanit.es/
 certificates:
-  - 4325e8f1f13f6074f2bed6a6186fe183791ab32d # expired 24 Jan 2022
+  - 23C30AC9655A8A7351A549538062B8C6B0D01A78 # expired 24 Jan 2022
 
 caps:
   categorymappings:


### PR DESCRIPTION
Tasmanit.es certificate expired on 24 Jan 2022