### PR TITLE
lossless: change encoding to UTF-8

### DIFF
--- a/src/Jackett.Common/Definitions/losslessclub.yml
+++ b/src/Jackett.Common/Definitions/losslessclub.yml
@@ -4,7 +4,7 @@ name: LosslessClub
 description: "LosslessClub is a Romanian Private site for High Quality Music"
 language: ru-RU
 type: private
-encoding: windows-1251
+encoding: UTF-8
 links:
   - https://losslessclub.com/
 


### PR DESCRIPTION
Current search results with windows-1251:
<img width="1385" alt="image" src="https://user-images.githubusercontent.com/3951176/220166518-fa8428c2-4a8e-441d-99fc-85ba8b4112bf.png">

Search results in build with UTF-8:
<img width="1388" alt="image" src="https://user-images.githubusercontent.com/3951176/220166609-231e0867-5502-4526-9ac8-6980e198d53c.png">

Also i'm writed Dockerfile for local development. I don't know if you need it or not, but for me it's really comfortable.