### PR TITLE
solve Lat-Team (API) exception

### DIFF
--- a/src/Jackett.Common/Definitions/lat-team-api.yml
+++ b/src/Jackett.Common/Definitions/lat-team-api.yml
@@ -28,6 +28,7 @@ caps:
     - {id: 19, cat: Audio/Audiobook, desc: "Audiolibros"}
     - {id: 20, cat: Movies/Other, desc: "Películas Oscars"}
     - {id: 21, cat: Audio/Video, desc: "VideoMixes"}
+    - {id: 22, cat: TV/Other, desc: "Playlist_Collection"}
 
   modes:
     search: [q]


### PR DESCRIPTION
Solve 'Exception (lat-team-api): Error while parsing field=category, selector=category_id, value=22: Object reference not set to an instance of an object.: Error while parsing field=category, selector=category_id, value=22: Object reference not set to an instance of an object.'