### PR TITLE
[RuTracker] Change public (semi-private) to private

### DIFF
--- a/src/Jackett.Common/Definitions/rutracker-ru.yml
+++ b/src/Jackett.Common/Definitions/rutracker-ru.yml
@@ -3,7 +3,7 @@ id: rutracker-ru
 name: RuTracker.RU
 description: "RuTracker.RU is a RUSSIAN Public Torrent Tracker for MOVIES / GENERAL"
 language: ru-RU
-type: public
+type: private
 encoding: UTF-8
 links:
   - http://rutracker.ru/ # site does not support https

--- a/src/Jackett.Common/Definitions/rutracker-ru.yml
+++ b/src/Jackett.Common/Definitions/rutracker-ru.yml
@@ -3,7 +3,7 @@ id: rutracker-ru
 name: RuTracker.RU
 description: "RuTracker.RU is a RUSSIAN Public Torrent Tracker for MOVIES / GENERAL"
 language: ru-RU
-type: private
+type: public
 encoding: UTF-8
 links:
   - http://rutracker.ru/ # site does not support https

--- a/src/Jackett.Common/Indexers/RuTracker.cs
+++ b/src/Jackett.Common/Indexers/RuTracker.cs
@@ -33,7 +33,8 @@ namespace Jackett.Common.Indexers
 
         public override string[] AlternativeSiteLinks { get; protected set; } = {
             "https://rutracker.org/",
-            "https://rutracker.net/"
+            "https://rutracker.net/",
+            "https://rutracker.nl/"
         };
 
         private Regex _regexToFindTagsInReleaseTitle = new Regex(@"\[[^\[]+\]|\([^(]+\)");

--- a/src/Jackett.Common/Indexers/RuTracker.cs
+++ b/src/Jackett.Common/Indexers/RuTracker.cs
@@ -43,7 +43,7 @@ namespace Jackett.Common.Indexers
             ICacheService cs)
             : base(id: "rutracker",
                    name: "RuTracker",
-                   description: "RuTracker is a Semi-Private Russian torrent site with a thriving file-sharing community",
+                   description: "RuTracker is a Private Russian torrent site with a thriving file-sharing community",
                    link: "https://rutracker.org/",
                    caps: new TorznabCapabilities
                    {

--- a/src/Jackett.Common/Indexers/RuTracker.cs
+++ b/src/Jackett.Common/Indexers/RuTracker.cs
@@ -72,7 +72,7 @@ namespace Jackett.Common.Indexers
         {
             Encoding = Encoding.GetEncoding("windows-1251");
             Language = "ru-RU";
-            Type = "semi-private";
+            Type = "private";
             // note: when refreshing the categories use the tracker.php page and NOT the search.php page!
             AddCategoryMapping(22, TorznabCatType.Movies, "Наше кино");
             AddCategoryMapping(941, TorznabCatType.Movies, "|- Кино СССР");


### PR DESCRIPTION
Hello, today I was surprised by a closure of the registration of rutracker.org, rutracker.nl, etc, and temporarily no new users can be registered, so I change the type of the site from public (semi-private) to private.
All the best.