### PR TITLE
abtorrents: Fixes for naming and details link

### DIFF
--- a/src/Jackett.Common/Definitions/abtorrents.yml
+++ b/src/Jackett.Common/Definitions/abtorrents.yml
@@ -133,9 +133,6 @@ search:
     details:
       selector: a[href^="details.php?id="]
       attribute: href
-      filters:
-        - name: replace
-          args: ["&hit=1", ""]
     download:
       selector: a[href^="download.php?torrent="]
       attribute: href

--- a/src/Jackett.Common/Definitions/abtorrents.yml
+++ b/src/Jackett.Common/Definitions/abtorrents.yml
@@ -129,9 +129,13 @@ search:
           args: cat
     title:
       selector: a[href^="details.php?id="]
+      remove: span
     details:
       selector: a[href^="details.php?id="]
       attribute: href
+      filters:
+        - name: replace
+          args: ["&hit=1", ""]
     download:
       selector: a[href^="download.php?torrent="]
       attribute: href


### PR DESCRIPTION
Remove "[REQUESTED]" from title and avoid redirect for details URL.