### PR TITLE
Base Indexer: Recognize Magnet Links in Redirects from Download Link

### DIFF
--- a/src/Jackett.Common/Indexers/BaseIndexer.cs
+++ b/src/Jackett.Common/Indexers/BaseIndexer.cs
@@ -456,6 +456,16 @@ namespace Jackett.Common.Indexers
             {
                 await FollowIfRedirect(response);
             }
+
+            if (response.IsRedirect)
+            {
+                var redirectingTo = new Uri(response.RedirectingTo);
+                if (redirectingTo.Scheme == "magnet")
+                    return Encoding.UTF8.GetBytes(redirectingTo.OriginalString);
+
+                await FollowIfRedirect(response);
+            }
+
             if (response.Status != System.Net.HttpStatusCode.OK && response.Status != System.Net.HttpStatusCode.Continue && response.Status != System.Net.HttpStatusCode.PartialContent)
             {
                 logger.Error("Failed download cookies: " + CookieHeader);
@@ -568,6 +578,11 @@ namespace Jackett.Common.Indexers
             {
                 if (!response.IsRedirect)
                     break;
+
+                var redirectingTo = new Uri(response.RedirectingTo);
+                if (redirectingTo.Scheme == "magnet")
+                    break;
+
                 await DoFollowIfRedirect(response, referrer, overrideRedirectUrl, overrideCookies, accumulateCookies);
                 if (accumulateCookies)
                 {


### PR DESCRIPTION
While working on Issue #13591, I noticed that magnet links are being generated as a part of redirect when we click on Download button. This is not supported by the base indexer as it tries to follow the redirect and fails when it doesn't recognize the "magnet" scheme.

It will be great if this pull can be tested on all the possible Cardigann indexers to make sure it doesn't break anything.
Once approved, I'll make a pull tor resolve #13591 too based on these changes.