### PR TITLE
nyaasi: add prefer magnet link setting

### DIFF
--- a/src/Jackett.Common/Definitions/nyaasi.yml
+++ b/src/Jackett.Common/Definitions/nyaasi.yml
@@ -169,6 +169,9 @@ search:
       optional: true
     download:
       text: "{{ if and (.Config.prefer_magnet_links) (.Result.magnet_optional) }}{{ or (.Result.magnet_optional) (.Result.download_optional) }}{{ else }}{{ or (.Result.download_optional) (.Result.magnet_optional) }}{{ end }}"
+    magnet:
+      text: "{{ if .Config.prefer_magnet_links }}{{ else }}{{ .Result.magnet_optional }}{{ end }}"
+      optional: true
     size:
       selector: td:nth-child(4)
     date:


### PR DESCRIPTION
This change gives priority to magnet links over torrents by default, with fallback at previous behavior torrents as download link. 

I'm inclined to set `prefer_magnet_links` to true by default because of the issues related in https://github.com/Prowlarr/Indexers/issues/282. 

Your call.