### PR TITLE
rutracker: no regex replace when SearchTerm is null. #13660

### DIFF
--- a/src/Jackett.Common/Indexers/RuTracker.cs
+++ b/src/Jackett.Common/Indexers/RuTracker.cs
@@ -1484,7 +1484,8 @@ namespace Jackett.Common.Indexers
             var searchString = query.SearchTerm;
             //  replace any space, special char, etc. with % (wildcard)
             var ReplaceRegex = new Regex("[^a-zA-Zа-яА-Я0-9]+");
-            searchString = ReplaceRegex.Replace(searchString, "%");
+            if (!string.IsNullOrWhiteSpace(searchString))
+                searchString = ReplaceRegex.Replace(searchString, "%");
 
             // if the search string is empty use the getnew view
             if (string.IsNullOrWhiteSpace(searchString))


### PR DESCRIPTION
fix for https://github.com/Jackett/Jackett/pull/13661#issuecomment-1286567697