### PR TITLE
indexers: set indexer details as properties

### DIFF
--- a/src/Jackett.Common/Indexers/Abstract/AvistazTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/AvistazTracker.cs
@@ -4,7 +4,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using Jackett.Common.Models;
 using Jackett.Common.Models.IndexerConfig.Bespoke;
@@ -18,8 +17,11 @@ using WebClient = Jackett.Common.Utils.Clients.WebClient;
 namespace Jackett.Common.Indexers.Abstract
 {
     [ExcludeFromCodeCoverage]
-    public abstract class AvistazTracker : BaseWebIndexer
+    public abstract class AvistazTracker : IndexerBase
     {
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         public override bool SupportsPagination => true;
 
         private readonly Dictionary<string, string> AuthHeaders = new Dictionary<string, string>
@@ -135,14 +137,8 @@ namespace Jackett.Common.Indexers.Abstract
             return cats;
         }
 
-        protected AvistazTracker(string link, string id, string name, string description,
-                                 IIndexerConfigurationService configService, WebClient client, Logger logger,
-                                 IProtectionService p, ICacheService cs, TorznabCapabilities caps)
-            : base(id: id,
-                   name: name,
-                   description: description,
-                   link: link,
-                   caps: caps,
+        protected AvistazTracker(IIndexerConfigurationService configService, WebClient client, Logger logger, IProtectionService p, ICacheService cs, TorznabCapabilities caps)
+            : base(caps: caps,
                    configService: configService,
                    client: client,
                    logger: logger,
@@ -150,10 +146,6 @@ namespace Jackett.Common.Indexers.Abstract
                    cacheService: cs,
                    configData: new ConfigurationDataAvistazTracker())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             webclient.requestDelay = 3;
         }
 

--- a/src/Jackett.Common/Indexers/Abstract/CouchPotatoTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/CouchPotatoTracker.cs
@@ -14,7 +14,7 @@ using NLog;
 namespace Jackett.Common.Indexers.Abstract
 {
     [ExcludeFromCodeCoverage]
-    public abstract class CouchPotatoTracker : BaseWebIndexer
+    public abstract class CouchPotatoTracker : IndexerBase
     {
         protected string endpoint;
         protected string APIUrl => SiteLink + endpoint;
@@ -25,15 +25,10 @@ namespace Jackett.Common.Indexers.Abstract
             set => base.configData = value;
         }
 
-        protected CouchPotatoTracker(string link, string id, string name, string description,
-                                     IIndexerConfigurationService configService, WebClient client, Logger logger,
+        protected CouchPotatoTracker(IIndexerConfigurationService configService, WebClient client, Logger logger,
                                      IProtectionService p, ICacheService cs, TorznabCapabilities caps,
                                      ConfigurationData configData, string endpoint)
-            : base(id: id,
-                   name: name,
-                   description: description,
-                   link: link,
-                   caps: caps,
+            : base(caps: caps,
                    configService: configService,
                    client: client,
                    logger: logger,

--- a/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/GazelleTracker.cs
@@ -21,8 +21,10 @@ using WebClient = Jackett.Common.Utils.Clients.WebClient;
 namespace Jackett.Common.Indexers.Abstract
 {
     [ExcludeFromCodeCoverage]
-    public abstract class GazelleTracker : BaseWebIndexer
+    public abstract class GazelleTracker : IndexerBase
     {
+        public override Encoding Encoding => Encoding.UTF8;
+
         protected virtual string LoginUrl => SiteLink + "login.php";
         protected virtual string APIUrl => SiteLink + "ajax.php";
         protected virtual string DownloadUrl => SiteLink + "torrents.php?action=download&usetoken=" + (useTokens ? "1" : "0") + (usePassKey ? "&torrent_pass=" + configData.PassKey.Value : "") + (useAuthKey ? "&authkey=" + configData.AuthKey.Value : "") + "&id=";
@@ -47,16 +49,11 @@ namespace Jackett.Common.Indexers.Abstract
             set => base.configData = value;
         }
 
-        protected GazelleTracker(string link, string id, string name, string description,
-                                 IIndexerConfigurationService configService, WebClient client, Logger logger,
+        protected GazelleTracker(IIndexerConfigurationService configService, WebClient client, Logger logger,
                                  IProtectionService p, ICacheService cs, TorznabCapabilities caps,
                                  bool supportsFreeleechTokens = false, bool supportsFreeleechOnly = false, bool imdbInTags = false, bool has2Fa = false,
                                  bool useApiKey = false, bool usePassKey = false, bool useAuthKey = false, string instructionMessageOptional = null)
-            : base(id: id,
-                   name: name,
-                   description: description,
-                   link: link,
-                   caps: caps,
+            : base(caps: caps,
                    configService: configService,
                    client: client,
                    logger: logger,
@@ -64,8 +61,6 @@ namespace Jackett.Common.Indexers.Abstract
                    cacheService: cs,
                    configData: new ConfigurationDataGazelleTracker(has2Fa, supportsFreeleechTokens, supportsFreeleechOnly, useApiKey, usePassKey, useAuthKey, instructionMessageOptional))
         {
-            Encoding = Encoding.UTF8;
-
             this.imdbInTags = imdbInTags;
             this.useApiKey = useApiKey;
             this.usePassKey = usePassKey;

--- a/src/Jackett.Common/Indexers/Abstract/SpeedAppTracker.cs
+++ b/src/Jackett.Common/Indexers/Abstract/SpeedAppTracker.cs
@@ -18,7 +18,7 @@ using WebClient = Jackett.Common.Utils.Clients.WebClient;
 namespace Jackett.Common.Indexers.Abstract
 {
     [ExcludeFromCodeCoverage]
-    public abstract class SpeedAppTracker : BaseWebIndexer
+    public abstract class SpeedAppTracker : IndexerBase
     {
         public override bool SupportsPagination => true;
 
@@ -37,20 +37,14 @@ namespace Jackett.Common.Indexers.Abstract
 
         private new ConfigurationDataBasicLoginWithEmail configData => (ConfigurationDataBasicLoginWithEmail)base.configData;
 
-        protected SpeedAppTracker(string link, string id, string name, string description,
-            IIndexerConfigurationService configService, WebClient client, Logger logger,
-            IProtectionService p, ICacheService cs, TorznabCapabilities caps)
-            : base(id: id,
-                name: name,
-                description: description,
-                link: link,
-                caps: caps,
-                configService: configService,
-                client: client,
-                logger: logger,
-                p: p,
-                cacheService: cs,
-                configData: new ConfigurationDataBasicLoginWithEmail())
+        protected SpeedAppTracker(IIndexerConfigurationService configService, WebClient client, Logger logger, IProtectionService p, ICacheService cs, TorznabCapabilities caps)
+            : base(caps: caps,
+                   configService: configService,
+                   client: client,
+                   logger: logger,
+                   p: p,
+                   cacheService: cs,
+                   configData: new ConfigurationDataBasicLoginWithEmail())
         {
         }
 

--- a/src/Jackett.Common/Indexers/AlphaRatio.cs
+++ b/src/Jackett.Common/Indexers/AlphaRatio.cs
@@ -12,12 +12,16 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class AlphaRatio : GazelleTracker
     {
+        public override string Id => "alpharatio";
+        public override string Name => "AlphaRatio";
+        public override string Description => "AlphaRatio (AR) is a Private Torrent Tracker for 0DAY / GENERAL";
+        public override string SiteLink { get; protected set; } = "https://alpharatio.cc/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         public AlphaRatio(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "alpharatio",
-                   name: "AlphaRatio",
-                   description: "AlphaRatio (AR) is a Private Torrent Tracker for 0DAY / GENERAL",
-                   link: "https://alpharatio.cc/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -38,9 +42,6 @@ namespace Jackett.Common.Indexers
                    supportsFreeleechOnly: true,
                    imdbInTags: true)
         {
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(1, TorznabCatType.TVSD, "TvSD");
             AddCategoryMapping(2, TorznabCatType.TVHD, "TvHD");
             AddCategoryMapping(3, TorznabCatType.TVUHD, "TvUHD");

--- a/src/Jackett.Common/Indexers/AniDUB.cs
+++ b/src/Jackett.Common/Indexers/AniDUB.cs
@@ -20,8 +20,15 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    internal class AniDUB : BaseWebIndexer
+    public class AniDUB : IndexerBase
     {
+        public override string Id => "anidub";
+        public override string Name => "AniDUB";
+        public override string Description => "AniDUB Tracker is a semi-private russian tracker and release group for anime";
+        public override string SiteLink { get; protected set; } = "https://tr.anidub.com/";
+        public override string Language => "ru-RU";
+        public override string Type => "semi-private";
+
         private static readonly Regex EpisodeInfoRegex = new Regex(@"\[(.*?)(?: \(.*?\))? из (.*?)\]$", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex SeasonInfoQueryRegex = new Regex(@"S(\d+)(?:E\d*)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex SeasonInfoRegex = new Regex(@"(?:(?:TV-)|(?:ТВ-))(\d+)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -29,10 +36,7 @@ namespace Jackett.Common.Indexers
 
         public AniDUB(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "anidub",
-                   name: "AniDUB",
-                   description: "AniDUB Tracker is a semi-private russian tracker and release group for anime",
-                   link: "https://tr.anidub.com/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -55,10 +59,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataAniDub())
         {
-            Encoding = Encoding.UTF8;
-            Language = "ru-RU";
-            Type = "semi-private";
-
             webclient.AddTrustedCertificate(new Uri(SiteLink).Host, "392E98CE1447B59CA62BAB8824CA1EEFC2ED3D37");
 
             AddCategoryMapping(2, TorznabCatType.TVAnime, "Аниме TV");

--- a/src/Jackett.Common/Indexers/Anidex.cs
+++ b/src/Jackett.Common/Indexers/Anidex.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Threading.Tasks;
 using AngleSharp.Dom;
 using AngleSharp.Html.Parser;
@@ -21,14 +20,18 @@ using static Jackett.Common.Models.IndexerConfig.ConfigurationData;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class Anidex : BaseWebIndexer
+    public class Anidex : IndexerBase
     {
+        public override string Id => "anidex";
+        public override string Name => "Anidex";
+        public override string Description => "Anidex is a Public torrent tracker and indexer, primarily for English fansub groups of anime";
+        public override string SiteLink { get; protected set; } = "https://anidex.info/";
+        public override string Language => "en-US";
+        public override string Type => "public";
+
         public Anidex(IIndexerConfigurationService configService, Utils.Clients.WebClient wc, Logger l,
             IProtectionService ps, ICacheService cs)
-            : base(id: "anidex",
-                   name: "Anidex",
-                   description: "Anidex is a Public torrent tracker and indexer, primarily for English fansub groups of anime",
-                   link: "https://anidex.info/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -51,10 +54,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationData())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "public";
-
             // Configure the category mappings
             AddCategoryMapping(1, TorznabCatType.TVAnime, "Anime - Sub");
             AddCategoryMapping(2, TorznabCatType.TVAnime, "Anime - Raw");

--- a/src/Jackett.Common/Indexers/AnimeBytes.cs
+++ b/src/Jackett.Common/Indexers/AnimeBytes.cs
@@ -6,7 +6,6 @@ using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using Jackett.Common.Models;
@@ -23,6 +22,13 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class AnimeBytes : BaseCachingWebIndexer
     {
+        public override string Id => "animebytes";
+        public override string Name => "AnimeBytes";
+        public override string Description => "Powered by Tentacles";
+        public override string SiteLink { get; protected set; } = "https://animebytes.tv/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string ScrapeUrl => SiteLink + "scrape.php";
         private bool AllowRaws => ConfigData.IncludeRaw.Value;
         private bool PadEpisode => ConfigData.PadEpisode != null && ConfigData.PadEpisode.Value;
@@ -36,11 +42,7 @@ namespace Jackett.Common.Indexers
 
         public AnimeBytes(IIndexerConfigurationService configService, WebClient client, Logger l,
             IProtectionService ps, ICacheService cs)
-            : base(id: "animebytes",
-                   name: "AnimeBytes",
-                   description: "Powered by Tentacles",
-                   link: "https://animebytes.tv/",
-                   configService: configService,
+            : base(configService: configService,
                    client: client,
                    caps: new TorznabCapabilities
                    {
@@ -67,10 +69,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataAnimeBytes("Note: Go to AnimeBytes site and open your account settings. Go to 'Account' tab, move cursor over black part near 'Passkey' and copy its value. Your username is case sensitive."))
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             webclient.EmulateBrowser = false; // Animebytes doesn't like fake user agents (issue #1535)
 
             AddCategoryMapping("anime[tv_series]", TorznabCatType.TVAnime, "TV Series");

--- a/src/Jackett.Common/Indexers/AnimeTorrents.cs
+++ b/src/Jackett.Common/Indexers/AnimeTorrents.cs
@@ -4,7 +4,6 @@ using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using AngleSharp.Dom;
@@ -20,8 +19,15 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class AnimeTorrents : BaseWebIndexer
+    public class AnimeTorrents : IndexerBase
     {
+        public override string Id => "animetorrents";
+        public override string Name => "AnimeTorrents";
+        public override string Description => "Definitive source for anime and manga";
+        public override string SiteLink { get; protected set; } = "https://animetorrents.me/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string LoginUrl => SiteLink + "login.php";
         private string SearchUrl => SiteLink + "ajax/torrents_data.php";
         private string SearchUrlReferer => SiteLink + "torrents.php?cat=0&searchin=filename&search=";
@@ -34,10 +40,7 @@ namespace Jackett.Common.Indexers
 
         public AnimeTorrents(IIndexerConfigurationService configService, WebClient c, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "animetorrents",
-                   name: "AnimeTorrents",
-                   description: "Definitive source for anime and manga",
-                   link: "https://animetorrents.me/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -56,10 +59,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataBasicLogin())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(1, TorznabCatType.MoviesSD, "Anime Movie");
             AddCategoryMapping(6, TorznabCatType.MoviesHD, "Anime Movie HD");
             AddCategoryMapping(2, TorznabCatType.TVAnime, "Anime Series");

--- a/src/Jackett.Common/Indexers/Aro.cs
+++ b/src/Jackett.Common/Indexers/Aro.cs
@@ -11,12 +11,16 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class Aro : GazelleTracker
     {
+        public override string Id => "aro";
+        public override string Name => "aro.lol";
+        public override string Description => "aro.lol is a SERBIAN/ENGLISH Private Torrent Tracker for ANIME";
+        public override string SiteLink { get; protected set; } = "https://aro.lol/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         public Aro(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "aro",
-                   name: "aro.lol",
-                   description: "aro.lol is a SERBIAN/ENGLISH Private Torrent Tracker for ANIME",
-                   link: "https://aro.lol/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -37,9 +41,6 @@ namespace Jackett.Common.Indexers
                    supportsFreeleechTokens: true
                    )
         {
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(1, TorznabCatType.Movies, "Movies");
             AddCategoryMapping(2, TorznabCatType.TVAnime, "Anime");
             AddCategoryMapping(3, TorznabCatType.Books, "Manga");

--- a/src/Jackett.Common/Indexers/AudioBookBay.cs
+++ b/src/Jackett.Common/Indexers/AudioBookBay.cs
@@ -22,14 +22,18 @@ using WebClient = Jackett.Common.Utils.Clients.WebClient;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class AudioBookBay : BaseWebIndexer
+    public class AudioBookBay : IndexerBase
     {
-        public override string[] AlternativeSiteLinks { get; protected set; } = {
+        public override string Id => "audiobookbay";
+        public override string Name => "AudioBook Bay";
+        public override string Description => "AudioBook Bay (ABB) is a public Torrent Tracker for AUDIOBOOKS";
+        public override string SiteLink { get; protected set; } = "https://audiobookbay.li/";
+        public override string[] AlternativeSiteLinks => new[]
+        {
             "https://audiobookbay.li/",
             "https://audiobookbay.se/"
         };
-
-        public override string[] LegacySiteLinks { get; protected set; } =
+        public override string[] LegacySiteLinks => new[]
         {
             "https://audiobookbay.la/",
             "http://audiobookbay.net/",
@@ -56,12 +60,11 @@ namespace Jackett.Common.Indexers
             "https://audiobookbay.unblockit.ink/",
             "https://audiobookbay.unblockit.bio/" // error 502
         };
+        public override string Language => "en-US";
+        public override string Type => "public";
 
         public AudioBookBay(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps, ICacheService cs)
-            : base(id: "audiobookbay",
-                   name: "AudioBook Bay",
-                   description: "AudioBook Bay (ABB) is a public Torrent Tracker for AUDIOBOOKS",
-                   link: "https://audiobookbay.li/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        BookSearchParams = new List<BookSearchParam>
@@ -76,10 +79,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationData())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "public";
-
             webclient.requestDelay = 3.1;
 
             // Age

--- a/src/Jackett.Common/Indexers/AvistaZ.cs
+++ b/src/Jackett.Common/Indexers/AvistaZ.cs
@@ -12,12 +12,14 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class AvistaZ : AvistazTracker
     {
+        public override string Id => "avistaz";
+        public override string Name => "AvistaZ";
+        public override string Description => "Aka AsiaTorrents";
+        public override string SiteLink { get; protected set; } = "https://avistaz.to/";
+
         public AvistaZ(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "avistaz",
-                   name: "AvistaZ",
-                   description: "Aka AsiaTorrents",
-                   link: "https://avistaz.to/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        LimitsDefault = 50,

--- a/src/Jackett.Common/Indexers/BJShare.cs
+++ b/src/Jackett.Common/Indexers/BJShare.cs
@@ -4,7 +4,6 @@ using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using AngleSharp.Dom;
@@ -20,20 +19,24 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class BJShare : BaseWebIndexer
+    public class BJShare : IndexerBase
     {
+        public override string Id => "bjshare";
+        public override string Name => "BJ-Share";
+        public override string Description => "A brazilian tracker.";
+        public override string SiteLink { get; protected set; } = "https://bj-share.info/";
+        public override string[] LegacySiteLinks => new[]
+        {
+            "https://bj-share.me/"
+        };
+        public override string Language => "pt-BR";
+        public override string Type => "private";
+
         private string BrowseUrl => SiteLink + "torrents.php";
         private string TodayUrl => SiteLink + "torrents.php?action=today";
         private static readonly Regex _EpisodeRegex = new Regex(@"(?:[SsEe]\d{2,4}){1,2}");
 
-        public override string[] LegacySiteLinks { get; protected set; } =
-        {
-            "https://bj-share.me/"
-        };
-
         private new ConfigurationDataCookieUA configData => (ConfigurationDataCookieUA)base.configData;
-
-
 
         private readonly List<string> _absoluteNumbering = new List<string>
         {
@@ -61,10 +64,7 @@ namespace Jackett.Common.Indexers
 
         public BJShare(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "bjshare",
-                    name: "BJ-Share",
-                    description: "A brazilian tracker.",
-                    link: "https://bj-share.info/",
+            : base(
                     caps: new TorznabCapabilities
                     {
                         TvSearchParams = new List<TvSearchParam>
@@ -91,10 +91,6 @@ namespace Jackett.Common.Indexers
                     cacheService: cs,
                     configData: new ConfigurationDataCookieUA())
         {
-            Encoding = Encoding.UTF8;
-            Language = "pt-BR";
-            Type = "private";
-
             AddCategoryMapping(1, TorznabCatType.Movies, "Filmes");
             AddCategoryMapping(2, TorznabCatType.TV, "Seriados");
             AddCategoryMapping(3, TorznabCatType.PC, "Aplicativos");

--- a/src/Jackett.Common/Indexers/BakaBT.cs
+++ b/src/Jackett.Common/Indexers/BakaBT.cs
@@ -20,8 +20,15 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class BakaBT : BaseWebIndexer
+    public class BakaBT : IndexerBase
     {
+        public override string Id => "bakabt";
+        public override string Name => "BakaBT";
+        public override string Description => "Anime Comunity";
+        public override string SiteLink { get; protected set; } = "https://bakabt.me/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string SearchUrl => SiteLink + "browse.php?only=0&hentai=1&incomplete=1&lossless=1&hd=1&multiaudio=1&bonus=1&reorder=1&q=";
         private string LoginUrl => SiteLink + "login.php";
         private readonly string LogoutStr = "<a href=\"logout.php\">Logout</a>";
@@ -38,10 +45,7 @@ namespace Jackett.Common.Indexers
 
         public BakaBT(IIndexerConfigurationService configService, Utils.Clients.WebClient wc, Logger l,
             IProtectionService ps, ICacheService cs)
-            : base(id: "bakabt",
-                   name: "BakaBT",
-                   description: "Anime Comunity",
-                   link: "https://bakabt.me/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -65,10 +69,6 @@ namespace Jackett.Common.Indexers
                    configData: new ConfigurationDataBakaBT("To prevent 0-results-error, Enable the " +
                                                                "Show-Adult-Content option in your BakaBT account Settings."))
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(1, TorznabCatType.TVAnime, "Anime Series");
             AddCategoryMapping(2, TorznabCatType.TVAnime, "OVA");
             AddCategoryMapping(3, TorznabCatType.AudioOther, "Soundtrack");

--- a/src/Jackett.Common/Indexers/BeyondHDAPI.cs
+++ b/src/Jackett.Common/Indexers/BeyondHDAPI.cs
@@ -16,8 +16,15 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class BeyondHDAPI : BaseWebIndexer
+    public class BeyondHDAPI : IndexerBase
     {
+        public override string Id => "beyond-hd-api";
+        public override string Name => "Beyond-HD (API)";
+        public override string Description => "Without BeyondHD, your HDTV is just a TV";
+        public override string SiteLink { get; protected set; } = "https://beyond-hd.me/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private readonly string APIBASE = "https://beyond-hd.me/api/torrents/";
 
         private new ConfigurationDataBeyondHDApi configData
@@ -28,10 +35,7 @@ namespace Jackett.Common.Indexers
 
         public BeyondHDAPI(IIndexerConfigurationService configService, WebClient wc, Logger l,
             IProtectionService ps, ICacheService cs)
-            : base(id: "beyond-hd-api",
-                   name: "Beyond-HD (API)",
-                   description: "Without BeyondHD, your HDTV is just a TV",
-                   link: "https://beyond-hd.me/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        LimitsDefault = 100,
@@ -52,10 +56,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataBeyondHDApi("Find the API and RSS keys under your security settings (your profile picture -> my security)"))
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping("Movies", TorznabCatType.Movies);
             AddCategoryMapping("TV", TorznabCatType.TV);
         }

--- a/src/Jackett.Common/Indexers/BitHDTV.cs
+++ b/src/Jackett.Common/Indexers/BitHDTV.cs
@@ -19,18 +19,23 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class BitHDTV : BaseWebIndexer
+    public class BitHDTV : IndexerBase
     {
+        public override string Id => "bithdtv";
+        public override string Name => "BIT-HDTV";
+        public override string Description => "BIT-HDTV - Home of High Definition";
+        public override string SiteLink { get; protected set; } = "https://www.bit-hdtv.com/";
+        public override Encoding Encoding => Encoding.GetEncoding("iso-8859-1");
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string SearchUrl => SiteLink + "torrents.php";
 
         private new ConfigurationDataCookie configData => (ConfigurationDataCookie)base.configData;
 
         public BitHDTV(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "bithdtv",
-                   name: "BIT-HDTV",
-                   description: "BIT-HDTV - Home of High Definition",
-                   link: "https://www.bit-hdtv.com/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -49,10 +54,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataCookie("For best results, change the 'Torrents per page' setting to 100 in your profile."))
         {
-            Encoding = Encoding.GetEncoding("iso-8859-1");
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(6, TorznabCatType.AudioLossless, "HQ Audio");
             AddCategoryMapping(7, TorznabCatType.Movies, "Movies");
             AddCategoryMapping(8, TorznabCatType.AudioVideo, "Music Videos");

--- a/src/Jackett.Common/Indexers/BrasilTracker.cs
+++ b/src/Jackett.Common/Indexers/BrasilTracker.cs
@@ -18,8 +18,15 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class BrasilTracker : BaseWebIndexer
+    public class BrasilTracker : IndexerBase
     {
+        public override string Id => "brasiltracker";
+        public override string Name => "BrasilTracker";
+        public override string Description => "BrasilTracker is a BRAZILIAN Private Torrent Tracker for MOVIES / TV / GENERAL";
+        public override string SiteLink { get; protected set; } = "https://brasiltracker.org/";
+        public override string Language => "pt-BR";
+        public override string Type => "private";
+
         private string LoginUrl => SiteLink + "login.php";
         private string BrowseUrl => SiteLink + "torrents.php";
         private static readonly Regex _EpisodeRegex = new Regex(@"(?:[SsEe]\d{2,4}){1,2}");
@@ -28,10 +35,7 @@ namespace Jackett.Common.Indexers
 
         public BrasilTracker(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "brasiltracker",
-                    name: "BrasilTracker",
-                    description: "BrasilTracker is a BRAZILIAN Private Torrent Tracker for MOVIES / TV / GENERAL",
-                    link: "https://brasiltracker.org/",
+            : base(
                     caps: new TorznabCapabilities
                     {
                         TvSearchParams = new List<TvSearchParam>
@@ -58,9 +62,6 @@ namespace Jackett.Common.Indexers
                     cacheService: cs,
                     configData: new ConfigurationDataBasicLogin("BrasilTracker does not return categories in its search results.</br>To add to your Apps' Torznab indexer, replace all categories with 8000(Other).</br>For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile."))
         {
-            Encoding = Encoding.UTF8;
-            Language = "pt-BR";
-            Type = "private";
             AddCategoryMapping(1, TorznabCatType.Other, "Other");
         }
 

--- a/src/Jackett.Common/Indexers/BroadcasTheNet.cs
+++ b/src/Jackett.Common/Indexers/BroadcasTheNet.cs
@@ -17,8 +17,15 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class BroadcasTheNet : BaseWebIndexer
+    public class BroadcasTheNet : IndexerBase
     {
+        public override string Id => "broadcasthenet";
+        public override string Name => "BroadcasTheNet";
+        public override string Description => "BroadcasTheNet (BTN) is an invite-only torrent tracker focused on TV shows";
+        public override string SiteLink { get; protected set; } = "https://broadcasthe.net/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         public override bool SupportsPagination => true;
 
         // based on https://github.com/Prowlarr/Prowlarr/tree/develop/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet
@@ -33,10 +40,7 @@ namespace Jackett.Common.Indexers
 
         public BroadcasTheNet(IIndexerConfigurationService configService, WebClient wc, Logger l,
             IProtectionService ps, ICacheService cs)
-            : base(id: "broadcasthenet",
-                   name: "BroadcasTheNet",
-                   description: "BroadcasTheNet (BTN) is an invite-only torrent tracker focused on TV shows",
-                   link: "https://broadcasthe.net/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        LimitsDefault = 100,
@@ -53,10 +57,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataAPIKey())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping("SD", TorznabCatType.TVSD, "SD");
             AddCategoryMapping("720p", TorznabCatType.TVHD, "720p");
             AddCategoryMapping("1080p", TorznabCatType.TVHD, "1080p");

--- a/src/Jackett.Common/Indexers/BrokenStones.cs
+++ b/src/Jackett.Common/Indexers/BrokenStones.cs
@@ -10,17 +10,20 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class BrokenStones : GazelleTracker
     {
-        public override string[] LegacySiteLinks { get; protected set; } = {
+        public override string Id => "brokenstones";
+        public override string Name => "BrokenStones";
+        public override string Description => "Broken Stones is a Private site for MacOS and iOS APPS / GAMES";
+        public override string SiteLink { get; protected set; } = "https://broken-stones.club/";
+        public override string[] LegacySiteLinks => new[]
+        {
             "https://brokenstones.club/"
         };
+        public override string Language => "en-US";
+        public override string Type => "private";
 
         public BrokenStones(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "brokenstones",
-                   name: "BrokenStones",
-                   description: "Broken Stones is a Private site for MacOS and iOS APPS / GAMES",
-                   link: "https://broken-stones.club/",
-                   caps: new TorznabCapabilities(),
+            : base(caps: new TorznabCapabilities(),
                    configService: configService,
                    client: wc,
                    logger: l,
@@ -29,9 +32,6 @@ namespace Jackett.Common.Indexers
                    supportsFreeleechTokens: true,
                    has2Fa: true)
         {
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(1, TorznabCatType.PCMac, "MacOS Apps");
             AddCategoryMapping(2, TorznabCatType.PCMac, "MacOS Games");
             AddCategoryMapping(3, TorznabCatType.PCMobileiOS, "iOS Apps");

--- a/src/Jackett.Common/Indexers/CGPeers.cs
+++ b/src/Jackett.Common/Indexers/CGPeers.cs
@@ -10,17 +10,20 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class CGPeers : GazelleTracker
     {
-        public override string[] LegacySiteLinks { get; protected set; } = {
+        public override string Id => "cgpeers";
+        public override string Name => "CGPeers";
+        public override string Description => "CGPeers is a Private Torrent Tracker for GRAPHICS SOFTWARE / TUTORIALS / ETC";
+        public override string SiteLink { get; protected set; } = "https://cgpeers.to/";
+        public override string[] LegacySiteLinks => new[]
+        {
             "https://www.cgpeers.com/"
         };
+        public override string Language => "en-US";
+        public override string Type => "private";
 
         public CGPeers(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "cgpeers",
-                   name: "CGPeers",
-                   description: "CGPeers is a Private Torrent Tracker for GRAPHICS SOFTWARE / TUTORIALS / ETC",
-                   link: "https://cgpeers.to/",
-                   caps: new TorznabCapabilities(),
+            : base(caps: new TorznabCapabilities(),
                    configService: configService,
                    client: wc,
                    logger: l,
@@ -28,9 +31,6 @@ namespace Jackett.Common.Indexers
                    cs: cs,
                    supportsFreeleechTokens: true)
         {
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(1, TorznabCatType.PCISO, "Full Applications");
             AddCategoryMapping(2, TorznabCatType.PC0day, "Plugins");
             AddCategoryMapping(3, TorznabCatType.Other, "Tutorials");

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -109,8 +109,8 @@ namespace Jackett.Common.Indexers
             }
 
             // init missing mandatory attributes
-            DisplayName = Definition.Name;
-            DisplayDescription = Definition.Description;
+            Name = Definition.Name;
+            Description = Definition.Description;
             if (Definition.Links.Count > 1)
                 AlternativeSiteLinks = Definition.Links.ToArray();
             DefaultSiteLink = Definition.Links[0];

--- a/src/Jackett.Common/Indexers/Cinecalidad.cs
+++ b/src/Jackett.Common/Indexers/Cinecalidad.cs
@@ -18,12 +18,14 @@ using WebClient = Jackett.Common.Utils.Clients.WebClient;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class Cinecalidad : BaseWebIndexer
+    public class Cinecalidad : IndexerBase
     {
-        private const int MaxLatestPageLimit = 3; // 12 items per page * 3 pages = 36
-        private const int MaxSearchPageLimit = 6;
-
-        public override string[] LegacySiteLinks { get; protected set; } = {
+        public override string Id => "cinecalidad";
+        public override string Name => "Cinecalidad";
+        public override string Description => "Películas Full HD en Latino Dual.";
+        public override string SiteLink { get; protected set; } = "https://cinecalidad.ms/";
+        public override string[] LegacySiteLinks => new[]
+        {
             "https://cinecalidad.website/",
             "https://www.cinecalidad.to/",
             "https://www.cinecalidad.im/", // working but outdated, maybe copycat
@@ -40,13 +42,15 @@ namespace Jackett.Common.Indexers
             "https://www.cinecalidad.lat/",
             "https://cinecalidad.dev/"
         };
+        public override string Language => "es-419";
+        public override string Type => "public";
+
+        private const int MaxLatestPageLimit = 3; // 12 items per page * 3 pages = 36
+        private const int MaxSearchPageLimit = 6;
 
         public Cinecalidad(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
-            ICacheService cs)
-            : base(id: "cinecalidad",
-                   name: "Cinecalidad",
-                   description: "Películas Full HD en Latino Dual.",
-                   link: "https://cinecalidad.ms/",
+                           ICacheService cs)
+            : base(
                    caps: new TorznabCapabilities
                    {
                        MovieSearchParams = new List<MovieSearchParam> { MovieSearchParam.Q }
@@ -58,10 +62,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationData())
         {
-            Encoding = Encoding.UTF8;
-            Language = "es-419";
-            Type = "public";
-
             AddCategoryMapping(1, TorznabCatType.MoviesHD);
         }
 

--- a/src/Jackett.Common/Indexers/CinemaZ.cs
+++ b/src/Jackett.Common/Indexers/CinemaZ.cs
@@ -11,12 +11,14 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class CinemaZ : AvistazTracker
     {
+        public override string Id => "cinemaz";
+        public override string Name => "CinemaZ";
+        public override string Description => "Part of the Avistaz network.";
+        public override string SiteLink { get; protected set; } = "https://cinemaz.to/";
+
         public CinemaZ(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "cinemaz",
-                   name: "CinemaZ",
-                   description: "Part of the Avistaz network.",
-                   link: "https://cinemaz.to/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        LimitsDefault = 50,

--- a/src/Jackett.Common/Indexers/DICMusic.cs
+++ b/src/Jackett.Common/Indexers/DICMusic.cs
@@ -15,12 +15,16 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class DICMusic : GazelleTracker
     {
+        public override string Id => "dicmusic";
+        public override string Name => "DICMusic";
+        public override string Description => "DICMusic is a CHINESE Private Torrent Tracker for MUSIC";
+        public override string SiteLink { get; protected set; } = "https://dicmusic.club/";
+        public override string Language => "zh-CN";
+        public override string Type => "private";
+
         public DICMusic(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "dicmusic",
-                   name: "DICMusic",
-                   description: "DICMusic is a CHINESE Private Torrent Tracker for MUSIC",
-                   link: "https://dicmusic.club/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        MusicSearchParams = new List<MusicSearchParam>
@@ -37,9 +41,6 @@ namespace Jackett.Common.Indexers
                    supportsFreeleechOnly: true,
                    has2Fa: true)
         {
-            Language = "zh-CN";
-            Type = "private";
-
             AddCategoryMapping(1, TorznabCatType.Audio, "Music");
             AddCategoryMapping(2, TorznabCatType.PC, "Applications");
         }

--- a/src/Jackett.Common/Indexers/DarmoweTorrenty.cs
+++ b/src/Jackett.Common/Indexers/DarmoweTorrenty.cs
@@ -20,8 +20,16 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class DarmoweTorenty : BaseWebIndexer
+    public class DarmoweTorenty : IndexerBase
     {
+        public override string Id => "darmowetorenty";
+        public override string Name => "Darmowe torenty";
+        public override string Description => "Darmowe torenty is a POLISH Semi-Private Torrent Tracker for MOVIES / TV / GENERAL";
+        public override string SiteLink { get; protected set; } = "https://darmowe-torenty.pl/";
+        public override Encoding Encoding => Encoding.GetEncoding("iso-8859-2");
+        public override string Language => "pl-PL";
+        public override string Type => "semi-private";
+
         private string LoginUrl => SiteLink + "login.php";
         private string BrowseUrl => SiteLink + "torrenty.php";
 
@@ -37,10 +45,7 @@ namespace Jackett.Common.Indexers
 
         public DarmoweTorenty(IIndexerConfigurationService configService, WebClient wc, Logger l,
             IProtectionService ps, ICacheService cs)
-            : base(id: "darmowetorenty",
-                   name: "Darmowe torenty",
-                   description: "Darmowe torenty is a POLISH Semi-Private Torrent Tracker for MOVIES / TV / GENERAL",
-                   link: "https://darmowe-torenty.pl/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -67,10 +72,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataBasicLoginWithRSSAndDisplay())
         {
-            Encoding = Encoding.GetEncoding("iso-8859-2");
-            Language = "pl-PL";
-            Type = "semi-private";
-
             AddCategoryMapping(14, TorznabCatType.Movies, "Filmy");
             AddCategoryMapping(27, TorznabCatType.MoviesDVD, "Filmy DVD-R");
             AddCategoryMapping(28, TorznabCatType.MoviesSD, "Filmy VCD/SVCD");

--- a/src/Jackett.Common/Indexers/DivxTotal.cs
+++ b/src/Jackett.Common/Indexers/DivxTotal.cs
@@ -23,8 +23,33 @@ using WebClient = Jackett.Common.Utils.Clients.WebClient;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class DivxTotal : BaseWebIndexer
+    public class DivxTotal : IndexerBase
     {
+        public override string Id => "divxtotal";
+        public override string Name => "DivxTotal";
+        public override string Description => "DivxTotal is a SPANISH site for Movies, TV series and Software";
+        public override string SiteLink { get; protected set; } = "https://www.divxtotal.pl/";
+        public override string[] LegacySiteLinks => new[]
+        {
+            "https://www.divxtotal.la/",
+            "https://www.divxtotal.one/",
+            "https://www.divxtotal.ch/",
+            "https://www.divxtotal.nz/",
+            "https://www.divxtotal.li/",
+            "https://www.divxtotal.nu/",
+            "https://www.divxtotal.se/",
+            "https://www.divxtotal.pm/",
+            "https://www.divxtotal.re/",
+            "https://www.divxtotal.nl/",
+            "https://www.divxtotal.ac/",
+            "https://www.divxtotal.dev/",
+            "https://www.divxtotal.ms/",
+            "https://www.divxtotal.fi/",
+            "https://www.divxtotal.cat/"
+        };
+        public override string Language => "es-ES";
+        public override string Type => "public";
+
         private const string DownloadLink = "/download_tt.php";
         private const int MaxNrOfResults = 100;
         private const int MaxPageLoads = 3;
@@ -48,30 +73,9 @@ namespace Jackett.Common.Indexers
             public static long Otros => 536870912; // 512 MB
         }
 
-        public override string[] LegacySiteLinks { get; protected set; } = {
-            "https://www.divxtotal.la/",
-            "https://www.divxtotal.one/",
-            "https://www.divxtotal.ch/",
-            "https://www.divxtotal.nz/",
-            "https://www.divxtotal.li/",
-            "https://www.divxtotal.nu/",
-            "https://www.divxtotal.se/",
-            "https://www.divxtotal.pm/",
-            "https://www.divxtotal.re/",
-            "https://www.divxtotal.nl/",
-            "https://www.divxtotal.ac/",
-            "https://www.divxtotal.dev/",
-            "https://www.divxtotal.ms/",
-            "https://www.divxtotal.fi/",
-            "https://www.divxtotal.cat/"
-        };
-
         public DivxTotal(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps,
-            ICacheService cs)
-            : base(id: "divxtotal",
-                   name: "DivxTotal",
-                   description: "DivxTotal is a SPANISH site for Movies, TV series and Software",
-                   link: "https://www.divxtotal.pl/",
+                         ICacheService cs)
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -90,10 +94,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationData())
         {
-            Encoding = Encoding.UTF8;
-            Language = "es-ES";
-            Type = "public";
-
             var matchWords = new BoolConfigurationItem("Match words in title") { Value = true };
             configData.AddDynamic("MatchWords", matchWords);
 

--- a/src/Jackett.Common/Indexers/DonTorrent.cs
+++ b/src/Jackett.Common/Indexers/DonTorrent.cs
@@ -20,9 +20,14 @@ using WebClient = Jackett.Common.Utils.Clients.WebClient;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class DonTorrent : BaseWebIndexer
+    public class DonTorrent : IndexerBase
     {
-        public override string[] AlternativeSiteLinks { get; protected set; } = {
+        public override string Id => "dontorrent";
+        public override string Name => "DonTorrent";
+        public override string Description => "DonTorrent is a SPANISH public tracker for MOVIES / TV / GENERAL";
+        public override string SiteLink { get; protected set; } = "https://dontorrent.cloud/";
+        public override string[] AlternativeSiteLinks => new[]
+        {
             "https://dontorrent.cloud/",
             "https://todotorrents.net/",
             "https://tomadivx.net/",
@@ -30,7 +35,8 @@ namespace Jackett.Common.Indexers
             "https://verdetorrent.com/",
             "https://naranjatorrent.com/"
         };
-        public override string[] LegacySiteLinks { get; protected set; } = {
+        public override string[] LegacySiteLinks => new[]
+        {
             "https://dontorrent.me/",
             "https://dontorrent.gs/",
             "https://dontorrent.gy/",
@@ -49,6 +55,8 @@ namespace Jackett.Common.Indexers
             "https://dontorrent.ninja/",
             "https://dontorrent.love/"
         };
+        public override string Language => "es-ES";
+        public override string Type => "public";
 
         private static class DonTorrentCatType
         {
@@ -66,21 +74,18 @@ namespace Jackett.Common.Indexers
         private const string SearchUrl = "buscar/";
 
         private static Dictionary<string, string> CategoriesMap => new Dictionary<string, string>
-        {
-            { "/pelicula/", DonTorrentCatType.Pelicula },
-            { "/serie/", DonTorrentCatType.Serie },
-            { "/documental", DonTorrentCatType.Documental },
-            { "/musica/", DonTorrentCatType.Musica },
-            { "/variado/", DonTorrentCatType.Variado },
-            { "/juego/", DonTorrentCatType.Juego } //games, it can be pc or console
-        };
+            {
+                { "/pelicula/", DonTorrentCatType.Pelicula },
+                { "/serie/", DonTorrentCatType.Serie },
+                { "/documental", DonTorrentCatType.Documental },
+                { "/musica/", DonTorrentCatType.Musica },
+                { "/variado/", DonTorrentCatType.Variado },
+                { "/juego/", DonTorrentCatType.Juego } //games, it can be pc or console
+            };
 
         public DonTorrent(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "dontorrent",
-                   name: "DonTorrent",
-                   description: "DonTorrent is a SPANISH public tracker for MOVIES / TV / GENERAL",
-                   link: "https://dontorrent.cloud/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -103,11 +108,7 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationData())
         {
-            Encoding = Encoding.UTF8;
-            Language = "es-ES";
-            Type = "public";
-
-            // avoid Cloudflare too many requests limiter
+            // avoid CLoudflare too many requests limiter
             webclient.requestDelay = 2.1;
 
             var matchWords = new BoolConfigurationItem("Match words in title") { Value = true };

--- a/src/Jackett.Common/Indexers/EpubLibre.cs
+++ b/src/Jackett.Common/Indexers/EpubLibre.cs
@@ -17,13 +17,19 @@ using WebClient = Jackett.Common.Utils.Clients.WebClient;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class EpubLibre : BaseWebIndexer
+    public class EpubLibre : IndexerBase
     {
-        public override string[] AlternativeSiteLinks { get; protected set; } = {
+        public override string Id => "epublibre";
+        public override string Name => "EpubLibre";
+        public override string Description => "Más libros, Más libres";
+        public override string SiteLink { get; protected set; } = "https://www.epublibre.org/";
+        public override string[] AlternativeSiteLinks => new[]
+        {
             "https://www.epublibre.org/",
             "https://epublibre.unblockit.boo/"
         };
-        public override string[] LegacySiteLinks { get; protected set; } = {
+        public override string[] LegacySiteLinks => new[]
+        {
             "https://epublibre.org/",
             "https://epublibre.unblockit.how/",
             "https://epublibre.unblockit.cam/",
@@ -40,6 +46,8 @@ namespace Jackett.Common.Indexers
             "https://epublibre.unblockit.ink/",
             "https://epublibre.unblockit.bio/"
         };
+        public override string Language => "es-ES";
+        public override string Type => "public";
 
         private string SearchUrl => SiteLink + "catalogo/index/{0}/nuevo/todos/sin/todos/{1}/ajax";
         private string SobrecargaUrl => SiteLink + "inicio/sobrecarga";
@@ -67,10 +75,7 @@ namespace Jackett.Common.Indexers
 
         public EpubLibre(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
                          ICacheService cs)
-            : base(id: "epublibre",
-                   name: "EpubLibre",
-                   description: "Más libros, Más libres",
-                   link: "https://www.epublibre.org/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        BookSearchParams = new List<BookSearchParam>
@@ -85,10 +90,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationData())
         {
-            Encoding = Encoding.UTF8;
-            Language = "es-ES";
-            Type = "public";
-
             AddCategoryMapping(1, TorznabCatType.BooksEBook);
         }
 

--- a/src/Jackett.Common/Indexers/EraiRaws.cs
+++ b/src/Jackett.Common/Indexers/EraiRaws.cs
@@ -15,17 +15,20 @@ using static Jackett.Common.Models.IndexerConfig.ConfigurationData;
 
 namespace Jackett.Common.Indexers
 {
-    public class EraiRaws : BaseWebIndexer
+    public class EraiRaws : IndexerBase
     {
-        const string RSS_PATH = "feed/?type=magnet";
-
-        public override string[] AlternativeSiteLinks { get; protected set; } = {
+        public override string Id => "erai-raws";
+        public override string Name => "Erai-Raws";
+        public override string Description => "Erai-Raws is a team release site for Anime subtitles.";
+        public override string SiteLink { get; protected set; } = "https://www.erai-raws.info/";
+        public override string[] AlternativeSiteLinks => new[]
+        {
             "https://www.erai-raws.info/",
             "https://beta.erai-raws.info/",
             "https://erairaws.mrunblock.guru/"
         };
-
-        public override string[] LegacySiteLinks { get; protected set; } = {
+        public override string[] LegacySiteLinks => new[]
+        {
             "https://erairaws.nocensor.space/",
             "https://erairaws.nocensor.work/",
             "https://erairaws.nocensor.biz/",
@@ -34,13 +37,14 @@ namespace Jackett.Common.Indexers
             "https://erairaws.nocensor.lol/",
             "https://erairaws.nocensor.art/"
         };
+        public override string Language => "en-US";
+        public override string Type => "semi-private";
+
+        const string RSS_PATH = "feed/?type=magnet";
 
         public EraiRaws(IIndexerConfigurationService configService, Utils.Clients.WebClient wc, Logger l,
             IProtectionService ps, ICacheService cs)
-            : base(id: "erai-raws",
-                   name: "Erai-Raws",
-                   description: "Erai-Raws is a team release site for Anime subtitles.",
-                   link: "https://www.erai-raws.info/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -55,10 +59,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationData())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "semi-private";
-
             var rssKey = new StringConfigurationItem("RSSKey") { Value = "" };
             configData.AddDynamic("rssKey", rssKey);
             configData.AddDynamic("rssKeyHelp", new DisplayInfoConfigurationItem(string.Empty, "Find the RSS Key by accessing <a href=\"https://www.erai-raws.info/rss-page/\" target =_blank>Erai-Raws RSS page</a> while you're logged in. Copy the <i>All RSS</i> URL, the RSS Key is the last part. Example: for the URL <b>.../feed/?type=torrent&0879fd62733b8db8535eb1be2333</b> the RSS Key is <b>0879fd62733b8db8535eb1be2333</b>"));
@@ -144,7 +144,7 @@ namespace Jackett.Common.Indexers
                 }
                 else
                 {
-                    logger.Warn($"Could not parse {DisplayName} RSS item '{node.OuterXml}'");
+                    logger.Warn($"Could not parse {Name} RSS item '{node.OuterXml}'");
                 }
             }
 
@@ -160,13 +160,13 @@ namespace Jackett.Common.Indexers
                 // Validate the release
                 if (releaseInfo.PublishDate == null)
                 {
-                    logger.Warn($"Failed to parse {DisplayName} RSS feed item '{fi.Title}' due to malformed publish date.");
+                    logger.Warn($"Failed to parse {Name} RSS feed item '{fi.Title}' due to malformed publish date.");
                     continue;
                 }
 
                 if (releaseInfo.MagnetLink == null && string.IsNullOrWhiteSpace(releaseInfo.InfoHash))
                 {
-                    logger.Warn($"Failed to parse {DisplayName} RSS feed item '{fi.Title}' due to malformed link URI and no infohash available.");
+                    logger.Warn($"Failed to parse {Name} RSS feed item '{fi.Title}' due to malformed link URI and no infohash available.");
                     continue;
                 }
 

--- a/src/Jackett.Common/Indexers/ExoticaZ.cs
+++ b/src/Jackett.Common/Indexers/ExoticaZ.cs
@@ -15,20 +15,20 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class ExoticaZ : AvistazTracker
     {
-        private new ConfigurationDataAvistazTracker configData => (ConfigurationDataAvistazTracker)base.configData;
-
-        public override string[] LegacySiteLinks { get; protected set; } =
+        public override string Id => "exoticaz";
+        public override string Name => "ExoticaZ";
+        public override string Description => "ExoticaZ (YourExotic) is a Private Torrent Tracker for 3X";
+        public override string SiteLink { get; protected set; } = "https://exoticaz.to/";
+        public override string[] LegacySiteLinks => new[]
         {
             "https://torrents.yourexotic.com/"
         };
 
+        private new ConfigurationDataAvistazTracker configData => (ConfigurationDataAvistazTracker)base.configData;
+
         public ExoticaZ(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "exoticaz",
-                   name: "ExoticaZ",
-                   description: "ExoticaZ (YourExotic) is a Private Torrent Tracker for 3X",
-                   link: "https://exoticaz.to/",
-                   caps: new TorznabCapabilities(),
+            : base(caps: new TorznabCapabilities(),
                    configService: configService,
                    client: wc,
                    logger: l,

--- a/src/Jackett.Common/Indexers/Feeds/AnimeTosho.cs
+++ b/src/Jackett.Common/Indexers/Feeds/AnimeTosho.cs
@@ -16,12 +16,15 @@ namespace Jackett.Common.Indexers.Feeds
     [ExcludeFromCodeCoverage]
     public class AnimeTosho : BaseNewznabIndexer
     {
-        public AnimeTosho(IIndexerConfigurationService configService, WebClient client, Logger logger,
-            IProtectionService ps, ICacheService cs)
-            : base(id: "animetosho",
-                   name: "Anime Tosho",
-                   description: "AnimeTosho (AT) is an automated service that provides torrent files, magnet links and DDL for all anime releases",
-                   link: "https://animetosho.org/",
+        public override string Id => "animetosho";
+        public override string Name => "Anime Tosho";
+        public override string Description => "AnimeTosho (AT) is an automated service that provides torrent files, magnet links and DDL for all anime releases";
+        public override string SiteLink { get; protected set; } = "https://animetosho.org/";
+        public override string Language => "en-US";
+        public override string Type => "public";
+
+        public AnimeTosho(IIndexerConfigurationService configService, WebClient client, Logger logger, IProtectionService ps, ICacheService cs)
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -36,10 +39,6 @@ namespace Jackett.Common.Indexers.Feeds
                    cs: cs,
                    configData: new ConfigurationData())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "public";
-
             AddCategoryMapping(1, TorznabCatType.TVAnime);
         }
 

--- a/src/Jackett.Common/Indexers/Feeds/BaseFeedIndexer.cs
+++ b/src/Jackett.Common/Indexers/Feeds/BaseFeedIndexer.cs
@@ -16,15 +16,10 @@ namespace Jackett.Common.Indexers.Feeds
     {
         protected abstract Uri FeedUri { get; }
 
-        protected BaseFeedIndexer(string link, string id, string name, string description,
-                                  IIndexerConfigurationService configService, WebClient client, Logger logger,
+        protected BaseFeedIndexer(IIndexerConfigurationService configService, WebClient client, Logger logger,
                                   ConfigurationData configData, IProtectionService p, ICacheService cs,
                                   TorznabCapabilities caps = null, string downloadBase = null)
-            : base(id: id,
-                   name: name,
-                   description: description,
-                   link: link,
-                   caps: caps,
+            : base(caps: caps,
                    configService: configService,
                    client: client,
                    logger: logger,

--- a/src/Jackett.Common/Indexers/Feeds/BaseNewznabIndexer.cs
+++ b/src/Jackett.Common/Indexers/Feeds/BaseNewznabIndexer.cs
@@ -15,15 +15,10 @@ namespace Jackett.Common.Indexers.Feeds
     [ExcludeFromCodeCoverage]
     public abstract class BaseNewznabIndexer : BaseFeedIndexer
     {
-        protected BaseNewznabIndexer(string link, string id, string name, string description,
-                                     IIndexerConfigurationService configService, WebClient client, Logger logger,
+        protected BaseNewznabIndexer(IIndexerConfigurationService configService, WebClient client, Logger logger,
                                      ConfigurationData configData, IProtectionService p, ICacheService cs,
                                      TorznabCapabilities caps = null, string downloadBase = null)
-            : base(id: id,
-                   name: name,
-                   description: description,
-                   link: link,
-                   caps: caps,
+            : base(caps: caps,
                    configService: configService,
                    client: client,
                    logger: logger,

--- a/src/Jackett.Common/Indexers/Feeds/MoreThanTVAPI.cs
+++ b/src/Jackett.Common/Indexers/Feeds/MoreThanTVAPI.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
-using System.Text;
 using System.Threading.Tasks;
 using System.Xml.Linq;
 using Jackett.Common.Models;
@@ -20,14 +19,18 @@ namespace Jackett.Common.Indexers.Feeds
     [ExcludeFromCodeCoverage]
     public class MoreThanTVAPI : BaseNewznabIndexer
     {
+        public override string Id => "morethantv-api";
+        public override string Name => "MoreThanTV (API)";
+        public override string Description => "Private torrent tracker for TV / MOVIES";
+        public override string SiteLink { get; protected set; } = "https://www.morethantv.me/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private new ConfigurationDataAPIKey configData => (ConfigurationDataAPIKey)base.configData;
 
         public MoreThanTVAPI(IIndexerConfigurationService configService, WebClient client, Logger logger,
             IProtectionService ps, ICacheService cs)
-            : base(id: "morethantv-api",
-                   name: "MoreThanTV (API)",
-                   description: "Private torrent tracker for TV / MOVIES",
-                   link: "https://www.morethantv.me/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -46,10 +49,6 @@ namespace Jackett.Common.Indexers.Feeds
                    cs: cs,
                    configData: new ConfigurationDataAPIKey())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(TorznabCatType.TVSD.ID, TorznabCatType.TVSD);
             AddCategoryMapping(TorznabCatType.TVHD.ID, TorznabCatType.TVHD);
             AddCategoryMapping(TorznabCatType.TVUHD.ID, TorznabCatType.TVUHD);

--- a/src/Jackett.Common/Indexers/FileList.cs
+++ b/src/Jackett.Common/Indexers/FileList.cs
@@ -17,19 +17,26 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class FileList : BaseWebIndexer
+    public class FileList : IndexerBase
     {
-        public override string[] AlternativeSiteLinks { get; protected set; } = {
+        public override string Id => "filelist";
+        public override string Name => "FileList";
+        public override string Description => "The best Romanian site.";
+        public override string SiteLink { get; protected set; } = "https://filelist.io/";
+        public override string[] AlternativeSiteLinks => new[]
+        {
             "https://filelist.io/",
             "https://flro.org/"
         };
-
-        public override string[] LegacySiteLinks { get; protected set; } =
+        public override string[] LegacySiteLinks => new[]
         {
             "https://filelist.ro/",
             "http://filelist.ro/",
             "http://flro.org/"
         };
+        public override Encoding Encoding => Encoding.UTF8;
+        public override string Language => "ro-RO";
+        public override string Type => "private";
 
         private string ApiUrl => SiteLink + "api.php";
         private string DetailsUrl => SiteLink + "details.php";
@@ -38,10 +45,7 @@ namespace Jackett.Common.Indexers
 
         public FileList(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "filelist",
-                   name: "FileList",
-                   description: "The best Romanian site.",
-                   link: "https://filelist.io/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -69,10 +73,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataFileList())
         {
-            Encoding = Encoding.UTF8;
-            Language = "ro-RO";
-            Type = "private";
-
             AddCategoryMapping(1, TorznabCatType.MoviesSD, "Filme SD");
             AddCategoryMapping(2, TorznabCatType.MoviesDVD, "Filme DVD");
             AddCategoryMapping(3, TorznabCatType.MoviesForeign, "Filme DVD-RO");

--- a/src/Jackett.Common/Indexers/FunFile.cs
+++ b/src/Jackett.Common/Indexers/FunFile.cs
@@ -17,8 +17,16 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class FunFile : BaseWebIndexer
+    public class FunFile : IndexerBase
     {
+        public override string Id => "funfile";
+        public override string Name => "FunFile";
+        public override string Description => "A general tracker";
+        public override string SiteLink { get; protected set; } = "https://www.funfile.org/";
+        public override Encoding Encoding => Encoding.GetEncoding("iso-8859-1");
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string LoginUrl => SiteLink + "takelogin.php";
         private string SearchUrl => SiteLink + "browse.php";
 
@@ -26,10 +34,7 @@ namespace Jackett.Common.Indexers
 
         public FunFile(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "funfile",
-                   name: "FunFile",
-                   description: "A general tracker",
-                   link: "https://www.funfile.org/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -56,10 +61,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataBasicLogin("For best results, change the 'Torrents per page' setting to 100 in your profile."))
         {
-            Encoding = Encoding.GetEncoding("iso-8859-1");
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(44, TorznabCatType.TVAnime, "Anime");
             AddCategoryMapping(22, TorznabCatType.PC, "Applications");
             AddCategoryMapping(43, TorznabCatType.AudioAudiobook, "Audio Books");

--- a/src/Jackett.Common/Indexers/GazelleGames.cs
+++ b/src/Jackett.Common/Indexers/GazelleGames.cs
@@ -19,8 +19,15 @@ using static Jackett.Common.Models.IndexerConfig.ConfigurationData;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class GazelleGames : BaseWebIndexer
+    public class GazelleGames : IndexerBase
     {
+        public override string Id => "gazellegames";
+        public override string Name => "GazelleGames";
+        public override string Description => "A gaming tracker.";
+        public override string SiteLink { get; protected set; } = "https://gazellegames.net/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string LoginUrl => SiteLink + "login.php";
         private string BrowseUrl => SiteLink + "torrents.php";
 
@@ -32,11 +39,7 @@ namespace Jackett.Common.Indexers
 
         public GazelleGames(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "gazellegames",
-                   name: "GazelleGames",
-                   description: "A gaming tracker.",
-                   link: "https://gazellegames.net/",
-                   caps: new TorznabCapabilities(),
+            : base(caps: new TorznabCapabilities(),
                    configService: configService,
                    client: wc,
                    logger: l,
@@ -44,10 +47,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataCookie())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             configData.AddDynamic("searchgroupnames", new BoolConfigurationItem("Search Group Names Only") { Value = false });
 
             // Apple

--- a/src/Jackett.Common/Indexers/GazelleGamesAPI.cs
+++ b/src/Jackett.Common/Indexers/GazelleGamesAPI.cs
@@ -20,6 +20,13 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class GazelleGamesApi : GazelleTracker
     {
+        public override string Id => "gazellegamesapi";
+        public override string Name => "GazelleGames (API)";
+        public override string Description => "A gaming tracker";
+        public override string SiteLink { get; protected set; } = "https://gazellegames.net/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         // API Reference: https://gazellegames.net/wiki.php?action=article&id=401
         protected override string APIUrl => SiteLink + "api.php";
         protected override string AuthorizationName => "X-API-Key";
@@ -27,11 +34,7 @@ namespace Jackett.Common.Indexers
         protected override string FlipOptionalTokenString(string requestLink) => requestLink.Replace("usetoken=1", "");
         public GazelleGamesApi(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "gazellegamesapi",
-                   name: "GazelleGames (API)",
-                   description: "A gaming tracker",
-                   link: "https://gazellegames.net/",
-                   caps: new TorznabCapabilities(),
+            : base(caps: new TorznabCapabilities(),
                    configService: configService,
                    client: wc,
                    logger: l,
@@ -44,9 +47,6 @@ namespace Jackett.Common.Indexers
                    useAuthKey: true,
                    instructionMessageOptional: "<ol><li>Go to GGn's site and open your account settings.</li><li>Under <b>Access Settings</b> click on 'Create a new token'</li><li>Give it a name you like and click <b>Generate</b>.</li><li>Copy the generated API Key and paste it in the above text field.</li></ol>")
         {
-            Language = "en-US";
-            Type = "private";
-
             configData.AddDynamic("searchgroupnames", new BoolConfigurationItem("Search Group Names Only") { Value = false });
 
             // Apple

--- a/src/Jackett.Common/Indexers/GreatPosterWall.cs
+++ b/src/Jackett.Common/Indexers/GreatPosterWall.cs
@@ -17,12 +17,16 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class GreatPosterWall : GazelleTracker
     {
+        public override string Id => "greatposterwall";
+        public override string Name => "GreatPosterWall";
+        public override string Description => "GreatPosterWall (GPW) is a CHINESE Private site for MOVIES";
+        public override string SiteLink { get; protected set; } = "https://greatposterwall.com/";
+        public override string Language => "zh-CN";
+        public override string Type => "private";
+
         public GreatPosterWall(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "greatposterwall",
-                   name: "GreatPosterWall",
-                   description: "GreatPosterWall (GPW) is a CHINESE Private site for MOVIES",
-                   link: "https://greatposterwall.com/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        MovieSearchParams = new List<MovieSearchParam>
@@ -44,9 +48,6 @@ namespace Jackett.Common.Indexers
                    instructionMessageOptional: null
                   )
         {
-            Language = "zh-CN";
-            Type = "private";
-
             AddCategoryMapping(1, TorznabCatType.Movies, "Movies 电影");
 
             configData.AddDynamic("showFilename", new BoolConfigurationItem("Use the first torrent filename as the title") { Value = false });

--- a/src/Jackett.Common/Indexers/HDBitsApi.cs
+++ b/src/Jackett.Common/Indexers/HDBitsApi.cs
@@ -16,8 +16,15 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class HDBitsApi : BaseWebIndexer
+    public class HDBitsApi : IndexerBase
     {
+        public override string Id => "hdbitsapi";
+        public override string Name => "HDBits (API)";
+        public override string Description => "The HighDefinition Bittorrent Community";
+        public override string SiteLink { get; protected set; } = "https://hdbits.org/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string APIUrl => SiteLink + "api/";
 
         private new ConfigurationDataHDBitsApi configData
@@ -28,10 +35,7 @@ namespace Jackett.Common.Indexers
 
         public HDBitsApi(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "hdbitsapi",
-                   name: "HDBits (API)",
-                   description: "The HighDefinition Bittorrent Community",
-                   link: "https://hdbits.org/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -50,10 +54,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataHDBitsApi())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(6, TorznabCatType.Audio, "Audio Track");
             AddCategoryMapping(3, TorznabCatType.TVDocumentary, "Documentary");
             AddCategoryMapping(8, TorznabCatType.Other, "Misc/Demo");

--- a/src/Jackett.Common/Indexers/HDSpace.cs
+++ b/src/Jackett.Common/Indexers/HDSpace.cs
@@ -20,8 +20,15 @@ using WebClient = Jackett.Common.Utils.Clients.WebClient;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class HDSpace : BaseWebIndexer
+    public class HDSpace : IndexerBase
     {
+        public override string Id => "hdspace";
+        public override string Name => "HD-Space";
+        public override string Description => "Sharing The Universe";
+        public override string SiteLink { get; protected set; } = "https://hd-space.org/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string LoginUrl => SiteLink + "index.php?page=login";
         private string SearchUrl => SiteLink + "index.php?page=torrents";
 
@@ -29,10 +36,7 @@ namespace Jackett.Common.Indexers
 
         public HDSpace(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "hdspace",
-                   name: "HD-Space",
-                   description: "Sharing The Universe",
-                   link: "https://hd-space.org/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -55,10 +59,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataBasicLogin())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             configData.AddDynamic("flaresolverr", new DisplayInfoConfigurationItem("FlareSolverr", "This site may use Cloudflare DDoS Protection, therefore Jackett requires <a href=\"https://github.com/Jackett/Jackett#configuring-flaresolverr\" target=\"_blank\">FlareSolverr</a> to access it."));
 
             AddCategoryMapping(15, TorznabCatType.MoviesBluRay, "Movie / Blu-ray");

--- a/src/Jackett.Common/Indexers/HDTorrents.cs
+++ b/src/Jackett.Common/Indexers/HDTorrents.cs
@@ -4,7 +4,6 @@ using System.Collections.Specialized;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
-using System.Text;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using AngleSharp.Html.Parser;
@@ -19,8 +18,22 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class HDTorrents : BaseWebIndexer
+    public class HDTorrents : IndexerBase
     {
+        public override string Id => "hdtorrents";
+        public override string Name => "HD-Torrents";
+        public override string Description => "HD-Torrents is a private torrent website with HD torrents and strict rules on their content.";
+        public override string SiteLink { get; protected set; } = "https://hdts.ru/"; // Domain https://hdts.ru/ seems more reliable
+        public override string[] AlternativeSiteLinks => new[]
+        {
+            "https://hdts.ru/",
+            "https://hd-torrents.org/",
+            "https://hd-torrents.net/",
+            "https://hd-torrents.me/"
+        };
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string SearchUrl => SiteLink + "torrents.php?";
         private string LoginUrl => SiteLink + "login.php";
         private readonly Regex _posterRegex = new Regex(@"src=\\'./([^']+)\\'", RegexOptions.IgnoreCase);
@@ -34,22 +47,11 @@ namespace Jackett.Common.Indexers
             "Owner"
         };
 
-        public override string[] AlternativeSiteLinks { get; protected set; } =
-        {
-            "https://hdts.ru/",
-            "https://hd-torrents.org/",
-            "https://hd-torrents.net/",
-            "https://hd-torrents.me/"
-        };
-
         private new ConfigurationDataBasicLogin configData => (ConfigurationDataBasicLogin)base.configData;
 
         public HDTorrents(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "hdtorrents",
-                   name: "HD-Torrents",
-                   description: "HD-Torrents is a private torrent website with HD torrents and strict rules on their content.",
-                   link: "https://hdts.ru/", // Domain https://hdts.ru/ seems more reliable
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -70,13 +72,8 @@ namespace Jackett.Common.Indexers
                    logger: l,
                    p: ps,
                    cacheService: cs,
-                   configData: new ConfigurationDataBasicLogin(
-                       "For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile."))
+                   configData: new ConfigurationDataBasicLogin("For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile."))
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             // Movie
             AddCategoryMapping("70", TorznabCatType.MoviesBluRay, "Movie/UHD/Blu-Ray");
             AddCategoryMapping("1", TorznabCatType.MoviesBluRay, "Movie/Blu-Ray");

--- a/src/Jackett.Common/Indexers/IIndexer.cs
+++ b/src/Jackett.Common/Indexers/IIndexer.cs
@@ -25,16 +25,18 @@ namespace Jackett.Common.Indexers
 
     public interface IIndexer
     {
+        string Id { get; }
+        string Name { get; }
+        string Description { get; }
+
         string SiteLink { get; }
         string[] AlternativeSiteLinks { get; }
 
-        string DisplayName { get; }
-        string DisplayDescription { get; }
-        string Type { get; }
-        string Language { get; }
-        string LastError { get; set; }
-        string Id { get; }
         Encoding Encoding { get; }
+        string Language { get; }
+        string Type { get; }
+
+        string LastError { get; set; }
 
         bool SupportsPagination { get; }
 

--- a/src/Jackett.Common/Indexers/IPTorrents.cs
+++ b/src/Jackett.Common/Indexers/IPTorrents.cs
@@ -19,13 +19,14 @@ using static Jackett.Common.Models.IndexerConfig.ConfigurationData;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class IPTorrents : BaseWebIndexer
+    public class IPTorrents : IndexerBase
     {
-        public override bool SupportsPagination => true;
-
-        private string SearchUrl => SiteLink + "t";
-
-        public override string[] AlternativeSiteLinks { get; protected set; } = {
+        public override string Id => "iptorrents";
+        public override string Name => "IPTorrents";
+        public override string Description => "Always a step ahead.";
+        public override string SiteLink { get; protected set; } = "https://iptorrents.com/";
+        public override string[] AlternativeSiteLinks => new[]
+        {
             "https://iptorrents.com/",
             "https://www.iptorrents.com/",
             "https://iptorrents.me/",
@@ -39,8 +40,8 @@ namespace Jackett.Common.Indexers
             "https://ipt.cool/",
             "https://ipt.world/"
         };
-
-        public override string[] LegacySiteLinks { get; protected set; } = {
+        public override string[] LegacySiteLinks => new[]
+        {
             "https://ipt-update.com/",
             "http://ipt.read-books.org/",
             "http://alien.eating-organic.net/",
@@ -51,15 +52,18 @@ namespace Jackett.Common.Indexers
             "http://baywatch.workisboring.com/",
             "https://iptorrents.eu/"
         };
+        public override string Language => "en-US";
+        public override string Type => "private";
+
+        public override bool SupportsPagination => true;
+
+        private string SearchUrl => SiteLink + "t";
 
         private new ConfigurationDataCookieUA configData => (ConfigurationDataCookieUA)base.configData;
 
         public IPTorrents(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "iptorrents",
-                   name: "IPTorrents",
-                   description: "Always a step ahead.",
-                   link: "https://iptorrents.com/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -87,10 +91,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataCookieUA("For best results, change the 'Torrents per page' option to 100 and check the 'Torrents - Show files count' option in the website Settings."))
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             var sort = new SingleSelectConfigurationItem("Sort requested from site", new Dictionary<string, string>
                 {
                     {"time", "created"},

--- a/src/Jackett.Common/Indexers/ImmortalSeed.cs
+++ b/src/Jackett.Common/Indexers/ImmortalSeed.cs
@@ -19,15 +19,22 @@ using static Jackett.Common.Models.IndexerConfig.ConfigurationData;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class ImmortalSeed : BaseWebIndexer
+    public class ImmortalSeed : IndexerBase
     {
+        public override string Id => "immortalseed";
+        public override string Name => "ImmortalSeed";
+        public override string Description => "ImmortalSeed (iS) is a Private Torrent Tracker for MOVIES / TV / GENERAL";
+        public override string SiteLink { get; protected set; } = "https://immortalseed.me/";
+        public override string[] LegacySiteLinks => new[]
+        {
+            "http://immortalseed.me/"
+        };
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string SearchUrl => SiteLink + "browse.php";
         private string LoginUrl => SiteLink + "takelogin.php";
         private readonly Regex _dateMatchRegex = new Regex(@"\d{4}-\d{2}-\d{2} \d{2}:\d{2} [AaPp][Mm]", RegexOptions.Compiled);
-
-        public override string[] LegacySiteLinks { get; protected set; } = {
-            "http://immortalseed.me/"
-        };
 
         private new ConfigurationDataBasicLogin configData
         {
@@ -37,10 +44,7 @@ namespace Jackett.Common.Indexers
 
         public ImmortalSeed(IIndexerConfigurationService configService, Utils.Clients.WebClient wc, Logger l,
             IProtectionService ps, ICacheService cs)
-            : base(id: "immortalseed",
-                   name: "ImmortalSeed",
-                   description: "ImmortalSeed (iS) is a Private Torrent Tracker for MOVIES / TV / GENERAL",
-                   link: "https://immortalseed.me/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -67,10 +71,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataBasicLogin())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(3, TorznabCatType.Other, "Nuked");
             AddCategoryMapping(32, TorznabCatType.TVAnime, "Anime");
             AddCategoryMapping(23, TorznabCatType.PC, "Apps");

--- a/src/Jackett.Common/Indexers/IndexerBase.cs
+++ b/src/Jackett.Common/Indexers/IndexerBase.cs
@@ -1,0 +1,30 @@
+using System.Text;
+using Jackett.Common.Models;
+using Jackett.Common.Models.IndexerConfig;
+using Jackett.Common.Services.Interfaces;
+using Jackett.Common.Utils.Clients;
+using NLog;
+
+namespace Jackett.Common.Indexers
+{
+    public abstract class IndexerBase : BaseWebIndexer
+    {
+        public abstract override string Id { get; }
+        public abstract override string Name { get; }
+        public abstract override string Description { get; }
+        public abstract override string SiteLink { get; protected set; }
+        public override Encoding Encoding => Encoding.UTF8;
+        public abstract override string Language { get; }
+        public abstract override string Type { get; }
+
+        protected IndexerBase(IIndexerConfigurationService configService, WebClient client, Logger logger, ConfigurationData configData, IProtectionService p, ICacheService cacheService, TorznabCapabilities caps, string downloadBase = null)
+            : base(configService, client, logger, configData, p, cacheService, caps, downloadBase)
+        {
+        }
+
+        protected IndexerBase(IIndexerConfigurationService configService, WebClient client, Logger logger, IProtectionService p, ICacheService cacheService)
+            : base(configService, client, logger, p, cacheService)
+        {
+        }
+    }
+}

--- a/src/Jackett.Common/Indexers/Libble.cs
+++ b/src/Jackett.Common/Indexers/Libble.cs
@@ -20,8 +20,15 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class Libble : BaseWebIndexer
+    public class Libble : IndexerBase
     {
+        public override string Id => "libble";
+        public override string Name => "Libble";
+        public override string Description => "Libble is a Private Torrent Tracker for MUSIC";
+        public override string SiteLink { get; protected set; } = "https://libble.me/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         public override bool SupportsPagination => true;
 
         private string LandingUrl => SiteLink + "login.php";
@@ -60,10 +67,7 @@ namespace Jackett.Common.Indexers
 
         public Libble(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "libble",
-                   name: "Libble",
-                   description: "Libble is a Private Torrent Tracker for MUSIC",
-                   link: "https://libble.me/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        MusicSearchParams = new List<MusicSearchParam>
@@ -78,10 +82,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataBasicLoginWith2FA())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(1, TorznabCatType.Audio, "Music");
             AddCategoryMapping(2, TorznabCatType.Audio, "Libble Mixtapes");
             AddCategoryMapping(7, TorznabCatType.AudioVideo, "Music Videos");

--- a/src/Jackett.Common/Indexers/LostFilm.cs
+++ b/src/Jackett.Common/Indexers/LostFilm.cs
@@ -20,14 +20,14 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    internal class LostFilm : BaseWebIndexer
+    public class LostFilm : IndexerBase
     {
-        public override string[] LegacySiteLinks { get; protected set; } = {
-            "https://lostfilm.site",
-            "https://lostfilm.tw/",
-        };
-
-        public override string[] AlternativeSiteLinks { get; protected set; } = {
+        public override string Id => "lostfilm";
+        public override string Name => "LostFilm.tv";
+        public override string Description => "Unique portal about foreign series";
+        public override string SiteLink { get; protected set; } = "https://www.lostfilm.run/";
+        public override string[] AlternativeSiteLinks => new[]
+        {
             "https://www.lostfilm.run/",
             "https://www.lostfilmtv.site/",
             "https://www.lostfilm.tv/",
@@ -36,8 +36,15 @@ namespace Jackett.Common.Indexers
             "https://www.lostfilmtv2.site/",
             "https://www.lostfilmtv5.site/",
             "https://www.lostfilm.uno/"
+        };
+        public override string[] LegacySiteLinks => new[]
+        {
+            "https://lostfilm.site",
+            "https://lostfilm.tw/",
+        };
+        public override string Language => "ru-RU";
+        public override string Type => "semi-private";
 
- };
         private static readonly Regex parsePlayEpisodeRegex = new Regex("PlayEpisode\\('(?<id>\\d{1,3})(?<season>\\d{3})(?<episode>\\d{3})'\\)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex parseReleaseDetailsRegex = new Regex("Видео:\\ (?<quality>.+).\\ Размер:\\ (?<size>.+).\\ Перевод", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
@@ -107,10 +114,7 @@ namespace Jackett.Common.Indexers
 
         public LostFilm(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "lostfilm",
-                   name: "LostFilm.tv",
-                   description: "Unique portal about foreign series",
-                   link: "https://www.lostfilm.run/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -129,10 +133,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataCaptchaLogin())
         {
-            Encoding = Encoding.UTF8;
-            Language = "ru-RU";
-            Type = "semi-private";
-
             webclient.AddTrustedCertificate(new Uri(SiteLink).Host, "98D43B6E740B42C02A9BD1A9D1A813E4350BE332"); // for *.win expired 26/Mar/22
             webclient.AddTrustedCertificate(new Uri(SiteLink).Host, "34287FB53A58EC6AE590E7DD7E03C70C0263CADC"); // for *.tw  expired 01/Apr/21
 

--- a/src/Jackett.Common/Indexers/Magnetico.cs
+++ b/src/Jackett.Common/Indexers/Magnetico.cs
@@ -16,8 +16,15 @@ using WebClient = Jackett.Common.Utils.Clients.WebClient;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class Magnetico : BaseWebIndexer
+    public class Magnetico : IndexerBase
     {
+        public override string Id => "magnetico";
+        public override string Name => "Magnetico (Local DHT)";
+        public override string Description => "Magnetico is a self-hosted BitTorrent DHT search engine";
+        public override string SiteLink { get; protected set; } = "http://127.0.0.1:8080/";
+        public override string Language => "en-US";
+        public override string Type => "semi-private";
+
         private string SearchURl => SiteLink + "api/v0.1/torrents";
         private string TorrentsUrl => SiteLink + "torrents";
 
@@ -25,10 +32,7 @@ namespace Jackett.Common.Indexers
 
         public Magnetico(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "magnetico",
-                   name: "Magnetico (Local DHT)",
-                   description: "Magnetico is a self-hosted BitTorrent DHT search engine",
-                   link: "http://127.0.0.1:8080/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -58,10 +62,6 @@ namespace Jackett.Common.Indexers
                                "If you have many torrents, it is recommended to use PostgreSQL database to make queries faster. With SQLite, timeouts may occur."))
 
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "semi-private";
-
             var sort = new ConfigurationData.SingleSelectConfigurationItem("Sort requested from site", new Dictionary<string, string>
                 {
                     {"DISCOVERED_ON", "discovered"},

--- a/src/Jackett.Common/Indexers/MejorTorrent.cs
+++ b/src/Jackett.Common/Indexers/MejorTorrent.cs
@@ -21,29 +21,19 @@ using WebClient = Jackett.Common.Utils.Clients.WebClient;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class MejorTorrent : BaseWebIndexer
+    public class MejorTorrent : IndexerBase
     {
-        private static class MejorTorrentCatType
+        public override string Id => "mejortorrent";
+        public override string Name => "MejorTorrent";
+        public override string Description => "MejorTorrent - Hay veces que un torrent viene mejor! :)";
+        public override string SiteLink { get; protected set; } = "https://mejortorrent.wtf/";
+        public override string[] AlternativeSiteLinks => new[]
         {
-            public static string Pelicula => "Película";
-            public static string Serie => "Serie";
-            public static string SerieHd => "SerieHD"; // this category is created, doesn't exist in the site
-            public static string Musica => "Música";
-            public static string Otro => "Otro";
-        }
-
-        private const string NewTorrentsUrl = "torrents";
-        private const string SearchUrl = "busqueda/page/";
-
-        private const int PagesToSearch = 3;
-
-        // uncomment when there are more than one domain available
-        public override string[] AlternativeSiteLinks { get; protected set; } = {
             "https://mejortorrent.wtf/",
             "https://mejortorrent.unblockit.boo/"
         };
-
-        public override string[] LegacySiteLinks { get; protected set; } = {
+        public override string[] LegacySiteLinks => new[]
+        {
             "https://www.mejortorrentt.net/",
             "http://www.mejortorrent.org/",
             "http://www.mejortorrent.tv/",
@@ -73,13 +63,26 @@ namespace Jackett.Common.Indexers
             "https://mejortorrent.unblockit.name/",
             "https://mejortorrent.unblockit.bio/"
         };
+        public override string Language => "es-ES";
+        public override string Type => "public";
+
+        private static class MejorTorrentCatType
+        {
+            public static string Pelicula => "Película";
+            public static string Serie => "Serie";
+            public static string SerieHd => "SerieHD"; // this category is created, doesn't exist in the site
+            public static string Musica => "Música";
+            public static string Otro => "Otro";
+        }
+
+        private const string NewTorrentsUrl = "torrents";
+        private const string SearchUrl = "busqueda/page/";
+
+        private const int PagesToSearch = 3;
 
         public MejorTorrent(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps,
-            ICacheService cs)
-            : base(id: "mejortorrent",
-                   name: "MejorTorrent",
-                   description: "MejorTorrent - Hay veces que un torrent viene mejor! :)",
-                   link: "https://mejortorrent.wtf/",
+                            ICacheService cs)
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -103,10 +106,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationData())
         {
-            Encoding = Encoding.UTF8;
-            Language = "es-ES";
-            Type = "public";
-
             var matchWords = new BoolConfigurationItem("Match words in title") { Value = true };
             configData.AddDynamic("MatchWords", matchWords);
 

--- a/src/Jackett.Common/Indexers/Meta/BaseMetaIndexer.cs
+++ b/src/Jackett.Common/Indexers/Meta/BaseMetaIndexer.cs
@@ -14,16 +14,13 @@ namespace Jackett.Common.Indexers.Meta
 {
     public abstract class BaseMetaIndexer : BaseWebIndexer
     {
-        protected BaseMetaIndexer(string name, string id, string description,
-                                  IFallbackStrategyProvider fallbackStrategyProvider,
+        public override string SiteLink { get; protected set; } = "http://127.0.0.1/";
+
+        protected BaseMetaIndexer(IFallbackStrategyProvider fallbackStrategyProvider,
                                   IResultFilterProvider resultFilterProvider, IIndexerConfigurationService configService,
                                   WebClient client, Logger logger, ConfigurationData configData, IProtectionService ps,
                                   ICacheService cs, Func<IIndexer, bool> filter)
-            : base(id: id,
-                   name: name,
-                   description: description,
-                   link: "http://127.0.0.1/",
-                   caps: new TorznabCapabilities(),
+            : base(caps: new TorznabCapabilities(),
                    configService: configService,
                    client: client,
                    logger: logger,

--- a/src/Jackett.Common/Indexers/Meta/MetaIndexers.cs
+++ b/src/Jackett.Common/Indexers/Meta/MetaIndexers.cs
@@ -11,12 +11,14 @@ namespace Jackett.Common.Indexers.Meta
 {
     public class AggregateIndexer : BaseMetaIndexer
     {
+        public override string Id => "all";
+        public override string Name => "AggregateSearch";
+        public override string Description => "This feed includes all configured trackers";
+
         public AggregateIndexer(IFallbackStrategyProvider fallbackStrategyProvider,
                                 IResultFilterProvider resultFilterProvider, IIndexerConfigurationService configService,
                                 WebClient client, Logger logger, IProtectionService ps, ICacheService cs)
-            : base(id: "all",
-                   name: "AggregateSearch",
-                   description: "This feed includes all configured trackers",
+            : base(
                    configService: configService,
                    client: client,
                    logger: logger,
@@ -43,13 +45,16 @@ namespace Jackett.Common.Indexers.Meta
 
     public class FilterIndexer : BaseMetaIndexer
     {
+        public override string Id => _filter;
+        public override string Name => _filter;
+        public override string Description => $"This feed includes all configured trackers filter by {_filter}";
+
+        private readonly string _filter;
+
         public FilterIndexer(string filter, IFallbackStrategyProvider fallbackStrategyProvider,
                           IResultFilterProvider resultFilterProvider, IIndexerConfigurationService configService,
                           WebClient client, Logger logger, IProtectionService ps, ICacheService cs, Func<IIndexer, bool> filterFunc)
-            : base(id: filter,
-                   name: filter,
-                   description: "This feed includes all configured trackers filter by " + filter,
-                   configService: configService,
+            : base(configService: configService,
                    client: client,
                    logger: logger,
                    ps: ps,
@@ -60,6 +65,7 @@ namespace Jackett.Common.Indexers.Meta
                    filter: filterFunc
                 )
         {
+            _filter = filter;
         }
 
         public override TorznabCapabilities TorznabCaps

--- a/src/Jackett.Common/Indexers/MyAnonamouse.cs
+++ b/src/Jackett.Common/Indexers/MyAnonamouse.cs
@@ -18,8 +18,15 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class MyAnonamouse : BaseWebIndexer
+    public class MyAnonamouse : IndexerBase
     {
+        public override string Id => "myanonamouse";
+        public override string Name => "MyAnonamouse";
+        public override string Description => "Friendliness, Warmth and Sharing";
+        public override string SiteLink { get; protected set; } = "https://www.myanonamouse.net/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         public override bool SupportsPagination => true;
 
         private string SearchUrl => SiteLink + "tor/js/loadSearchJSONbasic.php";
@@ -28,11 +35,7 @@ namespace Jackett.Common.Indexers
 
         public MyAnonamouse(IIndexerConfigurationService configService, WebClient c, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "myanonamouse",
-                   name: "MyAnonamouse",
-                   description: "Friendliness, Warmth and Sharing",
-                   link: "https://www.myanonamouse.net/",
-                   configService: configService,
+            : base(configService: configService,
                    caps: new TorznabCapabilities
                    {
                        BookSearchParams = new List<BookSearchParam>
@@ -46,9 +49,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataMyAnonamouse())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
             webclient.EmulateBrowser = false;
 
             AddCategoryMapping("13", TorznabCatType.AudioAudiobook, "AudioBooks");
@@ -275,7 +275,7 @@ namespace Jackett.Common.Indexers
                         catch (Exception)
                         {
                             // the JSON on author_info field can be malformed due to double quotes
-                            logger.Warn($"{DisplayName} error parsing author_info: {authorInfo}");
+                            logger.Warn($"{Name} error parsing author_info: {authorInfo}");
                         }
 
                     var flags = new List<string>();

--- a/src/Jackett.Common/Indexers/NCore.cs
+++ b/src/Jackett.Common/Indexers/NCore.cs
@@ -20,8 +20,19 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class NCore : BaseWebIndexer
+    public class NCore : IndexerBase
     {
+        public override string Id => "ncore";
+        public override string Name => "nCore";
+        public override string Description => "A Hungarian private torrent site.";
+        public override string SiteLink { get; protected set; } = "https://ncore.pro/";
+        public override string[] LegacySiteLinks => new[]
+        {
+            "https://ncore.cc/"
+        };
+        public override string Language => "hu-HU";
+        public override string Type => "private";
+
         private string LoginUrl => SiteLink + "login.php";
         private string SearchUrl => SiteLink + "torrents.php";
 
@@ -41,16 +52,9 @@ namespace Jackett.Common.Indexers
             "ebook"
         };
 
-        public override string[] LegacySiteLinks { get; protected set; } = {
-            "https://ncore.cc/"
-        };
-
         public NCore(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
-            ICacheService cs)
-            : base(id: "ncore",
-                  name: "nCore",
-                  description: "A Hungarian private torrent site.",
-                  link: "https://ncore.pro/",
+                     ICacheService cs)
+            : base(
                   caps: new TorznabCapabilities
                   {
                       TvSearchParams = new List<TvSearchParam>
@@ -77,10 +81,6 @@ namespace Jackett.Common.Indexers
                   cacheService: cs,
                   configData: new ConfigurationDataNCore())
         {
-            Encoding = Encoding.UTF8;
-            Language = "hu-HU";
-            Type = "private";
-
             AddCategoryMapping("xvid_hun", TorznabCatType.MoviesSD, "Film SD/HU");
             AddCategoryMapping("xvid", TorznabCatType.MoviesSD, "Film SD/EN");
             AddCategoryMapping("dvd_hun", TorznabCatType.MoviesDVD, "Film DVDR/HU");

--- a/src/Jackett.Common/Indexers/NebulanceAPI.cs
+++ b/src/Jackett.Common/Indexers/NebulanceAPI.cs
@@ -17,8 +17,15 @@ using static Jackett.Common.Models.IndexerConfig.ConfigurationData;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class NebulanceAPI : BaseWebIndexer
+    public class NebulanceAPI : IndexerBase
     {
+        public override string Id => "nebulanceapi";
+        public override string Name => "NebulanceAPI";
+        public override string Description => "At Nebulance we will change the way you think about TV. Using API.";
+        public override string SiteLink { get; protected set; } = "https://nebulance.io/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         public override bool SupportsPagination => true;
 
         // Docs at https://nebulance.io/articles.php?topic=api_key
@@ -34,10 +41,7 @@ namespace Jackett.Common.Indexers
 
         public NebulanceAPI(IIndexerConfigurationService configService, WebClient wc, Logger l,
             IProtectionService ps, ICacheService cs)
-            : base(id: "nebulanceapi",
-                   name: "NebulanceAPI",
-                   description: "At Nebulance we will change the way you think about TV. Using API.",
-                   link: "https://nebulance.io/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        LimitsDefault = 100,
@@ -55,10 +59,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataAPIKey())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping("tv", TorznabCatType.TV, "tv");
             AddCategoryMapping("sd", TorznabCatType.TVSD, "sd");
             AddCategoryMapping("hd", TorznabCatType.TVHD, "hd");

--- a/src/Jackett.Common/Indexers/NorBits.cs
+++ b/src/Jackett.Common/Indexers/NorBits.cs
@@ -24,6 +24,14 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class NorBits : BaseCachingWebIndexer
     {
+        public override string Id => "norbits";
+        public override string Name => "NorBits";
+        public override string Description => "NorBits is a Norwegian Private site for MOVIES / TV / GENERAL";
+        public override string SiteLink { get; protected set; } = "https://norbits.net/";
+        public override Encoding Encoding => Encoding.GetEncoding("iso-8859-1");
+        public override string Language => "nb-NO";
+        public override string Type => "private";
+
         private string LoginUrl => SiteLink + "login.php";
         private string LoginCheckUrl => SiteLink + "takelogin.php";
         private string SearchUrl => SiteLink + "browse.php";
@@ -32,10 +40,7 @@ namespace Jackett.Common.Indexers
 
         public NorBits(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "norbits",
-                   name: "NorBits",
-                   description: "NorBits is a Norwegian Private site for MOVIES / TV / GENERAL",
-                   link: "https://norbits.net/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -62,10 +67,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataNorbits())
         {
-            Encoding = Encoding.GetEncoding("iso-8859-1");
-            Language = "nb-NO";
-            Type = "private";
-
             AddCategoryMapping("main_cat[]=1&sub2_cat[]=49", TorznabCatType.MoviesUHD, "Filmer - UHD-2160p");
             AddCategoryMapping("main_cat[]=1&sub2_cat[]=19", TorznabCatType.MoviesHD, "Filmer - HD-1080p/i");
             AddCategoryMapping("main_cat[]=1&sub2_cat[]=20", TorznabCatType.MoviesHD, "Filmer - HD-720p");

--- a/src/Jackett.Common/Indexers/Orpheus.cs
+++ b/src/Jackett.Common/Indexers/Orpheus.cs
@@ -11,6 +11,13 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class Orpheus : GazelleTracker
     {
+        public override string Id => "orpheus";
+        public override string Name => "Orpheus";
+        public override string Description => "A music tracker";
+        public override string SiteLink { get; protected set; } = "https://orpheus.network/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         // API Reference: https://github.com/OPSnet/Gazelle/wiki/JSON-API-Documentation
         protected override string DownloadUrl => SiteLink + "ajax.php?action=download" + (useTokens ? "&usetoken=1" : "") + "&id=";
         protected override string AuthorizationFormat => "token {0}";
@@ -18,10 +25,7 @@ namespace Jackett.Common.Indexers
         protected override string FlipOptionalTokenString(string requestLink) => requestLink.Replace("usetoken=1", "");
         public Orpheus(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "orpheus",
-                   name: "Orpheus",
-                   description: "A music tracker",
-                   link: "https://orpheus.network/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        MovieSearchParams = new List<MovieSearchParam>
@@ -48,9 +52,6 @@ namespace Jackett.Common.Indexers
                    usePassKey: false,
                    instructionMessageOptional: "<ol><li>Go to Orpheus's site and open your account settings.</li><li>Under <b>Access Settings</b> click on 'Create a new token'</li><li>Give it a name you like and click <b>Generate</b>.</li><li>Copy the generated API Key and paste it in the above text field.</li></ol>")
         {
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(1, TorznabCatType.Audio, "Music");
             AddCategoryMapping(2, TorznabCatType.PC, "Applications");
             AddCategoryMapping(3, TorznabCatType.Books, "E-Books");

--- a/src/Jackett.Common/Indexers/PassThePopcorn.cs
+++ b/src/Jackett.Common/Indexers/PassThePopcorn.cs
@@ -17,8 +17,15 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class PassThePopcorn : BaseWebIndexer
+    public class PassThePopcorn : IndexerBase
     {
+        public override string Id => "passthepopcorn";
+        public override string Name => "PassThePopcorn";
+        public override string Description => "PassThePopcorn is a Private site for MOVIES / TV";
+        public override string SiteLink { get; protected set; } = "https://passthepopcorn.me/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private static string SearchUrl => "https://passthepopcorn.me/torrents.php";
         private string AuthKey { get; set; }
         private string PassKey { get; set; }
@@ -32,10 +39,7 @@ namespace Jackett.Common.Indexers
 
         public PassThePopcorn(IIndexerConfigurationService configService, Utils.Clients.WebClient c, Logger l,
             IProtectionService ps, ICacheService cs)
-            : base(id: "passthepopcorn",
-                   name: "PassThePopcorn",
-                   description: "PassThePopcorn is a Private site for MOVIES / TV",
-                   link: "https://passthepopcorn.me/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -56,10 +60,6 @@ namespace Jackett.Common.Indexers
                                                                         Separate options with a space if using more than one option.<br>Filter options available:
                                                                         <br><code>GoldenPopcorn</code><br><code>Scene</code><br><code>Checked</code><br><code>Free</code>"))
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             webclient.requestDelay = 2; // 0.5 requests per second
 
             AddCategoryMapping(1, TorznabCatType.Movies, "Feature Film");

--- a/src/Jackett.Common/Indexers/PirateTheNet.cs
+++ b/src/Jackett.Common/Indexers/PirateTheNet.cs
@@ -19,8 +19,15 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class PirateTheNet : BaseWebIndexer
+    public class PirateTheNet : IndexerBase
     {
+        public override string Id => "piratethenet";
+        public override string Name => "PirateTheNet";
+        public override string Description => "A movie tracker";
+        public override string SiteLink { get; protected set; } = "http://piratethenet.org/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string SearchUrl => SiteLink + "torrentsutils.php";
         private string LoginUrl => SiteLink + "takelogin.php";
         private string CaptchaUrl => SiteLink + "simpleCaptcha.php?numImages=1";
@@ -33,10 +40,7 @@ namespace Jackett.Common.Indexers
 
         public PirateTheNet(IIndexerConfigurationService configService, WebClient w, Logger l,
             IProtectionService ps, ICacheService cs)
-            : base(id: "piratethenet",
-                   name: "PirateTheNet",
-                   description: "A movie tracker",
-                   link: "http://piratethenet.org/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        MovieSearchParams = new List<MovieSearchParam>
@@ -51,10 +55,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataBasicLoginWithRSSAndDisplay("Only the results from the first search result page are shown, adjust your profile settings to show the maximum."))
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping("1080P", TorznabCatType.MoviesHD, "1080P");
             AddCategoryMapping("2160P", TorznabCatType.MoviesHD, "2160P");
             AddCategoryMapping("720P", TorznabCatType.MoviesHD, "720P");

--- a/src/Jackett.Common/Indexers/PixelHD.cs
+++ b/src/Jackett.Common/Indexers/PixelHD.cs
@@ -17,8 +17,15 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class PixelHD : BaseWebIndexer
+    public class PixelHD : IndexerBase
     {
+        public override string Id => "pixelhd";
+        public override string Name => "PiXELHD";
+        public override string Description => "PixelHD (PxHD) is a Private Torrent Tracker for HD .MP4 MOVIES / TV";
+        public override string SiteLink { get; protected set; } = "https://pixelhd.me/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string LoginUrl => SiteLink + "login.php";
         private string BrowseUrl => SiteLink + "torrents.php";
 
@@ -34,10 +41,7 @@ namespace Jackett.Common.Indexers
 
         public PixelHD(IIndexerConfigurationService configService, WebClient webClient, Logger logger,
             IProtectionService ps, ICacheService cs)
-            : base(id: "pixelhd",
-                   name: "PiXELHD",
-                   description: "PixelHD (PxHD) is a Private Torrent Tracker for HD .MP4 MOVIES / TV",
-                   link: "https://pixelhd.me/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        MovieSearchParams = new List<MovieSearchParam>
@@ -53,10 +57,6 @@ namespace Jackett.Common.Indexers
                    configData: new ConfigurationDataCaptchaLogin()
                 )
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(1, TorznabCatType.MoviesHD);
         }
 

--- a/src/Jackett.Common/Indexers/PornoLab.cs
+++ b/src/Jackett.Common/Indexers/PornoLab.cs
@@ -17,8 +17,16 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class PornoLab : BaseWebIndexer
+    public class PornoLab : IndexerBase
     {
+        public override string Id => "pornolab";
+        public override string Name => "PornoLab";
+        public override string Description => "PornoLab is a Semi-Private Russian site for Adult content";
+        public override string SiteLink { get; protected set; } = "https://pornolab.net/";
+        public override Encoding Encoding => Encoding.GetEncoding("windows-1251");
+        public override string Language => "ru-RU";
+        public override string Type => "semi-private";
+
         private string LoginUrl => SiteLink + "forum/login.php";
         private string SearchUrl => SiteLink + "forum/tracker.php";
 
@@ -32,13 +40,8 @@ namespace Jackett.Common.Indexers
             set => base.configData = value;
         }
 
-        public PornoLab(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
-            ICacheService cs)
-            : base(id: "pornolab",
-                   name: "PornoLab",
-                   description: "PornoLab is a Semi-Private Russian site for Adult content",
-                   link: "https://pornolab.net/",
-                   caps: new TorznabCapabilities(),
+        public PornoLab(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps, ICacheService cs)
+            : base(caps: new TorznabCapabilities(),
                    configService: configService,
                    client: wc,
                    logger: l,
@@ -46,10 +49,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataPornolab())
         {
-            Encoding = Encoding.GetEncoding("windows-1251");
-            Language = "ru-RU";
-            Type = "semi-private";
-
             AddCategoryMapping(1670, TorznabCatType.XXX, "Эротическое видео / Erotic & Softcore");
             AddCategoryMapping(1768, TorznabCatType.XXX, "Эротические фильмы / Erotic Movies");
             AddCategoryMapping(60, TorznabCatType.XXX, "Документальные фильмы / Documentary & Reality");

--- a/src/Jackett.Common/Indexers/PreToMe.cs
+++ b/src/Jackett.Common/Indexers/PreToMe.cs
@@ -17,18 +17,23 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class PreToMe : BaseWebIndexer
+    public class PreToMe : IndexerBase
     {
+        public override string Id => "pretome";
+        public override string Name => "PreToMe";
+        public override string Description => "BitTorrent site for High Quality, High Definition (HD) movies and TV Shows";
+        public override string SiteLink { get; protected set; } = "https://pretome.info/";
+        public override Encoding Encoding => Encoding.GetEncoding("iso-8859-1");
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string LoginUrl => SiteLink + "takelogin.php";
         private string SearchUrl => SiteLink + "browse.php";
         private new ConfigurationDataPinNumber configData => (ConfigurationDataPinNumber)base.configData;
 
         public PreToMe(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "pretome",
-                   name: "PreToMe",
-                   description: "BitTorrent site for High Quality, High Definition (HD) movies and TV Shows",
-                   link: "https://pretome.info/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -55,10 +60,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataPinNumber("For best results, change the 'Torrents per page' setting to 100 in 'Profile => Torrent browse settings'."))
         {
-            Encoding = Encoding.GetEncoding("iso-8859-1");
-            Language = "en-US";
-            Type = "private";
-
             // Unfortunately most of them are tags not categories and they return the parent category
             // we have to re-add the tags with the parent category so the results are not removed with the filtering
 

--- a/src/Jackett.Common/Indexers/PrivateHD.cs
+++ b/src/Jackett.Common/Indexers/PrivateHD.cs
@@ -11,12 +11,14 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class PrivateHD : AvistazTracker
     {
+        public override string Id => "privatehd";
+        public override string Name => "PrivateHD";
+        public override string Description => "BitTorrent site for High Quality, High Definition (HD) movies and TV Shows";
+        public override string SiteLink { get; protected set; } = "https://privatehd.to/";
+
         public PrivateHD(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "privatehd",
-                   name: "PrivateHD",
-                   description: "BitTorrent site for High Quality, High Definition (HD) movies and TV Shows",
-                   link: "https://privatehd.to/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        LimitsDefault = 50,

--- a/src/Jackett.Common/Indexers/RarBG.cs
+++ b/src/Jackett.Common/Indexers/RarBG.cs
@@ -19,8 +19,16 @@ using static Jackett.Common.Models.IndexerConfig.ConfigurationData;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class RarBG : BaseWebIndexer
+    public class RarBG : IndexerBase
     {
+        public override string Id => "rarbg";
+        public override string Name => "RARBG";
+        public override string Description => "RARBG is a Public torrent site for MOVIES / TV / GENERAL";
+        public override string SiteLink { get; protected set; } = "https://rarbg.to/";
+        public override Encoding Encoding => Encoding.GetEncoding("windows-1252");
+        public override string Language => "en-US";
+        public override string Type => "public";
+
         // API doc: https://torrentapi.org/apidocs_v2.txt?app_id=Jackett
         private string ApiEndpoint => ((StringConfigurationItem)configData.GetDynamic("apiEndpoint")).Value;
         private readonly TimeSpan TokenDuration = TimeSpan.FromMinutes(14); // 15 minutes expiration
@@ -33,10 +41,7 @@ namespace Jackett.Common.Indexers
 
         public RarBG(IIndexerConfigurationService configService, Utils.Clients.WebClient wc, Logger l,
             IProtectionService ps, ICacheService cs)
-            : base(id: "rarbg",
-                   name: "RARBG",
-                   description: "RARBG is a Public torrent site for MOVIES / TV / GENERAL",
-                   link: "https://rarbg.to/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -60,10 +65,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationData())
         {
-            Encoding = Encoding.GetEncoding("windows-1252");
-            Language = "en-US";
-            Type = "public";
-
             webclient.requestDelay = 5; // The api has a 1req/2s limit
 
             var ConfigApiEndpoint = new StringConfigurationItem("API URL") { Value = "https://torrentapi.org/pubapi_v2.php" };

--- a/src/Jackett.Common/Indexers/Redacted.cs
+++ b/src/Jackett.Common/Indexers/Redacted.cs
@@ -13,14 +13,18 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class Redacted : GazelleTracker
     {
+        public override string Id => "redacted";
+        public override string Name => "Redacted";
+        public override string Description => "A music tracker";
+        public override string SiteLink { get; protected set; } = "https://redacted.ch/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         protected override string DownloadUrl => SiteLink + "ajax.php?action=download&usetoken=" + (useTokens ? "1" : "0") + "&id=";
 
         public Redacted(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
                         ICacheService cs)
-            : base(id: "redacted",
-                   name: "Redacted",
-                   description: "A music tracker",
-                   link: "https://redacted.ch/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        MovieSearchParams = new List<MovieSearchParam>
@@ -47,9 +51,6 @@ namespace Jackett.Common.Indexers
                    instructionMessageOptional: "<ol><li>Go to Redacted's site and open your account settings.</li><li>Go to <b>Access Settings</b> tab and copy the API Key.</li><li>Ensure that you've checked <b>Confirm API Key</b>.</li><li>Finally, click <b>Save Profile</b>.</li></ol>"
                 )
         {
-            Language = "en-US";
-            Type = "private";
-
             webclient.EmulateBrowser = false; // Issue #9751
 
             AddCategoryMapping(1, TorznabCatType.Audio, "Music");

--- a/src/Jackett.Common/Indexers/RetroFlix.cs
+++ b/src/Jackett.Common/Indexers/RetroFlix.cs
@@ -12,20 +12,23 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class RetroFlix : SpeedAppTracker
     {
-        protected override bool UseP2PReleaseName => true;
-        protected override int minimumSeedTime => 432000; // 120h
-
-        public override string[] LegacySiteLinks { get; protected set; } = {
+        public override string Id => "retroflix";
+        public override string Name => "RetroFlix";
+        public override string Description => "Private Torrent Tracker for Classic Movies / TV / General Releases";
+        public override string SiteLink { get; protected set; } = "https://retroflix.club/";
+        public override string[] LegacySiteLinks => new[]
+        {
             "https://retroflix.net/"
         };
+        public override string Language => "en-US";
+        public override string Type => "private";
+
+        protected override bool UseP2PReleaseName => true;
+        protected override int minimumSeedTime => 432000; // 120h
 
         public RetroFlix(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
             : base(
-                id: "retroflix",
-                name: "RetroFlix",
-                description: "Private Torrent Tracker for Classic Movies / TV / General Releases",
-                link: "https://retroflix.club/",
                 caps: new TorznabCapabilities
                 {
                     TvSearchParams = new List<TvSearchParam>
@@ -51,10 +54,6 @@ namespace Jackett.Common.Indexers
                 p: ps,
                 cs: cs)
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             // requestDelay for API Limit (1 request per 2 seconds)
             webclient.requestDelay = 2.1;
 

--- a/src/Jackett.Common/Indexers/RevolutionTT.cs
+++ b/src/Jackett.Common/Indexers/RevolutionTT.cs
@@ -17,8 +17,16 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class RevolutionTT : BaseWebIndexer
+    public class RevolutionTT : IndexerBase
     {
+        public override string Id => "revolutiontt";
+        public override string Name => "RevolutionTT";
+        public override string Description => "The Revolution has begun";
+        public override string SiteLink { get; protected set; } = "https://revolutiontt.me/";
+        public override Encoding Encoding => Encoding.GetEncoding("iso-8859-1");
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string LandingPageURL => SiteLink + "login.php";
         private string LoginUrl => SiteLink + "takelogin.php";
         private string SearchUrl => SiteLink + "browse.php";
@@ -27,10 +35,7 @@ namespace Jackett.Common.Indexers
 
         public RevolutionTT(IIndexerConfigurationService configService, Utils.Clients.WebClient wc, Logger l,
             IProtectionService ps, ICacheService cs)
-            : base(id: "revolutiontt",
-                   name: "RevolutionTT",
-                   description: "The Revolution has begun",
-                   link: "https://revolutiontt.me/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -57,10 +62,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataBasicLogin("For best results, change the 'Torrents per page' setting to 100 in your Profile."))
         {
-            Encoding = Encoding.GetEncoding("iso-8859-1");
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping("23", TorznabCatType.TVAnime);
             AddCategoryMapping("22", TorznabCatType.PC0day);
             AddCategoryMapping("1", TorznabCatType.PCISO);

--- a/src/Jackett.Common/Indexers/RuTracker.cs
+++ b/src/Jackett.Common/Indexers/RuTracker.cs
@@ -20,13 +20,23 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class RuTracker : BaseWebIndexer
+    public class RuTracker : IndexerBase
     {
-        public override string[] AlternativeSiteLinks { get; protected set; } = {
+        public override string Id => "rutracker";
+        public override string Name => "RuTracker";
+        public override string Description => "RuTracker is a Semi-Private Russian torrent site with a thriving file-sharing community";
+        public override string SiteLink { get; protected set; } = "https://rutracker.org/";
+        public override string[] AlternativeSiteLinks => new[]
+        {
             "https://rutracker.org/",
             "https://rutracker.net/",
             "https://rutracker.nl/"
         };
+        public override Encoding Encoding => Encoding.GetEncoding("windows-1251");
+        public override string Language => "ru-RU";
+        public override string Type => "semi-private";
+
+
         private new ConfigurationDataRutracker configData => (ConfigurationDataRutracker)base.configData;
 
         private readonly TitleParser _titleParser = new TitleParser();
@@ -37,10 +47,7 @@ namespace Jackett.Common.Indexers
         private string _capCodeField;
 
         public RuTracker(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps, ICacheService cs)
-            : base(id: "rutracker",
-                   name: "RuTracker",
-                   description: "RuTracker is a Semi-Private Russian torrent site with a thriving file-sharing community",
-                   link: "https://rutracker.org/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -68,10 +75,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataRutracker())
         {
-            Encoding = Encoding.GetEncoding("windows-1251");
-            Language = "ru-RU";
-            Type = "semi-private";
-
             // note: when refreshing the categories use the tracker.php page and NOT the search.php page!
             AddCategoryMapping(22, TorznabCatType.Movies, "Наше кино");
             AddCategoryMapping(941, TorznabCatType.Movies, "|- Кино СССР");

--- a/src/Jackett.Common/Indexers/SceneHD.cs
+++ b/src/Jackett.Common/Indexers/SceneHD.cs
@@ -17,8 +17,15 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class SceneHD : BaseWebIndexer
+    public class SceneHD : IndexerBase
     {
+        public override string Id => "scenehd";
+        public override string Name => "SceneHD";
+        public override string Description => "SceneHD is Private site for HD TV / MOVIES";
+        public override string SiteLink { get; protected set; } = "https://scenehd.org/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string SearchUrl => SiteLink + "browse.php?";
         private string DetailsUrl => SiteLink + "details.php?";
         private string DownloadUrl => SiteLink + "download.php?";
@@ -27,11 +34,7 @@ namespace Jackett.Common.Indexers
 
         public SceneHD(IIndexerConfigurationService configService, WebClient c, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "scenehd",
-                   name: "SceneHD",
-                   description: "SceneHD is Private site for HD TV / MOVIES",
-                   link: "https://scenehd.org/",
-                   configService: configService,
+            : base(configService: configService,
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -54,10 +57,6 @@ namespace Jackett.Common.Indexers
                    configData: new ConfigurationDataPasskey("You can find the Passkey if you generate a RSS " +
                                                             "feed link. It's the last parameter in the URL."))
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             webclient.AddTrustedCertificate(new Uri(SiteLink).Host, "3A4090096DD95D31306B14BFDD8F8C98F52A8EA8");
 
             AddCategoryMapping(2, TorznabCatType.MoviesUHD, "Movie/2160");

--- a/src/Jackett.Common/Indexers/SceneTime.cs
+++ b/src/Jackett.Common/Indexers/SceneTime.cs
@@ -18,8 +18,15 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class SceneTime : BaseWebIndexer
+    public class SceneTime : IndexerBase
     {
+        public override string Id => "scenetime";
+        public override string Name => "SceneTime";
+        public override string Description => "Always on time";
+        public override string SiteLink { get; protected set; } = "https://www.scenetime.com/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string SearchUrl => SiteLink + "browse.php";
         private string DownloadUrl => SiteLink + "download.php/{0}/download.torrent";
 
@@ -27,10 +34,7 @@ namespace Jackett.Common.Indexers
 
         public SceneTime(IIndexerConfigurationService configService, WebClient w, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "scenetime",
-                   name: "SceneTime",
-                   description: "Always on time",
-                   link: "https://www.scenetime.com/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -58,10 +62,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataSceneTime())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(10, TorznabCatType.XXX, "Movies Adult");
             AddCategoryMapping(47, TorznabCatType.Movies, "Movie Packs");
             AddCategoryMapping(57, TorznabCatType.MoviesSD, "Movies SD");

--- a/src/Jackett.Common/Indexers/SecretCinema.cs
+++ b/src/Jackett.Common/Indexers/SecretCinema.cs
@@ -14,12 +14,16 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class SecretCinema : GazelleTracker
     {
+        public override string Id => "secretcinema";
+        public override string Name => "Secret Cinema";
+        public override string Description => "A tracker for rare movies.";
+        public override string SiteLink { get; protected set; } = "https://secret-cinema.pw/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         public SecretCinema(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "secretcinema",
-                   name: "Secret Cinema",
-                   description: "A tracker for rare movies.",
-                   link: "https://secret-cinema.pw/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        MovieSearchParams = new List<MovieSearchParam>
@@ -38,9 +42,6 @@ namespace Jackett.Common.Indexers
                    cs: cs,
                    supportsFreeleechTokens: false) // ratioless tracker
         {
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(1, TorznabCatType.Movies, "Movies");
             AddCategoryMapping(2, TorznabCatType.Audio, "Music");
             // cat=3 exists but it's required a refactor in Gazelle abstract to make it work

--- a/src/Jackett.Common/Indexers/Sharewood.cs
+++ b/src/Jackett.Common/Indexers/Sharewood.cs
@@ -21,8 +21,15 @@ using WebClient = Jackett.Common.Utils.Clients.WebClient;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class ShareWood : BaseWebIndexer
+    public class ShareWood : IndexerBase
     {
+        public override string Id => "sharewoodapi";
+        public override string Name => "Sharewood API";
+        public override string Description => "Sharewood is a Semi-Private FRENCH Torrent Tracker for GENERAL";
+        public override string SiteLink { get; protected set; } = "https://www.sharewood.tv/";
+        public override string Language => "fr-FR";
+        public override string Type => "semi-private";
+
         private readonly Dictionary<string, string> _apiHeaders = new Dictionary<string, string>
         {
             {"Accept", "application/json"},
@@ -35,10 +42,6 @@ namespace Jackett.Common.Indexers
         public ShareWood(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
             : base(
-                id: "sharewoodapi",
-                name: "Sharewood API",
-                description: "Sharewood is a Semi-Private FRENCH Torrent Tracker for GENERAL",
-                link: "https://www.sharewood.tv/",
                 caps: new TorznabCapabilities
                 {
                     TvSearchParams = new List<TvSearchParam>
@@ -67,10 +70,6 @@ namespace Jackett.Common.Indexers
                 configData: new ConfigurationDataPasskey()
                 )
         {
-            Encoding = Encoding.UTF8;
-            Language = "fr-FR";
-            Type = "semi-private";
-
             // requestDelay for API Limit (1 request per 2 seconds)
             webclient.requestDelay = 2.1;
 

--- a/src/Jackett.Common/Indexers/Shazbat.cs
+++ b/src/Jackett.Common/Indexers/Shazbat.cs
@@ -18,8 +18,15 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class Shazbat : BaseWebIndexer
+    public class Shazbat : IndexerBase
     {
+        public override string Id => "shazbat";
+        public override string Name => "Shazbat";
+        public override string Description => "Shazbat is a PRIVATE Torrent Tracker with highly curated TV content";
+        public override string SiteLink { get; protected set; } = "https://www.shazbat.tv/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string LoginUrl => SiteLink + "login";
         private string SearchUrl => SiteLink + "search";
         private string TorrentsUrl => SiteLink + "torrents";
@@ -30,10 +37,7 @@ namespace Jackett.Common.Indexers
 
         public Shazbat(IIndexerConfigurationService configService, WebClient c, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "shazbat",
-                   name: "Shazbat",
-                   description: "Shazbat is a PRIVATE Torrent Tracker with highly curated TV content",
-                   link: "https://www.shazbat.tv/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -48,10 +52,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataShazbat())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             webclient.requestDelay = 5.1;
 
             AddCategoryMapping(1, TorznabCatType.TV);

--- a/src/Jackett.Common/Indexers/SpeedApp.cs
+++ b/src/Jackett.Common/Indexers/SpeedApp.cs
@@ -12,7 +12,12 @@ namespace Jackett.Common.Indexers
     [ExcludeFromCodeCoverage]
     public class SpeedApp : SpeedAppTracker
     {
-        public override string[] LegacySiteLinks { get; protected set; } = {
+        public override string Id => "speedapp";
+        public override string Name => "SpeedApp";
+        public override string Description => "SpeedApp is a ROMANIAN Private Torrent Tracker for MOVIES / TV / GENERAL";
+        public override string SiteLink { get; protected set; } = "https://speedapp.io/";
+        public override string[] LegacySiteLinks => new[]
+        {
             "https://www.icetorrent.org/",
             "https://icetorrent.org/",
             "https://scenefz.me/",
@@ -22,43 +27,36 @@ namespace Jackett.Common.Indexers
             "https://www.myxz.eu/",
             "https://www.myxz.org/"
         };
+        public override string Language => "ro-RO";
+        public override string Type => "private";
 
         public SpeedApp(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
-            ICacheService cs)
-            : base(
-                id: "speedapp",
-                name: "SpeedApp",
-                description: "SpeedApp is a ROMANIAN Private Torrent Tracker for MOVIES / TV / GENERAL",
-                link: "https://speedapp.io/",
-                caps: new TorznabCapabilities
-                {
-                    TvSearchParams = new List<TvSearchParam>
-                    {
-                        TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId
-                    },
-                    MovieSearchParams = new List<MovieSearchParam>
-                    {
-                        MovieSearchParam.Q, MovieSearchParam.ImdbId
-                    },
-                    MusicSearchParams = new List<MusicSearchParam>
-                    {
-                        MusicSearchParam.Q
-                    },
-                    BookSearchParams = new List<BookSearchParam>
-                    {
-                        BookSearchParam.Q
-                    }
-                },
-                configService: configService,
-                client: wc,
-                logger: l,
-                p: ps,
-                cs: cs)
+                        ICacheService cs)
+            : base(configService: configService,
+                   caps: new TorznabCapabilities
+                   {
+                       TvSearchParams = new List<TvSearchParam>
+                       {
+                           TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId
+                       },
+                       MovieSearchParams = new List<MovieSearchParam>
+                       {
+                           MovieSearchParam.Q, MovieSearchParam.ImdbId
+                       },
+                       MusicSearchParams = new List<MusicSearchParam>
+                       {
+                           MusicSearchParam.Q
+                       },
+                       BookSearchParams = new List<BookSearchParam>
+                       {
+                           BookSearchParam.Q
+                       }
+                   },
+                   client: wc,
+                   logger: l,
+                   p: ps,
+                   cs: cs)
         {
-            Encoding = Encoding.UTF8;
-            Language = "ro-RO";
-            Type = "private";
-
             // requestDelay for API Limit (1 request per 2 seconds)
             webclient.requestDelay = 2.1;
 

--- a/src/Jackett.Common/Indexers/SpeedCD.cs
+++ b/src/Jackett.Common/Indexers/SpeedCD.cs
@@ -19,28 +19,32 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class SpeedCD : BaseWebIndexer
+    public class SpeedCD : IndexerBase
     {
+        public override string Id => "speedcd";
+        public override string Name => "Speed.cd";
+        public override string Description => "Your home now!";
+        public override string SiteLink { get; protected set; } = "https://speed.cd/";
+        public override string[] AlternativeSiteLinks => new[]
+        {
+            "https://speed.cd/",
+            "https://speed.click/",
+            "https://speeders.me/"
+        };
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         public override bool SupportsPagination => true;
 
         private string LoginUrl1 => SiteLink + "checkpoint/API";
         private string LoginUrl2 => SiteLink + "checkpoint/";
         private string SearchUrl => SiteLink + "browse/";
 
-        public override string[] AlternativeSiteLinks { get; protected set; } = {
-            "https://speed.cd/",
-            "https://speed.click/",
-            "https://speeders.me/"
-        };
-
         private new ConfigurationDataSpeedCD configData => (ConfigurationDataSpeedCD)base.configData;
 
         public SpeedCD(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "speedcd",
-                   name: "Speed.cd",
-                   description: "Your home now!",
-                   link: "https://speed.cd/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -70,10 +74,6 @@ namespace Jackett.Common.Indexers
                     in your Speed.Cd profile. Eg. Geo Locking, your seedbox may be in a different country to the one where you login via your
                     web browser.<br><br>For best results, change the 'Torrents per page' setting to 100 in 'Profile Settings > Torrents'."))
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(1, TorznabCatType.MoviesOther, "Movies/XviD");
             AddCategoryMapping(42, TorznabCatType.Movies, "Movies/Packs");
             AddCategoryMapping(32, TorznabCatType.Movies, "Movies/Kids");

--- a/src/Jackett.Common/Indexers/SubsPlease.cs
+++ b/src/Jackett.Common/Indexers/SubsPlease.cs
@@ -19,14 +19,19 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class SubsPlease : BaseWebIndexer
+    public class SubsPlease : IndexerBase
     {
-        public override string[] AlternativeSiteLinks { get; protected set; } = {
+        public override string Id => "subsplease";
+        public override string Name => "SubsPlease";
+        public override string Description => "SubsPlease - A better HorribleSubs/Erai replacement";
+        public override string SiteLink { get; protected set; } = "https://subsplease.org/";
+        public override string[] AlternativeSiteLinks => new[]
+        {
             "https://subsplease.org/",
             "https://subsplease.mrunblock.guru/"
         };
-
-        public override string[] LegacySiteLinks { get; protected set; } = {
+        public override string[] LegacySiteLinks => new[]
+        {
             "https://subsplease.nocensor.space/",
             "https://subsplease.nocensor.work/",
             "https://subsplease.nocensor.biz/",
@@ -35,14 +40,13 @@ namespace Jackett.Common.Indexers
             "https://subsplease.nocensor.lol/",
             "https://subsplease.nocensor.art/"
         };
+        public override string Language => "en-US";
+        public override string Type => "public";
 
         private string ApiEndpoint => SiteLink + "api/?";
 
         public SubsPlease(IIndexerConfigurationService configService, Utils.Clients.WebClient wc, Logger l, IProtectionService ps, ICacheService cs)
-            : base(id: "subsplease",
-                   name: "SubsPlease",
-                   description: "SubsPlease - A better HorribleSubs/Erai replacement",
-                   link: "https://subsplease.org/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -57,10 +61,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationData())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "public";
-
             // Configure the category mappings
             AddCategoryMapping(1, TorznabCatType.TVAnime, "Anime");
         }

--- a/src/Jackett.Common/Indexers/TVStore.cs
+++ b/src/Jackett.Common/Indexers/TVStore.cs
@@ -19,8 +19,15 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class TVStore : BaseWebIndexer
+    public class TVStore : IndexerBase
     {
+        public override string Id => "tvstore";
+        public override string Name => "TV Store";
+        public override string Description => "TV Store is a HUNGARIAN Private Torrent Tracker for TV";
+        public override string SiteLink { get; protected set; } = "https://tvstore.me/";
+        public override string Language => "hu-HU";
+        public override string Type => "private";
+
         private readonly Dictionary<int, long> _imdbLookup = new Dictionary<int, long>(); // _imdbLookup[internalId] = imdbId
 
         private readonly Dictionary<long, int>
@@ -34,10 +41,7 @@ namespace Jackett.Common.Indexers
 
         public TVStore(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs) :
-            base(id: "tvstore",
-                 name: "TV Store",
-                 description: "TV Store is a HUNGARIAN Private Torrent Tracker for TV",
-                 link: "https://tvstore.me/",
+            base(
                  caps: new TorznabCapabilities
                  {
                      TvSearchParams = new List<TvSearchParam>
@@ -56,10 +60,6 @@ namespace Jackett.Common.Indexers
                  cacheService: cs,
                  configData: new ConfigurationDataTVstore())
         {
-            Encoding = Encoding.UTF8;
-            Language = "hu-HU";
-            Type = "private";
-
             AddCategoryMapping(1, TorznabCatType.TV);
             AddCategoryMapping(2, TorznabCatType.TVHD);
             AddCategoryMapping(3, TorznabCatType.TVSD);

--- a/src/Jackett.Common/Indexers/Toloka.cs
+++ b/src/Jackett.Common/Indexers/Toloka.cs
@@ -17,8 +17,15 @@ using WebClient = Jackett.Common.Utils.Clients.WebClient;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class Toloka : BaseWebIndexer
+    public class Toloka : IndexerBase
     {
+        public override string Id => "toloka";
+        public override string Name => "Toloka.to";
+        public override string Description => "Toloka is a Semi-Private Ukrainian torrent site with a thriving file-sharing community";
+        public override string SiteLink { get; protected set; } = "https://toloka.to/";
+        public override string Language => "uk-UA";
+        public override string Type => "semi-private";
+
         private new ConfigurationDataToloka configData
         {
             get => (ConfigurationDataToloka)base.configData;
@@ -30,10 +37,7 @@ namespace Jackett.Common.Indexers
         private string SearchUrl => SiteLink + "tracker.php";
 
         public Toloka(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps, ICacheService cs)
-            : base(id: "toloka",
-                   name: "Toloka.to",
-                   description: "Toloka is a Semi-Private Ukrainian torrent site with a thriving file-sharing community",
-                   link: "https://toloka.to/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -60,10 +64,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataToloka())
         {
-            Encoding = Encoding.UTF8;
-            Language = "uk-UA";
-            Type = "semi-private";
-
             AddCategoryMapping(117, TorznabCatType.Movies, "Українське кіно");
             AddCategoryMapping(84, TorznabCatType.Movies, "|-Мультфільми і казки");
             AddCategoryMapping(42, TorznabCatType.Movies, "|-Художні фільми");

--- a/src/Jackett.Common/Indexers/TorrentBytes.cs
+++ b/src/Jackett.Common/Indexers/TorrentBytes.cs
@@ -17,8 +17,16 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class TorrentBytes : BaseWebIndexer
+    public class TorrentBytes : IndexerBase
     {
+        public override string Id => "torrentbytes";
+        public override string Name => "TorrentBytes";
+        public override string Description => "A decade of TorrentBytes";
+        public override string SiteLink { get; protected set; } = "https://www.torrentbytes.net/";
+        public override Encoding Encoding => Encoding.GetEncoding("iso-8859-1");
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string LoginUrl => SiteLink + "takelogin.php";
         private string SearchUrl => SiteLink + "browse.php";
 
@@ -26,10 +34,7 @@ namespace Jackett.Common.Indexers
 
         public TorrentBytes(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "torrentbytes",
-                   name: "TorrentBytes",
-                   description: "A decade of TorrentBytes",
-                   link: "https://www.torrentbytes.net/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -52,10 +57,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataBasicLogin("For best results, change the 'Torrents per page' setting to 100 in your profile on the TorrentBytes webpage."))
         {
-            Encoding = Encoding.GetEncoding("iso-8859-1");
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(23, TorznabCatType.TVAnime, "Anime");
             AddCategoryMapping(52, TorznabCatType.PCMac, "Apple/All");
             AddCategoryMapping(22, TorznabCatType.PC, "Apps/misc");

--- a/src/Jackett.Common/Indexers/TorrentDay.cs
+++ b/src/Jackett.Common/Indexers/TorrentDay.cs
@@ -18,11 +18,14 @@ using static Jackett.Common.Models.IndexerConfig.ConfigurationData;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class TorrentDay : BaseWebIndexer
+    public class TorrentDay : IndexerBase
     {
-        private string SearchUrl => SiteLink + "t.json";
-
-        public override string[] AlternativeSiteLinks { get; protected set; } = {
+        public override string Id => "torrentday";
+        public override string Name => "TorrentDay";
+        public override string Description => "TorrentDay (TD) is a Private site for TV / MOVIES / GENERAL";
+        public override string SiteLink { get; protected set; } = "https://tday.love/";
+        public override string[] AlternativeSiteLinks => new[]
+        {
             "https://tday.love/",
             "https://torrentday.cool/",
             "https://secure.torrentday.com/",
@@ -38,8 +41,8 @@ namespace Jackett.Common.Indexers
             "https://tday.venom.global/",
             "https://tday.workisboring.net/"
         };
-
-        public override string[] LegacySiteLinks { get; protected set; } = {
+        public override string[] LegacySiteLinks => new[]
+        {
             "https://torrentday.com/",
             "https://tdonline.org/", // redirect to https://www.torrentday.com/
             "https://torrentday.eu/", // redirect to https://www.torrentday.com/
@@ -48,15 +51,16 @@ namespace Jackett.Common.Indexers
             "https://www.torrentday.ru/",
             "https://www.td.af/"
         };
+        public override string Language => "en-US";
+        public override string Type => "private";
+
+        private string SearchUrl => SiteLink + "t.json";
 
         private new ConfigurationDataCookie configData => (ConfigurationDataCookie)base.configData;
 
         public TorrentDay(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "torrentday",
-                   name: "TorrentDay",
-                   description: "TorrentDay (TD) is a Private site for TV / MOVIES / GENERAL",
-                   link: "https://tday.love/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -84,10 +88,6 @@ namespace Jackett.Common.Indexers
                    configData: new ConfigurationDataCookie(
                        "Make sure you get the cookies from the same torrent day domain as configured above."))
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             wc.EmulateBrowser = false;
 
             configData.AddDynamic("freeleech", new BoolConfigurationItem("Search freeleech only") { Value = false });
@@ -171,14 +171,14 @@ namespace Jackett.Common.Indexers
         {
             var releases = new List<ReleaseInfo>();
 
-            /* notes: 
+            /* notes:
              * TorrentDay can search for genre (tags) using the default title&tags search
-             * qf= 
+             * qf=
              * "" = Title and Tags
              * ta = Tags
              * all = Title, Tags & Description
              * adv = Advanced
-             * 
+             *
              * But only movies and tv have tags and the t.json does not return tags in results.
              */
 

--- a/src/Jackett.Common/Indexers/TorrentHeaven.cs
+++ b/src/Jackett.Common/Indexers/TorrentHeaven.cs
@@ -18,14 +18,28 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class TorrentHeaven : BaseWebIndexer
+    public class TorrentHeaven : IndexerBase
     {
+        public override string Id => "torrentheaven";
+        public override string Name => "TorrentHeaven";
+        public override string Description => "A German general tracker.";
+        public override string SiteLink { get; protected set; } = "https://newheaven.nl/";
+        public override string[] LegacySiteLinks => new[]
+        {
+            "https://torrentheaven.myfqdn.info/"
+        };
+        public override Encoding Encoding => Encoding.GetEncoding("iso-8859-1");
+        public override string Language => "de-DE";
+        public override string Type => "private";
+
+        private new ConfigurationDataCaptchaLogin configData => (ConfigurationDataCaptchaLogin)base.configData;
+
+        private string IndexUrl => SiteLink + "index.php";
+        private string LoginCompleteUrl => SiteLink + "index.php?strWebValue=account&strWebAction=login_complete&ancestry=verify";
+
         public TorrentHeaven(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "torrentheaven",
-                   name: "TorrentHeaven",
-                   description: "A German general tracker.",
-                   link: "https://newheaven.nl/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -52,10 +66,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataCaptchaLogin())
         {
-            Encoding = Encoding.GetEncoding("iso-8859-1");
-            Language = "de-DE";
-            Type = "private";
-
             // incomplete CA chain
             wc.AddTrustedCertificate(new Uri(SiteLink).Host, "8612e46b2abd418b6398dbf2382ebcf44b10f378");
 
@@ -103,18 +113,6 @@ namespace Jackett.Common.Indexers
             AddCategoryMapping(70, TorznabCatType.PC, "APPLICATIONS/Linux");
             AddCategoryMapping(71, TorznabCatType.PCMac, "APPLICATIONS/Mac");
         }
-
-        private new ConfigurationDataCaptchaLogin configData => (ConfigurationDataCaptchaLogin)base.configData;
-
-        private string IndexUrl => SiteLink + "index.php";
-
-        public override string[] LegacySiteLinks { get; protected set; } =
-        {
-            "https://torrentheaven.myfqdn.info/"
-        };
-
-        private string LoginCompleteUrl =>
-            SiteLink + "index.php?strWebValue=account&strWebAction=login_complete&ancestry=verify";
 
         public override async Task<IndexerConfigurationStatus> ApplyConfiguration(JToken configJson)
         {

--- a/src/Jackett.Common/Indexers/TorrentNetwork.cs
+++ b/src/Jackett.Common/Indexers/TorrentNetwork.cs
@@ -18,8 +18,15 @@ using static Jackett.Common.Models.IndexerConfig.ConfigurationData;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class TorrentNetwork : BaseWebIndexer
+    public class TorrentNetwork : IndexerBase
     {
+        public override string Id => "torrentnetwork";
+        public override string Name => "Torrent Network";
+        public override string Description => "Torrent Network (TN) is a GERMAN Private site for TV / MOVIES / GENERAL";
+        public override string SiteLink { get; protected set; } = "https://tntracker.org/";
+        public override string Language => "de-DE";
+        public override string Type => "private";
+
         private string APIUrl => SiteLink + "api/";
         private string passkey;
 
@@ -36,10 +43,7 @@ namespace Jackett.Common.Indexers
 
         public TorrentNetwork(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "torrentnetwork",
-                   name: "Torrent Network",
-                   description: "Torrent Network (TN) is a GERMAN Private site for TV / MOVIES / GENERAL",
-                   link: "https://tntracker.org/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -66,10 +70,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataBasicLoginWithRSSAndDisplay())
         {
-            Encoding = Encoding.UTF8;
-            Language = "de-DE";
-            Type = "private";
-
             configData.AddDynamic("token", new HiddenStringConfigurationItem("token"));
             configData.AddDynamic("passkey", new HiddenStringConfigurationItem("passkey"));
 

--- a/src/Jackett.Common/Indexers/TorrentSyndikat.cs
+++ b/src/Jackett.Common/Indexers/TorrentSyndikat.cs
@@ -19,8 +19,15 @@ using WebClient = Jackett.Common.Utils.Clients.WebClient;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class TorrentSyndikat : BaseWebIndexer
+    public class TorrentSyndikat : IndexerBase
     {
+        public override string Id => "torrentsyndikat";
+        public override string Name => "Torrent-Syndikat";
+        public override string Description => "A German general tracker";
+        public override string SiteLink { get; protected set; } = "https://torrent-syndikat.org/";
+        public override string Language => "de-DE";
+        public override string Type => "private";
+
         private string ApiBase => SiteLink + "api_9djWe8Tb2NE3p6opyqnh/v1";
 
         private bool ProductsOnly => ((BoolConfigurationItem)configData.GetDynamic("productsOnly")).Value;
@@ -34,10 +41,7 @@ namespace Jackett.Common.Indexers
 
         public TorrentSyndikat(IIndexerConfigurationService configService, WebClient w, Logger l,
             IProtectionService ps, ICacheService cs)
-            : base(id: "torrentsyndikat",
-                   name: "Torrent-Syndikat",
-                   description: "A German general tracker",
-                   link: "https://torrent-syndikat.org/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -64,10 +68,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataAPIKey())
         {
-            Encoding = Encoding.UTF8;
-            Language = "de-DE";
-            Type = "private";
-
             AddCategoryMapping(2, TorznabCatType.PC, "Apps / Windows");
             AddCategoryMapping(13, TorznabCatType.PC, "Apps / Linux");
             AddCategoryMapping(4, TorznabCatType.PCMac, "Apps / MacOS");

--- a/src/Jackett.Common/Indexers/TorrentsCSV.cs
+++ b/src/Jackett.Common/Indexers/TorrentsCSV.cs
@@ -16,18 +16,22 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class TorrentsCSV : BaseWebIndexer
+    public class TorrentsCSV : IndexerBase
     {
+        public override string Id => "torrentscsv";
+        public override string Name => "Torrents.csv";
+        public override string Description => "Torrents.csv is a self-hostable, open source torrent search engine and database";
+        public override string SiteLink { get; protected set; } = "https://torrents-csv.ml/";
+        public override string Language => "en-US";
+        public override string Type => "public";
+
         private string SearchEndpoint => SiteLink + "service/search";
 
         private new ConfigurationData configData => base.configData;
 
         public TorrentsCSV(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "torrentscsv",
-                   name: "Torrents.csv",
-                   description: "Torrents.csv is a self-hostable, open source torrent search engine and database",
-                   link: "https://torrents-csv.ml/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -46,10 +50,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationData())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "public";
-
             // torrents.csv doesn't return categories
             AddCategoryMapping(1, TorznabCatType.Other);
         }

--- a/src/Jackett.Common/Indexers/Uniotaku.cs
+++ b/src/Jackett.Common/Indexers/Uniotaku.cs
@@ -16,13 +16,17 @@ using NLog;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class Uniotaku : BaseWebIndexer
+    public class Uniotaku : IndexerBase
     {
+        public override string Id => "uniotaku";
+        public override string Name => "UniOtaku";
+        public override string Description => "UniOtaku is a BRAZILIAN Semi-Private Torrent Tracker for ANIME";
+        public override string SiteLink { get; protected set; } = "https://tracker.uniotaku.com/";
+        public override string Language => "pt-BR";
+        public override string Type => "semi-private";
+
         public Uniotaku(IIndexerConfigurationService configService, Utils.Clients.WebClient wc, Logger l, IProtectionService ps, ICacheService cs)
-            : base(id: "uniotaku",
-                   name: "UniOtaku",
-                   description: "UniOtaku is a BRAZILIAN Semi-Private Torrent Tracker for ANIME",
-                   link: "https://tracker.uniotaku.com/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -49,10 +53,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataUniotaku())
         {
-            Encoding = Encoding.UTF8;
-            Language = "pt-BR";
-            Type = "semi-private";
-
             AddCategoryMapping(28, TorznabCatType.TVAnime, "Anime");
             AddCategoryMapping(47, TorznabCatType.MoviesOther, "Filme");
             AddCategoryMapping(48, TorznabCatType.TVAnime, "OVA");

--- a/src/Jackett.Common/Indexers/XSpeeds.cs
+++ b/src/Jackett.Common/Indexers/XSpeeds.cs
@@ -18,8 +18,15 @@ using static Jackett.Common.Models.IndexerConfig.ConfigurationData;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class XSpeeds : BaseWebIndexer
+    public class XSpeeds : IndexerBase
     {
+        public override string Id => "xspeeds";
+        public override string Name => "XSpeeds";
+        public override string Description => "XSpeeds (XS) is a Private Torrent Tracker for MOVIES / TV / GENERAL";
+        public override string SiteLink { get; protected set; } = "https://www.xspeeds.eu/";
+        public override string Language => "en-US";
+        public override string Type => "private";
+
         private string LandingUrl => SiteLink + "login.php";
         private string LoginUrl => SiteLink + "takelogin.php";
         private string GetRSSKeyUrl => SiteLink + "getrss.php";
@@ -31,10 +38,7 @@ namespace Jackett.Common.Indexers
 
         public XSpeeds(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "xspeeds",
-                   name: "XSpeeds",
-                   description: "XSpeeds (XS) is a Private Torrent Tracker for MOVIES / TV / GENERAL",
-                   link: "https://www.xspeeds.eu/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -57,10 +61,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataBasicLoginWithRSSAndDisplay())
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-US";
-            Type = "private";
-
             AddCategoryMapping(92, TorznabCatType.MoviesUHD, "4K Movies");
             AddCategoryMapping(91, TorznabCatType.TVUHD, "4K TV");
             AddCategoryMapping(94, TorznabCatType.TVUHD, "4K TV Boxsets");

--- a/src/Jackett.Common/Indexers/ZonaQ.cs
+++ b/src/Jackett.Common/Indexers/ZonaQ.cs
@@ -22,8 +22,15 @@ using WebClient = Jackett.Common.Utils.Clients.WebClient;
 namespace Jackett.Common.Indexers
 {
     [ExcludeFromCodeCoverage]
-    public class ZonaQ : BaseWebIndexer
+    public class ZonaQ : IndexerBase
     {
+        public override string Id => "zonaq";
+        public override string Name => "ZonaQ";
+        public override string Description => "ZonaQ is a SPANISH Private Torrent Tracker for MOVIES / TV";
+        public override string SiteLink { get; protected set; } = "https://www.zonaq.pw/";
+        public override string Language => "es-ES";
+        public override string Type => "private";
+
         private string Login1Url => SiteLink + "index.php";
         private string Login2Url => SiteLink + "paDentro.php";
         private string Login3Url => SiteLink + "retorno/include/puerta_8_ajax.php";
@@ -34,10 +41,7 @@ namespace Jackett.Common.Indexers
 
         public ZonaQ(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
             ICacheService cs)
-            : base(id: "zonaq",
-                   name: "ZonaQ",
-                   description: "ZonaQ is a SPANISH Private Torrent Tracker for MOVIES / TV",
-                   link: "https://www.zonaq.pw/",
+            : base(
                    caps: new TorznabCapabilities
                    {
                        TvSearchParams = new List<TvSearchParam>
@@ -57,10 +61,6 @@ namespace Jackett.Common.Indexers
                    configData: new ConfigurationDataBasicLogin("For best results, change the 'Torrents por página' option to 100 in 'Mi Panel' page."))
 
         {
-            Encoding = Encoding.UTF8;
-            Language = "es-ES";
-            Type = "private";
-
             AddCategoryMapping("cat[]=1&subcat[]=1", TorznabCatType.MoviesDVD, "Películas/DVD");
             AddCategoryMapping("cat[]=1&subcat[]=2", TorznabCatType.MoviesDVD, "Películas/BDVD + Autorías");
             AddCategoryMapping("cat[]=1&subcat[]=3", TorznabCatType.MoviesBluRay, "Películas/BD");

--- a/src/Jackett.Common/Models/DTO/Indexer.cs
+++ b/src/Jackett.Common/Models/DTO/Indexer.cs
@@ -46,8 +46,8 @@ namespace Jackett.Common.Models.DTO
         public Indexer(IIndexer indexer)
         {
             id = indexer.Id;
-            name = indexer.DisplayName;
-            description = indexer.DisplayDescription;
+            name = indexer.Name;
+            description = indexer.Description;
             type = indexer.Type;
             configured = indexer.IsConfigured;
             site_link = indexer.SiteLink;

--- a/src/Jackett.Common/Models/ResultPage.cs
+++ b/src/Jackett.Common/Models/ResultPage.cs
@@ -77,7 +77,7 @@ namespace Jackett.Common.Models
                         select new XElement("item",
                             new XElement("title", RemoveInvalidXMLChars(r.Title)),
                             new XElement("guid", r.Guid.AbsoluteUri),  // GUID and (Link or Magnet) are mandatory
-                            new XElement("jackettindexer", new XAttribute("id", r.Origin.Id), r.Origin.DisplayName),
+                            new XElement("jackettindexer", new XAttribute("id", r.Origin.Id), r.Origin.Name),
                             new XElement("type", r.Origin.Type),
                             r.Details == null ? null : new XElement("comments", r.Details.AbsoluteUri),
                             r.PublishDate == DateTime.MinValue ? new XElement("pubDate", XmlDateFormat(DateTime.Now)) : new XElement("pubDate", XmlDateFormat(r.PublishDate)),

--- a/src/Jackett.Common/Services/CacheService.cs
+++ b/src/Jackett.Common/Services/CacheService.cs
@@ -61,7 +61,7 @@ namespace Jackett.Common.Services
                     _cache.Add(indexer.Id, new TrackerCache
                     {
                         TrackerId = indexer.Id,
-                        TrackerName = indexer.DisplayName,
+                        TrackerName = indexer.Name,
                         TrackerType = indexer.Type
                     });
                 }

--- a/src/Jackett.Common/Services/IndexerConfigurationService.cs
+++ b/src/Jackett.Common/Services/IndexerConfigurationService.cs
@@ -53,7 +53,7 @@ namespace Jackett.Common.Services
             }
             catch (Exception e)
             {
-                logger.Error($"Failed loading configuration for {indexer.DisplayName}, trying backup\n{e}");
+                logger.Error($"Failed loading configuration for {indexer.Name}, trying backup\n{e}");
                 var configFilePathBak = configFilePath + ".bak";
                 if (File.Exists(configFilePathBak))
                     try
@@ -61,15 +61,15 @@ namespace Jackett.Common.Services
                         var fileStrBak = File.ReadAllText(configFilePathBak);
                         var jsonStringBak = JToken.Parse(fileStrBak);
                         indexer.LoadFromSavedConfiguration(jsonStringBak);
-                        logger.Info($"Successfully loaded backup config for {indexer.DisplayName}");
+                        logger.Info($"Successfully loaded backup config for {indexer.Name}");
                         indexer.SaveConfig();
                     }
                     catch (Exception e2)
                     {
-                        logger.Error($"Failed loading backup configuration for {indexer.DisplayName}, you must reconfigure this indexer\n{e2}");
+                        logger.Error($"Failed loading backup configuration for {indexer.Name}, you must reconfigure this indexer\n{e2}");
                     }
                 else
-                    logger.Error($"Failed loading backup configuration for {indexer.DisplayName} (no backup available), you must reconfigure this indexer\n{e}");
+                    logger.Error($"Failed loading backup configuration for {indexer.Name} (no backup available), you must reconfigure this indexer\n{e}");
             }
         }
 

--- a/src/Jackett.Common/Services/IndexerManagerService.cs
+++ b/src/Jackett.Common/Services/IndexerManagerService.cs
@@ -296,7 +296,7 @@ namespace Jackett.Common.Services
             throw new Exception($"Unknown indexer: {name}");
         }
 
-        public List<IIndexer> GetAllIndexers() => _indexers.Values.OrderBy(_ => _.DisplayName).ToList();
+        public List<IIndexer> GetAllIndexers() => _indexers.Values.OrderBy(_ => _.Name).ToList();
 
         public async Task TestIndexer(string name)
         {
@@ -309,10 +309,10 @@ namespace Jackett.Common.Services
             };
             var result = await indexer.ResultsForQuery(query);
 
-            _logger.Info($"Test search in {indexer.DisplayName} => Found {result.Releases.Count()} releases");
+            _logger.Info($"Test search in {indexer.Name} => Found {result.Releases.Count()} releases");
 
             if (!result.Releases.Any())
-                throw new Exception($"Test search in {indexer.DisplayName} => Found no results while trying to browse this tracker");
+                throw new Exception($"Test search in {indexer.Name} => Found no results while trying to browse this tracker");
         }
 
         public void DeleteIndexer(string name)

--- a/src/Jackett.Server/Controllers/BlackholeController.cs
+++ b/src/Jackett.Server/Controllers/BlackholeController.cs
@@ -43,7 +43,7 @@ namespace Jackett.Server.Controllers
                 var indexer = _indexerService.GetWebIndexer(indexerId);
                 if (!indexer.IsConfigured)
                 {
-                    _logger.Warn($"Rejected a request to {indexer.DisplayName} which is unconfigured.");
+                    _logger.Warn($"Rejected a request to {indexer.Name} which is unconfigured.");
                     throw new Exception("This indexer is not configured.");
                 }
 
@@ -82,7 +82,7 @@ namespace Jackett.Server.Controllers
                     throw new Exception($"Blackhole directory does not exist: {_serverConfig.BlackholeDir}");
                 }
 
-                var fileName = DateTime.Now.Ticks.ToString() + "-" + StringUtil.MakeValidFileName(indexer.DisplayName, '_', false);
+                var fileName = DateTime.Now.Ticks.ToString() + "-" + StringUtil.MakeValidFileName(indexer.Name, '_', false);
                 if (string.IsNullOrWhiteSpace(file))
                     fileName += fileExtension;
                 else

--- a/src/Jackett.Server/Controllers/DownloadController.cs
+++ b/src/Jackett.Server/Controllers/DownloadController.cs
@@ -45,7 +45,7 @@ namespace Jackett.Server.Controllers
 
                 if (!indexer.IsConfigured)
                 {
-                    _logger.Warn($"Rejected a request to {indexer.DisplayName} which is unconfigured.");
+                    _logger.Warn($"Rejected a request to {indexer.Name} which is unconfigured.");
                     return Forbid("This indexer is not configured.");
                 }
 

--- a/src/Jackett.Server/Controllers/ImageController.cs
+++ b/src/Jackett.Server/Controllers/ImageController.cs
@@ -42,7 +42,7 @@ namespace Jackett.Server.Controllers
                 var indexer = _indexerService.GetWebIndexer(indexerId);
                 if (!indexer.IsConfigured)
                 {
-                    _logger.Warn($"Rejected a request to {indexer.DisplayName} which is unconfigured.");
+                    _logger.Warn($"Rejected a request to {indexer.Name} which is unconfigured.");
                     return Forbid("This indexer is not configured.");
                 }
 

--- a/src/Jackett.Server/Controllers/ResultsController.cs
+++ b/src/Jackett.Server/Controllers/ResultsController.cs
@@ -270,7 +270,7 @@ namespace Jackett.Server.Controllers
                 if (indexer != null)
                 {
                     resultIndexer.ID = indexer.Id;
-                    resultIndexer.Name = indexer.DisplayName;
+                    resultIndexer.Name = indexer.Name;
                 }
                 return resultIndexer;
             }).ToList();
@@ -283,7 +283,7 @@ namespace Jackett.Server.Controllers
                 return searchResults.Select(result =>
                 {
                     var item = MapperUtil.Mapper.Map<TrackerCacheResult>(result);
-                    item.Tracker = indexer.DisplayName;
+                    item.Tracker = indexer.Name;
                     item.TrackerId = indexer.Id;
                     item.TrackerType = indexer.Type;
                     item.Peers = item.Peers - item.Seeders; // Use peers as leechers
@@ -318,7 +318,7 @@ namespace Jackett.Server.Controllers
             {
                 if (!(CurrentIndexer is BaseMetaIndexer)) // shouldn't be needed because CanHandleQuery should return false
                 {
-                    logger.Warn($"A search request with t=indexers from {Request.HttpContext.Connection.RemoteIpAddress} was made but the indexer {CurrentIndexer.DisplayName} isn't a meta indexer.");
+                    logger.Warn($"A search request with t=indexers from {Request.HttpContext.Connection.RemoteIpAddress} was made but the indexer {CurrentIndexer.Name} isn't a meta indexer.");
                     return GetErrorXML(203, "Function Not Available: this isn't a meta indexer");
                 }
                 var CurrentBaseMetaIndexer = (BaseMetaIndexer)CurrentIndexer;
@@ -335,8 +335,8 @@ namespace Jackett.Server.Controllers
                         select new XElement("indexer",
                             new XAttribute("id", i.Id),
                             new XAttribute("configured", i.IsConfigured),
-                            new XElement("title", i.DisplayName),
-                            new XElement("description", i.DisplayDescription),
+                            new XElement("title", i.Name),
+                            new XElement("description", i.Description),
                             new XElement("link", i.SiteLink),
                             new XElement("language", i.Language),
                             new XElement("type", i.Type),
@@ -367,13 +367,13 @@ namespace Jackett.Server.Controllers
 
                 if (CurrentQuery.IsMovieSearch && !CurrentIndexer.TorznabCaps.MovieSearchImdbAvailable)
                 {
-                    logger.Warn($"A search request with imdbid from {Request.HttpContext.Connection.RemoteIpAddress} was made but the indexer {CurrentIndexer.DisplayName} doesn't support it.");
+                    logger.Warn($"A search request with imdbid from {Request.HttpContext.Connection.RemoteIpAddress} was made but the indexer {CurrentIndexer.Name} doesn't support it.");
                     return GetErrorXML(203, "Function Not Available: imdbid is not supported for movie search by this indexer");
                 }
 
                 if (CurrentQuery.IsTVSearch && !CurrentIndexer.TorznabCaps.TvSearchImdbAvailable)
                 {
-                    logger.Warn($"A search request with imdbid from {Request.HttpContext.Connection.RemoteIpAddress} was made but the indexer {CurrentIndexer.DisplayName} doesn't support it.");
+                    logger.Warn($"A search request with imdbid from {Request.HttpContext.Connection.RemoteIpAddress} was made but the indexer {CurrentIndexer.Name} doesn't support it.");
                     return GetErrorXML(203, "Function Not Available: imdbid is not supported for TV search by this indexer");
                 }
             }
@@ -382,13 +382,13 @@ namespace Jackett.Server.Controllers
             {
                 if (CurrentQuery.IsMovieSearch && !CurrentIndexer.TorznabCaps.MovieSearchTmdbAvailable)
                 {
-                    logger.Warn($"A search request with tmdbid from {Request.HttpContext.Connection.RemoteIpAddress} was made but the indexer {CurrentIndexer.DisplayName} doesn't support it.");
+                    logger.Warn($"A search request with tmdbid from {Request.HttpContext.Connection.RemoteIpAddress} was made but the indexer {CurrentIndexer.Name} doesn't support it.");
                     return GetErrorXML(203, "Function Not Available: tmdbid is not supported for movie search by this indexer");
                 }
 
                 if (CurrentQuery.IsTVSearch && !CurrentIndexer.TorznabCaps.TvSearchTmdbAvailable)
                 {
-                    logger.Warn($"A search request with tmdbid from {Request.HttpContext.Connection.RemoteIpAddress} was made but the indexer {CurrentIndexer.DisplayName} doesn't support it.");
+                    logger.Warn($"A search request with tmdbid from {Request.HttpContext.Connection.RemoteIpAddress} was made but the indexer {CurrentIndexer.Name} doesn't support it.");
                     return GetErrorXML(203, "Function Not Available: tmdbid is not supported for TV search by this indexer");
                 }
             }
@@ -397,7 +397,7 @@ namespace Jackett.Server.Controllers
             {
                 if (CurrentQuery.IsTVSearch && !CurrentIndexer.TorznabCaps.TvSearchAvailable)
                 {
-                    logger.Warn($"A search request with tvdbid from {Request.HttpContext.Connection.RemoteIpAddress} was made but the indexer {CurrentIndexer.DisplayName} doesn't support it.");
+                    logger.Warn($"A search request with tvdbid from {Request.HttpContext.Connection.RemoteIpAddress} was made but the indexer {CurrentIndexer.Name} doesn't support it.");
                     return GetErrorXML(203, "Function Not Available: tvdbid is not supported for movie search by this indexer");
                 }
             }
@@ -409,15 +409,15 @@ namespace Jackett.Server.Controllers
                 // Log info
                 var cacheStr = result.IsFromCache ? " (from cache)" : "";
                 if (string.IsNullOrWhiteSpace(CurrentQuery.SanitizedSearchTerm))
-                    logger.Info($"Torznab search in {CurrentIndexer.DisplayName} => Found {result.Releases.Count()} releases{cacheStr}");
+                    logger.Info($"Torznab search in {CurrentIndexer.Name} => Found {result.Releases.Count()} releases{cacheStr}");
                 else
-                    logger.Info($"Torznab search in {CurrentIndexer.DisplayName} for {CurrentQuery.GetQueryString()} => Found {result.Releases.Count()} releases{cacheStr}");
+                    logger.Info($"Torznab search in {CurrentIndexer.Name} for {CurrentQuery.GetQueryString()} => Found {result.Releases.Count()} releases{cacheStr}");
 
                 var serverUrl = serverService.GetServerUrl(Request);
                 var resultPage = new ResultPage(new ChannelInfo
                 {
-                    Title = CurrentIndexer.DisplayName,
-                    Description = CurrentIndexer.DisplayDescription,
+                    Title = CurrentIndexer.Name,
+                    Description = CurrentIndexer.Description,
                     Link = new Uri(CurrentIndexer.SiteLink)
                 });
 
@@ -525,9 +525,9 @@ namespace Jackett.Server.Controllers
             // Log info
             var cacheStr = result.IsFromCache ? " (from cache)" : "";
             if (string.IsNullOrWhiteSpace(CurrentQuery.SanitizedSearchTerm))
-                logger.Info($"Potato search in {CurrentIndexer.DisplayName} => Found {result.Releases.Count()} releases{cacheStr}");
+                logger.Info($"Potato search in {CurrentIndexer.Name} => Found {result.Releases.Count()} releases{cacheStr}");
             else
-                logger.Info($"Potato search in {CurrentIndexer.DisplayName} for {CurrentQuery.GetQueryString()} => Found {result.Releases.Count()} releases{cacheStr}");
+                logger.Info($"Potato search in {CurrentIndexer.Name} for {CurrentQuery.GetQueryString()} => Found {result.Releases.Count()} releases{cacheStr}");
 
             var serverUrl = serverService.GetServerUrl(Request);
             var potatoReleases = result.Releases.Where(r => r.Link != null || r.MagnetUri != null).Select(r =>
@@ -541,7 +541,7 @@ namespace Jackett.Server.Controllers
                 // characters are broken). We must use Uri.AbsoluteUri instead that handles encoding correctly
                 var item = new TorrentPotatoResponseItem()
                 {
-                    release_name = release.Title + "[" + CurrentIndexer.DisplayName + "]", // Suffix the indexer so we can see which tracker we are using in CPS as it just says torrentpotato >.>
+                    release_name = release.Title + "[" + CurrentIndexer.Name + "]", // Suffix the indexer so we can see which tracker we are using in CPS as it just says torrentpotato >.>
                     torrent_id = release.Guid.AbsoluteUri, // GUID and (Link or Magnet) are mandatory
                     details_url = release.Details?.AbsoluteUri,
                     download_url = (release.Link != null ? release.Link.AbsoluteUri : release.MagnetUri.AbsoluteUri),

--- a/src/Jackett.Test/Common/Models/ResultPageTests.cs
+++ b/src/Jackett.Test/Common/Models/ResultPageTests.cs
@@ -12,12 +12,13 @@ namespace Jackett.Test.Common.Models
 {
     class TestIndexer : BaseIndexer
     {
+        public override string Id => "test_id";
+        public override string Name => "test_name";
+        public override string Description => "test_description";
+        public override string SiteLink => "https://test.link/";
+
         public TestIndexer()
-            : base(id: "test_id",
-                   name: "test_name",
-                   description: "test_description",
-                   link: "https://test.link/",
-                   configService: null,
+            : base(configService: null,
                    logger: null,
                    configData: null,
                    p: null,

--- a/src/Jackett.Test/Common/Utils/FilterFuncs/IndexerBaseStub.cs
+++ b/src/Jackett.Test/Common/Utils/FilterFuncs/IndexerBaseStub.cs
@@ -14,9 +14,9 @@ namespace Jackett.Test.Common.Utils.FilterFuncs
 
         public virtual string[] AlternativeSiteLinks => throw TestExceptions.UnexpectedInvocation;
 
-        public virtual string DisplayName => throw TestExceptions.UnexpectedInvocation;
+        public virtual string Name => throw TestExceptions.UnexpectedInvocation;
 
-        public virtual string DisplayDescription => throw TestExceptions.UnexpectedInvocation;
+        public virtual string Description => throw TestExceptions.UnexpectedInvocation;
 
         public virtual string Type => throw TestExceptions.UnexpectedInvocation;
 

--- a/src/Jackett.Test/TestHelpers/TestWebIndexer.cs
+++ b/src/Jackett.Test/TestHelpers/TestWebIndexer.cs
@@ -11,12 +11,25 @@ namespace Jackett.Test.TestHelpers
 {
     public class TestWebIndexer : BaseWebIndexer
     {
+        public override string Id => "test_id";
+        public override string Name => "test_name";
+        public override string Description => "test_description";
+        public override string SiteLink => "https://test.link/";
+        public override string[] AlternativeSiteLinks => new[]
+        {
+            "https://test.link/",
+            "https://alternative-test.link/"
+        };
+        public override string[] LegacySiteLinks => new[]
+        {
+            "https://legacy-test.link/"
+        };
+        public override Encoding Encoding { get; protected set; } = Encoding.UTF8;
+        public override string Language { get; protected set; } = "en-us";
+        public override string Type { get; protected set; } = "private";
+
         public TestWebIndexer() :
-            base(id: "test_id",
-                 name: "test_name",
-                 description: "test_description",
-                 link: "https://test.link/",
-                 caps: new TorznabCapabilities(),
+            base(caps: new TorznabCapabilities(),
                  client: null,
                  configService: null,
                  logger: null,
@@ -24,19 +37,7 @@ namespace Jackett.Test.TestHelpers
                  p: null,
                  cacheService: null)
         {
-            Encoding = Encoding.UTF8;
-            Language = "en-us";
-            Type = "private";
         }
-
-        public override string[] AlternativeSiteLinks { get; protected set; } = {
-            "https://test.link/",
-            "https://alternative-test.link/"
-        };
-
-        public override string[] LegacySiteLinks { get; protected set; } = {
-            "https://legacy-test.link/"
-        };
 
         public override Task<IndexerConfigurationStatus> ApplyConfiguration(JToken configJson) =>
             throw new NotImplementedException();


### PR DESCRIPTION
I was thinking about moving the details from passing along in constructors to properties for C# indexers. 🤔 

Code readability improvement.