### PR TITLE
apisearch: parse season/episode only if it's at the end of the query

### DIFF
--- a/src/Jackett.Common/Indexers/XSpeeds.cs
+++ b/src/Jackett.Common/Indexers/XSpeeds.cs
@@ -247,7 +247,6 @@ namespace Jackett.Common.Indexers
 
         protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
         {
-            var searchString = query.GetQueryString();
             var prevCook = CookieHeader + "";
 
             var categoryMapping = MapTorznabCapsToTrackers(query);
@@ -261,12 +260,14 @@ namespace Jackett.Common.Indexers
                 { "order", GetOrder }
             };
 
+            var searchString = Regex.Replace(query.GetQueryString(), @"[ -._]+", " ").Trim();
+
             if (query.IsImdbQuery)
             {
                 searchParams.Add("keywords", query.ImdbID);
                 searchParams.Add("search_type", "t_both");
             }
-            else
+            else if (!string.IsNullOrWhiteSpace(searchString))
             {
                 searchParams.Add("keywords", searchString);
                 searchParams.Add("search_type", "t_name");

--- a/src/Jackett.Test/Common/Models/DTO/ApiSearchTests.cs
+++ b/src/Jackett.Test/Common/Models/DTO/ApiSearchTests.cs
@@ -1,0 +1,32 @@
+using Jackett.Common.Models.DTO;
+using NUnit.Framework;
+
+namespace Jackett.Test.Common.Models.DTO
+{
+    [TestFixture]
+    public class ApiSearchTests
+    {
+        [TestCase("The.Good.Lord.S01E05.720p.WEB.H264-CAKES", "The.Good.Lord.S01E05.720p.WEB.H264-CAKES", 0, null)]
+        [TestCase("The.Good.Lord.S01E05.", "The.Good.Lord.S01E05.", 0, null)]
+        [TestCase("The.Good.Lord.S01E05", "The.Good.Lord. S01E05", 1, "5")]
+        [TestCase("The Good Lord S01E05", "The Good Lord S01E05", 1, "5")]
+        [TestCase("The Good Lord S01 E05", "The Good Lord S01E05", 1, "5")]
+        [TestCase("The Good Lord S01", "The Good Lord S01", 1, null)]
+        [TestCase("The Good Lord E05", "The Good Lord", 0, "5")]
+        [TestCase("The.Good.Lord.s01e05", "The.Good.Lord.s01e05", 0, null)]
+        [TestCase("The.Good.Lord.S01e05", "The.Good.Lord.S01e05", 0, null)]
+        [TestCase("The.Good.Lord.s01E05", "The.Good.Lord.s01E05", 0, null)]
+        [TestCase("The.Good.Lord.S1E5", "The.Good.Lord.S1E5", 0, null)]
+        [TestCase("The.Good.Lord.S11E5", "The.Good.Lord.S11E5", 0, null)]
+        [TestCase("The.Good.Lord.S1E15", "The.Good.Lord.S1E15", 0, null)]
+        public void TestToTorznabQuery(string query, string expected, int season, string episode)
+        {
+            var request = new ApiSearch { Query = query };
+            var currentQuery = ApiSearch.ToTorznabQuery(request);
+
+            Assert.AreEqual(expected, currentQuery.GetQueryString());
+            Assert.AreEqual(season, currentQuery.Season);
+            Assert.AreEqual(episode, currentQuery.Episode);
+        }
+    }
+}


### PR DESCRIPTION
Possible fix for #10041 by not parsing the season/episode information if it's not at the end of the query. Needs testing.