### PR TITLE
sharewood: enable raw search support

### DIFF
--- a/src/Jackett.Common/Definitions/sharewood.yml
+++ b/src/Jackett.Common/Definitions/sharewood.yml
@@ -54,6 +54,7 @@ caps:
     movie-search: [q]
     music-search: [q]
     book-search: [q]
+  allowrawsearch: true
 
 settings:
   - name: username


### PR DESCRIPTION
> Hi everyone. I've a little issue with radarr ot prowlarr I do not know exactly where it occurs but I've the same when using Jackett so I guess it comes from radarr. When I add a movie with a dot or a quote in the title when it performs the search with the indexers these character are removed so instead of searching for Alibi.com it searches for Alibicom or instead of L'aile ou la cuisse it searches for Laile ou la cuisse and because of that it do not finds any release. I've tried to tweak some settings but did not manage to make it work. Am I missing something or is this a normal behavior? Thanks.

https://discord.com/channels/264387956343570434/264388019585286144/1059951898431590460

Enables Raw Search for sharewood
