### PR TITLE
Revert "[RuTracker] Change public (semi-private) to private"

### DIFF
--- a/src/Jackett.Common/Indexers/RuTracker.cs
+++ b/src/Jackett.Common/Indexers/RuTracker.cs
@@ -33,7 +33,8 @@ namespace Jackett.Common.Indexers
 
         public override string[] AlternativeSiteLinks { get; protected set; } = {
             "https://rutracker.org/",
-            "https://rutracker.net/"
+            "https://rutracker.net/",
+            "https://rutracker.nl/"
         };
 
         private Regex _regexToFindTagsInReleaseTitle = new Regex(@"\[[^\[]+\]|\([^(]+\)");


### PR DESCRIPTION
Reverts Jackett/Jackett#13040
Reason: RuTracker Registration is open again.