### PR TITLE
Bump FlareSolverrSharp 2.2.5

### DIFF
--- a/src/Jackett.Common/Jackett.Common.csproj
+++ b/src/Jackett.Common/Jackett.Common.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Autofac" Version="6.3.0" />
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="BencodeNET" Version="4.0.0" />
-    <PackageReference Include="FlareSolverrSharp" Version="2.2.4" />
+    <PackageReference Include="FlareSolverrSharp" Version="2.2.5" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
     <PackageReference Include="DotNet4.SocksProxy" Version="1.4.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />


### PR DESCRIPTION
- Fix the error: The cookies provided by FlareSolverr are not valid
- Allow FlareSolverr timeouts > 100 s
- Fix vulnerabilities