### PR TITLE
UHDBits Scene Naming Convention Regexes

### DIFF
--- a/src/Jackett.Common/Definitions/uhdbits.yml
+++ b/src/Jackett.Common/Definitions/uhdbits.yml
@@ -133,7 +133,9 @@ search:
         - name: replace
           args: [" / 2x", ""]
         - name: re_replace
-          args: [" / ", "-"]
+          args: [" / ", " "]
+        - name: re_replace
+          args: ["\\b(\\w+)$", " -$1"]
         #  #10423
         - name: re_replace
           args: ["(?i)(season )", "S"]

--- a/src/Jackett.Common/Definitions/uhdbits.yml
+++ b/src/Jackett.Common/Definitions/uhdbits.yml
@@ -133,10 +133,16 @@ search:
         - name: replace
           args: [" / 2x", ""]
         - name: re_replace
-          args: [" / ", " "]
+          args: [" / ", "-"]
         #  #10423
         - name: re_replace
           args: ["(?i)(season )", "S"]
+        - name: replace
+          args: ["Encode", "Blu-Ray"]
+        - name: replace
+          args: ["Blu-ray", "BR-Disk"]
+        - name: replace
+          args: ["Remux", "Blu-Ray Remux"]
     details:
       selector: a.torrent_name
       attribute: href


### PR DESCRIPTION
This pull request makes UHDbits search results more conformant to scene standards so that the arr apps can properly parse out fields.

It fixes the ability for arr apps to properly recognize:

- release group names
- Blu-Ray Encodes
- Blu-Ray Disk Rips
- Blue-Ray Remuxes
- The 4k variants of the above