### PR TITLE
blutopia-api: genre search support

### DIFF
--- a/src/Jackett.Common/Definitions/blutopia-api.yml
+++ b/src/Jackett.Common/Definitions/blutopia-api.yml
@@ -109,10 +109,6 @@ search:
       selector: tmdb_id
     tvdbid:
       selector: tvdb_id
-    genre:
-      selector: genres
-    description:
-      text: "{{ .Result.genre }}"
     files:
       selector: num_file
     seeders:
@@ -148,4 +144,4 @@ search:
     minimumseedtime:
       # 7 day (as seconds = 7 x 24 x 60 x 60)
       text: 604800
-# json UNIT3D 6.3.0
+# json UNIT3D 1.1 beta

--- a/src/Jackett.Common/Definitions/blutopia-api.yml
+++ b/src/Jackett.Common/Definitions/blutopia-api.yml
@@ -17,8 +17,8 @@ caps:
 
   modes:
     search: [q]
-    tv-search: [q, season, ep, imdbid, tvdbid, tmdbid]
-    movie-search: [q, imdbid, tmdbid]
+    tv-search: [q, season, ep, imdbid, tvdbid, tmdbid, genre]
+    movie-search: [q, imdbid, tmdbid, genre]
 
 settings:
   - name: apikey
@@ -71,7 +71,7 @@ search:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
     api_token: "{{ .Config.apikey }}"
     name: "{{ .Keywords }}"
-    $raw: "{{ if .Query.Season }}&seasonNumber={{ .Query.Season }}{{ else }}{{ end }}{{ if .Query.Ep }}&episodeNumber={{ .Query.Ep }}{{ else }}{{ end }}{{ if .Query.TMDBID }}&tmdbId={{ .Query.TMDBID }}{{ else }}{{ end }}{{ if .Query.IMDBIDShort }}&imdbId={{ .Query.IMDBIDShort }}{{ else }}{{ end }}{{ if  .Query.TVDBID }}&tvdbId={{ .Query.TVDBID }}{{ else }}{{ end }}{{ range .Categories }}&categories[]={{.}}{{end}}{{ if .Config.freeleech }}&free=1{{ else }}{{ end }}"
+    $raw: "{{ if .Query.Season }}&seasonNumber={{ .Query.Season }}{{ else }}{{ end }}{{ if .Query.Ep }}&episodeNumber={{ .Query.Ep }}{{ else }}{{ end }}{{ if .Query.TMDBID }}&tmdbId={{ .Query.TMDBID }}{{ else }}{{ end }}{{ if .Query.IMDBIDShort }}&imdbId={{ .Query.IMDBIDShort }}{{ else }}{{ end }}{{ if  .Query.TVDBID }}&tvdbId={{ .Query.TVDBID }}{{ else }}{{ end }}{{ if .Query.Genre }}&genre[]={{ .Query.Genre }}{{ else }}{{ end }}{{ range .Categories }}&categories[]={{.}}{{end}}{{ if .Config.freeleech }}&free=1{{ else }}{{ end }}"
     sortField: "{{ .Config.sort }}"
     sortDirection: "{{ .Config.type }}"
     perPage: 100
@@ -109,6 +109,10 @@ search:
       selector: tmdb_id
     tvdbid:
       selector: tvdb_id
+    genre:
+      selector: genres
+    description:
+      text: "{{ .Result.genre }}"
     files:
       selector: num_file
     seeders:
@@ -144,4 +148,4 @@ search:
     minimumseedtime:
       # 7 day (as seconds = 7 x 24 x 60 x 60)
       text: 604800
-# json UNIT3D 6.1.1 beta
+# json UNIT3D 6.3.0


### PR DESCRIPTION
@garfield69 please test.

Presumably this would need changed to something like `{{ range .Genre }}` when https://github.com/Jackett/Jackett/issues/13405 is implemented.