### PR TITLE
Fix: Pornotorrent Redirect to Magnet Link

### DIFF
--- a/src/Jackett.Common/Definitions/pornotorrent.yml
+++ b/src/Jackett.Common/Definitions/pornotorrent.yml
@@ -7,7 +7,7 @@ type: public
 encoding: UTF-8
 links:
   - https://www.pornotorrent.eu/
-
+testlinktorrent: false
 caps:
   categorymappings:
     - {id: XXX, cat: XXX, desc: XXX}
@@ -19,8 +19,11 @@ settings: []
 
 download:
   selectors:
-    - selector: a[href^="magnet:?xt="]
+    - selector: a.button_link
       attribute: href
+      filters:
+          - name: replace
+            args: ["////", "//"]
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/pornotorrent.yml
+++ b/src/Jackett.Common/Definitions/pornotorrent.yml
@@ -5,9 +5,10 @@ description: "PornoTorrent is a SPANISH Public Torrent Tracker for 3X"
 language: en-US
 type: public
 encoding: UTF-8
+testlinktorrent: false
 links:
   - https://www.pornotorrent.eu/
-testlinktorrent: false
+
 caps:
   categorymappings:
     - {id: XXX, cat: XXX, desc: XXX}

--- a/src/Jackett.Common/Definitions/pornotorrent.yml
+++ b/src/Jackett.Common/Definitions/pornotorrent.yml
@@ -22,8 +22,8 @@ download:
     - selector: a.button_link
       attribute: href
       filters:
-          - name: replace
-            args: ["////", "//"]
+        - name: replace
+          args: ["////", "//"]
 
 search:
   paths:


### PR DESCRIPTION
With this fix, the download links in Jackett should resolve and redirect to a magnet link.
Solves #13591 