### PR TITLE
Publish release to winget

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -9,4 +9,4 @@ jobs:
       - uses: vedantmgoyal2009/vedantmgoyal2009/winget-pkgs-automation/releaser-action@v1.0.0
         with:
           identifier: Jackett.Jackett
-          token: ${{ secrets.CI_PAT }}
+          token: ${{ secrets.WINGET }}

--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -1,0 +1,12 @@
+name: Publish to WinGet
+on:
+  release:
+    types: [released]
+jobs:
+  publish:
+    runs-on: windows-latest
+    steps:
+      - uses: vedantmgoyal2009/vedantmgoyal2009/winget-pkgs-automation/releaser-action@v1.0.0
+        with:
+          identifier: Jackett.Jackett
+          token: ${{ secrets.CI_PAT }}


### PR DESCRIPTION
This workflow automatically generates and publishes Jackett's releases to WinGet (windows package manager).