### PR TITLE
Fix: ShizaProject Null File

### DIFF
--- a/src/Jackett.Common/Indexers/ShizaProject.cs
+++ b/src/Jackett.Common/Indexers/ShizaProject.cs
@@ -136,8 +136,8 @@ namespace Jackett.Common.Indexers
                     release.Seeders = t.Seeders;
                     release.Peers = t.Leechers + t.Seeders;
                     release.Grabs = t.Downloaded;
-                    release.Link = t.File.Url;
-                    release.Guid = t.File.Url;
+                    release.Link = t.File?.Url;
+                    release.Guid = t.File?.Url;
                     release.MagnetUri = t.MagnetUri;
                     release.PublishDate = getActualPublishDate(n, t);
                     releases.Add(release);


### PR DESCRIPTION
Some torrents only had magnet links. This was causing an error which should be fixed now.
Solves Issue: #13578 