### PR TITLE
re-Add certificate hash for tasmanit.es

### DIFF
--- a/src/Jackett.Common/Definitions/tasmanit.yml
+++ b/src/Jackett.Common/Definitions/tasmanit.yml
@@ -8,7 +8,8 @@ encoding: UTF-8
 links:
   - https://tasmanit.es/
 certificates:
-  - 4325e8f1f13f6074f2bed6a6186fe183791ab32d # expired ‎1 ‎March ‎2022
+  - 23C30AC9655A8A7351A549538062B8C6B0D01A78 # expired 24 Jan 2022
+  - 4325e8f1f13f6074f2bed6a6186fe183791ab32d # expired 1 March 2022
 
 caps:
   categorymappings:


### PR DESCRIPTION
for some reason my previous change from https://github.com/Jackett/Jackett/pull/12955 was changed in 5584438a949bf8081752467c4d075a96049921fe by @garfield69

The tracker still needs to have custom DNS/host to be accessed, and still has the thumbprint i added in my previous PR.

In order not to break what @garfield69 added, i just re-added the thumbprint that's working for me.