### PR TITLE
assorted: use GetArgumentFromQueryString and other minor fixes

### DIFF
--- a/src/Jackett.Common/Indexers/HDTorrents.cs
+++ b/src/Jackett.Common/Indexers/HDTorrents.cs
@@ -170,15 +170,14 @@ namespace Jackett.Common.Indexers
                     var poster = posterMatch.Success ? new Uri(SiteLink + posterMatch.Groups[1].Value.Replace("\\", "/")) : null;
 
                     var link = new Uri(SiteLink + row.Children[4].FirstElementChild.GetAttribute("href"));
-                    var description = row.Children[2].QuerySelector("span").TextContent;
+                    var description = row.Children[2].QuerySelector("span")?.TextContent.Trim();
                     var size = ReleaseInfo.GetBytes(row.Children[7].TextContent);
 
-                    var dateTag = row.Children[6].FirstElementChild;
-                    var dateString = string.Join(" ", dateTag.Attributes.Select(attr => attr.Name));
-                    var publishDate = DateTime.ParseExact(dateString, "dd MMM yyyy HH:mm:ss zz00", CultureInfo.InvariantCulture).ToLocalTime();
+                    var dateAdded = string.Join(" ", row.Children[6].FirstElementChild.Attributes.Select(a => a.Name).Take(4));
+                    var publishDate = DateTime.ParseExact(dateAdded, "dd MMM yyyy HH:mm:ss", CultureInfo.InvariantCulture);
 
-                    var catStr = row.FirstElementChild.FirstElementChild.GetAttribute("href").Split('=')[1];
-                    var cat = MapTrackerCatToNewznab(catStr);
+                    var categoryLink = row.FirstElementChild.FirstElementChild.GetAttribute("href");
+                    var cat = ParseUtil.GetArgumentFromQueryString(categoryLink, "category");
 
                     // Sometimes the uploader column is missing, so seeders, leechers, and grabs may be at a different index.
                     // There's room for improvement, but this works for now.
@@ -230,7 +229,7 @@ namespace Jackett.Common.Indexers
                         Guid = details,
                         Link = link,
                         PublishDate = publishDate,
-                        Category = cat,
+                        Category = MapTrackerCatToNewznab(cat),
                         Description = description,
                         Poster = poster,
                         Imdb = imdb,


### PR DESCRIPTION
- use `ParseUtil.GetArgumentFromQueryString()` instead of `Split` (there a few more, but I can't test or find out what's the name of param)
- use [NameValueCollection.Set()](https://learn.microsoft.com/en-us/dotnet/api/system.collections.specialized.namevaluecollection.set?view=net-6.0#remarks)
- use `WebUtility.HtmlDecode()` for titles taken from download links
- ignore the hardcoded timezone in HDTS
- ST: use the date added before falling back to elapsed time, and change encoding to UTF-8 to match both header and meta `content-type` charset.