### PR TITLE
Inno setup: pass MyAppVersion as a parameter

### DIFF
--- a/Installer.iss
+++ b/Installer.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Jackett"
-#define MyAppVersion GetFileVersion(MyFileForVersion)
+; #define MyAppVersion GetFileVersion(MyFileForVersion) (passed as a parameter)
 #define MyAppPublisher "Jackett"
 #define MyAppURL "https://github.com/Jackett/Jackett"
 #define MyAppExeName "JackettTray.exe"

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -266,7 +266,7 @@ stages:
               script: >
                 iscc.exe $(Build.SourcesDirectory)/Installer.iss
                 /O"$(Build.ArtifactStagingDirectory)"
-                /DMyFileForVersion=$(Build.BinariesDirectory)/Jackett/Jackett.Common.dll
+                /DMyAppVersion=$(jackettVersion)
                 /DMySourceFolder=$(Build.BinariesDirectory)/Jackett
                 /DMyOutputFilename=Jackett.Installer.Windows
 


### PR DESCRIPTION
Currently, Jackett's installer appends a `.0` in Programs and Features Entries in Control Panel. This change fixes it so that it doesn't append a revision version to it.

For example: 

Jackett's version is `0.20.1010`, but in the control panel, it shows `0.20.1010.0`.

From now onwards, both will be the same.