### PR TITLE
assorted c#: remove . from keywords. #12965

### DIFF
--- a/src/Jackett.Common/Indexers/Anthelion.cs
+++ b/src/Jackett.Common/Indexers/Anthelion.cs
@@ -105,7 +105,8 @@ namespace Jackett.Common.Indexers
             foreach (var cat in catList)
                 qc.Add($"filter_cat[{cat}]", "1");
 
-            var searchUrl = BrowseUrl + "?" + qc.GetQueryString();
+            // remove . as not used in titles 
+            var searchUrl = BrowseUrl + "?" + qc.GetQueryString().Replace(".", " ");
             var results = await RequestWithCookiesAsync(searchUrl);
             try
             {

--- a/src/Jackett.Common/Indexers/HDSpace.cs
+++ b/src/Jackett.Common/Indexers/HDSpace.cs
@@ -126,7 +126,8 @@ namespace Jackett.Common.Indexers
                 queryCollection.Add("search", query.GetQueryString());
             }
 
-            var response = await RequestWithCookiesAndRetryAsync(SearchUrl + queryCollection.GetQueryString());
+            // remove . as not used in titles
+            var response = await RequestWithCookiesAndRetryAsync(SearchUrl + queryCollection.GetQueryString().Replace(".", " "));
 
             try
             {


### PR DESCRIPTION
@garfield69 I don't have an account for Anthelion, can you confirm that the issue reported in #12965 exists, and that removing `.` from the search string doesn't remove other relevant results?