### PR TITLE
ourbits: update inputs for category

### DIFF
--- a/src/Jackett.Common/Definitions/ourbits.yml
+++ b/src/Jackett.Common/Definitions/ourbits.yml
@@ -57,13 +57,13 @@ search:
   paths:
     - path: torrents.php
   inputs:
-    $raw: "{{ range .Categories }}cat{{.}}=1&{{end}}"
+    $raw: "{{ range .Categories }}cat[]={{.}}&{{end}}"
     search: "{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}"
     # 0=incldead, 1=active, 2=dead
     incldead: 0
     # show promotions: 0=all, 1=normal, 2=free, 3=2x, 4=2xFree, 5=50%, 6=2x50%, 7=30%
     spstate: "{{ if .Config.freeleech }}2{{ else }}0{{ end }}"
-    # 0=title, 1=descr, 3=uploader, 4=imdb URL
+    # 0=title, 3=uploader, 4=imdb URL, 5=douban URL
     search_area: "{{ if .Query.IMDBID }}4{{ else }}0{{ end }}"
     # 0=AND, 1=OR, 2=Exact
     search_mode: 0
@@ -138,4 +138,4 @@ search:
     description:
       selector: td.rowfollow:nth-child(2)
       remove: a, img
-# Ourbits 1.1.0 (Based on NexusPHP Standard v1.5 Beta 4) 3f7f4b0 2023-02-01
+# Ourbits 1.1.0 (Based on NexusPHP Standard v1.5 Beta 4) e71117f 2023-02-05


### PR DESCRIPTION
Hey, I'm sysop for site `ourbits`.
from old commit `3f7f4b0` to current commit `e71117f`, We update our search engines and many searchparams sign changed. 
for example:
 - `&cat401=1` (no other category in filter) changed to `&cat=401` (retained from the past) or `&cat[]=401`
 - `&cat401=1&cat402=1` (more than two category in filter) changed to `&cat[]=401&cat[]=402`

---

We also introduce our jsonapi (though it's no stable in current time), You can find in [ourbits/docs](https://github.com/ourbits/docs#31-%E7%A7%8D%E5%AD%90%E6%90%9C%E7%B4%A2) (in chinese)

here is example

```bash
curl 'https://xxxxxxx.club/jsonapi.php?action=torrent/search&search=<search_text>&cat[]=401&<other_search_params>' \
  -H 'cookie: ourbits_jwt=........' \
```