### PR TITLE
anilibria: update to v3 api, add strip russian & add rus settings

### DIFF
--- a/src/Jackett.Common/Definitions/anilibria.yml
+++ b/src/Jackett.Common/Definitions/anilibria.yml
@@ -54,15 +54,16 @@ search:
       selector: ..names.ru
     title_en:
       selector: ..names.en
-    title_alternative_all:
+    title_alternative:
       selector: ..names.alternative
       optional: true
-    title_alternative_notru:
-      selector: ..names.alternative:not(:contains(а)):not(:contains(э)):not(:contains(ы)):not(:contains(у)):not(:contains(о)):not(:contains(я)):not(:contains(е)):not(:contains(ё)):not(:contains(ю)):not(:contains(и)):not(:contains(й))
-      optional: true
-    title_alternative:
-      text: "{{ if .Config.striprussian }}{{ .Result.title_alternative_notru }}{{ else }}{{ .Result.title_alternative_all }}{{ end }}"
-      optional: true
+      filters:
+        - name: re_replace
+          args: ["([А-Яа-яЁё]+)", "{{ if .Config.striprussian }}{{ else }}$1{{ end }}"]
+        - name: re_replace
+          args: ["^[\\.\\s\\d,\\-—:]+", ""]
+        - name: re_replace
+          args: ["^OVA$", ""]
     year:
       selector: ..season.year
     _quality:
@@ -72,6 +73,8 @@ search:
       filters:
         - name: replace
           args: [" - EФильм", " - MOVIE"]
+        - name: replace
+          args: [" - EOVA", " - OVA"]
         - name: append
           args: "{{ if .Config.addrussian }} - RUS{{ else }}{{ end }}"
     _code:

--- a/src/Jackett.Common/Definitions/anilibria.yml
+++ b/src/Jackett.Common/Definitions/anilibria.yml
@@ -71,10 +71,10 @@ search:
     title:
       text: "{{ if .Config.striprussian }}{{ else }}{{ .Result.title_ru }} / {{ end }}{{ .Result.title_en }}{{ if .Result.title_alternative }} / AKA {{ .Result.title_alternative }}{{ else }}{{ end }} ({{ .Result.year }}) [{{ .Result._quality }}]{{ if .Result._episodes }} - E{{ .Result._episodes }}{{ else }}{{ end }}"
       filters:
-        - name: replace
-          args: [" - EФильм", " - MOVIE"]
-        - name: replace
-          args: [" - EOVA", " - OVA"]
+        - name: re_replace
+          args: [" - \\bEФильм\\b", " - MOVIE"]
+        - name: re_replace
+          args: [" - \\bEOVA\\b", " - OVA"]
         - name: append
           args: "{{ if .Config.addrussian }} - RUS{{ else }}{{ end }}"
     _code:

--- a/src/Jackett.Common/Definitions/anilibria.yml
+++ b/src/Jackett.Common/Definitions/anilibria.yml
@@ -54,15 +54,21 @@ search:
       selector: ..names.ru
     title_en:
       selector: ..names.en
-    title_alternative:
+    title_alternative_all:
       selector: ..names.alternative
+      optional: true
+    title_alternative_notru:
+      selector: ..names.alternative:not(:contains(а)):not(:contains(э)):not(:contains(ы)):not(:contains(у)):not(:contains(о)):not(:contains(я)):not(:contains(е)):not(:contains(ё)):not(:contains(ю)):not(:contains(и)):not(:contains(й))
+      optional: true
+    title_alternative:
+      text: "{{ if .Config.striprussian }}{{ .Result.title_alternative_notru }}{{ else }}{{ .Result.title_alternative_all }}{{ end }}"
       optional: true
     year:
       selector: ..season.year
     _quality:
       selector: quality.string
     title:
-      text: "{{ if .Config.striprussian }}{{ else }}{{ .Result.title_ru }} / {{ end }}{{ .Result.title_en }}{{ if .Result.title_alternative }} / {{ .Result.title_alternative }}{{ else }}{{ end }} ({{ .Result.year }}) [{{ .Result._quality }}]{{ if .Result._episodes }} - E{{ .Result._episodes }}{{ else }}{{ end }}"
+      text: "{{ if .Config.striprussian }}{{ else }}{{ .Result.title_ru }} / {{ end }}{{ .Result.title_en }}{{ if .Result.title_alternative }} / AKA {{ .Result.title_alternative }}{{ else }}{{ end }} ({{ .Result.year }}) [{{ .Result._quality }}]{{ if .Result._episodes }} - E{{ .Result._episodes }}{{ else }}{{ end }}"
       filters:
         - name: replace
           args: [" - EФильм", " - MOVIE"]

--- a/src/Jackett.Common/Definitions/anilibria.yml
+++ b/src/Jackett.Common/Definitions/anilibria.yml
@@ -9,19 +9,28 @@ links:
   - https://www.anilibria.tv/
 
 caps:
-  categorymappings:
-    - {id: 1, cat: TV/Anime, desc: Anime}
+  categories:
+    Anime: TV/Anime
+    Movies: Movies/Other
 
   modes:
     search: [q]
     tv-search: [q, season, ep]
 
-settings: []
+settings:
+  - name: striprussian
+    type: checkbox
+    label: Strip Russian Title
+    default: false
+  - name: addrussian
+    type: checkbox
+    label: Add RUS to end of all titles to improve language detection by Sonarr and Radarr. Will cause English-only results to be misidentified.
+    default: false
 
 search:
   paths:
-    # https://github.com/anilibria/docs/blob/master/api_v2.md
-    - path: "https://api.anilibria.tv/v2/{{ if .Keywords }}searchTitles?filter=names,poster.url,code,torrents.list,season.year&limit=100&search={{ .Keywords }}{{ else }}getUpdates?filter=names,poster.url,code,torrents.list,season.year&limit=100{{ end }}"
+    # https://github.com/anilibria/docs/blob/master/api_v3.md
+    - path: "https://api.anilibria.tv/v3/{{ if .Keywords }}searchTitles?search={{ .Keywords }}&{{ else }}getUpdates?{{ end }}filter=names,posters.small.url,code,torrents.list,season.year,description&limit=100"
       response:
         type: json
 
@@ -31,13 +40,16 @@ search:
       args: ["(?i)(?:[SE]?\\d{1,4}){1,2}$", ""]
 
   rows:
-    selector: $
+    selector: list
     attribute: torrents.list
     multiple: true
 
   fields:
+    _episodes:
+      selector: episodes.string
+      optional: true
     category:
-      text: 1
+      text: "{{ if eq .Result._episodes \"Фильм\" }}Movies{{ else }}Anime{{ end }}"
     title_ru:
       selector: ..names.ru
     title_en:
@@ -49,11 +61,13 @@ search:
       selector: ..season.year
     _quality:
       selector: quality.string
-    _series:
-      selector: series.string
-      optional: true
     title:
-      text: "{{ .Result.title_ru }} / {{ .Result.title_en }}{{ if .Result.title_alternative }} / {{ .Result.title_alternative }}{{ else }}{{ end }} ({{ .Result.year }}) [{{ .Result._quality }}]{{ if .Result._series }} - {{ .Result._series }}{{ else }}{{ end }}"
+      text: "{{ if .Config.striprussian }}{{ else }}{{ .Result.title_ru }} / {{ end }}{{ .Result.title_en }}{{ if .Result.title_alternative }} / {{ .Result.title_alternative }}{{ else }}{{ end }} ({{ .Result.year }}) [{{ .Result._quality }}]{{ if .Result._episodes }} - E{{ .Result._episodes }}{{ else }}{{ end }}"
+      filters:
+        - name: replace
+          args: [" - EФильм", " - MOVIE"]
+        - name: append
+          args: "{{ if .Config.addrussian }} - RUS{{ else }}{{ end }}"
     _code:
       selector: ..code
     details:
@@ -63,11 +77,13 @@ search:
       filters:
         - name: prepend
           args: "{{ .Config.sitelink }}"
+    magnet:
+      selector: magnet
     poster:
-      selector: ..poster.url
+      selector: ..posters.small.url
       filters:
         - name: prepend
-          args: "https://static.anilibria.tv/"
+          args: "https://static.anilibria.tv"
     seeders:
       selector: seeders
     leechers:
@@ -83,4 +99,6 @@ search:
       text: 0
     uploadvolumefactor:
       text: 1
-# json api v2
+    description:
+      selector: ..description
+# json api v3

--- a/src/Jackett.Common/Definitions/anilibria.yml
+++ b/src/Jackett.Common/Definitions/anilibria.yml
@@ -20,7 +20,7 @@ caps:
 settings:
   - name: striprussian
     type: checkbox
-    label: Strip Russian Title
+    label: Strip Russian
     default: false
   - name: addrussian
     type: checkbox


### PR DESCRIPTION
Replaces #14020.

Updated to v3 API - fixes posters, adds magnets and description.

Checks if movie, uses the added Movies cat.

@alikhanz given that we're building the title anyway, I think this is a better solution. Give it a test.

@garfield69 / @mynameisbogdan is there a way to make the below (or something like it) work?:

```yml
    title_alternative_notru:
      selector: ..names.alternative:not(:contains([А-Яа-яЁё]))
      optional: true
```