### PR TITLE
UI: Add OR Filter in Table Search

### DIFF
--- a/src/Jackett.Common/Content/custom.js
+++ b/src/Jackett.Common/Content/custom.js
@@ -1319,7 +1319,7 @@ function updateSearchResultTable(element, results) {
                 var newInputSearch = inputSearch.clone();
                 newInputSearch.attr("custom", "true");
                 newInputSearch.attr("data-toggle", "tooltip");
-                newInputSearch.attr("title", "Search query consists of several keywords.\nKeyword starting with \"-\" is considered a negative match.");
+                newInputSearch.attr("title", "Search query consists of several keywords.\nKeyword starting with \"-\" is considered a negative match.\nKeywords separated by \"|\" are considered as OR filters.");
                 newInputSearch.on("input", function () {
                     var newKeywords = [];
                     var filterTextKeywords = $(this).val().split(" ");
@@ -1327,17 +1327,15 @@ function updateSearchResultTable(element, results) {
                         if (keyword === "" || keyword === "+" || keyword === "-")
                             return;
                         var newKeyword;
-                        var pipedKeyword = '(' + keyword.substring(1).split('|').map(k => $.fn.dataTable.util.escapeRegex(k)).join('|') + ')';
                         if (keyword.startsWith("+"))
-                            newKeyword = pipedKeyword;
+                            newKeyword = $.fn.dataTable.util.escapeRegex(keyword.substring(1));
                         else if (keyword.startsWith("-"))
-                            newKeyword = "^((?!" + pipedKeyword + ").)*$";
+                            newKeyword = "^((?!" + $.fn.dataTable.util.escapeRegex(keyword.substring(1)) + ").)*$";
                         else
-                            newKeyword = $.fn.dataTable.util.escapeRegex(keyword);
+                            newKeyword = '(' + keyword.split('|').map(k => $.fn.dataTable.util.escapeRegex(k)).join('|') + ')';
                         newKeywords.push(newKeyword);
                     });
                     var filterText = newKeywords.join(" ");
-                    console.log("Filter Text", filterText);
                     table.api().search(filterText, true, true).draw();
                 });
                 inputSearch.replaceWith(newInputSearch);

--- a/src/Jackett.Common/Content/custom.js
+++ b/src/Jackett.Common/Content/custom.js
@@ -1327,15 +1327,17 @@ function updateSearchResultTable(element, results) {
                         if (keyword === "" || keyword === "+" || keyword === "-")
                             return;
                         var newKeyword;
+                        var pipedKeyword = '(' + keyword.substring(1).split('|').map(k => $.fn.dataTable.util.escapeRegex(k)).join('|') + ')';
                         if (keyword.startsWith("+"))
-                            newKeyword = $.fn.dataTable.util.escapeRegex(keyword.substring(1));
+                            newKeyword = pipedKeyword;
                         else if (keyword.startsWith("-"))
-                            newKeyword = "^((?!" + $.fn.dataTable.util.escapeRegex(keyword.substring(1)) + ").)*$";
+                            newKeyword = "^((?!" + pipedKeyword + ").)*$";
                         else
                             newKeyword = $.fn.dataTable.util.escapeRegex(keyword);
                         newKeywords.push(newKeyword);
                     });
                     var filterText = newKeywords.join(" ");
+                    console.log("Filter Text", filterText);
                     table.api().search(filterText, true, true).draw();
                 });
                 inputSearch.replaceWith(newInputSearch);

--- a/src/Jackett.Common/Content/index.html
+++ b/src/Jackett.Common/Content/index.html
@@ -28,7 +28,7 @@
     <link rel="stylesheet" type="text/css" href="../bootstrap/bootstrap.min.css?changed=2017083001">
     <link rel="stylesheet" type="text/css" href="../animate.css?changed=2017083001">
     <link rel="stylesheet" type="text/css" href="../css/tagify.css?changed=11662">
-    <link rel="stylesheet" type="text/css" href="../custom.css?changed=20221002" media="only screen and (min-device-width: 480px)">
+    <link rel="stylesheet" type="text/css" href="../custom.css?changed=20220721002" media="only screen and (min-device-width: 480px)">
     <link rel="stylesheet" type="text/css" href="../custom_mobile.css?changed=20220721002" media="only screen and (max-device-width: 480px)">
     <link rel="stylesheet" type="text/css" href="../css/jquery.dataTables.min.css?changed=2017083001">
     <link rel="stylesheet" type="text/css" href="../css/bootstrap-multiselect.css?changed=2017083001" />
@@ -754,6 +754,6 @@
     </script>
 
     <script type="text/javascript" src="../libs/api.js?changed=2017083001"></script>
-    <script type="text/javascript" src="../custom.js?changed=20220721002"></script>
+    <script type="text/javascript" src="../custom.js?changed=20221002"></script>
 </body>
 </html>

--- a/src/Jackett.Common/Content/index.html
+++ b/src/Jackett.Common/Content/index.html
@@ -28,7 +28,7 @@
     <link rel="stylesheet" type="text/css" href="../bootstrap/bootstrap.min.css?changed=2017083001">
     <link rel="stylesheet" type="text/css" href="../animate.css?changed=2017083001">
     <link rel="stylesheet" type="text/css" href="../css/tagify.css?changed=11662">
-    <link rel="stylesheet" type="text/css" href="../custom.css?changed=20220721002" media="only screen and (min-device-width: 480px)">
+    <link rel="stylesheet" type="text/css" href="../custom.css?changed=20221002" media="only screen and (min-device-width: 480px)">
     <link rel="stylesheet" type="text/css" href="../custom_mobile.css?changed=20220721002" media="only screen and (max-device-width: 480px)">
     <link rel="stylesheet" type="text/css" href="../css/jquery.dataTables.min.css?changed=2017083001">
     <link rel="stylesheet" type="text/css" href="../css/bootstrap-multiselect.css?changed=2017083001" />


### PR DESCRIPTION
Resolves #13619.

The logic is a little different than mentioned in the issue.
Here is the equivalence comparison.
`+(x265 hevc)` = `+x265|hevc` = Filters out the results that contain either HEVC or x265 in the torrent name.
`-(x265 hevc)` = `-x265|hev` = Filters out the results that contain neither HEVC nor x265 in the torrent name.

The pipe operator is less likely to occur in a torrent name and saves some coding time for detecting enclosing bracket and pair and then splitting on the space, hence I thought this was better as well as more native to the Regex Logic.