### PR TITLE
nebulance: add tvmaze support

### DIFF
--- a/src/Jackett.Common/Indexers/NebulanceAPI.cs
+++ b/src/Jackett.Common/Indexers/NebulanceAPI.cs
@@ -42,7 +42,7 @@ namespace Jackett.Common.Indexers
                        LimitsMax = 1000,
                        TvSearchParams = new List<TvSearchParam>
                        {
-                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.Genre
+                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.Genre, TvSearchParam.TvmazeId
                        },
                        SupportsRawSearch = true
                    },
@@ -161,7 +161,13 @@ namespace Jackett.Common.Indexers
 
             var searchString = query.GetQueryString();
             if (!string.IsNullOrWhiteSpace(searchString))
-                searchParam["name"] = "%" + Regex.Replace(searchString, @"[ -._]+", "%").Trim() + "%";
+                searchParam["name"] = "%" + Regex.Replace(searchString, "[\\W]+", "%").Trim() + "%";
+
+            if (query.IsTvmazeQuery && query.TvmazeID.HasValue)
+            {
+                searchParam["tvmaze"] = query.TvmazeID;
+                searchParam["name"] = "%" + Regex.Replace(query.GetEpisodeSearchString(), "[\\W]+", "%").Trim() + "%";
+            }
 
             if (query.IsGenreQuery)
             {


### PR DESCRIPTION
Related #6413

This indexer is built around tvmaze, so let's use it when possible. 

Also replacing everything that's not a word with `%` to include all special chars.

@garfield69 try `t=tvsearch&tvmazeid=11968&season=2020&ep=07/22`

Any objections against adding support for TvmazeId?