### PR TITLE
Use Mono.Posix package instead of Mono.Posix.NETStandard package

### DIFF
--- a/src/Jackett.Common/Services/UpdateService.cs
+++ b/src/Jackett.Common/Services/UpdateService.cs
@@ -267,9 +267,6 @@ namespace Jackett.Common.Services
                 || variant == Variants.JackettVariant.CoreLinuxAmdx64 || variant == Variants.JackettVariant.CoreLinuxArm32
                 || variant == Variants.JackettVariant.CoreLinuxArm64 || variant == Variants.JackettVariant.Mono)
                 {
-                    //Calling the file permission service to limit usage to netcoreapp. The Mono.Posix.NETStandard library causes issues outside of .NET Core
-                    //https://github.com/xamarin/XamarinComponents/issues/282
-
                     // When the files get extracted, the execute permission for jackett and JackettUpdater don't get carried across
 
                     var jackettPath = tempDir + "/Jackett/jackett";

--- a/src/Jackett.Server/Jackett.Server.csproj
+++ b/src/Jackett.Server/Jackett.Server.csproj
@@ -33,7 +33,6 @@
 
   <!-- Conditionally obtain references for the .NET 6.0 target -->
   <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
-    <PackageReference Include="Mono.Posix.NETStandard" Version="1.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="6.0.0" />
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="6.0.0" />
@@ -57,6 +56,7 @@
     <PackageReference Include="Autofac.Extensions.DependencyInjection" Version="7.2.0" />
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
+	<PackageReference Include="Mono.Posix" Version="7.1.0-final.1.21458.1" />
     <PackageReference Include="NLog" Version="4.7.12" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="4.14.0" />
     <PackageReference Include="System.ServiceProcess.ServiceController" Version="6.0.0" />

--- a/src/Jackett.Server/Services/FilePermissionService.cs
+++ b/src/Jackett.Server/Services/FilePermissionService.cs
@@ -1,9 +1,7 @@
-using Jackett.Common.Services.Interfaces;
-using NLog;
-#if !NET461
 using System;
+using Jackett.Common.Services.Interfaces;
 using Mono.Unix;
-#endif
+using NLog;
 
 namespace Jackett.Server.Services
 {
@@ -15,11 +13,6 @@ namespace Jackett.Server.Services
 
         public void MakeFileExecutable(string path)
         {
-#if !NET461
-
-            //Calling the file permission service to limit usage to netcoreapp. The Mono.Posix.NETStandard library causes issues outside of .NET Core
-            //https://github.com/xamarin/XamarinComponents/issues/282
-
             logger.Debug($"Attempting to give execute permission to: {path}");
             try
             {
@@ -32,7 +25,6 @@ namespace Jackett.Server.Services
             {
                 logger.Error(ex);
             }
-#endif
         }
     }
 }


### PR DESCRIPTION
Avoids problems documented in issue #13080.

It seems like the two libraries are essentially API-compatible, and it certainly didn't cause any problems in this case. Mono.Posix is seeing active development, whereas Mono.Posix.NETStandard is deprecated. Only slight downside is that it is pre-release — but just barely, and should be stable soon.