### PR TITLE
editorconfig: change indent_size to 4 for js,ts,json,html,cshtml

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -75,7 +75,7 @@ indent_size=2
 
 # JavaScript/HTML
 [*.{js,ts,json,html,cshtml}]
-indent_size=2
+indent_size=4
 
 # Code files
 [*.{cs,csx,vb,vbx}]


### PR DESCRIPTION
It's really annoying when dealing with JS/HTML/JSON files while the `indent_size` is 2 even if they're clearly using 4, thus breaking formatting and c/p.

Any objections @garfield69 @ilike2burnthing?