### PR TITLE
fix building in Visual Studio 2022

### DIFF
--- a/src/Jackett.Server/Jackett.Server.csproj
+++ b/src/Jackett.Server/Jackett.Server.csproj
@@ -1,6 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
+    <PackageId>$(MSBuildProjectName)</PackageId>
     <TargetFrameworks>net6.0;net462</TargetFrameworks>
     <ApplicationIcon>jackett.ico</ApplicationIcon>
     <OutputType>Exe</OutputType>


### PR DESCRIPTION
Using Visual Studio 2022 I was getting a lot of wrong/false positive errors like this:
```
Error	NU1201	Project Jackett.Server is not compatible with net6.0 (.NETCoreApp,Version=v6.0). Project Jackett.Server does not support any target frameworks.	Jackett.Test ...\Jackett\src\Jackett.Test\Jackett.Test.csproj	1	
Error	NU1201	Project Jackett.Server is not compatible with net462 (.NETFramework,Version=v4.6.2). Project Jackett.Server does not support any target frameworks.	Jackett.Test	...\Jackett\src\Jackett.Test\Jackett.Test.csproj	1	
Error	NU1201	Project Jackett.Server is not compatible with net6.0 (.NETCoreApp,Version=v6.0). Project Jackett.Server does not support any target frameworks.	Jackett.Test	...\Jackett\src\Jackett.Test\Jackett.Test.csproj	1	
Error	NU1201	Project Jackett.Server is not compatible with net462 (.NETFramework,Version=v4.6.2). Project Jackett.Server does not support any target frameworks.	Jackett.Test	...\Jackett\src\Jackett.Test\Jackett.Test.csproj	1	
Error	NU1105	Unable to read project information for 'Jackett.Server': Sequence contains more than one element	Jackett.Server	...\Jackett\src\Jackett.Server\Jackett.Server.csproj	1	
Error	NU1105	Unable to read project information for 'Jackett.Server': Sequence contains more than one element	Jackett.Server	...\Jackett\src\Jackett.Server\Jackett.Server.csproj	1	
```
setting PackageId fixed it for me.