### PR TITLE
[YggTorrent] New baseUrl

### DIFF
--- a/src/Jackett.Common/Definitions/yggtorrent.yml
+++ b/src/Jackett.Common/Definitions/yggtorrent.yml
@@ -7,8 +7,9 @@ type: semi-private
 encoding: UTF-8
 followredirect: true
 links:
-  - https://www3.yggtorrent.re/
+  - https://yggtorrent.la/
 legacylinks:
+  - https://www3.yggtorrent.re/
   - https://yggtorrent.com/
   - https://ww1.yggtorrent.com/
   - https://yggtorrent.is/


### PR DESCRIPTION
Changed from "https://www3.yggtorrent.re/" to "https://yggtorrent.la/"