### PR TITLE
linkomanija: prepend + to each word

### DIFF
--- a/src/Jackett.Common/Definitions/linkomanija.yml
+++ b/src/Jackett.Common/Definitions/linkomanija.yml
@@ -58,11 +58,6 @@ settings:
     type: password
     label: Password
 
-#  - name: andmatch
-#    type: checkbox
-#    label: Accept non english characters in torrent names (get more results)
-#    default: true
-
   - name: searchindesc
     type: checkbox
     label: Search in torrent description (get more results)
@@ -88,10 +83,12 @@ search:
     incldead: 1
     searchindesc: "{{ .Config.searchindesc }}"
 
+  keywordsfilters:
+    - name: re_replace
+      args: ["(\\w+)", "+$1"] # prepend + to each word
+
   rows:
     selector: table> tbody > tr:has(a[href^="details?"])
-#    filters:
-#      - name: "{{ if .Config.andmatch }}andmatch{{ else }}{{ end }}" Currently, -name must be simple string, not a variable
 
   fields:
     category:


### PR DESCRIPTION
I don't have an account to test the change, but an user keeps complaining about very non relevant results.

`
basically says that by default the search returns all results where at least one of the words exist. to get exact matches, using quote marks "title search" or plus signs +title +search is recommended 
`

EDIT: the user confirmed with screenshots.