### PR TITLE
cardigann: switch to standard datetime format

### DIFF
--- a/src/Jackett.Common/Definitions/acervos-api.yml
+++ b/src/Jackett.Common/Definitions/acervos-api.yml
@@ -158,7 +158,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/aither-api.yml
+++ b/src/Jackett.Common/Definitions/aither-api.yml
@@ -143,7 +143,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/animetracker.yml
+++ b/src/Jackett.Common/Definitions/animetracker.yml
@@ -143,7 +143,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/animeworld-api.yml
+++ b/src/Jackett.Common/Definitions/animeworld-api.yml
@@ -131,7 +131,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/blutopia-api.yml
+++ b/src/Jackett.Common/Definitions/blutopia-api.yml
@@ -137,7 +137,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/brsociety-api.yml
+++ b/src/Jackett.Common/Definitions/brsociety-api.yml
@@ -141,7 +141,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/danishbytes-api.yml
+++ b/src/Jackett.Common/Definitions/danishbytes-api.yml
@@ -124,7 +124,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/datascene-api.yml
+++ b/src/Jackett.Common/Definitions/datascene-api.yml
@@ -144,7 +144,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/desitorrents-api.yml
+++ b/src/Jackett.Common/Definitions/desitorrents-api.yml
@@ -137,7 +137,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/generationfree-api.yml
+++ b/src/Jackett.Common/Definitions/generationfree-api.yml
@@ -177,7 +177,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/hawke-uno.yml
+++ b/src/Jackett.Common/Definitions/hawke-uno.yml
@@ -120,7 +120,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/hd-unit3d-api.yml
+++ b/src/Jackett.Common/Definitions/hd-unit3d-api.yml
@@ -123,7 +123,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/hdolimpo-api.yml
+++ b/src/Jackett.Common/Definitions/hdolimpo-api.yml
@@ -165,7 +165,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/jme-reunit3d-api.yml
+++ b/src/Jackett.Common/Definitions/jme-reunit3d-api.yml
@@ -131,7 +131,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/lat-team-api.yml
+++ b/src/Jackett.Common/Definitions/lat-team-api.yml
@@ -160,7 +160,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/locadora.yml
+++ b/src/Jackett.Common/Definitions/locadora.yml
@@ -129,7 +129,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/lst.yml
+++ b/src/Jackett.Common/Definitions/lst.yml
@@ -134,7 +134,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/portugas-api.yml
+++ b/src/Jackett.Common/Definitions/portugas-api.yml
@@ -147,7 +147,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/racing4everyone-api.yml
+++ b/src/Jackett.Common/Definitions/racing4everyone-api.yml
@@ -153,7 +153,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/redbits-api.yml
+++ b/src/Jackett.Common/Definitions/redbits-api.yml
@@ -163,7 +163,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/reelflix-api.yml
+++ b/src/Jackett.Common/Definitions/reelflix-api.yml
@@ -136,7 +136,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/shareisland-api.yml
+++ b/src/Jackett.Common/Definitions/shareisland-api.yml
@@ -172,7 +172,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/skipthecommercials-api.yml
+++ b/src/Jackett.Common/Definitions/skipthecommercials-api.yml
@@ -132,7 +132,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/skipthetrailers.yml
+++ b/src/Jackett.Common/Definitions/skipthetrailers.yml
@@ -132,7 +132,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/tellytorrent-api.yml
+++ b/src/Jackett.Common/Definitions/tellytorrent-api.yml
@@ -131,7 +131,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/thedarkcommunity-api.yml
+++ b/src/Jackett.Common/Definitions/thedarkcommunity-api.yml
@@ -133,7 +133,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/theoldschool-api.yml
+++ b/src/Jackett.Common/Definitions/theoldschool-api.yml
@@ -183,7 +183,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/theshinning-api.yml
+++ b/src/Jackett.Common/Definitions/theshinning-api.yml
@@ -142,7 +142,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Definitions/torrentseeds-api.yml
+++ b/src/Jackett.Common/Definitions/torrentseeds-api.yml
@@ -119,7 +119,7 @@ search:
         - name: append
           args: " +00:00" # GMT
         - name: dateparse
-          args: "01/02/2006 15:04:05 -07:00"
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
       selector: size
     downloadvolumefactor:

--- a/src/Jackett.Common/Utils/DateTimeUtil.cs
+++ b/src/Jackett.Common/Utils/DateTimeUtil.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Globalization;
+using System.Linq;
 using System.Text.RegularExpressions;
 
 namespace Jackett.Common.Utils
@@ -114,6 +115,11 @@ namespace Jackett.Common.Utils
             {
                 str = ParseUtil.NormalizeSpace(str);
                 var now = relativeFrom ?? DateTime.Now;
+
+                // try parsing the str as an unix timestamp
+                if (str.All(char.IsDigit) && long.TryParse(str, out var unixTimeStamp))
+                    return UnixTimestampToDateTime(unixTimeStamp);
+
                 if (str.ToLower().Contains("now"))
                     return now;
 
@@ -186,13 +192,6 @@ namespace Jackett.Common.Utils
                         dt = dt.AddDays(-1);
                     return dt;
                 }
-
-                // try parsing the str as an unix timestamp
-                if (long.TryParse(str, out var unixTimeStamp))
-                {
-                    return UnixTimestampToDateTime(unixTimeStamp);
-                }
-                // it wasn't a timestamp, continue....
 
                 // add missing year
                 match = _MissingYearRegexp.Match(str);


### PR DESCRIPTION
**WIP. Don't merge.**

Any reason why standard datetime format is not used? This way should be a little faster without trying to figure out the format with `DateTimeUtil.ParseDateTimeGoLang`. 

~Also disabled the date handling by the JSON library which it will be a BC for older versions of Jackett/Prowlarr.~

Running a benchmark in Prowlarr, but this affect Jackett too since they share the same logic, current date parsing is rather slow. 

Why all this micro-optimizations? We're trying to optimize Cardigann parsing since some indexers in Prowlarr can take 6-10s to only parse a single page with 100 items.