### PR TITLE
lemonhd: add doubanid search

### DIFF
--- a/src/Jackett.Common/Definitions/lemonhd.yml
+++ b/src/Jackett.Common/Definitions/lemonhd.yml
@@ -22,8 +22,8 @@ caps:
 
   modes:
     search: [q]
-    tv-search: [q, season, ep, imdbid]
-    movie-search: [q, imdbid]
+    tv-search: [q, season, ep, imdbid, doubanid]
+    movie-search: [q, imdbid, doubanid]
     music-search: [q]
     book-search: [q]
 
@@ -71,9 +71,9 @@ search:
   paths:
     - path: torrents.php
   inputs:
-    search: "{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}"
+    search: "{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ end }}{{ if .Query.DoubanID }}{{ .Query.DoubanID }}{{ else }}{{ end }}{{ if or .Query.IMDBID .Query.DoubanID }}{{ else }}{{ .Keywords }}{{ end }}"
     # name, imdb, douban
-    search_area: "{{ if .Query.IMDBID }}imdb{{ else }}name{{ end }}"
+    search_area: "{{ if .Query.IMDBID }}imdb{{ else }}{{ end }}{{ if .Query.DoubanID }}douban{{ else }}{{ end }}{{ if or .Query.IMDBID .Query.DoubanID }}{{ else }}name{{ end }}"
     suggest: 0
     column: "{{ .Config.sort }}"
     sort: "{{ .Config.type }}"


### PR DESCRIPTION
@Uzibird @horseytr @hoong7 @tuningman9790 @finikium @skygunner @tjxme we want to add searching by Douban ID, but this needs tested as none of the maintainers have an account.

Please download this test build from [here](https://dev.azure.com/Jackett/0f0cb3d0-9b6b-4a86-876d-0c2e17c18801/_apis/build/builds/6188/artifacts?artifactName=drop&api-version=7.0&%24format=zip), extract the version for your system, and install over your current install (if you're using Docker, you'll need to test this natively instead, e.g. on a Windows computer, and add LemonHD).

To test that searching by Douban ID is working, use the links below, changing the address if needed, and replace `YOURAPIKEY` with your Jackett API key.

TV search for The Mandalorian:
http://127.0.0.1:9117/api/v2.0/indexers/lemonhd/results/torznab/api?apikey=YOURAPIKEY&t=tvsearch&cat=&doubanid=30344167

Movie search for Lightyear:
http://127.0.0.1:9117/api/v2.0/indexers/lemonhd/results/torznab/api?apikey=YOURAPIKEY&t=movie&cat=&doubanid=35284168

Searching within Jackett's UI will NOT work.

Check that the results are the same as those in your browser on LemonHD by clicking the links below:
[The Mandalorian](https://lemonhd.org/torrents.php?search=30344167&search_area=douban&suggest=0&column=date&sort=desc)
[Lightyear](https://lemonhd.org/torrents.php?search=35284168&search_area=douban&suggest=0&column=date&sort=desc)
Results may differ slightly if you've set the freeleech, sort, and order Jackett settings.

If there are no results even on the website, please pick a different TV show or movie from https://movie.douban.com/ - for example The Mandalorian ID is `30344167`, this can be found at the end of its URL - https://movie.douban.com/subject/30344167/