### PR TITLE
cloudtorrents: add fake user-agent to bypass blocking

### DIFF
--- a/src/Jackett.Common/Definitions/cloudtorrents.yml
+++ b/src/Jackett.Common/Definitions/cloudtorrents.yml
@@ -35,6 +35,10 @@ download:
       attribute: href
 
 search:
+  headers:
+    # site blocks automation User-Agents, so slightly alter it here (e.g. Safari/537.37 > Safari/537.36)
+    User-Agent: ["Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/104.0.0.0 Safari/537.36"]
+
   paths:
     - path: "{{ if .Keywords }}search?query={{ .Keywords }}{{ else }}latest{{ end }}"
 
@@ -65,7 +69,7 @@ search:
       attribute: title
       filters:
         - name: append
-          args: " -09:00" # CUS
+          args: " +00:00" # GMT
         - name: dateparse
           args: "02 Jan, 2006 15:04 -07:00"
     size:


### PR DESCRIPTION
Apparently they block Prowlarr's User Agent, but not Jackett's. So it's up to you if you'll like to accept this change, if not I'll push just to `prowlarr/indexers`.

Also the timezone seems off, I'm above minus 300 minutes for the latest release. I couldn't figure it out since they didn't released anything in the last hour.