### PR TITLE
assorted: replace nocensor proxies with mrunblock

### DIFF
--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -14,7 +14,7 @@ links:
   - https://x1337x.eu/
   - https://x1337x.se/
   - https://1337x.unblockit.bio/
-  - https://1337x.nocensor.art/
+  - https://1337x.mrunblock.guru/
   - https://1337x.unblockninja.com/
 legacylinks:
   - https://1337x.is/
@@ -38,6 +38,7 @@ legacylinks:
   - https://1337x.unblockit.pet/
   - https://1337x.nocensor.lol/
   - https://1337x.unblockit.ink/
+  - https://1337x.nocensor.art/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/badasstorrents.yml
+++ b/src/Jackett.Common/Definitions/badasstorrents.yml
@@ -8,13 +8,14 @@ encoding: UTF-8
 requestDelay: 2
 links:
   - https://badasstorrents.com/
-  - https://badasstorrents.nocensor.art/
+  - https://badasstorrents.mrunblock.guru/
 legacylinks:
   - https://badasstorrents.nocensor.work/
   - https://badasstorrents.nocensor.biz/
   - https://badasstorrents.nocensor.sbs/
   - https://badasstorrents.nocensor.world/
   - https://badasstorrents.nocensor.lol/
+  - https://badasstorrents.nocensor.art/
 
 caps:
   categories:

--- a/src/Jackett.Common/Definitions/bitsearch.yml
+++ b/src/Jackett.Common/Definitions/bitsearch.yml
@@ -7,6 +7,7 @@ type: public
 encoding: UTF-8
 links:
   - https://bitsearch.to/
+  - https://bitsearch.mrunblock.guru/
 legacylinks:
   - https://bitsearch.nocensor.biz/
   - https://bitsearch.nocensor.sbs/

--- a/src/Jackett.Common/Definitions/bulltorrent.yml
+++ b/src/Jackett.Common/Definitions/bulltorrent.yml
@@ -7,6 +7,7 @@ type: public
 encoding: UTF-8
 links:
   - https://www.bulltorrent.com/
+  - https://toros.mrunblock.guru/
 legacylinks:
   - https://toros.nocensor.space/
   - https://toros.nocensor.work/

--- a/src/Jackett.Common/Definitions/demonoid.yml
+++ b/src/Jackett.Common/Definitions/demonoid.yml
@@ -14,10 +14,8 @@ links:
   - https://demonoidevmsgasmojajlhikwetsr4pxzw6xkjt3dgdv6nr5yxvsamid.tor2web.to/
   - https://demonoid.unblockit.bio/
   - https://demonoid.torrentbay.to/
-  - https://demonoid.nocensor.art/
+  - https://demonoid.mrunblock.guru/
 legacylinks:
-  - https://demonoid.nocensor.work/
-  - https://demonoid.unblockit.tv/
   - https://demonoid.unblockit.how/
   - https://demonoid.unblockit.cam/
   - https://demonoid.nocensor.biz/
@@ -37,6 +35,7 @@ legacylinks:
   - https://demonoid.unblockit.pet/
   - https://demonoid.nocensor.lol/
   - https://demonoid.unblockit.ink/
+  - https://demonoid.nocensor.art/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/extratorrent-st.yml
+++ b/src/Jackett.Common/Definitions/extratorrent-st.yml
@@ -8,7 +8,7 @@ encoding: UTF-8
 links:
   - https://extratorrent.st/
   - https://extratorrent.unblockit.bio/
-  - https://extratorrent.nocensor.art/
+  - https://extratorrent.mrunblock.guru/
 legacylinks:
   - https://extratorrent.nocensor.work/
   - https://extratorrent.unblockit.tv/
@@ -29,6 +29,7 @@ legacylinks:
   - https://extratorrent.unblockit.pet/
   - https://extratorrent.nocensor.lol/
   - https://extratorrent.unblockit.ink/
+  - https://extratorrent.nocensor.art/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/eztv.yml
+++ b/src/Jackett.Common/Definitions/eztv.yml
@@ -14,15 +14,12 @@ links:
   - https://eztv1.xyz/
   - https://eztv.unblockninja.com/
   - https://eztv.unblockit.bio/
-  - https://eztv.nocensor.art/
+  - https://eztv.mrunblock.guru/
 legacylinks:
   - https://eztv.ag/ # redirects to .re
   - https://eztv.it/ # redirects to .re
   - https://eztv.ch/ # redirects to .re
   - https://eztv.io/
-  - https://eztv.unblockit.tv/
-  - https://eztv.unblockit.how/
-  - https://eztv.unblockit.cam/
   - https://eztv.nocensor.biz/
   - https://eztv.unblockit.day/
   - https://eztv.unblockit.llc/
@@ -38,6 +35,7 @@ legacylinks:
   - https://eztv.unblockit.pet/
   - https://eztv.nocensor.lol/
   - https://eztv.unblockit.ink/
+  - https://eztv.nocensor.art/
 
 caps:
   categories:

--- a/src/Jackett.Common/Definitions/filelisting.yml
+++ b/src/Jackett.Common/Definitions/filelisting.yml
@@ -7,12 +7,13 @@ type: public
 encoding: UTF-8
 links:
   - https://filelisting.com/
-  - https://filelisting.nocensor.art/
+  - https://filelisting.mrunblock.guru/
 legacylinks:
   - https://filelisting.nocensor.biz/
   - https://filelisting.nocensor.sbs/
   - https://filelisting.nocensor.world/
   - https://filelisting.nocensor.lol/
+  - https://filelisting.nocensor.art/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/gktorrent.yml
+++ b/src/Jackett.Common/Definitions/gktorrent.yml
@@ -9,6 +9,7 @@ followredirect: true
 # to fetch current domain use https://www.protege-liens.com/Gktorrent
 links:
   - https://www.gktorrents.cc/
+  - https://gktorrent.mrunblock.guru/
 legacylinks:
   - https://www.gktorrent.org/
   - https://www.gktorrent.me/

--- a/src/Jackett.Common/Definitions/glodls.yml
+++ b/src/Jackett.Common/Definitions/glodls.yml
@@ -11,13 +11,11 @@ links:
   - https://gtdb.cc/
   - https://www.gtdb.to/
   - https://glotorrents.unblockit.bio/
-  - https://glotorrents.nocensor.art/
+  - https://glotorrents.mrunblock.guru/
   - https://glodls.unblockninja.com/
 legacylinks:
   - https://glodls.rocks/
   - https://gtdb.to/
-  - https://glotorrents.nocensor.work/
-  - https://glotorrents.unblockit.tv/
   - https://glotorrents.unblockit.how/
   - https://glotorrents.unblockit.cam/
   - https://glotorrents.nocensor.biz/
@@ -35,6 +33,7 @@ legacylinks:
   - https://glotorrents.unblockit.pet/
   - https://glotorrents.nocensor.lol/
   - https://glotorrents.unblockit.ink/
+  - https://glotorrents.nocensor.art/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/ilcorsaronero.yml
+++ b/src/Jackett.Common/Definitions/ilcorsaronero.yml
@@ -12,7 +12,7 @@ links:
   - https://ilcorsaronero.fun/
   - https://ilcorsaronero.pro/
   - https://ilcorsaronero.torrentbay.to/
-  - https://ilcorsaronero.nocensor.art/
+  - https://ilcorsaronero.mrunblock.guru/
 legacylinks:
   - https://ilcorsaronero.live/
   - https://ilcorsaronero.vip/
@@ -32,6 +32,7 @@ legacylinks:
   - https://ilcorsaronero.nocensor.sbs/
   - https://ilcorsaronero.nocensor.world/
   - https://ilcorsaronero.nocensor.lol/
+  - https://ilcorsaronero.nocensor.art/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/limetorrents.yml
+++ b/src/Jackett.Common/Definitions/limetorrents.yml
@@ -11,7 +11,7 @@ links:
   - https://www.limetorrents.lol/
   - https://limetorrents.unblockit.bio/
   - https://limetorrents.unblockninja.com/
-  - https://limetorrents.nocensor.art/
+  - https://limetorrents.mrunblock.guru/
 legacylinks:
   - https://www.limetorrents.io/
   - https://www.limetorrents.cc/
@@ -22,12 +22,7 @@ legacylinks:
   - https://www.limetorrents.co/
   - https://limetor.com/
   - https://www.limetor.pro/
-  - https://limetorrents.nocensor.biz/
   - https://www.limetorrents.pro/
-  - https://limetorrents.unblockit.llc/
-  - https://limetorrents.unblockit.blue/
-  - https://limetorrents.unblockit.name/
-  - https://limetorrents.nocensor.sbs/
   - https://limetorrents.unblockit.ist/
   - https://limetorrents.unblockit.bet/
   - https://limetorrents.unblockit.cat/
@@ -37,6 +32,7 @@ legacylinks:
   - https://limetorrents.unblockit.pet/
   - https://limetorrents.nocensor.lol/
   - https://limetorrents.unblockit.ink/
+  - https://limetorrents.nocensor.art/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/nyaasi.yml
+++ b/src/Jackett.Common/Definitions/nyaasi.yml
@@ -9,7 +9,7 @@ requestDelay: 2
 links:
   - https://nyaa.si/
   - https://nyaa.iss.ink/
-  - https://nyaa.nocensor.art/ # for magnets only
+  - https://nyaa.mrunblock.guru/ # for magnets only
   - https://nyaa.unblockninja.com/ # for magnets only
 legacylinks:
   - https://nyaa.black-mirror.xyz/
@@ -24,6 +24,7 @@ legacylinks:
   - https://nyaa.lol/ # dropped at request of owner
   - https://nyaa.nocensor.world/
   - https://nyaa.nocensor.lol/
+  - https://nyaa.nocensor.art/
 
 settings:
   - name: filter-id

--- a/src/Jackett.Common/Definitions/rutor.yml
+++ b/src/Jackett.Common/Definitions/rutor.yml
@@ -9,7 +9,7 @@ links:
   - http://rutor.info/ # site does not support https ERR_CONNECTION_REFUSED
   - http://rutor.is/ # site does not support https ERR_CONNECTION_REFUSED
   - http://new-rutor.org/ # site does not support https ERR_CONNECTION_REFUSED
-  - https://rutor.nocensor.art/ # for magnet only
+  - https://rutor.mrunblock.guru/ # for magnet only
 legacylinks:
   - http://live-rutor.org/ # domain expired 9 Feb 2020
   - https://rutor.black-mirror.xyz/
@@ -28,6 +28,7 @@ legacylinks:
   - http://6tor.org/
   - https://rutor.nocensor.world/
   - https://rutor.nocensor.lol/
+  - https://rutor.nocensor.art/
 
 caps:
   # unfortunately RuTor does not display categories anywhere in its search results page :-(

--- a/src/Jackett.Common/Definitions/tokyotosho.yml
+++ b/src/Jackett.Common/Definitions/tokyotosho.yml
@@ -7,7 +7,7 @@ type: public
 encoding: UTF-8
 links:
   - https://www.tokyotosho.info/
-  - https://tokyotosho.nocensor.art/
+  - https://tokyotosho.mrunblock.guru/
 legacylinks:
   - https://tokyotosho.black-mirror.xyz/
   - https://tokyotosho.unblocked.casa/
@@ -25,6 +25,7 @@ legacylinks:
   - https://tokyotosho.nocensor.sbs/
   - https://tokyotosho.nocensor.world/
   - https://tokyotosho.nocensor.lol/
+  - https://tokyotosho.nocensor.art/
 
 settings:
   - name: cat

--- a/src/Jackett.Common/Definitions/torlock.yml
+++ b/src/Jackett.Common/Definitions/torlock.yml
@@ -11,9 +11,9 @@ links:
   - https://www.torlock2.com/
   - https://www.torlock.com/
   - https://torlock.unblockit.bio/
+  - https://torlock.mrunblock.guru/
 legacylinks:
   - https://torlock.com/
-  - https://torlock.nocensor.work/
   - https://torlock.unblockit.tv/
   - https://torlock.unblockit.how/
   - https://torlock.unblockit.cam/

--- a/src/Jackett.Common/Definitions/torrent9clone.yml
+++ b/src/Jackett.Common/Definitions/torrent9clone.yml
@@ -9,12 +9,12 @@ followredirect: true
 # to fetch current domain use https://www.protege-torrent.com/Torrent9
 links:
   - https://ww5.torrent9.re/
+  - https://torrent9.mrunblock.guru/
 legacylinks:
   - https://wvw.torrent9.one/
   - https://wwv.torrent9.one/
   - https://vww.torrent9.one/
   - https://www.torrent9.srl/
-  - https://torrent9.unblocked.monster/
   - https://www.torrent9.la/
   - https://www.torrent9.ninja/
   - https://torrent9.nocensor.space/

--- a/src/Jackett.Common/Definitions/torrentdownload.yml
+++ b/src/Jackett.Common/Definitions/torrentdownload.yml
@@ -9,6 +9,7 @@ followredirect: true
 links:
   - https://www.torrentdownload.info/
   - https://torrentdownload.unblockit.bio/
+  - https://torrentdownload.mrunblock.guru/
 legacylinks:
   - https://torrentdownload.nocensor.space/
   - https://torrentdownload.nocensor.work/

--- a/src/Jackett.Common/Definitions/torrentdownloads.yml
+++ b/src/Jackett.Common/Definitions/torrentdownloads.yml
@@ -10,10 +10,10 @@ links:
   - https://www.torrentdownloads.info/
   - https://www.torrentdownloads.pro/
   - https://torrentdownloads.unblockit.bio/
+  - https://torrentdownloads.mrunblock.guru/
   - https://torrentdownloads.unblockninja.com/
 legacylinks:
   - https://www.torrentdownloads.me/
-  - https://torrentdownloads.nocensor.space/
   - https://torrentdownloads.nocensor.work/
   - https://torrentdownloads.unblockit.tv/
   - https://torrentdownloads.unblockit.how/

--- a/src/Jackett.Common/Definitions/torrentfunk.yml
+++ b/src/Jackett.Common/Definitions/torrentfunk.yml
@@ -10,6 +10,7 @@ links:
   - https://www.torrentfunk.com/
   - https://www.torrentfunk2.com/
   - https://torrentfunk.unblockit.bio/
+  - https://torrentfunk.mrunblock.guru/
 legacylinks:
   - https://torrentfunk.nocensor.space/
   - https://torrentfunk.nocensor.work/

--- a/src/Jackett.Common/Definitions/torrentz2nz.yml
+++ b/src/Jackett.Common/Definitions/torrentz2nz.yml
@@ -7,10 +7,11 @@ type: public
 encoding: UTF-8
 links:
   - https://torrentz2.nz/
-  - https://torrentz2.nocensor.art/
+  - https://torrentz2.mrunblock.guru/
 legacylinks:
   - https://torrentz2.nocensor.world/
   - https://torrentz2.nocensor.lol/
+  - https://torrentz2.nocensor.art/
 
 caps:
   # unfortunately torrentz2nz does not display categories anywhere in its search results page :-(

--- a/src/Jackett.Common/Definitions/yourbittorrent.yml
+++ b/src/Jackett.Common/Definitions/yourbittorrent.yml
@@ -8,6 +8,7 @@ encoding: UTF-8
 links:
   - https://yourbittorrent.com/
   - https://yourbittorrent2.com/
+  - https://yourbittorrent.mrunblock.guru/
 legacylinks:
   - https://yourbittorrent.host/
   - https://yourbittorrent.nocensor.space/

--- a/src/Jackett.Common/Definitions/yts.yml
+++ b/src/Jackett.Common/Definitions/yts.yml
@@ -11,14 +11,11 @@ links:
   - https://yts.mx/
   - https://yts.unblockit.bio/
   - https://yts.unblockninja.com/
-  - https://yts.nocensor.art/
+  - https://yts.mrunblock.guru/
 legacylinks:
   - https://yts.ag/
   - https://yts.am/
   - https://yts.lt/
-  - https://yts.nocensor.work/
-  - https://yts.unblockit.tv/
-  - https://yts.unblockit.how/
   - https://yts.unblockit.cam/
   - https://yts.nocensor.biz/
   - https://yts.unblockit.day/
@@ -35,6 +32,7 @@ legacylinks:
   - https://yts.unblockit.pet/
   - https://yts.nocensor.lol/
   - https://yts.unblockit.ink/
+  - https://yts.nocensor.art/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/zetorrents.yml
+++ b/src/Jackett.Common/Definitions/zetorrents.yml
@@ -8,7 +8,7 @@ encoding: UTF-8
 # to fetch current domain use https://www.protege-liens.com/Zetorrents
 links:
   - https://www.zetorrents.ch/
-  - https://zetorrents.nocensor.art/
+  - https://zetorrents.mrunblock.guru/
 legacylinks:
   - https://www.zetorrents.co/
   - https://www.zetorrents.io/
@@ -25,6 +25,7 @@ legacylinks:
   - https://zetorrents.nocensor.world/
   - https://www.zetorrents.biz/
   - https://zetorrents.nocensor.lol/
+  - https://zetorrents.nocensor.art/
 
 caps:
   categories:

--- a/src/Jackett.Common/Indexers/EraiRaws.cs
+++ b/src/Jackett.Common/Indexers/EraiRaws.cs
@@ -21,7 +21,7 @@ namespace Jackett.Common.Indexers
         public override string[] AlternativeSiteLinks { get; protected set; } = {
             "https://www.erai-raws.info/",
             "https://beta.erai-raws.info/",
-            "https://erairaws.nocensor.art/"
+            "https://erairaws.mrunblock.guru/"
         };
 
         public override string[] LegacySiteLinks { get; protected set; } = {
@@ -30,7 +30,8 @@ namespace Jackett.Common.Indexers
             "https://erairaws.nocensor.biz/",
             "https://erairaws.nocensor.sbs/",
             "https://erairaws.nocensor.world/",
-            "https://erairaws.nocensor.lol/"
+            "https://erairaws.nocensor.lol/",
+            "https://erairaws.nocensor.art/"
         };
 
         public EraiRaws(IIndexerConfigurationService configService, Utils.Clients.WebClient wc, Logger l,

--- a/src/Jackett.Common/Indexers/SubsPlease.cs
+++ b/src/Jackett.Common/Indexers/SubsPlease.cs
@@ -23,7 +23,7 @@ namespace Jackett.Common.Indexers
     {
         public override string[] AlternativeSiteLinks { get; protected set; } = {
             "https://subsplease.org/",
-            "https://subsplease.nocensor.art/"
+            "https://subsplease.mrunblock.guru/"
         };
 
         public override string[] LegacySiteLinks { get; protected set; } = {
@@ -32,7 +32,8 @@ namespace Jackett.Common.Indexers
             "https://subsplease.nocensor.biz/",
             "https://subsplease.nocensor.sbs/",
             "https://subsplease.nocensor.world/",
-            "https://subsplease.nocensor.lol/"
+            "https://subsplease.nocensor.lol/",
+            "https://subsplease.nocensor.art/"
         };
 
         private string ApiEndpoint => SiteLink + "api/?";


### PR DESCRIPTION
From the same [overall source](https://unblocksource.nl/torrent-proxy.php), but restores access to those removed in https://github.com/Jackett/Jackett/commit/b6e29968335ce8b56556f854c04819b4dd440d02.