### PR TITLE
Correct search TV Shows with season and ep parameters

### DIFF
--- a/src/Jackett.Common/Definitions/hdspain.yml
+++ b/src/Jackett.Common/Definitions/hdspain.yml
@@ -23,7 +23,7 @@ caps:
 
   modes:
     search: [q]
-    tv-search: [q]
+    tv-search: [q, season, ep]
     movie-search: [q]
     music-search: [q]
 


### PR DESCRIPTION
Sonarr doesn't search correctly this tracker because use season and ep parameters