### PR TITLE
indexers: add `SupportsPagination` to prevent fetching the first page multiple times

### DIFF
--- a/src/Jackett.Common/Indexers/Abstract/SpeedAppTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/SpeedAppTracker.cs
@@ -20,6 +20,8 @@ namespace Jackett.Common.Indexers.Abstract
     [ExcludeFromCodeCoverage]
     public abstract class SpeedAppTracker : BaseWebIndexer
     {
+        public override bool SupportsPagination => true;
+
         protected virtual bool UseP2PReleaseName => false;
         protected virtual int minimumSeedTime => 172800; // 48h
 
@@ -90,10 +92,16 @@ namespace Jackett.Common.Indexers.Abstract
             //var categoryMapping = MapTorznabCapsToTrackers(query).Distinct().ToList();
             var qc = new List<KeyValuePair<string, string>> // NameValueCollection don't support cat[]=19&cat[]=6
             {
-                {"itemsPerPage", "100"},
-                {"sort", "torrent.createdAt"},
-                {"direction", "desc"}
+                { "itemsPerPage", "100" },
+                { "sort", "torrent.createdAt" },
+                { "direction", "desc" }
             };
+
+            if (query.Limit > 0 && query.Offset > 0)
+            {
+                var page = query.Offset / query.Limit + 1;
+                qc.Add("page", page.ToString());
+            }
 
             foreach (var cat in MapTorznabCapsToTrackers(query))
                 qc.Add("categories[]", cat);

--- a/src/Jackett.Common/Indexers/BaseIndexer.cs
+++ b/src/Jackett.Common/Indexers/BaseIndexer.cs
@@ -29,6 +29,7 @@ namespace Jackett.Common.Indexers
         public string Language { get; protected set; }
         public string Type { get; protected set; }
 
+        public virtual bool SupportsPagination => false;
 
         [JsonConverter(typeof(EncodingJsonConverter))]
         public Encoding Encoding { get; protected set; }
@@ -297,7 +298,10 @@ namespace Jackett.Common.Indexers
             var queryCopy = query.Clone();
 
             if (!CanHandleQuery(queryCopy) || !CanHandleCategories(queryCopy, isMetaIndexer))
-                return new IndexerResult(this, new ReleaseInfo[0], false);
+                return new IndexerResult(this, Array.Empty<ReleaseInfo>(), false);
+
+            if (!SupportsPagination && queryCopy.Offset > 0)
+                return new IndexerResult(this, Array.Empty<ReleaseInfo>(), false);
 
             if (queryCopy.Cache)
             {

--- a/src/Jackett.Common/Indexers/BroadcasTheNet.cs
+++ b/src/Jackett.Common/Indexers/BroadcasTheNet.cs
@@ -19,6 +19,8 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class BroadcasTheNet : BaseWebIndexer
     {
+        public override bool SupportsPagination => true;
+
         // based on https://github.com/Prowlarr/Prowlarr/tree/develop/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet
         private readonly string APIBASE = "https://api.broadcasthe.net";
 
@@ -71,8 +73,9 @@ namespace Jackett.Common.Indexers
             try
             {
                 var results = await PerformQuery(new TorznabQuery());
-                if (results.Count() == 0)
+                if (!results.Any())
                     throw new Exception("Testing returned no results!");
+
                 IsConfigured = true;
                 SaveConfig();
             }

--- a/src/Jackett.Common/Indexers/IIndexer.cs
+++ b/src/Jackett.Common/Indexers/IIndexer.cs
@@ -36,6 +36,8 @@ namespace Jackett.Common.Indexers
         string Id { get; }
         Encoding Encoding { get; }
 
+        bool SupportsPagination { get; }
+
         TorznabCapabilities TorznabCaps { get; }
 
         // Whether this indexer has been configured, verified and saved in the past and has the settings required for functioning

--- a/src/Jackett.Common/Indexers/IPTorrents.cs
+++ b/src/Jackett.Common/Indexers/IPTorrents.cs
@@ -21,6 +21,8 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class IPTorrents : BaseWebIndexer
     {
+        public override bool SupportsPagination => true;
+
         private string SearchUrl => SiteLink + "t";
 
         public override string[] AlternativeSiteLinks { get; protected set; } = {
@@ -270,6 +272,12 @@ namespace Jackett.Common.Indexers
                 qc.Set("q", $"{string.Join(" ", searchQuery)}");
 
             qc.Set("o", ((SingleSelectConfigurationItem)configData.GetDynamic("sort")).Value);
+
+            if (query.Limit > 0 && query.Offset > 0)
+            {
+                var page = query.Offset / query.Limit + 1;
+                qc.Add("p", page.ToString());
+            }
 
             var searchUrl = SearchUrl + "?" + qc.GetQueryString();
             var response = await RequestWithCookiesAndRetryAsync(searchUrl, referer: SearchUrl, headers: headers);

--- a/src/Jackett.Common/Indexers/MyAnonamouse.cs
+++ b/src/Jackett.Common/Indexers/MyAnonamouse.cs
@@ -20,6 +20,8 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class MyAnonamouse : BaseWebIndexer
     {
+        public override bool SupportsPagination => true;
+
         private string SearchUrl => SiteLink + "tor/js/loadSearchJSONbasic.php";
 
         private new ConfigurationDataMyAnonamouse configData => (ConfigurationDataMyAnonamouse)base.configData;

--- a/src/Jackett.Common/Indexers/NebulanceAPI.cs
+++ b/src/Jackett.Common/Indexers/NebulanceAPI.cs
@@ -19,6 +19,8 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class NebulanceAPI : BaseWebIndexer
     {
+        public override bool SupportsPagination => true;
+
         // Docs at https://nebulance.io/articles.php?topic=api_key
         protected virtual string APIUrl => SiteLink + "api.php";
         protected virtual int KeyLength => 32;

--- a/src/Jackett.Common/Indexers/SpeedCD.cs
+++ b/src/Jackett.Common/Indexers/SpeedCD.cs
@@ -21,6 +21,8 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class SpeedCD : BaseWebIndexer
     {
+        public override bool SupportsPagination => true;
+
         private string LoginUrl1 => SiteLink + "checkpoint/API";
         private string LoginUrl2 => SiteLink + "checkpoint/";
         private string SearchUrl => SiteLink + "browse/";
@@ -190,6 +192,14 @@ namespace Jackett.Common.Indexers
 
                 qc.Add("q");
                 qc.Add(WebUtilityHelpers.UrlEncode(term.Trim(), Encoding));
+            }
+
+            if (query.Limit > 0 && query.Offset > 0)
+            {
+                var page = query.Offset / query.Limit + 1;
+
+                qc.Add("p");
+                qc.Add(page.ToString());
             }
 
             var searchUrl = SearchUrl + string.Join("/", qc);

--- a/src/Jackett.Test/Common/Utils/FilterFuncs/IndexerBaseStub.cs
+++ b/src/Jackett.Test/Common/Utils/FilterFuncs/IndexerBaseStub.cs
@@ -22,6 +22,8 @@ namespace Jackett.Test.Common.Utils.FilterFuncs
 
         public virtual string Language => throw TestExceptions.UnexpectedInvocation;
 
+        public virtual bool SupportsPagination => false;
+
         public virtual string LastError
         {
             get => throw TestExceptions.UnexpectedInvocation;


### PR DESCRIPTION
If the indexer doesn't support pagination there's no point on serving the first page multiple times, even if it's cached.

~~As a POC it's only enabled for MAM and NBL.~~