### PR TITLE
Fix torrent9 selectors:

### DIFF
--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -135,7 +135,7 @@ search:
         i[class="fa fa-laptop"]: logiciels
         i[class="fa fa-book"]: ebook
     site_date:
-      selector: td:nth-child(1) a
+      selector: td:nth-child(2)
       filters:
         # year is at the end of the title, so we get it and name it site_date
         - name: regexp
@@ -182,7 +182,7 @@ search:
     date:
       text: now
     size:
-      selector: td:nth-child(2)
+      selector: td:nth-child(3)
       filters:
         - name: replace
           args: ["Ko", "KB"]
@@ -193,12 +193,12 @@ search:
         - name: replace
           args: ["To", "TB"]
     seeders_optional:
-      selector: td:nth-child(3)
+      selector: td:nth-child(4)
       optional: true
     seeders:
       text: "{{ if .Result.seeders_optional }}{{ .Result.seeders_optional }}{{ else }}0{{ end }}"
     leechers_optional:
-      selector: td:nth-child(4)
+      selector: td:nth-child(5)
       optional: true
     leechers:
       text: "{{ if .Result.leechers_optional }}{{ .Result.leechers_optional }}{{ else }}0{{ end }}"

--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -104,7 +104,7 @@ download:
 
 search:
   paths:
-    - path: "{{ if .Keywords }}/search_torrent/{{ .Keywords }}{{ .Config.sort }}{{ else }}{{ end }}"
+    - path: "/search_torrent/{{ if .Keywords }}{{ .Keywords }}{{ else }}{{ .Today.Year }}{{ end }}{{ .Config.sort }}"
   keywordsfilters:
     # if searching for season packs with S01 to saison 1 #9712
     - name: re_replace
@@ -135,7 +135,7 @@ search:
         i[class="fa fa-laptop"]: logiciels
         i[class="fa fa-book"]: ebook
     site_date:
-      selector: td:nth-child(2)
+      selector: td:nth-child(1) a
       filters:
         # year is at the end of the title, so we get it and name it site_date
         - name: regexp
@@ -180,7 +180,10 @@ search:
       selector: td:nth-child(1) a
       attribute: href
     date:
-      text: now
+      selector: td:nth-child(2)
+      filters:
+        - name: dateparse
+          args: "02/01/2006"
     size:
       selector: td:nth-child(3)
       filters:


### PR DESCRIPTION
Hello 👋 , thank you for this project, it's really cool!

- Torrent9 slightly modified their markups and added a new table
  cell which shifts the rest.

  This is the new markup for a result

  ```html
  <tr>
    <td>
      <i class="fa fa-tv" style="color:#404040"></i>
      <a title="Lupin Saison 1 FRENCH HDTV" href="/torrent/76158/lupin-saison-1-french-hdtv" style="color:#000; font-size:12px; font-weight:bold;"><h3><span class="blue">Lupin</span> Saison 1 FRENCH HDTV</h3></a>
    </td>
    <td style="font-size:12px">14/01/2021</td>
    <td style="font-size:12px">1.6Go</td>
    <td style="font-size:13px;text-align:right; padding-right:5px">
      <span class="seed_ok">2264 <img class="hidden-md" src="/Public/images/up.png"></span>
    </td>
    <td style="font-size:13px;text-align:right; padding-right:5px">573 <img class="hidden-md" src="/Public/images/down.png"></td>
  </tr>
  ```

<img width="1059" alt="Screenshot 2022-04-16 at 23 35 52" src="https://user-images.githubusercontent.com/8122246/163692059-ab0720c9-302a-4e58-a006-6d14c4ae1ae2.png">
