### PR TITLE
update yamllint to allow linting on windows

### DIFF
--- a/yamllint.yml
+++ b/yamllint.yml
@@ -13,5 +13,7 @@ rules:
     level: error
   line-length: disable
   truthy: disable
+  new-lines:
+    type: platform
   comments:
     min-spaces-from-content: 1


### PR DESCRIPTION
fixes line ending errors when linting on windows

commit is LF
local repo checked out is CRLF
yamllint default expects LF...this makes it systembased
![image](https://user-images.githubusercontent.com/55419169/181673940-e303e73a-9d21-41ce-b7f6-3e468a008e59.png)
