### PR TITLE
assorted tsue: fuzzytime date fix

### DIFF
--- a/src/Jackett.Common/Definitions/bitturk.yml
+++ b/src/Jackett.Common/Definitions/bitturk.yml
@@ -181,8 +181,6 @@ search:
       filters:
         - name: regexp
           args: "Uploaded (.+?) by"
-        - name: replace
-          args: [" at ", " "]
         - name: fuzzytime
     date_unix:
       # within the hour (unix)

--- a/src/Jackett.Common/Definitions/btnext.yml
+++ b/src/Jackett.Common/Definitions/btnext.yml
@@ -256,9 +256,7 @@ search:
         - name: replace
           args: [" by", ""]
         - name: replace
-          args: ["às ", ""] # at
-        - name: replace
-          args: ["at ", ""]
+          args: ["às ", "at "]
         - name: replace
           args: ["Hoje", "Today"]
         - name: replace

--- a/src/Jackett.Common/Definitions/torrent-turk.yml
+++ b/src/Jackett.Common/Definitions/torrent-turk.yml
@@ -176,8 +176,6 @@ search:
       filters:
         - name: regexp
           args: "Uploaded (.+?) by"
-        - name: replace
-          args: [" at ", " "]
         - name: fuzzytime
     date_unix:
       # within the hour (unix)

--- a/src/Jackett.Common/Definitions/turktorrent.yml
+++ b/src/Jackett.Common/Definitions/turktorrent.yml
@@ -167,8 +167,6 @@ search:
       filters:
         - name: regexp
           args: "Uploaded (.+?) by"
-        - name: replace
-          args: [" at ", " "]
         - name: fuzzytime
     date_unix:
       # within the hour (unix)

--- a/src/Jackett.Common/Definitions/vizuk.yml
+++ b/src/Jackett.Common/Definitions/vizuk.yml
@@ -190,9 +190,9 @@ search:
         - name: replace
           args: [": ", ":"]
         - name: replace
-          args: ["Ayer a las", "Yesterday"]
+          args: ["Ayer a las", "Yesterday at"]
         - name: replace
-          args: ["Hoy en", "Today"]
+          args: ["Hoy en", "Today at"]
         - name: replace
           args: ["Lunes a", "Monday at"]
         - name: replace
@@ -209,7 +209,7 @@ search:
           args: ["Sábado a", "Saturday at"]
         - name: replace
           args: ["Domingo a", "Sunday at"]
-        - name: fuzzytime # eg: Yesterday 14:22 or Monday at 14:22
+        - name: fuzzytime # eg: Yesterday at 14:22 or Monday at 14:22
     date3:
       selector: td.torrent_name:contains("Uploaded"):contains("-"), .torrentOwner:contains("Uploaded"):contains("-")
       optional: true
@@ -226,11 +226,7 @@ search:
       filters:
         - name: regexp
           args: "(?<=Uploaded )(.*)(?= by)"
-        - name: replace
-          args: ["Yesterday at", "Yesterday"]
-        - name: replace
-          args: ["Today at", "Today"]
-        - name: fuzzytime # eg: Yesterday 14:22 or Monday at 14:22
+        - name: fuzzytime # eg: Yesterday at 14:22 or Monday at 14:22
     date:
       text: "{{ if or .Result.date1 .Result.date2 .Result.date3 .Result.date4 }}{{ or .Result.date1 .Result.date2 .Result.date3 .Result.date4 }}{{ else }}now{{ end }}"
     size:


### PR DESCRIPTION
`at` is required for fuzzytime in `Yesterday at 14:22` or `Monday at 14:22`

@garfield69 I only have access to bitturk of these, so if you could check the 3 you have accounts for to make sure there's nothing else needing done for this.