### PR TITLE
[FEATURE] DONT Noise hot search words in NexusPHP sites

### DIFF
--- a/src/Jackett.Common/Definitions/1ptbar.yml
+++ b/src/Jackett.Common/Definitions/1ptbar.yml
@@ -85,6 +85,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/2xfree.yml
+++ b/src/Jackett.Common/Definitions/2xfree.yml
@@ -127,6 +127,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(a[href^="details.php?id="])

--- a/src/Jackett.Common/Definitions/3changtrai.yml
+++ b/src/Jackett.Common/Definitions/3changtrai.yml
@@ -99,6 +99,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
     # does not return imdb link in results
 
   rows:

--- a/src/Jackett.Common/Definitions/52pt.yml
+++ b/src/Jackett.Common/Definitions/52pt.yml
@@ -89,6 +89,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
     # does not return imdb or doubanid in results
 
   rows:

--- a/src/Jackett.Common/Definitions/audiences.yml
+++ b/src/Jackett.Common/Definitions/audiences.yml
@@ -86,6 +86,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/beitai.yml
+++ b/src/Jackett.Common/Definitions/beitai.yml
@@ -90,6 +90,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/btschool.yml
+++ b/src/Jackett.Common/Definitions/btschool.yml
@@ -82,6 +82,7 @@ search:
     search_mode: 0
     sort: 4
     type: desc
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/byrbt.yml
+++ b/src/Jackett.Common/Definitions/byrbt.yml
@@ -98,6 +98,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/carpt.yml
+++ b/src/Jackett.Common/Definitions/carpt.yml
@@ -102,6 +102,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(a[href^="details.php?id="])

--- a/src/Jackett.Common/Definitions/ceskeforum.yml
+++ b/src/Jackett.Common/Definitions/ceskeforum.yml
@@ -96,6 +96,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
     # can support genre searching but you need to know the id, eg &team10=1 for Drama (id is 10)
 
   rows:

--- a/src/Jackett.Common/Definitions/chdbits.yml
+++ b/src/Jackett.Common/Definitions/chdbits.yml
@@ -95,6 +95,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/discfan.yml
+++ b/src/Jackett.Common/Definitions/discfan.yml
@@ -102,6 +102,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/gainbound.yml
+++ b/src/Jackett.Common/Definitions/gainbound.yml
@@ -78,6 +78,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(a[href^="details.php?id="])

--- a/src/Jackett.Common/Definitions/haidan.yml
+++ b/src/Jackett.Common/Definitions/haidan.yml
@@ -101,6 +101,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: div.group_content:has(a[href^="download.php?id="])

--- a/src/Jackett.Common/Definitions/haitang.yml
+++ b/src/Jackett.Common/Definitions/haitang.yml
@@ -94,6 +94,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/hd4fans.yml
+++ b/src/Jackett.Common/Definitions/hd4fans.yml
@@ -75,6 +75,7 @@ search:
     search_area: "{{ if .Query.IMDBID }}4{{ else }}0{{ end }}"
     # 0=AND, 1=OR, 2=Exact
     search_mode: 0
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/hdarea.yml
+++ b/src/Jackett.Common/Definitions/hdarea.yml
@@ -95,6 +95,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/hdatmos.yml
+++ b/src/Jackett.Common/Definitions/hdatmos.yml
@@ -105,6 +105,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/hdc.yml
+++ b/src/Jackett.Common/Definitions/hdc.yml
@@ -90,6 +90,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: div.trblock

--- a/src/Jackett.Common/Definitions/hdchina.yml
+++ b/src/Jackett.Common/Definitions/hdchina.yml
@@ -84,6 +84,7 @@ search:
     search_area: "{{ if .Query.IMDBID }}4{{ else }}0{{ end }}"
     # 0=AND, 1=OR, 2=Exact
     search_mode: 0
+    notnewword: 1
 
   rows:
     selector: table.torrent_list > tbody > tr:has(a[href^="?cat="])

--- a/src/Jackett.Common/Definitions/hddolby.yml
+++ b/src/Jackett.Common/Definitions/hddolby.yml
@@ -94,6 +94,7 @@ search:
     search_area: "{{ if .Query.IMDBID }}4{{ else }}0{{ end }}"
     # 0=AND, 1=OR, 2=Exact
     search_mode: 0
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/hdfans.yml
+++ b/src/Jackett.Common/Definitions/hdfans.yml
@@ -114,6 +114,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/hdhome.yml
+++ b/src/Jackett.Common/Definitions/hdhome.yml
@@ -104,6 +104,7 @@ search:
     inclbookmarked: 0
     search_area: "{{ if .Query.IMDBID }}4{{ else }}0{{ end }}"
     search_mode: 0
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/hdmayi.yml
+++ b/src/Jackett.Common/Definitions/hdmayi.yml
@@ -83,6 +83,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(a[href^="details.php?id="])

--- a/src/Jackett.Common/Definitions/hdsky.yml
+++ b/src/Jackett.Common/Definitions/hdsky.yml
@@ -73,6 +73,7 @@ search:
     search_area: "{{ if .Query.IMDBID }}4{{ else }}0{{ end }}"
     # 0=AND, 1=OR, 2=exact
     search_mode: 0
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/hdtime.yml
+++ b/src/Jackett.Common/Definitions/hdtime.yml
@@ -105,6 +105,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(a[href^="details.php?id="])

--- a/src/Jackett.Common/Definitions/hdu.yml
+++ b/src/Jackett.Common/Definitions/hdu.yml
@@ -78,6 +78,7 @@ search:
     search_area: "{{ if .Query.IMDBID }}4{{ else }}0{{ end }}"
     # 0=AND, 1=OR, 2=Exact
     search_mode: 0
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/hdzone.yml
+++ b/src/Jackett.Common/Definitions/hdzone.yml
@@ -125,6 +125,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/hhanclub.yml
+++ b/src/Jackett.Common/Definitions/hhanclub.yml
@@ -82,6 +82,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(a[href^="details.php?id="])

--- a/src/Jackett.Common/Definitions/icc2022.yml
+++ b/src/Jackett.Common/Definitions/icc2022.yml
@@ -113,6 +113,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(a[href^="details.php?id="])

--- a/src/Jackett.Common/Definitions/ihdbits.yml
+++ b/src/Jackett.Common/Definitions/ihdbits.yml
@@ -105,6 +105,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(a[href^="details.php?id="])

--- a/src/Jackett.Common/Definitions/joyhd.yml
+++ b/src/Jackett.Common/Definitions/joyhd.yml
@@ -91,6 +91,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/keepfriends.yml
+++ b/src/Jackett.Common/Definitions/keepfriends.yml
@@ -98,6 +98,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
     # supports imdbid searches but does not display imdb links in results.
 
   rows:

--- a/src/Jackett.Common/Definitions/lemonhd.yml
+++ b/src/Jackett.Common/Definitions/lemonhd.yml
@@ -79,6 +79,7 @@ search:
     column: "{{ .Config.sort }}"
     sort: "{{ .Config.type }}"
     $raw: "{{ if .Config.freeleech }}&free{{ else }}{{ end }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(a[href^="download.php?"])

--- a/src/Jackett.Common/Definitions/mteamtp.yml
+++ b/src/Jackett.Common/Definitions/mteamtp.yml
@@ -134,6 +134,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/mteamtp2fa.yml
+++ b/src/Jackett.Common/Definitions/mteamtp2fa.yml
@@ -134,6 +134,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   headers:
     User-Agent: ["{{ .Config.useragent }}"]

--- a/src/Jackett.Common/Definitions/nethd.yml
+++ b/src/Jackett.Common/Definitions/nethd.yml
@@ -89,6 +89,7 @@ search:
     incldead: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: tr:has(td.name)

--- a/src/Jackett.Common/Definitions/nicept.yml
+++ b/src/Jackett.Common/Definitions/nicept.yml
@@ -97,6 +97,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(a[href^="details.php?id="])

--- a/src/Jackett.Common/Definitions/oldtoonsworld.yml
+++ b/src/Jackett.Common/Definitions/oldtoonsworld.yml
@@ -106,6 +106,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(a[href^="details.php?id="])

--- a/src/Jackett.Common/Definitions/opencd.yml
+++ b/src/Jackett.Common/Definitions/opencd.yml
@@ -90,6 +90,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/oshenpt.yml
+++ b/src/Jackett.Common/Definitions/oshenpt.yml
@@ -106,6 +106,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/ourbits.yml
+++ b/src/Jackett.Common/Definitions/ourbits.yml
@@ -67,6 +67,7 @@ search:
     search_area: "{{ if .Query.IMDBID }}4{{ else }}0{{ end }}"
     # 0=AND, 1=OR, 2=Exact
     search_mode: 0
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/pignetwork.yml
+++ b/src/Jackett.Common/Definitions/pignetwork.yml
@@ -106,6 +106,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(a[href^="details.php?id="])

--- a/src/Jackett.Common/Definitions/ptchina.yml
+++ b/src/Jackett.Common/Definitions/ptchina.yml
@@ -98,6 +98,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(a[href^="details.php?id="])

--- a/src/Jackett.Common/Definitions/pterclub.yml
+++ b/src/Jackett.Common/Definitions/pterclub.yml
@@ -89,6 +89,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/pthome.yml
+++ b/src/Jackett.Common/Definitions/pthome.yml
@@ -65,6 +65,7 @@ search:
     search: "{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}"
     search_area: "{{ if .Query.IMDBID }}4{{ else }}0{{ end }}"
     search_mode: 0
+    notnewword: 1
 
   rows:
     selector: table.torrents tr:has(a[href^="?cat="])

--- a/src/Jackett.Common/Definitions/ptmsg.yml
+++ b/src/Jackett.Common/Definitions/ptmsg.yml
@@ -84,6 +84,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/ptsbao.yml
+++ b/src/Jackett.Common/Definitions/ptsbao.yml
@@ -87,6 +87,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
     # does not return imdb link in results
 
   rows:

--- a/src/Jackett.Common/Definitions/pttime.yml
+++ b/src/Jackett.Common/Definitions/pttime.yml
@@ -95,6 +95,7 @@ search:
     search_area: "{{ if .Query.IMDBID }}4{{ else }}{{ end }}{{ if .Query.DoubanID }}5{{ else }}{{ end }}{{ if or .Query.IMDBID .Query.DoubanID }}{{ else }}0{{ end }}"
     # 0 AND, 1 OR, 2 exact
     search_mode: 0
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(a[href^="download.php?id="])

--- a/src/Jackett.Common/Definitions/putao.yml
+++ b/src/Jackett.Common/Definitions/putao.yml
@@ -117,6 +117,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
     # does not return imdb or dubanid in results
 
   rows:

--- a/src/Jackett.Common/Definitions/sharkpt.yml
+++ b/src/Jackett.Common/Definitions/sharkpt.yml
@@ -82,6 +82,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(a[href^="details.php?id="])

--- a/src/Jackett.Common/Definitions/soulvoice.yml
+++ b/src/Jackett.Common/Definitions/soulvoice.yml
@@ -83,6 +83,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/spidertk.yml
+++ b/src/Jackett.Common/Definitions/spidertk.yml
@@ -176,6 +176,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/springsunday.yml
+++ b/src/Jackett.Common/Definitions/springsunday.yml
@@ -85,6 +85,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
     # supports imdbid searching and displays imdb link in results.
 
   rows:

--- a/src/Jackett.Common/Definitions/teamctgame.yml
+++ b/src/Jackett.Common/Definitions/teamctgame.yml
@@ -161,6 +161,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(a[href^="download.php?id="])

--- a/src/Jackett.Common/Definitions/tjupt.yml
+++ b/src/Jackett.Common/Definitions/tjupt.yml
@@ -90,6 +90,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/tlfbits.yml
+++ b/src/Jackett.Common/Definitions/tlfbits.yml
@@ -98,6 +98,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/torrentccf.yml
+++ b/src/Jackett.Common/Definitions/torrentccf.yml
@@ -96,6 +96,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/u2.yml
+++ b/src/Jackett.Common/Definitions/u2.yml
@@ -102,6 +102,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/ydypt.yml
+++ b/src/Jackett.Common/Definitions/ydypt.yml
@@ -94,6 +94,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)

--- a/src/Jackett.Common/Definitions/zmpt.yml
+++ b/src/Jackett.Common/Definitions/zmpt.yml
@@ -102,6 +102,7 @@ search:
     search_mode: 0
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
+    notnewword: 1
 
   rows:
     selector: table.torrents > tbody > tr:has(a[href^="details.php?id="])


### PR DESCRIPTION
Recently, many people report to me that the hot search in site has been polluted by automatic program ( not only Jackett and not only one site)

![image](https://user-images.githubusercontent.com/13842140/223458018-1dda0a5a-937b-4d72-bd2e-f06de0643776.png)
![image](https://user-images.githubusercontent.com/13842140/223460038-c0f779a4-8198-4839-823f-0a31729e6d6f.png)
![image](https://user-images.githubusercontent.com/13842140/223460142-8248fca7-cf4f-42d8-a200-e5d08b682ee4.png)

So this pr want to add a new search input `&notnewword=1` in all sites which use NexusPHP schema, as it won't let NexusPHP update it's suggest table.

Source Code From: 
- https://github.com/zjutjh/NexusPHP/blob/f781c10a0adbf5dc7a4af60c34980d3b118658e7/torrents.php#L662-L668
- https://github.com/xiaomlove/nexusphp/blob/77420ea1e18e5cf54f88e0fee74eedef2958f6a9/public/torrents.php#L690-L696