### PR TITLE
pterclub: fix title and description on game search

### DIFF
--- a/src/Jackett.Common/Definitions/pterclub.yml
+++ b/src/Jackett.Common/Definitions/pterclub.yml
@@ -124,7 +124,7 @@ search:
       selector: a[href^="details.php?id="]
     title_optional:
       optional: true
-      selector: a[title][href^="details.php?id="]
+      selector: a[title][href^="details.php?id="],a[title][href^="detailsgame.php?id="]
       attribute: title
     title:
       text: "{{ if .Result.title_optional }}{{ .Result.title_optional }}{{ else }}{{ .Result.title_default }}{{ end }}"
@@ -192,7 +192,7 @@ search:
         "*": 1
     description:
       selector: td:has(table.torrentname)
-      remove: a, img
+      remove: a, b, font, img
     minimumratio:
       text: 0.9
 # NexusPHP custom v2019.12


### PR DESCRIPTION
1. If the torrent is a game, the link is `/detailsgame.php?id=`, currently, the title is showing the comment counts
2. remove `font` tag on description due to empty IMDB and DOUBAN, causing `N/AN/A` in description
3. remove `b` tag on description in order to remove the word `[热门]` completely

![image](https://user-images.githubusercontent.com/4951333/189039344-e53e013c-66bb-48f9-b1ee-18a7f8961865.png)
