### PR TITLE
Remove reference to ettv.yml

### DIFF
--- a/src/Jackett.Updater/Program.cs
+++ b/src/Jackett.Updater/Program.cs
@@ -331,7 +331,6 @@ namespace Jackett.Updater
                 "Definitions/erzsebetpl.yml",
                 "Definitions/estrenosdtl.yml",
                 "Definitions/ethor.yml",
-                "Definitions/ettv.yml",
                 "Definitions/evolutionpalace.yml",
                 "Definitions/exoticaz.yml", // migrated to C#
                 "Definitions/extratorrent-ag.yml",


### PR DESCRIPTION
Now that ettv has shut down (https://github.com/Jackett/Jackett/issues/2052#issuecomment-1030887495) this should be removed