### PR TITLE
torrent-explosiv & dark-shadow: use ssl download

### DIFF
--- a/src/Jackett.Common/Definitions/dark-shadow.yml
+++ b/src/Jackett.Common/Definitions/dark-shadow.yml
@@ -168,7 +168,7 @@ search:
       attribute: href
       filters:
         - name: replace
-          args: ["details.php?id=", "download.php?torrent="]
+          args: ["details.php?id=", "download_ssl.php?torrent="]
     poster:
       selector: div[id^="details"] img
       attribute: src

--- a/src/Jackett.Common/Definitions/torrent-explosiv.yml
+++ b/src/Jackett.Common/Definitions/torrent-explosiv.yml
@@ -151,7 +151,7 @@ search:
       attribute: href
       filters:
         - name: replace
-          args: ["details.php?id=", "download.php?torrent="]
+          args: ["details.php?id=", "download_ssl.php?torrent="]
     title:
       selector: a.selection_a
       filters:


### PR DESCRIPTION
They don't have the same issue as fixed in e891be739f85d3fca599495f6c9706ee565ae8ae, but the trackers are using `_ssl`.