### PR TITLE
Add DisableRootWarning environment variable

### DIFF
--- a/src/Jackett.Server/Services/ServerService.cs
+++ b/src/Jackett.Server/Services/ServerService.cs
@@ -272,7 +272,7 @@ namespace Jackett.Server.Services
 
             try
             {
-                if (Environment.UserName == "root")
+                if (Environment.UserName == "root" && String.IsNullOrEmpty(Environment.GetEnvironmentVariable("DisableRootWarning")))
                 {
                     var notice = "Jackett is running with root privileges. You should run Jackett as an unprivileged user.";
                     notices.Add(notice);


### PR DESCRIPTION
Allow users to disable "Jackett is running with root privileges..." warning for sandboxed environments (rootless containers, etc) with the DisableRootWarning environment variable. Addresses #12938