### PR TITLE
karagarga: rework genre and description

### DIFF
--- a/src/Jackett.Common/Definitions/karagarga.yml
+++ b/src/Jackett.Common/Definitions/karagarga.yml
@@ -134,18 +134,14 @@ search:
     _subs:
       selector: span:contains("Subs:")
       optional: true
-    _genre:
+    genre:
       selector: td:nth-child(5)
-      optional: true
-      filters:
-        - name: prepend
-          args: "Genre: "
     _mom:
       selector: img[title^="CURRENT"]
       attribute: title
       optional: true
     description:
-      text: "{{ .Result._subs }} {{ .Result._genre }}{{ if .Result._mom }} Current MoM{{ else }}{{ end }}"
+      text: "{{ if .Result._subs }}Subs: {{ .Result._subs }}</br>{{ else }}{{ end }}{{ if .Result.genre }}Genre: {{ .Result.genre }}</br>{{ else }}{{ end }}{{ if .Result._mom }}Current MoM{{ else }}{{ end }}"
     downloadvolumefactor:
       case:
         "span:contains(\"Freeleech\")": 0

--- a/src/Jackett.Common/Definitions/karagarga.yml
+++ b/src/Jackett.Common/Definitions/karagarga.yml
@@ -136,6 +136,8 @@ search:
       optional: true
     genre:
       selector: td:nth-child(5)
+        - name: replace
+          args: ["\n", " "]
     _mom:
       selector: img[title^="CURRENT"]
       attribute: title


### PR DESCRIPTION
@RoloSoze @cinico-gmail @duramato @dmucli @Norin-Radd @grocovid @fim

We want to bring this indexer up to date with others, but this needs tested as none of the maintainers have an account.

Please download this test build from [here](https://dev.azure.com/Jackett/0f0cb3d0-9b6b-4a86-876d-0c2e17c18801/_apis/build/builds/6492/artifacts?artifactName=drop&api-version=7.0&%24format=zip), extract the version for your system, and install over your current install (if you're using Docker, you'll need to test this natively instead, e.g. on a Windows computer, and add Karagarga).

To test that this is working, right-click the `Copy RSS Feed` button for Karagarga in Jackett and open in a new tab. Right-click this page and save it as a text document.

Remove any personal information from the document, such as public IP or DDNS domain - easiest way to do this (using Notepad for example) is to highlight what you want to remove, press Ctrl+H, replace with `REMOVED`, click Replace All, and then save the document.

Please attach your edited document in a comment below.

[edit] entirely likely that the build will have expired by the time any of you get around to testing this, so if that is the case just let us know and we will re-build asap.