### PR TITLE
Remove Appendfrom Category Schema

### DIFF
--- a/src/Jackett.Common/Definitions/schema.json
+++ b/src/Jackett.Common/Definitions/schema.json
@@ -647,7 +647,7 @@
                 "^((title|description)\\|(append))?$": {
                     "$ref": "#/definitions/SelectorBlock"
                 },
-                "^((category|categorydesc)\\|(noappend|append))?$": {
+                "^((category|categorydesc)\\|(noappend))?$": {
                     "$ref": "#/definitions/SelectorBlock"
                 },
                 "^(download|magnet|infohash|details|comments|title|description|category|categorydesc|size|leechers|seeders|date|files|grabs|downloadvolumefactor|uploadvolumefactor|minimumratio|minimumseedtime|imdb|imdbid|tmdbid|rageid|traktid|tvdbid|doubanid|poster|genre|year|author|booktitle|artist|album)(_([A-Za-z0-9_])*)?$": {


### PR DESCRIPTION
https://github.com/Jackett/Jackett/blob/7868b74f35efd2756f981fea1fb0ffcde54d51a9/src/Jackett.Common/Indexers/CardigannIndexer.cs#L1966

Append is not supported.

Need to figure out what to do for FunkyTorrents

```yml
    category:
      selector: a[href^="browse.php?cat="]
      attribute: href
      filters:
        - name: querystring
          args: cat
    category|append:
      optional: true
      case:
        a[href="/browse.php?ext=1&bitrate=Lossless"]: 3040
        a[href="/browse.php?ext=1&format=MP3"]: 3010
```