### PR TITLE
anthelion-api: append release group to title and fix media `WEB`

### DIFF
--- a/src/Jackett.Common/Definitions/anthelion-api.yml
+++ b/src/Jackett.Common/Definitions/anthelion-api.yml
@@ -84,6 +84,9 @@ search:
       selector: container
     _media:
       selector: media
+      filters:
+        - name: replace
+          args: ["WEB", "WEB-DL"]
     _resolution:
       selector: resolution
     _audioFormat:

--- a/src/Jackett.Common/Definitions/anthelion-api.yml
+++ b/src/Jackett.Common/Definitions/anthelion-api.yml
@@ -100,13 +100,18 @@ search:
     _language:
       selector: language
       optional: true
+    _releaseGroup:
+      selector: releaseGroup
+      optional: true
+      filters:
+        - name: trim
     title:
       selector: title
       filters:
         - name: replace
           args: ["&#39;", "'"]
         - name: append
-          args: " {{ .Result.year }} {{ .Result._codec }} {{ .Result._container }} {{ .Result._media }} {{ .Result._resolution }} {{ .Result._audioFormat }}{{ if .Result._subbing }} Subs{{ else }}{{ end }}{{ if .Result._flags }} {{ .Result._flags }}{{ else }}{{ end }}{{ if .Result._language }} {{ .Result._language }}{{ else }}{{ end }}"
+          args: " {{ .Result.year }} {{ .Result._codec }} {{ .Result._container }} {{ .Result._media }} {{ .Result._resolution }} {{ .Result._audioFormat }}{{ if .Result._subbing }} Subs{{ else }}{{ end }}{{ if .Result._flags }} {{ .Result._flags }}{{ else }}{{ end }}{{ if .Result._language }} {{ .Result._language }}{{ else }}{{ end }}{{ if and (.Result._releaseGroup) (ne .Result._releaseGroup \"NULL\") }}-{{ .Result._releaseGroup }}{{ else }}{{ end}}"
     details:
       selector: guid
     download:

--- a/src/Jackett.Common/Definitions/anthelion-api.yml
+++ b/src/Jackett.Common/Definitions/anthelion-api.yml
@@ -114,7 +114,7 @@ search:
         - name: replace
           args: ["&#39;", "'"]
         - name: append
-          args: " {{ .Result.year }} {{ .Result._codec }} {{ .Result._container }} {{ .Result._media }} {{ .Result._resolution }} {{ .Result._audioFormat }}{{ if .Result._subbing }} Subs{{ else }}{{ end }}{{ if .Result._flags }} {{ .Result._flags }}{{ else }}{{ end }}{{ if .Result._language }} {{ .Result._language }}{{ else }}{{ end }}{{ if and (.Result._releaseGroup) (ne .Result._releaseGroup \"NULL\") }}-{{ .Result._releaseGroup }}{{ else }}{{ end}}"
+          args: " {{ .Result.year }} {{ .Result._codec }} {{ .Result._container }} {{ .Result._media }} {{ .Result._resolution }} {{ .Result._audioFormat }}{{ if .Result._subbing }} Subs{{ else }}{{ end }}{{ if .Result._flags }} {{ .Result._flags }}{{ else }}{{ end }}{{ if .Result._language }} {{ .Result._language }}{{ else }}{{ end }}{{ if and (.Result._releaseGroup) (ne .Result._releaseGroup \"NULL\") }} -{{ .Result._releaseGroup }}{{ else }}{{ end }}"
     details:
       selector: guid
     download:


### PR DESCRIPTION
It seems to be a new field `releaseGroup` in the response, so it's useful for CF scores and blocking LQ groups, etc.

Also fixed the media for WEB releases to prevent false positive as scene.