### PR TITLE
[libble] Extend login cookie TTL

### DIFF
--- a/README.md
+++ b/README.md
@@ -410,7 +410,7 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * leech24
  * LegacyHD (HD4Free)
  * LemonHD
- * Libble [![(invite needed)][inviteneeded]](#)
+ * Libble
  * LibraNet (LN)
  * LinkoManija [![(invite needed)][inviteneeded]](#)
  * Locadora

--- a/src/Jackett.Common/Indexers/Libble.cs
+++ b/src/Jackett.Common/Indexers/Libble.cs
@@ -98,6 +98,7 @@ namespace Jackett.Common.Indexers
                         {
                             {"username", configData.Username.Value},
                             {"password", configData.Password.Value},
+                            {"keeplogged", "1"}
                             {"login", "Login"}
                         };
 


### PR DESCRIPTION
Hello,

It seems like adding `keeplogged=1` extends the cookie `session` from session to lifetime of 1 year. 👍 