### PR TITLE
sharewood: improve title

### DIFF
--- a/src/Jackett.Common/Definitions/sharewood.yml
+++ b/src/Jackett.Common/Definitions/sharewood.yml
@@ -146,22 +146,22 @@ search:
           args: "/img/NewIcones/(.+?).png"
     title_phase1:
       selector: a.view-torrent
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\smulti\\s)", " {{ .Config.multilanguage }} "]
+          args: ["(?i)\\b(VOSTFR)\\b", "ENGLISH"]
+        - name: re_replace
+          args: ["(?i)\\b(SUBFRENCH)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\svostfr\\s)", " ENGLISH "]
-        - name: re_replace
-          args: ["(?i)(\\ssubfrench\\s)", " ENGLISH "]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     download:
       selector: a.view-torrent
       attribute: href


### PR DESCRIPTION
- moved VOSTFR replacing first to prevent issues when `Replace MULTI by this language` is set to `VOSTFR` in the end becoming `ENGLISH`.
- use word boundary instead of spacing
- use negative lookahead to replace `MULTI` only if isn't followed by `FRENCH`, `ENGLISH` or `VOSTFR`. (this includes `TRUEFRENCH`)