### PR TITLE
polishtracker-api removed wide and nfo params from input

### DIFF
--- a/src/Jackett.Common/Definitions/polishtracker-api.yml
+++ b/src/Jackett.Common/Definitions/polishtracker-api.yml
@@ -66,9 +66,9 @@ search:
     tpage: 1
     imdb_id: "{{ .Query.IMDBIDShort }}"
     # search in nfo text also
-    nfo: false
+    #nfo: false
     # search is more broad
-    wide: false
+    #wide: false
     $raw: "{{ range .Categories }}&cat[]={{.}}{{end}}"
     # can search by genre but need range support. &tags[]=Action&tags[]=Comedy for Action and Comedy
 

--- a/src/Jackett.Common/Definitions/polishtracker-api.yml
+++ b/src/Jackett.Common/Definitions/polishtracker-api.yml
@@ -65,10 +65,10 @@ search:
     search: "{{ .Keywords }}"
     tpage: 1
     imdb_id: "{{ .Query.IMDBIDShort }}"
-    # search in nfo text also
-    #nfo: false
-    # search is more broad
-    #wide: false
+    # search in nfo text also - broken
+    # nfo: false
+    # search is more broad - broken
+    # wide: false
     $raw: "{{ range .Categories }}&cat[]={{.}}{{end}}"
     # can search by genre but need range support. &tags[]=Action&tags[]=Comedy for Action and Comedy
 


### PR DESCRIPTION
it looks like there is issue with this param in PTE API, no matter if it is true or false, as long it is present it works the same and once present it affects serch result, most relevant search results are not necessary at the beggining of the reponse often not event at the first page and because of this indexer often do not return valid results at all, when there is no wide param in input but nfo remains sometimes it does not return valid response as well