### PR TITLE
cardigann: move check for Rfc1123ZPattern

### DIFF
--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -2035,7 +2035,7 @@ namespace Jackett.Common.Indexers
                     value = release.Seeders.ToString();
                     break;
                 case "date":
-                    release.PublishDate = DateTime.TryParseExact(value, DateTimeUtil.Rfc1123ZPattern, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedDate) ? parsedDate : DateTimeUtil.FromUnknown(value);
+                    release.PublishDate = DateTimeUtil.FromUnknown(value);
                     value = release.PublishDate.ToString(DateTimeUtil.Rfc1123ZPattern, CultureInfo.InvariantCulture);
                     break;
                 case "files":

--- a/src/Jackett.Common/Utils/DateTimeUtil.cs
+++ b/src/Jackett.Common/Utils/DateTimeUtil.cs
@@ -115,6 +115,10 @@ namespace Jackett.Common.Utils
             try
             {
                 str = ParseUtil.NormalizeSpace(str);
+
+                if (DateTime.TryParseExact(str, Rfc1123ZPattern, CultureInfo.InvariantCulture, DateTimeStyles.None, out var parsedDate))
+                    return parsedDate;
+
                 var now = relativeFrom ?? DateTime.Now;
 
                 // try parsing the str as an unix timestamp


### PR DESCRIPTION
Since `DateTimeUtil.FromUnknown` might be called from other places than Cardigann, I moved the check for Rfc1123ZPattern at the beginning of the method. 