### PR TITLE
Fix Lat-Team Definition to find TV Shows

### DIFF
--- a/src/Jackett.Common/Definitions/lat-team-api.yml
+++ b/src/Jackett.Common/Definitions/lat-team-api.yml
@@ -166,4 +166,4 @@ search:
     minimumseedtime:
       # 2 days (as seconds = 2 x 24 x 60 x 60)
       text: 172800
-# json UNIT3D 6.4.0b
+# json UNIT3D 6.4.1

--- a/src/Jackett.Common/Definitions/lat-team-api.yml
+++ b/src/Jackett.Common/Definitions/lat-team-api.yml
@@ -93,8 +93,6 @@ search:
   keywordsfilters:
     - name: re_replace
       args: ["\\.", " "]
-    - name: re_replace
-      args: ["(?i)\\bS(\\d+)", "T$1"]
 
   rows:
     selector: data
@@ -109,24 +107,12 @@ search:
       selector: name:contains(VOSE)
       optional: true
       filters:
-        - name: re_replace
-          args: ["^ *\\[[^\\]]*\\] *", ""] # Remove prefix tags
-        - name: re_replace
-          args: ["(?i)\\bT(\\d+)", "S$1"]
-        - name: re_replace
-          args: ["UHDRip", "BDRip"] # Fix for Radarr
         - name: append
           args: " ENGLiSH"
     title_notvose:
       selector: name:not(:contains(VOSE))
       optional: true
       filters:
-        - name: re_replace
-          args: ["^ *\\[[^\\]]*\\] *", ""] # Remove prefix tags
-        - name: re_replace
-          args: ["(?i)\\bT(\\d+)", "S$1"]
-        - name: re_replace
-          args: ["UHDRip", "BDRip"] # Fix for Radarr
         - name: append
           args: " SPANiSH"
     title:
@@ -138,7 +124,7 @@ search:
     infohash:
       selector: info_hash
     poster:
-      selector: poster
+      selector: meta.poster
       filters:
         - name: replace
           args: ["https://via.placeholder.com/90x135", ""]
@@ -177,9 +163,7 @@ search:
       case:
         0: 1 # normal
         1: 2 # double
-    minimumratio:
-      text: 1.0
     minimumseedtime:
-      # 4 days (as seconds = 4 x 24 x 60 x 60)
-      text: 345600
-# json UNIT3D 6.3.0
+      # 2 days (as seconds = 2 x 24 x 60 x 60)
+      text: 172800
+# json UNIT3D 6.4.0b


### PR DESCRIPTION
Previously, the S01E01 part of a query would get changed to T01E01 which made it impossible to find TV shows from the tracker.

Searching for Generic Show S01E01 resulted in a API query that included Generic Show T01E01. Consequently, Jackett was not finding any TV show from the tracker.

I tested it locally and now it works as intended.

Other changes include:
- Update the minimum seeding time according to the tracker rules
- Remove minimum ratio as the minimum seeding time is mandatory despite of ratio