### PR TITLE
assorted: enable ssl/trackerssl for nexusphp-based definitions

### DIFF
--- a/src/Jackett.Common/Definitions/hddolby.yml
+++ b/src/Jackett.Common/Definitions/hddolby.yml
@@ -71,7 +71,7 @@ login:
     logout: ""
     securelogin: ""
     ssl: yes
-    trackerssl: ""
+    trackerssl: yes
   error:
     - selector: td.embedded:has(h2:contains("失败"))
       message:

--- a/src/Jackett.Common/Definitions/hdu.yml
+++ b/src/Jackett.Common/Definitions/hdu.yml
@@ -57,7 +57,7 @@ login:
     username: "{{ .Config.username }}"
     password: "{{ .Config.password }}"
     ssl: yes
-    trackerssl: ""
+    trackerssl: yes
   error:
     - selector: td.embedded:has(h2:contains("失败"))
   test:

--- a/src/Jackett.Common/Definitions/nethd.yml
+++ b/src/Jackett.Common/Definitions/nethd.yml
@@ -66,8 +66,8 @@ login:
     password: "{{ .Config.password }}"
     logout: ""
     securelogin: ""
-    ssl: ""
-    trackerssl: ""
+    ssl: yes
+    trackerssl: yes
   error:
     - selector: form#loginform > span.warning
   test:

--- a/src/Jackett.Common/Definitions/oshenpt.yml
+++ b/src/Jackett.Common/Definitions/oshenpt.yml
@@ -82,8 +82,8 @@ login:
     two_step_code: "{{ .Config.2facode }}"
     logout: ""
     securelogin: ""
-    ssl: ""
-    trackerssl: ""
+    ssl: yes
+    trackerssl: yes
   error:
     - selector: td.embedded:has(h2:contains("失败"))
   test:

--- a/src/Jackett.Common/Definitions/spidertk.yml
+++ b/src/Jackett.Common/Definitions/spidertk.yml
@@ -149,7 +149,7 @@ login:
     logout: ""
     securelogin: ""
     ssl: yes
-    trackerssl: ""
+    trackerssl: yes
   error:
     - selector: td.embedded:has(h2:contains("Echoué")) # invalid captcha
     - selector: td.embedded:has(h2:contains("Échec")) # invalid uid or pwd


### PR DESCRIPTION
I didn't test, since I don't have accounts for these.