### PR TITLE
myanonamouse: add selectable search type, show max 5 authors

### DIFF
--- a/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationDataMyAnonamouse.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationDataMyAnonamouse.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Jackett.Common.Models.IndexerConfig.Bespoke
@@ -7,16 +8,30 @@ namespace Jackett.Common.Models.IndexerConfig.Bespoke
     {
         public StringConfigurationItem MamId { get; private set; }
         public DisplayInfoConfigurationItem MamIdHint { get; private set; }
-        public BoolConfigurationItem ExcludeVip { get; private set; }
-        public DisplayInfoConfigurationItem Instructions { get; private set; }
+        public SingleSelectConfigurationItem SearchType { get; private set; }
+        public BoolConfigurationItem SearchInDescription { get; private set; }
+        public BoolConfigurationItem SearchInSeries { get; private set; }
+        public BoolConfigurationItem SearchInFilenames { get; private set; }
 
         public ConfigurationDataMyAnonamouse()
         {
             MamId = new StringConfigurationItem("mam_id");
             MamIdHint = new DisplayInfoConfigurationItem("mam_id instructions", "Go to your <a href=\"https://www.myanonamouse.net/preferences/index.php?view=security\" target=\"_blank\">security preferences</a> and create a new session for the IP used by the Jackett server. Then paste the resulting mam_id value into the mam_id field here.");
-            ExcludeVip = new BoolConfigurationItem("Exclude VIP torrents");
-            Instructions = new DisplayInfoConfigurationItem("", "For best results, change the 'Torrents per page' setting to 100 in your Profile => Torrent tab.");
+            SearchType = new SingleSelectConfigurationItem(
+                "Search Type",
+                new Dictionary<string, string>
+                {
+                    { "all", "All torrents" },
+                    { "active", "Only active" },
+                    { "fl", "Freeleech" },
+                    { "fl-VIP", "Freeleech or VIP" },
+                    { "VIP", "VIP torrents" },
+                    { "nVIP", "Torrents not VIP" },
+                })
+            { Value = "all" };
+            SearchInDescription = new BoolConfigurationItem("Also search text in the description") { Value = false };
+            SearchInSeries = new BoolConfigurationItem("Also search text in the series") { Value = false };
+            SearchInFilenames = new BoolConfigurationItem("Also search text in the filenames") { Value = false };
         }
     }
-
 }


### PR DESCRIPTION
I'm porting some of my changes from Prowlarr.

- added selectable search type (default `all`)
- added `Search in narrator` by default to match their default search on the site
- added `Search text in the description` (default `false`)
- added `Search text in the series` (default `false`)
- added `Search text in the filenames` (default `false`)
- added support for multiple authors, maximum 5.
- show filetype in uppercase
- ~~check for freeleech vip only torrents if the user has class `VIP`or `Elite VIP`~~

TODO: 
- ~~cache `HasUserVipAsync` response for at least one hour. Suggestions/example welcome here.~~
- ~~Jackett requires `ToLocalTime()`? Seems fine without in webui.~~