### PR TITLE
Increase the number of cookies per domain and remove old cookies

### DIFF
--- a/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
@@ -66,7 +66,10 @@ namespace Jackett.Common.Utils.Clients
         {
             ServicePointManager.SecurityProtocol = (SecurityProtocolType)192 | (SecurityProtocolType)768 | (SecurityProtocolType)3072;
 
-            var cookies = new CookieContainer();
+            var cookies = new CookieContainer
+            {
+                PerDomainCapacity = 100 // By default only 20 cookies are allowed per domain
+            };
             if (!string.IsNullOrWhiteSpace(webRequest.Cookies))
             {
                 // don't include the path, Scheme is needed for mono compatibility

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
@@ -31,7 +31,10 @@ namespace Jackett.Common.Utils.Clients
                    c: c,
                    sc: sc)
         {
-            cookies = new CookieContainer();
+            cookies = new CookieContainer
+            {
+                PerDomainCapacity = 100 // By default only 20 cookies are allowed per domain
+            };
             CreateClient();
         }
 
@@ -112,12 +115,10 @@ namespace Jackett.Common.Utils.Clients
             request.Headers.ExpectContinue = false;
             request.RequestUri = new Uri(webRequest.Url);
 
-            // clear cookies from cookiecontainer
-            var oldCookies = cookies.GetCookies(request.RequestUri);
-            foreach (Cookie oldCookie in oldCookies)
-                oldCookie.Expired = true;
+            // clear all the cookies from CookieContainer
+            CookieUtil.RemoveAllCookies(cookies);
 
-            // add cookies to cookiecontainer
+            // add cookies to CookieContainer
             if (!string.IsNullOrWhiteSpace(webRequest.Cookies))
             {
                 // don't include the path, Scheme is needed for mono compatibility

--- a/src/Jackett.Test/Common/Utils/CookieUtilTests.cs
+++ b/src/Jackett.Test/Common/Utils/CookieUtilTests.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using Jackett.Common.Utils;
 using NUnit.Framework;
 using Assert = NUnit.Framework.Assert;
@@ -99,6 +100,22 @@ namespace Jackett.Test.Common.Utils
             // null cookie dictionary
             var expectedCookieHeader = "";
             CollectionAssert.AreEqual(expectedCookieHeader, CookieUtil.CookieDictionaryToHeader(null));
+        }
+
+        [Test]
+        public void RemoveAllCookies()
+        {
+            var cookiesContainer = new CookieContainer();
+            var domainHttp = new Uri("http://testdomain1.com");
+            cookiesContainer.Add(domainHttp, new Cookie("cookie1", "value1"));
+            var domainHttps = new Uri("https://testdomain2.com");
+            cookiesContainer.Add(domainHttps, new Cookie("cookie2", "value2"));
+            Assert.AreEqual(1, cookiesContainer.GetCookies(domainHttp).Count);
+            Assert.AreEqual(1, cookiesContainer.GetCookies(domainHttps).Count);
+
+            CookieUtil.RemoveAllCookies(cookiesContainer);
+            Assert.AreEqual(0, cookiesContainer.GetCookies(domainHttp).Count);
+            Assert.AreEqual(0, cookiesContainer.GetCookies(domainHttps).Count);
         }
     }
 }


### PR DESCRIPTION
- Max number of cookies per domain is just 20 by default -> now 100
- When the indexer domain changes, old cookies where kept in memory