### PR TITLE
assorted: normalise multi/vostfr/subfrench/pl replacements

### DIFF
--- a/src/Jackett.Common/Definitions/2fast4you.yml
+++ b/src/Jackett.Common/Definitions/2fast4you.yml
@@ -97,22 +97,22 @@ settings:
     default: false
   - name: multilang
     type: checkbox
-    label: Replace MULTI by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI by this language
+    label: Replace MULTi by this language
     default: FRENCH
     options:
-      FRENCH: "FRENCH"
-      MULTI.FRENCH: "MULTI.FRENCH"
-      ENGLISH: "ENGLISH"
-      MULTI.ENGLISH: "MULTI.ENGLISH"
-      VOSTFR: "VOSTFR"
-      MULTI.VOSTFR: "MULTI.VOSTFR"
+      FRENCH: FRENCH
+      MULTi FRENCH: MULTi FRENCH
+      ENGLISH: ENGLISH
+      MULTi ENGLISH: MULTi ENGLISH
+      VOSTFR: VOSTFR
+      MULTi VOSTFR: MULTi VOSTFR
   - name: vostfr
     type: checkbox
-    label: Replace VOSTFR with ENGLISH
+    label: Replace VOSTFR and SUBFRENCH with ENGLISH
     default: false
   - name: sort
     type: select
@@ -182,16 +182,14 @@ search:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\smulti\\s)", " {{ .Config.multilanguage }} "]
+          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
     title_phase2:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     title_vostfr:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\svostfr\\s)", " ENGLISH "]
-        - name: re_replace
-          args: ["(?i)(\\ssubfrench\\s)", " ENGLISH "]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title:
       text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:

--- a/src/Jackett.Common/Definitions/2fast4you.yml
+++ b/src/Jackett.Common/Definitions/2fast4you.yml
@@ -178,20 +178,20 @@ search:
       filters:
         - name: replace
           args: [" - (Nouveau!)", ""]
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       selector: a[href^="torrents-details.php?id="]
       attribute: href

--- a/src/Jackett.Common/Definitions/abnormal.yml
+++ b/src/Jackett.Common/Definitions/abnormal.yml
@@ -124,20 +124,20 @@ search:
           args: SelectedCats
     title_phase1:
       selector: td.grid-release-column > a
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       selector: a[href^="/Torrent/Details?ReleaseId="]
       attribute: href

--- a/src/Jackett.Common/Definitions/cinemamovies.yml
+++ b/src/Jackett.Common/Definitions/cinemamovies.yml
@@ -56,15 +56,15 @@ settings:
     default: false
   - name: multilang
     type: checkbox
-    label: Replace MULTI & PL by another language in release name
+    label: Replace MULTi & PL by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI & PL by this language
+    label: Replace MULTi & PL by this language
     default: POLISH
     options:
       POLISH: POLISH
-      MULTI.POLISH: MULTI.POLISH
+      MULTi POLISH: MULTi POLISH
   - name: sort
     type: select
     label: Sort requested from site
@@ -122,9 +122,9 @@ search:
       text: "{{ .Result.title_raw }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\[multi\\])", " {{ .Config.multilanguage }} "]
+          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
         - name: re_replace
-          args: ["(?i)(\\[pl\\])", " {{ .Config.multilanguage }} "]
+          args: ["(?i)\\b(pl)\\b", "{{ .Config.multilanguage }}"]
     title_phase1:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_raw }}{{ end }}"
     title_stripped:

--- a/src/Jackett.Common/Definitions/cinemamovies.yml
+++ b/src/Jackett.Common/Definitions/cinemamovies.yml
@@ -122,7 +122,7 @@ search:
       text: "{{ .Result.title_raw }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(MULTI(?!.*(?:POLISH|ENGLISH|\\bPL\\b)))\\b", "{{ .Config.multilanguage }}"]
         - name: re_replace
           args: ["(?i)\\b(pl)\\b", "POLISH"]
     title_phase1:

--- a/src/Jackett.Common/Definitions/cinemamovies.yml
+++ b/src/Jackett.Common/Definitions/cinemamovies.yml
@@ -56,11 +56,11 @@ settings:
     default: false
   - name: multilang
     type: checkbox
-    label: Replace MULTi & PL by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTi & PL by this language
+    label: Replace MULTi by this language
     default: POLISH
     options:
       POLISH: POLISH
@@ -124,7 +124,7 @@ search:
         - name: re_replace
           args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
         - name: re_replace
-          args: ["(?i)\\b(pl)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(pl)\\b", "POLISH"]
     title_phase1:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_raw }}{{ end }}"
     title_stripped:

--- a/src/Jackett.Common/Definitions/cpabien.yml
+++ b/src/Jackett.Common/Definitions/cpabien.yml
@@ -132,20 +132,20 @@ search:
         # and we delete it at the end
         - name: re_replace
           args: ["(19|20\\d{2})$", ""]
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       selector: a
       attribute: href

--- a/src/Jackett.Common/Definitions/cpasbienclone.yml
+++ b/src/Jackett.Common/Definitions/cpasbienclone.yml
@@ -111,20 +111,20 @@ search:
         # and we delete it at the end
         - name: re_replace
           args: ["(19|20\\d{2})$", ""]
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       selector: a
       attribute: href

--- a/src/Jackett.Common/Definitions/cpasbiensi.yml
+++ b/src/Jackett.Common/Definitions/cpasbiensi.yml
@@ -80,20 +80,20 @@ search:
         # and we delete it at the end
         - name: re_replace
           args: ["(19|20\\d{2})$", ""]
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       selector: a
       attribute: href

--- a/src/Jackett.Common/Definitions/crazyspirits.yml
+++ b/src/Jackett.Common/Definitions/crazyspirits.yml
@@ -120,22 +120,22 @@ settings:
     default: false
   - name: multilang
     type: checkbox
-    label: Replace MULTI by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI by this language
+    label: Replace MULTi by this language
     default: FRENCH
     options:
       FRENCH: FRENCH
-      MULTI.FRENCH: MULTI.FRENCH
+      MULTi FRENCH: MULTi FRENCH
       ENGLISH: ENGLISH
-      MULTI.ENGLISH: MULTI.ENGLISH
+      MULTi ENGLISH: MULTi ENGLISH
       VOSTFR: VOSTFR
-      MULTI.VOSTFR: MULTI.VOSTFR
+      MULTi VOSTFR: MULTi VOSTFR
   - name: vostfr
     type: checkbox
-    label: Replace VOSTFR with ENGLISH
+    label: Replace VOSTFR and SUBFRENCH with ENGLISH
     default: false
   - name: sort
     type: select
@@ -212,16 +212,14 @@ search:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\smulti\\s)", " {{ .Config.multilanguage }} "]
+          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
     title_phase3:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     title_vostfr:
       text: "{{ .Result.title_phase3 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\svostfr\\s)", " ENGLISH "]
-        - name: re_replace
-          args: ["(?i)(\\ssubfrench\\s)", " ENGLISH "]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title:
       text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase3 }}{{ end }}"
     category:

--- a/src/Jackett.Common/Definitions/crazyspirits.yml
+++ b/src/Jackett.Common/Definitions/crazyspirits.yml
@@ -208,20 +208,20 @@ search:
           args: ["-NoTag", ""]
     title_phase2:
       text: "{{ if .Result.title_phase1 }}{{ .Result.title_phase1 }}{{ else }}{{ .Result.title_phase0 }}{{ end }}"
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase3:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase3 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase3 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase3 }}{{ end }}"
     category:
       selector: a[href^="torrents.php?cat="]
       attribute: href

--- a/src/Jackett.Common/Definitions/devil-torrents.yml
+++ b/src/Jackett.Common/Definitions/devil-torrents.yml
@@ -128,6 +128,8 @@ search:
       filters:
         - name: re_replace
           args: ["(?i)(\\bmulti\\b)", "{{ .Config.multilanguage }}"]
+        - name: re_replace
+          args: ["(?i)\\b(pl)\\b", "POLISH"]
     title:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     details:

--- a/src/Jackett.Common/Definitions/devil-torrents.yml
+++ b/src/Jackett.Common/Definitions/devil-torrents.yml
@@ -51,15 +51,15 @@ settings:
     label: Password
   - name: multilang
     type: checkbox
-    label: Replace MULTI by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI by this language
+    label: Replace MULTi by this language
     default: POLISH
     options:
       POLISH: POLISH
-      MULTI.POLISH: MULTI.POLISH
+      MULTi POLISH: MULTi POLISH
 
 login:
   path: logowanie

--- a/src/Jackett.Common/Definitions/devil-torrents.yml
+++ b/src/Jackett.Common/Definitions/devil-torrents.yml
@@ -127,7 +127,7 @@ search:
       attribute: title
       filters:
         - name: re_replace
-          args: ["(?i)(\\bmulti\\b)", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(MULTI(?!.*(?:POLISH|ENGLISH|\\bPL\\b)))\\b", "{{ .Config.multilanguage }}"]
         - name: re_replace
           args: ["(?i)\\b(pl)\\b", "POLISH"]
     title:

--- a/src/Jackett.Common/Definitions/electro-torrent.yml
+++ b/src/Jackett.Common/Definitions/electro-torrent.yml
@@ -141,7 +141,7 @@ search:
       attribute: title
       filters:
         - name: re_replace
-          args: ["(?i)(\\bmulti\\b)", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(MULTI(?!.*(?:POLISH|ENGLISH|\\bPL\\b)))\\b", "{{ .Config.multilanguage }}"]
         - name: re_replace
           args: ["(?i)\\b(pl)\\b", "POLISH"]
     title:

--- a/src/Jackett.Common/Definitions/electro-torrent.yml
+++ b/src/Jackett.Common/Definitions/electro-torrent.yml
@@ -142,6 +142,8 @@ search:
       filters:
         - name: re_replace
           args: ["(?i)(\\bmulti\\b)", "{{ .Config.multilanguage }}"]
+        - name: re_replace
+          args: ["(?i)\\b(pl)\\b", "POLISH"]
     title:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     details:

--- a/src/Jackett.Common/Definitions/electro-torrent.yml
+++ b/src/Jackett.Common/Definitions/electro-torrent.yml
@@ -57,15 +57,15 @@ settings:
     label: Password
   - name: multilang
     type: checkbox
-    label: Replace MULTI by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI by this language
+    label: Replace MULTi by this language
     default: POLISH
     options:
       POLISH: POLISH
-      MULTI.POLISH: MULTI.POLISH
+      MULTi POLISH: MULTi POLISH
 
 login:
   path: logowanie

--- a/src/Jackett.Common/Definitions/generationfree-api.yml
+++ b/src/Jackett.Common/Definitions/generationfree-api.yml
@@ -121,9 +121,6 @@ search:
       selector: category_id
     title_phase1:
       selector: name
-      filters:
-        - name: replace
-          args: [".", " "]
     title_vfq:
       text: "{{ .Result.title_phase1 }}"
       filters:

--- a/src/Jackett.Common/Definitions/generationfree-api.yml
+++ b/src/Jackett.Common/Definitions/generationfree-api.yml
@@ -38,25 +38,29 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
-  - name: vfq
-    type: checkbox
-    label: Replace VFQ with FRENCH in release name
-    default: false
   - name: multilang
     type: checkbox
-    label: Replace MULTI by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI by this language
-    default: VOSTFR
+    label: Replace MULTi by this language
+    default: FRENCH
     options:
       FRENCH: FRENCH
-      "MULTI FRENCH": "MULTI FRENCH"
+      MULTi FRENCH: MULTi FRENCH
       ENGLISH: ENGLISH
-      "MULTI ENGLISH": "MULTI ENGLISH"
+      MULTi ENGLISH: MULTi ENGLISH
       VOSTFR: VOSTFR
-      "MULTI VOSTFR": "MULTI VOSTFR"
+      MULTi VOSTFR: MULTi VOSTFR
+  - name: vostfr
+    type: checkbox
+    label: Replace VOSTFR and SUBFRENCH with ENGLISH
+    default: false
+  - name: vfq
+    type: checkbox
+    label: Replace VFQ with FRENCH
+    default: false
   - name: sort
     type: select
     label: Sort requested from site
@@ -115,25 +119,32 @@ search:
   fields:
     category:
       selector: category_id
-    title_original:
+    title_phase1:
       selector: name
       filters:
         - name: replace
           args: [".", " "]
     title_vfq:
-      text: "{{ .Result.title_original }}"
+      text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\sVFQ\\s)", " FRENCH "]
-    title_step2:
-      text: "{{ if .Config.vfq }}{{ .Result.title_vfq }}{{ else }}{{ .Result.title_original }}{{ end }}"
+          args: ["(?i)\\b(VFQ)\\b)", "FRENCH"]
+    title_phase2:
+      text: "{{ if .Config.vfq }}{{ .Result.title_vfq }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     title_multilang:
-      text: "{{ .Result.title_step2 }}"
+      text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\sMULTI\\s)", " {{ .Config.multilanguage }} "]
+          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+    title_phase3:
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+    title_vostfr:
+      text: "{{ .Result.title_phase3 }}"
+      filters:
+        - name: re_replace
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_step2 }}{{ end }}"
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase3 }}{{ end }}"
     details:
       selector: details_link
     download:

--- a/src/Jackett.Common/Definitions/generationfree-api.yml
+++ b/src/Jackett.Common/Definitions/generationfree-api.yml
@@ -125,7 +125,7 @@ search:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(VFQ)\\b)", "FRENCH"]
+          args: ["(?i)\\b(VFQ)\\b", "FRENCH"]
     title_phase2:
       text: "{{ if .Config.vfq }}{{ .Result.title_vfq }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     title_vostfr:

--- a/src/Jackett.Common/Definitions/generationfree-api.yml
+++ b/src/Jackett.Common/Definitions/generationfree-api.yml
@@ -128,20 +128,20 @@ search:
           args: ["(?i)\\b(VFQ)\\b)", "FRENCH"]
     title_phase2:
       text: "{{ if .Config.vfq }}{{ .Result.title_vfq }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase3:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase3 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase3 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase3 }}{{ end }}"
     details:
       selector: details_link
     download:

--- a/src/Jackett.Common/Definitions/gktorrent.yml
+++ b/src/Jackett.Common/Definitions/gktorrent.yml
@@ -121,20 +121,20 @@ search:
         # and we delete it at the end
         - name: re_replace
           args: ["(19|20\\d{2})$", ""]
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       selector: td:nth-child(1) a
       attribute: href

--- a/src/Jackett.Common/Definitions/hdforever.yml
+++ b/src/Jackett.Common/Definitions/hdforever.yml
@@ -236,20 +236,20 @@ search:
           args: [".VOF", ".FRENCH"]
         - name: replace
           args: [".VFQ.MULTI", ".MULTI.VFQ"]
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     description:
       selector: div.group_info
     poster:

--- a/src/Jackett.Common/Definitions/hdonly.yml
+++ b/src/Jackett.Common/Definitions/hdonly.yml
@@ -237,20 +237,20 @@ search:
           args: ["[Série]", ""]
         - name: re_replace
           args: ["\\[(\\d{4})\\]", "$1"]
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     description:
       selector: div.group_info
     poster:

--- a/src/Jackett.Common/Definitions/les-cinephiles.yml
+++ b/src/Jackett.Common/Definitions/les-cinephiles.yml
@@ -313,20 +313,20 @@ search:
         img[src$="/serievostfrcoffret.png"]: 180
     title_phase1:
       selector: a[href^="torrents-details.php?id="]
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       selector: a[href^="torrents-details.php?id="]
       attribute: href

--- a/src/Jackett.Common/Definitions/les-cinephiles.yml
+++ b/src/Jackett.Common/Definitions/les-cinephiles.yml
@@ -127,22 +127,22 @@ settings:
     default: false
   - name: multilang
     type: checkbox
-    label: Replace MULTI by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI by this language
+    label: Replace MULTi by this language
     default: FRENCH
     options:
       FRENCH: FRENCH
-      MULTI.FRENCH: MULTI.FRENCH
+      MULTi.FRENCH: MULTi.FRENCH
       ENGLISH: ENGLISH
-      MULTI.ENGLISH: MULTI.ENGLISH
+      MULTi.ENGLISH: MULTi.ENGLISH
       VOSTFR: VOSTFR
-      MULTI.VOSTFR: MULTI.VOSTFR
+      MULTi.VOSTFR: MULTi.VOSTFR
   - name: vostfr
     type: checkbox
-    label: Replace VOSTFR with ENGLISH
+    label: Replace VOSTFR and SUBFRENCH with ENGLISH
     default: false
   - name: sort
     type: select
@@ -317,16 +317,14 @@ search:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\smulti\\s)", " {{ .Config.multilanguage }} "]
+          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
     title_phase2:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     title_vostfr:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\svostfr\\s)", " ENGLISH "]
-        - name: re_replace
-          args: ["(?i)(\\ssubfrench\\s)", " ENGLISH "]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title:
       text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:

--- a/src/Jackett.Common/Definitions/lesaloon.yml
+++ b/src/Jackett.Common/Definitions/lesaloon.yml
@@ -167,7 +167,7 @@ search:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(VFQ)\\b)", "FRENCH"]
+          args: ["(?i)\\b(VFQ)\\b", "FRENCH"]
     title_phase2:
       text: "{{ if .Config.vfq }}{{ .Result.title_vfq }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     title_vostfr:

--- a/src/Jackett.Common/Definitions/lesaloon.yml
+++ b/src/Jackett.Common/Definitions/lesaloon.yml
@@ -96,28 +96,28 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
-  - name: vfq
-    type: checkbox
-    label: Replace VFQ with FRENCH in release name
-    default: false
   - name: multilang
     type: checkbox
-    label: Replace MULTI by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI by this language
+    label: Replace MULTi by this language
     default: FRENCH
     options:
       FRENCH: FRENCH
-      MULTI.FRENCH: MULTI.FRENCH
+      MULTi FRENCH: MULTi FRENCH
       ENGLISH: ENGLISH
-      MULTI.ENGLISH: MULTI.ENGLISH
+      MULTi ENGLISH: MULTi ENGLISH
       VOSTFR: VOSTFR
-      MULTI.VOSTFR: MULTI.VOSTFR
+      MULTi VOSTFR: MULTi VOSTFR
   - name: vostfr
     type: checkbox
-    label: Replace VOSTFR with ENGLISH
+    label: Replace VOSTFR and SUBFRENCH with ENGLISH
+    default: false
+  - name: vfq
+    type: checkbox
+    label: Replace VFQ with FRENCH
     default: false
 
 login:
@@ -161,34 +161,29 @@ search:
       filters:
         - name: querystring
           args: category
-    title_original:
+    title_phase1:
       selector: td a[href^="index.php?page=torrent-details"]
-      filters:
-        - name: replace
-          args: [".", " "]
     title_vfq:
-      text: "{{ .Result.title_original }}"
+      text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\sVFQ\\s)", " FRENCH "]
-    title_step2:
-      text: "{{ if .Config.vfq }}{{ .Result.title_vfq }}{{ else }}{{ .Result.title_original }}{{ end }}"
+          args: ["(?i)\\b(VFQ)\\b)", "FRENCH"]
+    title_phase2:
+      text: "{{ if .Config.vfq }}{{ .Result.title_vfq }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     title_multilang:
-      text: "{{ .Result.title_step2 }}"
+      text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\smulti\\s)", " {{ .Config.multilanguage }} "]
-    title_step3:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_step2 }}{{ end }}"
+          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+    title_phase3:
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     title_vostfr:
-      text: "{{ .Result.title_step3 }}"
+      text: "{{ .Result.title_phase3 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\svostfr\\s)", " ENGLISH "]
-        - name: re_replace
-          args: ["(?i)(\\ssubfrench\\s)", " ENGLISH "]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_step3 }}{{ end }}"
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase3 }}{{ end }}"
     details:
       selector: td a[href^="index.php?page=torrent-details"]
       attribute: href

--- a/src/Jackett.Common/Definitions/lesaloon.yml
+++ b/src/Jackett.Common/Definitions/lesaloon.yml
@@ -170,20 +170,20 @@ search:
           args: ["(?i)\\b(VFQ)\\b)", "FRENCH"]
     title_phase2:
       text: "{{ if .Config.vfq }}{{ .Result.title_vfq }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase3:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase3 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase3 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase3 }}{{ end }}"
     details:
       selector: td a[href^="index.php?page=torrent-details"]
       attribute: href

--- a/src/Jackett.Common/Definitions/polishsource.yml
+++ b/src/Jackett.Common/Definitions/polishsource.yml
@@ -121,7 +121,7 @@ search:
       selector: a[href^="details.php?id="]
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(MULTI(?!.*(?:POLISH|ENGLISH|\\bPL\\b)))\\b", "{{ .Config.multilanguage }}"]
         - name: re_replace
           args: ["(?i)\\b(pl)\\b", "POLISH"]
     title:

--- a/src/Jackett.Common/Definitions/polishsource.yml
+++ b/src/Jackett.Common/Definitions/polishsource.yml
@@ -121,9 +121,9 @@ search:
       selector: a[href^="details.php?id="]
       filters:
         - name: re_replace
-          args: ["(?i)(\\.multi\\.)", ".{{ .Config.multilanguage }}."]
+          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
         - name: re_replace
-          args: ["(?i)(\\.pl\\.)", ".POLISH."]
+          args: ["(?i)\\b(pl)\\b", "POLISH"]
     title:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     details:

--- a/src/Jackett.Common/Definitions/polishtracker-api.yml
+++ b/src/Jackett.Common/Definitions/polishtracker-api.yml
@@ -45,15 +45,15 @@ settings:
     default: "Find your API Key by accessing your <a href=\"https://pte.nu/\" target =_blank>PolishTracker</a> account <i>Settings</i> page and clicking on the <b>API</b> section."
   - name: multilang
     type: checkbox
-    label: Replace MULTI by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI by this language
+    label: Replace MULTi by this language
     default: POLISH
     options:
       POLISH: POLISH
-      MULTI.POLISH: MULTI.POLISH
+      MULTi.POLISH: MULTi.POLISH
 
 # login:
 #   path: "https://api-test.pte.nu/api/v1/torrents"
@@ -104,9 +104,9 @@ search:
       selector: name
       filters:
         - name: re_replace
-          args: ["(?i)(\\.multi\\.)", ".{{ .Config.multilanguage }}."]
+          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
         - name: re_replace
-          args: ["(?i)(\\.pl\\.)", ".POLISH."]
+          args: ["(?i)\\b(pl)\\b", "POLISH"]
     title:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     details:

--- a/src/Jackett.Common/Definitions/polishtracker-api.yml
+++ b/src/Jackett.Common/Definitions/polishtracker-api.yml
@@ -104,7 +104,7 @@ search:
       selector: name
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(MULTI(?!.*(?:POLISH|ENGLISH|\\bPL\\b)))\\b", "{{ .Config.multilanguage }}"]
         - name: re_replace
           args: ["(?i)\\b(pl)\\b", "POLISH"]
     title:

--- a/src/Jackett.Common/Definitions/sharewood.yml
+++ b/src/Jackett.Common/Definitions/sharewood.yml
@@ -146,20 +146,20 @@ search:
           args: "/img/NewIcones/(.+?).png"
     title_phase1:
       selector: a.view-torrent
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     download:
       selector: a.view-torrent
       attribute: href

--- a/src/Jackett.Common/Definitions/sharewood.yml
+++ b/src/Jackett.Common/Definitions/sharewood.yml
@@ -69,22 +69,22 @@ settings:
     default: false
   - name: multilang
     type: checkbox
-    label: Replace MULTI by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI by this language
+    label: Replace MULTi by this language
     default: FRENCH
     options:
       FRENCH: FRENCH
-      MULTI.FRENCH: MULTI.FRENCH
+      MULTi FRENCH: MULTi FRENCH
       ENGLISH: ENGLISH
-      MULTI.ENGLISH: MULTI.ENGLISH
+      MULTi ENGLISH: MULTi ENGLISH
       VOSTFR: VOSTFR
-      MULTI.VOSTFR: MULTI.VOSTFR
+      MULTi VOSTFR: MULTi VOSTFR
   - name: vostfr
     type: checkbox
-    label: Replace VOSTFR with ENGLISH
+    label: Replace VOSTFR and SUBFRENCH with ENGLISH
     default: false
   - name: sort
     type: select
@@ -146,22 +146,20 @@ search:
           args: "/img/NewIcones/(.+?).png"
     title_phase1:
       selector: a.view-torrent
-    title_vostfr:
+    title_multilang:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(VOSTFR)\\b", "ENGLISH"]
-        - name: re_replace
-          args: ["(?i)\\b(SUBFRENCH)\\b", "ENGLISH"]
+          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
     title_phase2:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_multilang:
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_vostfr:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     download:
       selector: a.view-torrent
       attribute: href

--- a/src/Jackett.Common/Definitions/spidertk.yml
+++ b/src/Jackett.Common/Definitions/spidertk.yml
@@ -187,20 +187,20 @@ search:
           args: cat
     title_phase1:
       selector: a[href^="details.php?id="]
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       selector: a[href^="details.php?id="]
       attribute: href

--- a/src/Jackett.Common/Definitions/teamctgame.yml
+++ b/src/Jackett.Common/Definitions/teamctgame.yml
@@ -85,22 +85,22 @@ settings:
     default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
   - name: multilang
     type: checkbox
-    label: Replace MULTI by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI by this language
+    label: Replace MULTi by this language
     default: FRENCH
     options:
       FRENCH: FRENCH
-      MULTI.FRENCH: MULTI.FRENCH
+      MULTi FRENCH: MULTi FRENCH
       ENGLISH: ENGLISH
-      MULTI.ENGLISH: MULTI.ENGLISH
+      MULTi ENGLISH: MULTi ENGLISH
       VOSTFR: VOSTFR
-      MULTI.VOSTFR: MULTI.VOSTFR
+      MULTi VOSTFR: MULTi VOSTFR
   - name: vostfr
     type: checkbox
-    label: Replace VOSTFR with ENGLISH
+    label: Replace VOSTFR and SUBFRENCH with ENGLISH
     default: false
   - name: sort
     type: select
@@ -178,16 +178,14 @@ search:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\smulti\\s)", " {{ .Config.multilanguage }} "]
+          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
     title_phase2:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     title_vostfr:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\svostfr\\s)", " ENGLISH "]
-        - name: re_replace
-          args: ["(?i)(\\ssubfrench\\s)", " ENGLISH "]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title:
       text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:

--- a/src/Jackett.Common/Definitions/teamctgame.yml
+++ b/src/Jackett.Common/Definitions/teamctgame.yml
@@ -174,20 +174,20 @@ search:
           args: cat
     title_phase1:
       selector: a[href^="details.php?id="] b
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       selector: a[href^="details.php?id="]
       attribute: href

--- a/src/Jackett.Common/Definitions/theoldschool-api.yml
+++ b/src/Jackett.Common/Definitions/theoldschool-api.yml
@@ -130,20 +130,20 @@ search:
           args: ["(?i)\\b(VFQ)\\b)", "FRENCH"]
     title_phase2:
       text: "{{ if .Config.vfq }}{{ .Result.title_vfq }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase3:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase3 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase3 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase3 }}{{ end }}"
     details:
       selector: details_link
     download:

--- a/src/Jackett.Common/Definitions/theoldschool-api.yml
+++ b/src/Jackett.Common/Definitions/theoldschool-api.yml
@@ -127,7 +127,7 @@ search:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(VFQ)\\b)", "FRENCH"]
+          args: ["(?i)\\b(VFQ)\\b", "FRENCH"]
     title_phase2:
       text: "{{ if .Config.vfq }}{{ .Result.title_vfq }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     title_vostfr:

--- a/src/Jackett.Common/Definitions/theoldschool-api.yml
+++ b/src/Jackett.Common/Definitions/theoldschool-api.yml
@@ -123,9 +123,6 @@ search:
       selector: category_id
     title_phase1:
       selector: name
-      filters:
-        - name: replace
-          args: [".", " "]
     title_vfq:
       text: "{{ .Result.title_phase1 }}"
       filters:

--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -67,22 +67,22 @@ caps:
 settings:
   - name: multilang
     type: checkbox
-    label: Replace MULTI by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI by this language
+    label: Replace MULTi by this language
     default: FRENCH
     options:
       FRENCH: FRENCH
-      MULTI.FRENCH: MULTI.FRENCH
+      MULTi FRENCH: MULTi FRENCH
       ENGLISH: ENGLISH
-      MULTI.ENGLISH: MULTI.ENGLISH
+      MULTi ENGLISH: MULTi ENGLISH
       VOSTFR: VOSTFR
-      MULTI.VOSTFR: MULTI.VOSTFR
+      MULTi VOSTFR: MULTi VOSTFR
   - name: vostfr
     type: checkbox
-    label: Replace VOSTFR with ENGLISH
+    label: Replace VOSTFR and SUBFRENCH with ENGLISH
     default: false
   - name: sort
     type: select
@@ -166,16 +166,14 @@ search:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\smulti\\s)", " {{ .Config.multilanguage }} "]
+          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
     title_phase2:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     title_vostfr:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\svostfr\\s)", " ENGLISH "]
-        - name: re_replace
-          args: ["(?i)(\\ssubfrench\\s)", " ENGLISH "]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title:
       text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:

--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -162,20 +162,20 @@ search:
         # and we delete it at the end
         - name: re_replace
           args: ["(19|20\\d{2})$", ""]
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       selector: td:nth-child(1) a
       attribute: href

--- a/src/Jackett.Common/Definitions/torrent911.yml
+++ b/src/Jackett.Common/Definitions/torrent911.yml
@@ -132,20 +132,20 @@ search:
         # and we delete it at the end
         - name: re_replace
           args: ["(19|20\\d{2})$", ""]
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       selector: td:nth-child(1) a
       attribute: href

--- a/src/Jackett.Common/Definitions/torrent9clone.yml
+++ b/src/Jackett.Common/Definitions/torrent9clone.yml
@@ -127,20 +127,20 @@ search:
         # and we delete it at the end
         - name: re_replace
           args: ["(19|20\\d{2})$", ""]
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       selector: td:nth-child(1) a
       attribute: href

--- a/src/Jackett.Common/Definitions/tvroad.yml
+++ b/src/Jackett.Common/Definitions/tvroad.yml
@@ -133,22 +133,22 @@ settings:
     label: Password
   - name: multilang
     type: checkbox
-    label: Replace MULTI by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI by this language
+    label: Replace MULTi by this language
     default: FRENCH
     options:
       FRENCH: FRENCH
-      MULTI.FRENCH: MULTI.FRENCH
+      MULTi.FRENCH: MULTi.FRENCH
       ENGLISH: ENGLISH
-      MULTI.ENGLISH: MULTI.ENGLISH
+      MULTi.ENGLISH: MULTi.ENGLISH
       VOSTFR: VOSTFR
-      MULTI.VOSTFR: MULTI.VOSTFR
+      MULTi.VOSTFR: MULTi.VOSTFR
   - name: vostfr
     type: checkbox
-    label: Replace VOSTFR with ENGLISH
+    label: Replace VOSTFR and SUBFRENCH with ENGLISH
     default: false
 
 login:
@@ -194,16 +194,14 @@ search:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\smulti\\s)", " {{ .Config.multilanguage }} "]
+          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
     title_phase2:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     title_vostfr:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\svostfr\\s)", " ENGLISH "]
-        - name: re_replace
-          args: ["(?i)(\\ssubfrench\\s)", " ENGLISH "]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title:
       text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:

--- a/src/Jackett.Common/Definitions/tvroad.yml
+++ b/src/Jackett.Common/Definitions/tvroad.yml
@@ -190,20 +190,20 @@ search:
     title_phase1:
       selector: a.infobulletorrent
       attribute: title
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       selector: a.infobulletorrent
       attribute: href

--- a/src/Jackett.Common/Definitions/unleashthecartoons.yml
+++ b/src/Jackett.Common/Definitions/unleashthecartoons.yml
@@ -133,7 +133,7 @@ search:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\bmulti\\b)", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(MULTI(?!.*(?:ROMAINIAN|ENGLISH|\\bRO\\b)))\\b", "{{ .Config.multilanguage }}"]
     title:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     details:

--- a/src/Jackett.Common/Definitions/vtorrent.yml
+++ b/src/Jackett.Common/Definitions/vtorrent.yml
@@ -121,7 +121,7 @@ search:
       selector: a[href^="details.php?id="]
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(MULTI(?!.*(?:POLISH|ENGLISH|\\bPL\\b)))\\b", "{{ .Config.multilanguage }}"]
         - name: re_replace
           args: ["(?i)\\b(pl)\\b", "POLISH"]
     title:

--- a/src/Jackett.Common/Definitions/vtorrent.yml
+++ b/src/Jackett.Common/Definitions/vtorrent.yml
@@ -64,15 +64,15 @@ settings:
     label: Password
   - name: multilang
     type: checkbox
-    label: Replace MULTI by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI by this language
+    label: Replace MULTi by this language
     default: POLISH
     options:
       POLISH: POLISH
-      MULTI.POLISH: MULTI.POLISH
+      MULTi POLISH: MULTIi POLISH
   - name: info_tpp
     type: info
     label: Results Per Page
@@ -121,9 +121,9 @@ search:
       selector: a[href^="details.php?id="]
       filters:
         - name: re_replace
-          args: ["(?i)(\\.multi\\.)", ".{{ .Config.multilanguage }}."]
+          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
         - name: re_replace
-          args: ["(?i)(\\.pl\\.)", ".POLISH."]
+          args: ["(?i)\\b(pl)\\b", "POLISH"]
     title:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     details:

--- a/src/Jackett.Common/Definitions/wihd.yml
+++ b/src/Jackett.Common/Definitions/wihd.yml
@@ -115,20 +115,20 @@ search:
           args: ["(?i)(SEASON|SAISON) (\\d\\d)", "S$2"]
         - name: re_replace
           args: ["(?i)(SEASON|SAISON) (\\d)", "S0$2"]
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     poster:
       selector: a.torrentlink > img.img-responsive
       attribute: src

--- a/src/Jackett.Common/Definitions/wihd.yml
+++ b/src/Jackett.Common/Definitions/wihd.yml
@@ -58,22 +58,22 @@ settings:
     default: false
   - name: multilang
     type: checkbox
-    label: Replace MULTI by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI by this language
+    label: Replace MULTi by this language
     default: FRENCH
     options:
       FRENCH: FRENCH
-      MULTI.FRENCH: MULTI.FRENCH
+      MULTi FRENCH: MULTi FRENCH
       ENGLISH: ENGLISH
-      MULTI.ENGLISH: MULTI.ENGLISH
+      MULTi ENGLISH: MULTi ENGLISH
       VOSTFR: VOSTFR
-      MULTI.VOSTFR: MULTI.VOSTFR
+      MULTi VOSTFR: MULTi VOSTFR
   - name: vostfr
     type: checkbox
-    label: Replace VOSTFR with ENGLISH
+    label: Replace VOSTFR and SUBFRENCH with ENGLISH
     default: false
 
 login:
@@ -119,16 +119,14 @@ search:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\smulti\\s)", " {{ .Config.multilanguage }} "]
+          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
     title_phase2:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     title_vostfr:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)(\\svostfr\\s)", " ENGLISH "]
-        - name: re_replace
-          args: ["(?i)(\\ssubfrench\\s)", " ENGLISH "]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title:
       text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     poster:

--- a/src/Jackett.Common/Definitions/xthor-api.yml
+++ b/src/Jackett.Common/Definitions/xthor-api.yml
@@ -151,20 +151,20 @@ search:
       selector: category
     title_phase1:
       selector: name
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       text: "{{ .Config.sitelink }}details.php?id={{ .Result._id }}"
     download:

--- a/src/Jackett.Common/Definitions/xthor-api.yml
+++ b/src/Jackett.Common/Definitions/xthor-api.yml
@@ -36,7 +36,6 @@ caps:
     - {id: 125, cat: TV/Sport, desc: "Films/Sports"}
     - {id: 20, cat: Audio/Video, desc: "Films/Concerts, Clips"}
     - {id: 9, cat: Movies/Other, desc: "Films/VOSTFR"}
-
     # TV Series / Series TV
     - {id: 104, cat: TV/Other, desc: "Series/BluRay"}
     - {id: 13, cat: TV, desc: "Series/Pack VF"}
@@ -52,7 +51,6 @@ caps:
     - {id: 109, cat: TV/Documentary, desc: "Series/DOC"}
     - {id: 34, cat: TV/Sport, desc: "Series/Sport"}
     - {id: 30, cat: TV/Other, desc: "Series/Emission TV"}
-
     # Porn / XxX
     - {id: 36, cat: XXX, desc: "MISC/XxX/Films"}
     - {id: 105, cat: XXX, desc: "MISC/XxX/Séries"}
@@ -60,7 +58,6 @@ caps:
     - {id: 115, cat: XXX, desc: "MISC/XxX/Gays"}
     - {id: 113, cat: XXX, desc: "MISC/XxX/Hentai"}
     - {id: 120, cat: XXX, desc: "MISC/XxX/Magazines"}
-
     # Books / Livres
     - {id: 24, cat: Books/EBook, desc: "Livres/Romans"}
     - {id: 124, cat: Audio/Audiobook, desc: "Livres/Audio Books"}
@@ -69,7 +66,6 @@ caps:
     - {id: 116, cat: Books/EBook, desc: "Livres/Romans Jeunesse"}
     - {id: 102, cat: Books/Comics, desc: "Livres/Comics"}
     - {id: 103, cat: Books/Other, desc: "Livres/Mangas"}
-
     # Softwares / Logiciels
     - {id: 25, cat: PC/Games, desc: "Logiciels/Jeux PC"}
     - {id: 27, cat: Console/PS3, desc: "Logiciels/Playstation"}
@@ -101,14 +97,25 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
+  - name: multilang
+    type: checkbox
+    label: Replace MULTi by another language in release name
+    default: false
   - name: multilanguage
-    type: text
-    label: Replace MULTI by
-    default: MULTI
-  - name: subfrench
-    type: text
-    label: Replace "VOSTFR/SUBFRENCH" by
-    default: ""
+    type: select
+    label: Replace MULTi by this language
+    default: FRENCH
+    options:
+      FRENCH: FRENCH
+      MULTi.FRENCH: MULTi.FRENCH
+      ENGLISH: ENGLISH
+      MULTi.ENGLISH: MULTi.ENGLISH
+      VOSTFR: VOSTFR
+      MULTi.VOSTFR: MULTi.VOSTFR
+  - name: vostfr
+    type: checkbox
+    label: Replace VOSTFR and SUBFRENCH with ENGLISH
+    default: false
 
 login:
   path: "https://api.xthor.tk/"
@@ -142,24 +149,22 @@ search:
       selector: id
     category:
       selector: category
-    title_original:
+    title_phase1:
       selector: name
-    title_multi:
-      text: "{{ .Result.title_original }}"
+    title_multilang:
+      text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)[\\.\\s\\[\\-]multi[\\.\\s\\]\\-]", ".{{ .Config.multilanguage }}."]
-    title_multi_out:
-      text: "{{ if .Config.multilanguage }}{{ .Result.title_multi }}{{ else }}{{ .Result.title_original }}{{ end }}"
+          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+    title_phase2:
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     title_vostfr:
-      text: "{{ .Result.title_multi_out }}"
+      text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)[\\.\\s\\[\\-]vostfr[\\.\\s\\]\\-]", ".{{ .Config.subfrench }}."]
-        - name: re_replace
-          args: ["(?i)[\\.\\s\\[\\-]subfrench[\\.\\s\\]\\-]", ".{{ .Config.subfrench }}."]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title:
-      text: "{{ if .Config.subfrench }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_multi_out }}{{ end }}"
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       text: "{{ .Config.sitelink }}details.php?id={{ .Result._id }}"
     download:

--- a/src/Jackett.Common/Definitions/xtorrenty.yml
+++ b/src/Jackett.Common/Definitions/xtorrenty.yml
@@ -150,6 +150,8 @@ search:
       filters:
         - name: re_replace
           args: ["(?i)(\\bmulti\\b)", "{{ .Config.multilanguage }}"]
+        - name: re_replace
+          args: ["(?i)\\b(pl)\\b", "POLISH"]
     title:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     details:

--- a/src/Jackett.Common/Definitions/xtorrenty.yml
+++ b/src/Jackett.Common/Definitions/xtorrenty.yml
@@ -149,7 +149,7 @@ search:
       selector: a
       filters:
         - name: re_replace
-          args: ["(?i)(\\bmulti\\b)", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(MULTI(?!.*(?:POLISH|ENGLISH|\\bPL\\b)))\\b", "{{ .Config.multilanguage }}"]
         - name: re_replace
           args: ["(?i)\\b(pl)\\b", "POLISH"]
     title:

--- a/src/Jackett.Common/Definitions/xtorrenty.yml
+++ b/src/Jackett.Common/Definitions/xtorrenty.yml
@@ -52,15 +52,15 @@ settings:
     label: Password
   - name: multilang
     type: checkbox
-    label: Replace MULTI by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI by this language
+    label: Replace MULTi by this language
     default: POLISH
     options:
       POLISH: POLISH
-      MULTI.POLISH: MULTI.POLISH
+      MULTi POLISH: MULTi POLISH
   - name: sort
     type: select
     label: Sort requested from site

--- a/src/Jackett.Common/Definitions/yggcookie.yml
+++ b/src/Jackett.Common/Definitions/yggcookie.yml
@@ -290,20 +290,20 @@ search:
         - name: trim
     title_phase1:
       text: "{{ if .Config.filter_title }}{{ .Result.title_filtered }}{{ else }}{{ .Result.title_normal }}{{ end }}"
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
       filters:
         # Sonarr need E in front of 3 digit number or else it thinks it is episode
         # S01E10 for number 110 for example ==> enhancedAnime

--- a/src/Jackett.Common/Definitions/yggcookie.yml
+++ b/src/Jackett.Common/Definitions/yggcookie.yml
@@ -146,22 +146,22 @@ settings:
     default: false
   - name: multilang
     type: checkbox
-    label: Replace MULTI by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI by this language
+    label: Replace MULTi by this language
     default: FRENCH
     options:
       FRENCH: FRENCH
-      MULTI.FRENCH: MULTI.FRENCH
+      MULTi.FRENCH: MULTi.FRENCH
       ENGLISH: ENGLISH
-      MULTI.ENGLISH: MULTI.ENGLISH
+      MULTi.ENGLISH: MULTi.ENGLISH
       VOSTFR: VOSTFR
-      MULTI.VOSTFR: MULTI.VOSTFR
+      MULTi.VOSTFR: MULTi.VOSTFR
   - name: vostfr
     type: checkbox
-    label: Replace VOSTFR with ENGLISH
+    label: Replace VOSTFR and SUBFRENCH with ENGLISH
     default: false
   - name: enhancedAnime
     type: checkbox
@@ -272,23 +272,19 @@ search:
           args: ["(?i)(.*)s([1-9])$", "$1 S0$2"]
         - name: re_replace # Full season S >= 10
           args: ["(?i)(.*)s([1-9][0-9])$", "$1 S$2"]
-        - name: re_replace
-          args: ["(?i)(multi)", "MULTi"]
         # Replace French Saison by Season
         - name: re_replace
-          args: ["(?i)(saison|saison )([1-9])", "S0$2"]
+          args: ["(?i)\\b(saison\\s*)\\b([1-9])", "S0$2"]
         - name: re_replace
-          args: ["(?i)(saison|saison )(\\d{1,4})", "S$2"]
+          args: ["(?i)\\b(saison\\s*)\\b(\\d{1,4})", "S$2"]
     title_filtered:
       text: "{{ .Result.title_normal }}"
       filters:
         - name: re_replace
           args: ["(?i)^(?:(.+?)((?:[\\.\\-\\s_\\[]+(?:imax|(?:dvd|bd|tv)(?:rip|scr)|bluray(?:\\-?rip)?|720\\s*p?|1080\\s*p?|vof?|vost(?:fr)?|multi|vf(?:f|q)?[1-3]?|(?:true)?french|eng?)[\\.\\-\\s_\\]]*)*)([\\(\\[]?(?:20|1[7-9])\\d{2}[\\)\\]]?)(.*)$|(.*))$", "$1 $3 $2 $4 $5"]
-        - name: replace
-          args: [".", " "]
         - name: trim
         - name: re_replace
-          args: ["(?i)\\s(mkv|avi|divx|xvid|mp4)$", ""]
+          args: ["(?i)(.\\b(mkv|avi|divx|xvid|mp4)\\b)$", ""]
         - name: re_replace
           args: ["(\\s{2,5})", " "]
         - name: trim
@@ -298,20 +294,16 @@ search:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)[\\.\\s\\[\\-]multi[\\.\\s\\]\\-]", ".{{ .Config.multilanguage }}."]
+          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
     title_phase2:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     title_vostfr:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)[\\.\\s\\[\\-]vostfr[\\.\\s\\]\\-]", ".ENGLISH."]
-        - name: re_replace
-          args: ["(?i)[\\.\\s\\[\\-]subfrench[\\.\\s\\]\\-]", ".ENGLISH."]
-    title_phase3:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title:
-      text: "{{ .Result.title_phase3 }}"
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
       filters:
         # Sonarr need E in front of 3 digit number or else it thinks it is episode
         # S01E10 for number 110 for example ==> enhancedAnime

--- a/src/Jackett.Common/Definitions/yggtorrent.yml
+++ b/src/Jackett.Common/Definitions/yggtorrent.yml
@@ -138,22 +138,22 @@ settings:
     default: false
   - name: multilang
     type: checkbox
-    label: Replace MULTI by another language in release name
+    label: Replace MULTi by another language in release name
     default: false
   - name: multilanguage
     type: select
-    label: Replace MULTI by this language
+    label: Replace MULTi by this language
     default: FRENCH
     options:
       FRENCH: FRENCH
-      MULTI.FRENCH: MULTI.FRENCH
+      MULTi.FRENCH: MULTi.FRENCH
       ENGLISH: ENGLISH
-      MULTI.ENGLISH: MULTI.ENGLISH
+      MULTi.ENGLISH: MULTi.ENGLISH
       VOSTFR: VOSTFR
-      MULTI.VOSTFR: MULTI.VOSTFR
+      MULTi.VOSTFR: MULTi.VOSTFR
   - name: vostfr
     type: checkbox
-    label: Replace VOSTFR with ENGLISH
+    label: Replace VOSTFR and SUBFRENCH with ENGLISH
     default: false
   - name: enhancedAnime
     type: checkbox
@@ -279,23 +279,19 @@ search:
           args: ["(?i)(.*)s([1-9])$", "$1 S0$2"]
         - name: re_replace # Full season S >= 10
           args: ["(?i)(.*)s([1-9][0-9])$", "$1 S$2"]
-        - name: re_replace
-          args: ["(?i)(multi)", "MULTi"]
         # Replace French Saison by Season
         - name: re_replace
-          args: ["(?i)(saison|saison )([1-9])", "S0$2"]
+          args: ["(?i)\\b(saison\\s*)\\b([1-9])", "S0$2"]
         - name: re_replace
-          args: ["(?i)(saison|saison )(\\d{1,4})", "S$2"]
+          args: ["(?i)\\b(saison\\s*)\\b(\\d{1,4})", "S$2"]
     title_filtered:
       text: "{{ .Result.title_normal }}"
       filters:
         - name: re_replace
           args: ["(?i)^(?:(.+?)((?:[\\.\\-\\s_\\[]+(?:imax|(?:dvd|bd|tv)(?:rip|scr)|bluray(?:\\-?rip)?|720\\s*p?|1080\\s*p?|vof?|vost(?:fr)?|multi|vf(?:f|q)?[1-3]?|(?:true)?french|eng?)[\\.\\-\\s_\\]]*)*)([\\(\\[]?(?:20|1[7-9])\\d{2}[\\)\\]]?)(.*)$|(.*))$", "$1 $3 $2 $4 $5"]
-        - name: replace
-          args: [".", " "]
         - name: trim
         - name: re_replace
-          args: ["(?i)\\s(mkv|avi|divx|xvid|mp4)$", ""]
+          args: ["(?i)(.\\b(mkv|avi|divx|xvid|mp4)\\b)$", ""]
         - name: re_replace
           args: ["(\\s{2,5})", " "]
         - name: trim
@@ -305,20 +301,16 @@ search:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)[\\.\\s\\[\\-]multi[\\.\\s\\]\\-]", ".{{ .Config.multilanguage }}."]
+          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
     title_phase2:
       text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
     title_vostfr:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)[\\.\\s\\[\\-]vostfr[\\.\\s\\]\\-]", ".ENGLISH."]
-        - name: re_replace
-          args: ["(?i)[\\.\\s\\[\\-]subfrench[\\.\\s\\]\\-]", ".ENGLISH."]
-    title_phase3:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title:
-      text: "{{ .Result.title_phase3 }}"
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
       filters:
         # Sonarr need E in front of 3 digit number or else it thinks it is episode
         # S01E10 for number 110 for example ==> enhancedAnime

--- a/src/Jackett.Common/Definitions/yggtorrent.yml
+++ b/src/Jackett.Common/Definitions/yggtorrent.yml
@@ -297,20 +297,20 @@ search:
         - name: trim
     title_phase1:
       text: "{{ if .Config.filter_title }}{{ .Result.title_filtered }}{{ else }}{{ .Result.title_normal }}{{ end }}"
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
       filters:
         # Sonarr need E in front of 3 digit number or else it thinks it is episode
         # S01E10 for number 110 for example ==> enhancedAnime

--- a/src/Jackett.Common/Definitions/zetorrents.yml
+++ b/src/Jackett.Common/Definitions/zetorrents.yml
@@ -112,20 +112,20 @@ search:
         # and we delete it at the end
         - name: re_replace
           args: ["(19|20\\d{2})$", ""]
-    title_multilang:
+    title_vostfr:
       text: "{{ .Result.title_phase1 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(multi)\\b", "{{ .Config.multilanguage }}"]
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
     title_phase2:
-      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
-    title_vostfr:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
       text: "{{ .Result.title_phase2 }}"
       filters:
         - name: re_replace
-          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\\b", "{{ .Config.multilanguage }}"]
     title:
-      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       selector: a[href^="/torrent/"]
       attribute: href

--- a/src/Jackett.Common/Indexers/Sharewood.cs
+++ b/src/Jackett.Common/Indexers/Sharewood.cs
@@ -159,7 +159,7 @@ namespace Jackett.Common.Indexers
         private string MultiRename(string term, string replacement)
         {
             replacement = " " + replacement + " ";
-            term = Regex.Replace(term, @"(?i)\b(multi)\b", replacement);
+            term = Regex.Replace(term, @"(?i)\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR)))\b", replacement);
             return term;
         }
 

--- a/src/Jackett.Common/Indexers/Sharewood.cs
+++ b/src/Jackett.Common/Indexers/Sharewood.cs
@@ -133,24 +133,24 @@ namespace Jackett.Common.Indexers
             var FreeLeechOnly = new BoolConfigurationItem("Search freeleech only");
             configData.AddDynamic("freeleechonly", FreeLeechOnly);
 
-            var ReplaceMulti = new BoolConfigurationItem("Replace MULTI by another language in release name");
+            var ReplaceMulti = new BoolConfigurationItem("Replace MULTi by another language in release name");
             configData.AddDynamic("replacemulti", ReplaceMulti);
 
             // Configure the language select option for MULTI
-            var languageSelect = new SingleSelectConfigurationItem("Replace MULTI by this language", new Dictionary<string, string>
+            var languageSelect = new SingleSelectConfigurationItem("Replace MULTi by this language", new Dictionary<string, string>
             {
                 {"FRENCH", "FRENCH"},
-                {"MULTI.FRENCH", "MULTI.FRENCH"},
+                {"MULTi FRENCH", "MULTi FRENCH"},
                 {"ENGLISH", "ENGLISH"},
-                {"MULTI.ENGLISH", "MULTI.ENGLISH" },
+                {"MULTi ENGLISH", "MULTi ENGLISH" },
                 {"VOSTFR", "VOSTFR"},
-                {"MULTI.VOSTFR", "MULTI.VOSTFR"}
+                {"MULTi VOSTFR", "MULTi VOSTFR"}
             })
             { Value = "FRENCH" };
             ;
             configData.AddDynamic("languageid", languageSelect);
 
-            var ReplaceVostfr = new BoolConfigurationItem("Replace VOSTFR with ENGLISH");
+            var ReplaceVostfr = new BoolConfigurationItem("Replace VOSTFR and SUBFRENCH with ENGLISH");
             configData.AddDynamic("replacevostfr", ReplaceVostfr);
 
             EnableConfigurableRetryAttempts();
@@ -159,15 +159,13 @@ namespace Jackett.Common.Indexers
         private string MultiRename(string term, string replacement)
         {
             replacement = " " + replacement + " ";
-            term = Regex.Replace(term, @"(?i)(\smulti\s)", replacement);
-            term = Regex.Replace(term, @"(?i)(\smulti$)", replacement);
+            term = Regex.Replace(term, @"(?i)\b(multi)\b", replacement);
             return term;
         }
 
         private string VostfrRename(string term, string replacement)
         {
-            term = Regex.Replace(term, @"(?i)(vostfr)", replacement);
-            term = Regex.Replace(term, @"(?i)(subfrench)", replacement);
+            term = Regex.Replace(term, @"(?i)\b(vostfr|subfrench)\b", replacement);
             return term;
         }
 


### PR DESCRIPTION
Only differences between indexers should be for the tracker's language, whether titles  (generally) use spaces or dots, e.g. `MULTi.FRENCH` vs `MULTi FRENCH`, and accommodating additional language labels, e.g. `VFQ` or `VFF`.

I'll test again what I have access to. Feel free to test as well, but the review request is just to make sure nothing obvious has been overlooked.