### PR TITLE
fix: bitbr rename title in order to try and have better language matchings

### DIFF
--- a/src/Jackett.Common/Definitions/bitbr.yml
+++ b/src/Jackett.Common/Definitions/bitbr.yml
@@ -135,6 +135,11 @@ search:
       attribute: title
     title:
       text: "{{ if .Result.title_optional }}{{ .Result.title_optional }}{{ else }}{{ .Result.title_default }}{{ end }}"
+      filters:
+        - name: re_replace
+          args:
+            - "\\bDUAL\\b"
+            - "pt-BR/en-US"
     details:
       selector: a[href^="details.php?id="]
       attribute: href


### PR DESCRIPTION
This make sure that all words with \bDUAL\b are replaced by pt-BR/en-US even though en-US may not be the origin language, but this should at least allow sonarr/radarr to find movies dubbed in portuguese.
