### PR TITLE
720pier: add user-agent to fix expired session issue

### DIFF
--- a/src/Jackett.Common/Definitions/pier720.yml
+++ b/src/Jackett.Common/Definitions/pier720.yml
@@ -86,10 +86,17 @@ settings:
   - name: cookie
     type: text
     label: Cookie
-  - name: info
+  - name: info_cookie
     type: info
     label: How to get the Cookie
     default: "<ol><li>Login to this tracker with your browser<li>Open the <b>DevTools</b> panel by pressing <b>F12</b><li>Select the <b>Network</b> tab<li>Click on the <b>Doc</b> button (Chrome Browser) or <b>HTML</b> button (FireFox)<li>Refresh the page by pressing <b>F5</b><li>Click on the first row entry<li>Select the <b>Headers</b> tab on the Right panel<li>Find <b>'cookie:'</b> in the <b>Request Headers</b> section<li><b>Select</b> and <b>Copy</b> the whole cookie string <i>(everything after 'cookie: ')</i> and <b>Paste</b> here.</ol>"
+  - name: useragent
+    type: text
+    label: User-Agent
+  - name: info_useragent
+    type: info
+    label: How to get the User-Agent
+    default: "<ol><li>From the same place you fetched the cookie,<li>Find <b>'user-agent:'</b> in the <b>Request Headers</b> section<li><b>Select</b> and <b>Copy</b> the whole user-agent string <i>(everything after 'user-agent: ')</i> and <b>Paste</b> here.</ol>"
   - name: sort
     type: select
     label: Sort requested from site
@@ -121,6 +128,8 @@ download:
       attribute: href
 
 search:
+  headers:
+    User-Agent: ["{{ .Config.useragent }}"]
   paths:
     - path: search.php
   inputs:


### PR DESCRIPTION
A fellow user tried this change and they confirmed it fixed the issue with the cookies being valid only for the first query.