### PR TITLE
[tracker fix] Fix yggtorrent exact match search

### DIFF
--- a/src/Jackett.Common/Definitions/yggcookie.yml
+++ b/src/Jackett.Common/Definitions/yggcookie.yml
@@ -224,7 +224,7 @@ search:
     - name: trim
     # put each word in quotations to prevent exact phrase search
     - name: re_replace
-      args: ["(\\w+)", "\"$1\""]
+      args: ["([^\\s]+)", "\"$1\""]
   paths:
     - path: "engine/search?category={{ .Config.category }}&name={{ .Keywords }}&description=&file=&uploader=&sub_category=&do=search&order={{ .Config.type }}&sort={{ .Config.sort }}"
       followredirect: true

--- a/src/Jackett.Common/Definitions/yggtorrent.yml
+++ b/src/Jackett.Common/Definitions/yggtorrent.yml
@@ -234,7 +234,7 @@ search:
     - name: trim
     # put each word in quotations to prevent exact phrase search
     - name: re_replace
-      args: ["(\\w+)", "\"$1\""]
+      args: ["([^\\s]+)", "\"$1\""]
   paths:
     - path: "engine/search?category={{ .Config.category }}&name={{ .Keywords }}&description=&file=&uploader=&sub_category=&do=search&order={{ .Config.type }}&sort={{ .Config.sort }}"
       followredirect: true


### PR DESCRIPTION
The yggtorrent configuration quotes every word in order to prevent exact match phrase search (see #11101)
The idea was to add quotes arround each word (ex `Daemon slayer` => `"Daemon" "Slayer")

But the regex wasn´t enough permissive and titles like `Stargate SG-1` was transformed into `"Stargate" "SG"-"1"` which gave an empty result.