### PR TITLE
speedcd: add freeleech only, exclude archives and fix TZ

### DIFF
--- a/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationDataSpeedCD.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationDataSpeedCD.cs
@@ -1,0 +1,18 @@
+using System.Diagnostics.CodeAnalysis;
+
+namespace Jackett.Common.Models.IndexerConfig.Bespoke
+{
+    [ExcludeFromCodeCoverage]
+    public class ConfigurationDataSpeedCD : ConfigurationDataBasicLogin
+    {
+        public BoolConfigurationItem Freeleech { get; set; }
+        public BoolConfigurationItem ExcludeArchives { get; set; }
+
+        public ConfigurationDataSpeedCD(string instructionMessageOptional = null)
+            : base(instructionMessageOptional)
+        {
+            Freeleech = new BoolConfigurationItem("Search freeleech only") { Value = false };
+            ExcludeArchives = new BoolConfigurationItem("Exclude torrents with RAR files") { Value = false };
+        }
+    }
+}


### PR DESCRIPTION
I didn't get any errors while changing the `configData` implementation. Is there anything special to do when you're changing the implementation of the configuration?

Added also a fix when searching season and only episodes are available by adding wildcard. For testing search `tt0412253 S03` before and after.