### PR TITLE
Transform MEGAPACK and AUDIOEDITADO tags to PROPER

### DIFF
--- a/src/Jackett.Common/Definitions/hdspain.yml
+++ b/src/Jackett.Common/Definitions/hdspain.yml
@@ -79,6 +79,10 @@ search:
           args: "["
         - name: append
           args: "]"
+        - name: re_replace
+          args: ["(?i)(MEGAPACK)", "PROPER"]
+        - name: re_replace
+          args: ["(?i)(AUDIOEDITADO)", "PROPER"]
     title_vose:
       selector: td.titulo a[id]:contains("VOSE")
       optional: true

--- a/src/Jackett.Common/Definitions/hdspain.yml
+++ b/src/Jackett.Common/Definitions/hdspain.yml
@@ -80,7 +80,7 @@ search:
         - name: append
           args: "]"
         - name: re_replace
-          args: ["(?i)(MEGAPACK)", "PROPER"]
+          args: ["(?i)(MEGAPACK)", "REPACK"]
         - name: re_replace
           args: ["(?i)(AUDIOEDITADO)", "PROPER"]
     title_vose:


### PR DESCRIPTION
Convert some tags to better manage of PROPER edited files, and packs with multiple files.