### PR TITLE
hellashut: remove prepending + to word

### DIFF
--- a/src/Jackett.Common/Definitions/hellashut.yml
+++ b/src/Jackett.Common/Definitions/hellashut.yml
@@ -138,10 +138,6 @@ search:
     order: "{{ .Config.type }}"
     # does not return imdb link in results
 
-  keywordsfilters:
-    - name: re_replace
-      args: ["(\\w+)", "+$1"] # prepend + to each word
-
   rows:
     selector: table.ttable_headinner tr.t-row
 


### PR DESCRIPTION
@ilike2burnthing I suggest removing this since their search doesn't work with Greek words with `+` in front anyways.