### PR TITLE
torznabquery: allow accents in split regex

### DIFF
--- a/src/Jackett.Common/Extensions/StringExtensions.cs
+++ b/src/Jackett.Common/Extensions/StringExtensions.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+
+namespace Jackett.Common.Extensions
+{
+    public static class StringExtensions
+    {
+        public static bool ContainsIgnoreCase(this string source, string contains) => source != null && contains != null && CultureInfo.InvariantCulture.CompareInfo.IndexOf(source, contains, CompareOptions.IgnoreCase | CompareOptions.IgnoreNonSpace) >= 0;
+
+        public static bool ContainsIgnoreCase(this IEnumerable<string> source, string value) => source.Contains(value, StringComparer.InvariantCultureIgnoreCase);
+    }
+}


### PR DESCRIPTION
hellashut is just for practice, even though prepending `+` to Greek words breaks the search.

you can use `το σοι σου` and `ΤΟ ΣΟΙ ΣΟΥ` for testing.

* fixes #7673