### PR TITLE
avistaztracker: add genre search support

### DIFF
--- a/src/Jackett.Common/Indexers/Abstract/AvistazTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/AvistazTracker.cs
@@ -69,6 +69,9 @@ namespace Jackett.Common.Indexers.Abstract
             else
                 qc.Add("search", GetSearchTerm(query).Trim());
 
+            if (!string.IsNullOrWhiteSpace(query.Genre))
+                qc.Add("tags", query.Genre);
+
             return qc;
         }
 

--- a/src/Jackett.Common/Indexers/AvistaZ.cs
+++ b/src/Jackett.Common/Indexers/AvistaZ.cs
@@ -21,11 +21,11 @@ namespace Jackett.Common.Indexers
                    {
                        TvSearchParams = new List<TvSearchParam>
                        {
-                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId
+                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId, TvSearchParam.Genre
                        },
                        MovieSearchParams = new List<MovieSearchParam>
                        {
-                           MovieSearchParam.Q, MovieSearchParam.ImdbId
+                           MovieSearchParam.Q, MovieSearchParam.ImdbId, MovieSearchParam.Genre
                        },
                        SupportsRawSearch = true
                    },

--- a/src/Jackett.Common/Indexers/CinemaZ.cs
+++ b/src/Jackett.Common/Indexers/CinemaZ.cs
@@ -21,10 +21,10 @@ namespace Jackett.Common.Indexers
                    {
                        TvSearchParams = new List<TvSearchParam>
                        {
-                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId
+                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId, TvSearchParam.Genre
                        },
                        MovieSearchParams = new List<MovieSearchParam> {
-                           MovieSearchParam.Q, MovieSearchParam.ImdbId
+                           MovieSearchParam.Q, MovieSearchParam.ImdbId, MovieSearchParam.Genre
 
                        }
                    },

--- a/src/Jackett.Common/Indexers/PrivateHD.cs
+++ b/src/Jackett.Common/Indexers/PrivateHD.cs
@@ -21,11 +21,11 @@ namespace Jackett.Common.Indexers
                    {
                        TvSearchParams = new List<TvSearchParam>
                        {
-                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId
+                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId, TvSearchParam.Genre
                        },
                        MovieSearchParams = new List<MovieSearchParam>
                        {
-                           MovieSearchParam.Q, MovieSearchParam.ImdbId
+                           MovieSearchParam.Q, MovieSearchParam.ImdbId, MovieSearchParam.Genre
                        },
                        MusicSearchParams = new List<MusicSearchParam>
                        {


### PR DESCRIPTION
Does not provide `tags` in API results.