### PR TITLE
[Indexers Feature] Add colon as a supported character inside TorznabQueries

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * Demonoid
  * DivxTotal
  * dmhy
+ * Dodder (菟丝子资源社区)
  * DonTorrent
  * E-Hentai
  * elitetorrent

--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -13,12 +13,11 @@ links:
   - https://x1337x.ws/
   - https://x1337x.eu/
   - https://x1337x.se/
-  - https://1337x.unblockit.page/
+  - https://1337x.unblockit.pet/
   - https://1337x.nocensor.lol/
   - https://1337x.unblockninja.com/
 legacylinks:
   - https://1337x.is/
-  - https://1337x.unblockit.ws/
   - https://1337x.nocensor.work/
   - https://1337x.unblockit.kim/
   - https://1337x.unblockit.bz/
@@ -37,6 +36,7 @@ legacylinks:
   - https://1337x.unblockit.cat/
   - https://1337x.unblockit.nz/
   - https://1337x.nocensor.world/
+  - https://1337x.unblockit.page/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/audiobookbay.yml
+++ b/src/Jackett.Common/Definitions/audiobookbay.yml
@@ -9,10 +9,9 @@ requestDelay: 2
 links:
   - https://audiobookbay.li/
   - https://audiobookbay.se/
-  - https://audiobookbay.unblockit.page/
+  - https://audiobookbay.unblockit.pet/
 legacylinks:
   - https://audiobookbay.la/
-  - https://audiobookbay.unblockit.ws/
   - http://audiobookbay.net/
   - https://audiobookbay.unblockit.kim/
   - https://audiobookbay.unblockit.bz/
@@ -34,6 +33,7 @@ legacylinks:
   - https://audiobookbay.unblockit.cat/
   - https://audiobookbay.unblockit.nz/
   - https://audiobookbay.fi/
+  - https://audiobookbay.unblockit.page/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/audiobookbay.yml
+++ b/src/Jackett.Common/Definitions/audiobookbay.yml
@@ -7,12 +7,11 @@ type: public
 encoding: UTF-8
 requestDelay: 2
 links:
-  - https://audiobookbay.fi/
+  - https://audiobookbay.li/
   - https://audiobookbay.se/
   - https://audiobookbay.unblockit.page/
 legacylinks:
   - https://audiobookbay.la/
-  - https://audiobookbay.unblockit.ch/
   - https://audiobookbay.unblockit.ws/
   - http://audiobookbay.net/
   - https://audiobookbay.unblockit.kim/
@@ -34,6 +33,7 @@ legacylinks:
   - https://audiobookbay.unblockit.bet/
   - https://audiobookbay.unblockit.cat/
   - https://audiobookbay.unblockit.nz/
+  - https://audiobookbay.fi/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/demonoid.yml
+++ b/src/Jackett.Common/Definitions/demonoid.yml
@@ -12,11 +12,10 @@ links:
   - https://www.dnoid.pw/
   - https://demonoidevmsgasmojajlhikwetsr4pxzw6xkjt3dgdv6nr5yxvsamid.onion.ly/
   - https://demonoidevmsgasmojajlhikwetsr4pxzw6xkjt3dgdv6nr5yxvsamid.tor2web.to/
-  - https://demonoid.unblockit.page/
+  - https://demonoid.unblockit.pet/
   - https://demonoid.torrentbay.to/
   - https://demonoid.nocensor.lol/
 legacylinks:
-  - https://demonoid.unblockit.ws/
   - https://demonoid.nocensor.work/
   - https://demonoid.unblockit.kim/
   - https://demonoid.unblockit.bz/
@@ -36,6 +35,7 @@ legacylinks:
   - https://demonoid.nocensor.world/
   - https://demonoidevmsgasmojajlhikwetsr4pxzw6xkjt3dgdv6nr5yxvsamid.onion.ws/
   - https://demonoidevmsgasmojajlhikwetsr4pxzw6xkjt3dgdv6nr5yxvsamid.onion.pet/
+  - https://demonoid.unblockit.page/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/dodder.yml
+++ b/src/Jackett.Common/Definitions/dodder.yml
@@ -1,0 +1,75 @@
+---
+id: dodder
+name: Dodder
+description: "Dodder (菟丝子资源社区) is a CHINESE Public BitTorrent DHT search engine"
+language: zh-CN
+type: public
+encoding: UTF-8
+links:
+  - https://dodder.top/
+
+caps:
+  categories:
+    Other: Other
+
+  modes:
+    search: [q]
+
+settings: []
+
+download:
+  infohash:
+    hash:
+      selector: a[href^="magnet:?xt"]
+      attribute: href
+      filters:
+        - name: regexp
+          args: ([A-F|a-f|0-9]{40})
+    title:
+      selector: b
+      attribute: title
+      filters:
+        - name: validfilename
+
+search:
+  paths:
+    - path: /
+  inputs:
+    fileName: "{{ if .Keywords }}{{ .Keywords }}{{ else }}{{ .Today.Year }}{{ end }}"
+
+  rows:
+    selector: table.dodder-torrent-list > tbody > tr
+    filters:
+      - name: andmatch
+
+  fields:
+    category:
+      text: Other
+    title:
+      selector: a[href^="/info/"]
+      attribute: title
+    details:
+      selector: a[href^="/info/"]
+      attribute: href
+    download:
+      selector: a[href^="/info/"]
+      attribute: href
+    date:
+      selector: div.layui-hide-xs
+      filters:
+        - name: dateparse
+          args: "2006-01-02 15:04:05"
+    size:
+      selector: span.layui-bg-gray
+    seeders:
+      text: 1
+    leechers:
+      text: 1
+    description:
+      selector: span.layui-row
+      remove: span.layui-badge
+    downloadvolumefactor:
+      text: 0
+    uploadvolumefactor:
+      text: 1
+# engine n/a

--- a/src/Jackett.Common/Definitions/extratorrent-st.yml
+++ b/src/Jackett.Common/Definitions/extratorrent-st.yml
@@ -7,8 +7,8 @@ type: public
 encoding: UTF-8
 links:
   - https://extratorrent.st/
-  - https://extratorrent.unblockit.page/
-  - https://extratorrent.nocensor.world/
+  - https://extratorrent.unblockit.pet/
+  - https://extratorrent.nocensor.lol/
 legacylinks:
   - https://extratorrent.nocensor.work/
   - https://extratorrent.unblockit.kim/
@@ -26,6 +26,8 @@ legacylinks:
   - https://extratorrent.unblockit.bet/
   - https://extratorrent.unblockit.cat/
   - https://extratorrent.unblockit.nz/
+  - https://extratorrent.nocensor.world/
+  - https://extratorrent.unblockit.page/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/eztv.yml
+++ b/src/Jackett.Common/Definitions/eztv.yml
@@ -13,7 +13,7 @@ links:
   - https://eztv.yt/
   - https://eztv1.xyz/
   - https://eztv.unblockninja.com/
-  - https://eztv.unblockit.page/
+  - https://eztv.unblockit.pet/
   - https://eztv.nocensor.lol/
 legacylinks:
   - https://eztv.ag/ # redirects to .re
@@ -36,6 +36,7 @@ legacylinks:
   - https://eztv.unblockit.cat/
   - https://eztv.unblockit.nz/
   - https://eztv.nocensor.world/
+  - https://eztv.unblockit.page/
 
 caps:
   categories:

--- a/src/Jackett.Common/Definitions/gktorrent.yml
+++ b/src/Jackett.Common/Definitions/gktorrent.yml
@@ -6,7 +6,7 @@ language: fr-FR
 type: public
 encoding: UTF-8
 followredirect: true
-# to fetch current domain use https://www.protege-liens.com/gktorrent
+# to fetch current domain use https://www.protege-liens.com/Gktorrent
 links:
   - https://www.gktorrents.cc/
   - https://gktorrent.nocensor.lol/

--- a/src/Jackett.Common/Definitions/glodls.yml
+++ b/src/Jackett.Common/Definitions/glodls.yml
@@ -10,13 +10,12 @@ links:
   - https://glodls.to/
   - https://gtdb.cc/
   - https://www.gtdb.to/
-  - https://glotorrents.unblockit.page/
+  - https://glotorrents.unblockit.pet/
   - https://glotorrents.nocensor.lol/
   - https://glodls.unblockninja.com/
 legacylinks:
   - https://glodls.rocks/
   - https://gtdb.to/
-  - https://glotorrents.unblockit.ws/
   - https://glotorrents.nocensor.work/
   - https://glotorrents.unblockit.kim/
   - https://glotorrents.unblockit.bz/
@@ -34,6 +33,7 @@ legacylinks:
   - https://glotorrents.unblockit.cat/
   - https://glotorrents.unblockit.nz/
   - https://glotorrents.nocensor.world/
+  - https://glotorrents.unblockit.page/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/limetorrents.yml
+++ b/src/Jackett.Common/Definitions/limetorrents.yml
@@ -9,7 +9,7 @@ followredirect: true
 # changes to this indexer should also be made to limetorrentsclone
 links:
   - https://www.limetorrents.lol/
-  - https://limetorrents.unblockit.page/
+  - https://limetorrents.unblockit.pet/
   - https://limetorrents.unblockninja.com/
   - https://limetorrents.nocensor.lol/
 legacylinks:
@@ -33,6 +33,7 @@ legacylinks:
   - https://limetorrents.unblockit.cat/
   - https://limetorrents.unblockit.nz/
   - https://limetorrents.nocensor.world/
+  - https://limetorrents.unblockit.page/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/polishtracker-api.yml
+++ b/src/Jackett.Common/Definitions/polishtracker-api.yml
@@ -55,15 +55,15 @@ settings:
       POLISH: POLISH
       MULTI.POLISH: MULTI.POLISH
 
-#login:
-#  path: "https://api-test.pte.nu/api/v1/torrents"
-#  method: get
-#  inputs:
-#    tpage: 1
-#  error:
-#    - selector: ":root:contains(\"ACCESS_DENIED\")"
-#      message:
-#        text: "The API key was not accepted by {{ .Config.sitelink }}."
+# login:
+#   path: "https://api-test.pte.nu/api/v1/torrents"
+#   method: get
+#   inputs:
+#     tpage: 1
+#   error:
+#     - selector: ":root:contains(\"ACCESS_DENIED\")"
+#       message:
+#         text: "The API key was not accepted by {{ .Config.sitelink }}."
 
 search:
   paths:

--- a/src/Jackett.Common/Definitions/redbits-api.yml
+++ b/src/Jackett.Common/Definitions/redbits-api.yml
@@ -6,6 +6,8 @@ language: es-ES
 type: private
 encoding: UTF-8
 links:
+  - https://redbits.xyz/
+legacylinks:
   - https://red-bits.com/
 
 caps:
@@ -80,6 +82,10 @@ search:
     perPage: 100
     page: 1
 
+  keywordsfilters:
+    - name: re_replace
+      args: ["\\.", " "]
+
   rows:
     selector: data
     attribute: attributes
@@ -121,7 +127,7 @@ search:
     infohash:
       selector: info_hash
     poster:
-      selector: poster
+      selector: meta.poster
       filters:
         - name: replace
           args: ["https://via.placeholder.com/90x135", ""]
@@ -131,6 +137,17 @@ search:
       selector: tmdb_id
     tvdbid:
       selector: tvdb_id
+    genre:
+      selector: meta.genres
+      filters:
+        - name: re_replace
+          args: ["(?i)(Película de TV)", "Película_de_TV"]
+        - name: re_replace
+          args: ["(?i)(Science Fiction)", "Science_Fiction"]
+        - name: replace
+          args: [" & ", "_&_"]
+    description:
+      text: "{{ .Result.genre }}"
     files:
       selector: num_file
     seeders:
@@ -163,4 +180,4 @@ search:
     minimumseedtime:
       # 4 days (as seconds = 4 x 24 x 60 x 60)
       text: 345600
-# json UNIT3D 6.1.0
+# json UNIT3D 6.4.1

--- a/src/Jackett.Common/Definitions/rutor.yml
+++ b/src/Jackett.Common/Definitions/rutor.yml
@@ -88,6 +88,8 @@ search:
       selector: td:nth-of-type(2) a[href^="/torrent/"]
       filters:
         - name: re_replace
+          args: [".+\\/\\s([^а-яА-я\\/]+)\\s.*\\[(?:S*(\\d+-\\d+))\\].*\\)\\s+(.+)\\s+(?:\\||от)\\s*(.+)", "$1 - S$2 - rus - $3 - $4"]
+        - name: re_replace
           args: [".+\\/\\s([^а-яА-я\\/]+)\\s.*\\[(?:S*(\\d+))(?:x*(\\d+-*\\d*).*)*\\].*\\)\\s+(.+)\\s+(?:\\||от)\\s*(.+)", "$1 - S$2E$3 - rus - $4 - $5"]
         - name: replace
           args: ["E -", "E01-99 -"]

--- a/src/Jackett.Common/Definitions/torlock.yml
+++ b/src/Jackett.Common/Definitions/torlock.yml
@@ -10,11 +10,10 @@ requestDelay: 2
 links:
   - https://www.torlock2.com/
   - https://www.torlock.com/
-  - https://torlock.unblockit.page/
+  - https://torlock.unblockit.pet/
   - https://torlock.nocensor.lol/
 legacylinks:
   - https://torlock.com/
-  - https://torlock.unblockit.ws/
   - https://torlock.nocensor.work/
   - https://torlock.unblockit.kim/
   - https://torlock.unblockit.bz/
@@ -33,6 +32,7 @@ legacylinks:
   - https://torlock.unblockit.cat/
   - https://torlock.unblockit.nz/
   - https://torlock.nocensor.world/
+  - https://torlock.unblockit.page/
 
 caps:
   # dont forget to update the search fields category case block

--- a/src/Jackett.Common/Definitions/torrent911.yml
+++ b/src/Jackett.Common/Definitions/torrent911.yml
@@ -6,7 +6,7 @@ language: fr-FR
 type: public
 encoding: UTF-8
 followredirect: true
-# to fetch current domain use https://www.protege-liens.com/t911 and https://www.protege-liens.com/torrent911
+# to fetch current domain use https://www.protege-liens.com/T911 and https://www.protege-liens.com/Torrent911
 links:
   - https://www.torrent911.tv/
   - https://www.t911.tv/

--- a/src/Jackett.Common/Definitions/torrentdownload.yml
+++ b/src/Jackett.Common/Definitions/torrentdownload.yml
@@ -8,12 +8,10 @@ encoding: UTF-8
 followredirect: true
 links:
   - https://www.torrentdownload.info/
-  - https://torrentdownload.unblockit.page/
+  - https://torrentdownload.unblockit.pet/
   - https://torrentdownload.nocensor.lol/
 legacylinks:
-  - https://torrentdownload.unblockit.ch/
   - https://torrentdownload.nocensor.space/
-  - https://torrentdownload.unblockit.ws/
   - https://torrentdownload.nocensor.work/
   - https://torrentdownload.unblockit.kim/
   - https://torrentdownload.unblockit.bz/
@@ -31,6 +29,7 @@ legacylinks:
   - https://torrentdownload.unblockit.cat/
   - https://torrentdownload.unblockit.nz/
   - https://torrentdownload.nocensor.world/
+  - https://torrentdownload.unblockit.page/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/torrentdownloads.yml
+++ b/src/Jackett.Common/Definitions/torrentdownloads.yml
@@ -9,13 +9,12 @@ followredirect: true
 links:
   - https://www.torrentdownloads.info/
   - https://www.torrentdownloads.pro/
-  - https://torrentdownloads.unblockit.page/
+  - https://torrentdownloads.unblockit.pet/
   - https://torrentdownloads.nocensor.lol/
   - https://torrentdownloads.unblockninja.com/
 legacylinks:
   - https://www.torrentdownloads.me/
   - https://torrentdownloads.nocensor.space/
-  - https://torrentdownloads.unblockit.ws/
   - https://torrentdownloads.nocensor.work/
   - https://torrentdownloads.unblockit.kim/
   - https://torrentdownloads.unblockit.bz/
@@ -33,6 +32,7 @@ legacylinks:
   - https://torrentdownloads.unblockit.cat/
   - https://torrentdownloads.unblockit.nz/
   - https://torrentdownloads.nocensor.world/
+  - https://torrentdownloads.unblockit.page/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/torrentfunk.yml
+++ b/src/Jackett.Common/Definitions/torrentfunk.yml
@@ -9,12 +9,10 @@ followredirect: true
 links:
   - https://www.torrentfunk.com/
   - https://www.torrentfunk2.com/
-  - https://torrentfunk.unblockit.page/
+  - https://torrentfunk.unblockit.pet/
   - https://torrentfunk.nocensor.lol/
 legacylinks:
-  - https://torrentfunk.unblockit.ch/
   - https://torrentfunk.nocensor.space/
-  - https://torrentfunk.unblockit.ws/
   - https://torrentfunk.nocensor.work/
   - https://torrentfunk.unblockit.kim/
   - https://torrentfunk.unblockit.bz/
@@ -32,6 +30,7 @@ legacylinks:
   - https://torrentfunk.unblockit.cat/
   - https://torrentfunk.unblockit.nz/
   - https://torrentfunk.nocensor.world/
+  - https://torrentfunk.unblockit.page/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/torrentgalaxy.yml
+++ b/src/Jackett.Common/Definitions/torrentgalaxy.yml
@@ -12,14 +12,12 @@ links:
   - https://torrentgalaxy.su/
   - https://tgx.rs/
   - https://torrentgalaxy.unblockninja.com/
-  - https://torrentgalaxy.unblockit.page/
+  - https://torrentgalaxy.unblockit.pet/
 legacylinks:
   - https://torrentgalaxy.org/ # redirects to *.to
   - https://torrentgalaxy.pw/ # proxy list only
   - https://tgx.unblocked.monster/
-  - https://torrentgalaxy.unblockit.ch/
   - https://torrentgalaxy.nocensor.space/
-  - https://torrentgalaxy.unblockit.ws/
   - https://torrentgalaxy.nocensor.work/
   - https://torrentgalaxy.unblockit.kim/
   - https://torrentgalaxy.unblockit.bz/
@@ -37,6 +35,7 @@ legacylinks:
   - https://torrentgalaxy.nocensor.world/ # banned
   - https://torrentgalaxy.unblockit.cat/
   - https://torrentgalaxy.unblockit.nz/
+  - https://torrentgalaxy.unblockit.page/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/yts.yml
+++ b/src/Jackett.Common/Definitions/yts.yml
@@ -9,7 +9,7 @@ requestDelay: 2.5 # 2.5 requests per second (2 causes problems)
 links:
   # dont forget to update the details, download and poster replace args
   - https://yts.mx/
-  - https://yts.unblockit.page/
+  - https://yts.unblockit.pet/
   - https://yts.unblockninja.com/
   - https://yts.nocensor.lol/
 legacylinks:
@@ -33,6 +33,7 @@ legacylinks:
   - https://yts.unblockit.cat/
   - https://yts.unblockit.nz/
   - https://yts.nocensor.world/
+  - https://yts.unblockit.page/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Indexers/DonTorrent.cs
+++ b/src/Jackett.Common/Indexers/DonTorrent.cs
@@ -39,7 +39,7 @@ namespace Jackett.Common.Indexers
         private const string SearchUrl = "buscar/";
 
         public override string[] AlternativeSiteLinks { get; protected set; } = {
-            "https://dontorrent.fail/",
+            "https://dontorrent.futbol/",
             "https://todotorrents.net/",
             "https://tomadivx.net/",
             "https://seriesblanco.one/",
@@ -62,7 +62,8 @@ namespace Jackett.Common.Indexers
             "https://dontorrent.me/",
             "https://dontorrent.gs/",
             "https://dontorrent.gy/",
-            "https://dontorrent.click/"
+            "https://dontorrent.click/",
+            "https://dontorrent.fail/"
         };
 
         private static Dictionary<string, string> CategoriesMap => new Dictionary<string, string>
@@ -80,7 +81,7 @@ namespace Jackett.Common.Indexers
             : base(id: "dontorrent",
                    name: "DonTorrent",
                    description: "DonTorrent is a SPANISH public tracker for MOVIES / TV / GENERAL",
-                   link: "https://dontorrent.fail/",
+                   link: "https://dontorrent.futbol/",
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>

--- a/src/Jackett.Common/Indexers/EpubLibre.cs
+++ b/src/Jackett.Common/Indexers/EpubLibre.cs
@@ -45,13 +45,11 @@ namespace Jackett.Common.Indexers
 
         public override string[] AlternativeSiteLinks { get; protected set; } = {
             "https://www.epublibre.org/",
-            "https://epublibre.unblockit.page/"
+            "https://epublibre.unblockit.pet/"
         };
 
         public override string[] LegacySiteLinks { get; protected set; } = {
             "https://epublibre.org/",
-            "https://epublibre.unblockit.ch/",
-            "https://epublibre.unblockit.ws/",
             "https://epublibre.unblockit.kim/",
             "https://epublibre.unblockit.bz/",
             "https://epublibre.unblockit.tv/",
@@ -64,7 +62,8 @@ namespace Jackett.Common.Indexers
             "https://epublibre.unblockit.ist/",
             "https://epublibre.unblockit.bet/",
             "https://epublibre.unblockit.cat/",
-            "https://epublibre.unblockit.nz/"
+            "https://epublibre.unblockit.nz/",
+            "https://epublibre.unblockit.page/"
         };
 
         public EpubLibre(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,

--- a/src/Jackett.Common/Indexers/MejorTorrent.cs
+++ b/src/Jackett.Common/Indexers/MejorTorrent.cs
@@ -415,7 +415,7 @@ namespace Jackett.Common.Indexers
             return queryWords.All(word => titleWords.Contains(word));
         }
 
-        private static TorznabQuery ParseQuery(TorznabQuery query)
+        private TorznabQuery ParseQuery(TorznabQuery query)
         {
             // Eg. Doctor.Who.2005.(Доктор.Кто).S02E08
 
@@ -425,8 +425,8 @@ namespace Jackett.Common.Indexers
             // query.Episode = 8
             var searchTerm = query.GetQueryString();
 
-            // replace non-english alphanumeric characters with spaces
-            // searchTerm = Doctor Who 2005
+            // Server returns a 500 error if a UTF character higher than \u00FF (ÿ) is included,
+            // so we need to strip them
             searchTerm = Regex.Replace(searchTerm, @"[^a-zA-Z0-9]+", " ");
             searchTerm = Regex.Replace(searchTerm, @"\s+", " ");
             searchTerm = searchTerm.Trim();

--- a/src/Jackett.Common/Models/TorznabQuery.cs
+++ b/src/Jackett.Common/Models/TorznabQuery.cs
@@ -94,6 +94,7 @@ namespace Jackett.Common.Models
                                                  || c == ']'
                                                  || c == '+'
                                                  || c == '%'
+                                                 || c == ':'
                                                ));
                 return string.Concat(safeTitle);
             }


### PR DESCRIPTION
I've identified that some indexers (for example Mejortorrent), need the special characters to be available in order to execute a successful query.

In this case, for example the film "Avengers: Endgame" would be converted to "Avengers Endgame", and the indexer won't return any result.

This PR aims to fix that, by allowing the colon symbol to be passed down to all indexers