### PR TITLE
cardigann: custom headers in login and download

### DIFF
--- a/src/Jackett.Common/Definitions/hd4fans.yml
+++ b/src/Jackett.Common/Definitions/hd4fans.yml
@@ -45,6 +45,7 @@ settings:
 login:
   path: takelogin.php
   method: post
+  cookies: ["c_lang_folder=en"]
   inputs:
     username: "{{ .Config.username }}"
     password: "{{ .Config.password }}"
@@ -53,7 +54,7 @@ login:
     ssl: yes
     trackerssl: yes
   error:
-    - selector: td.embedded:has(h2:contains("失败"))
+    - selector: td.embedded:has(h2:contains("失败")), td.embedded:has(h2:contains("failed"))
       message:
         selector: td.text
   test:

--- a/src/Jackett.Common/Definitions/schema.json
+++ b/src/Jackett.Common/Definitions/schema.json
@@ -327,6 +327,18 @@
                 },
                 "test": {
                     "$ref": "#/definitions/PageTestBlock"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[A-Za-z0-9-]*$": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
                 }
             },
             "title": "Login"
@@ -675,6 +687,18 @@
                 },
                 "infohash": {
                     "$ref": "#/definitions/InfoHashBlock"
+                },
+                "headers": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "patternProperties": {
+                        "^[A-Za-z0-9-]*$": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
                 }
             },
             "title": "DownloadBlock"

--- a/src/Jackett.Common/Indexers/BaseIndexer.cs
+++ b/src/Jackett.Common/Indexers/BaseIndexer.cs
@@ -538,7 +538,7 @@ namespace Jackett.Common.Indexers
             {
                 Url = url,
                 Type = RequestType.POST,
-                Cookies = cookies,
+                Cookies = cookies ?? CookieHeader,
                 Referer = referer,
                 PostData = data,
                 Encoding = Encoding,

--- a/src/Jackett.Common/Models/IndexerDefinition.cs
+++ b/src/Jackett.Common/Models/IndexerDefinition.cs
@@ -96,6 +96,7 @@ namespace Jackett.Common.Models
         public List<errorBlock> Error { get; set; }
         public pageTestBlock Test { get; set; }
         public captchaBlock Captcha { get; set; }
+        public Dictionary<string, List<string>> Headers { get; set; }
     }
 
     public class errorBlock
@@ -190,6 +191,7 @@ namespace Jackett.Common.Models
         public string Method { get; set; }
         public beforeBlock Before { get; set; }
         public infohashBlock Infohash { get; set; }
+        public Dictionary<string, List<string>> Headers { get; set; }
     }
 
     public class selectorField


### PR DESCRIPTION
Apparently the login part of cardigann doesn't use the custom headers (like User-Agent) from `search.headers`, sending the auth requests with Jackett's User-Agent. 

This PR is trying to allow custom headers in login and download blocks, while inheriting `search.headers` if not set.