### PR TITLE
Do not mask Jackett exit code in launcher

### DIFF
--- a/jackett_launcher.sh
+++ b/jackett_launcher.sh
@@ -8,6 +8,7 @@ JACKETT_DIR="$(dirname "$(readlink -f "$0")")"
 
 # Launch Jackett (with CLI parameters)
 "${JACKETT_DIR}/jackett" --NoRestart "$@"
+ec=$?
 
 # Get user running the service
 JACKETT_USER=$(whoami)
@@ -16,3 +17,5 @@ JACKETT_USER=$(whoami)
 while pgrep -u "${JACKETT_USER}" JackettUpdater > /dev/null; do
     sleep 1
 done
+
+exit $ec


### PR DESCRIPTION
Currently, in the launcher script the whoami and updater loop are masking the exit code of Jackett. So even if Jackett errors out, the systemd service sees an exit code of "0", which e.g. breaks the `Restart=on-failure` in the [non-mono service template](https://github.com/Jackett/Jackett/wiki/Systemd-service#not-using-mono).

This commit stores the exit code of Jackett in a variable and exits the script explicitly with this exit code, after the updater has been waited for. This way `Restart=on-failure` again can apply and `systemctl status jackett` reports the correct status if Jackett failed.
_________
Somehow related question. When an update is applied, I see now this:
```
Dec 28 07:41:05 VM-Bullseye Jackett[1478]: 12-28 07:41:05 Info File copying complete
Dec 28 07:41:05 VM-Bullseye Jackett[1478]: 12-28 07:41:05 Info Process 1441 is already dead
Dec 28 07:41:05 VM-Bullseye systemd[1]: jackett.service: Main process exited, code=exited, status=139/n/a
Dec 28 07:41:05 VM-Bullseye systemd[1]: jackett.service: Failed with result 'exit-code'.
Dec 28 07:41:11 VM-Bullseye systemd[1]: jackett.service: Scheduled restart job, restart counter is at 1.
Dec 28 07:41:11 VM-Bullseye systemd[1]: Stopped Jackett.
Dec 28 07:41:11 VM-Bullseye systemd[1]: Started Jackett.
Dec 28 07:41:11 VM-Bullseye Jackett[1493]: 12-28 07:41:11 Info Starting Jackett v0.20.2447
```
If I'm not mistaken, `Process xxxx is already dead` is logged if the updater tries to kill a Jackett process which is not running anymore: https://github.com/Jackett/Jackett/blob/ae18515/src/Jackett.Updater/Program.cs#L85-L121
However, I'm missing the `Killing process xxxx` line which should be logged before, isn't it? Is it expected then that Jackett returns with exit code 139, and does it so as well in case the updater does SIGTERM (while the process is still up) so that Jackett always formally exits with failure when an update is applied? Otherwise `Restart=on-failure` wouldn't (always) restart the service after an update.