### PR TITLE
hellashut: update inputs

### DIFF
--- a/src/Jackett.Common/Definitions/hellashut.yml
+++ b/src/Jackett.Common/Definitions/hellashut.yml
@@ -188,4 +188,7 @@ search:
       text: 1
     minimumratio:
       text: 1.0
+    minimumseedtime:
+      # 10 day (as seconds = 10 x 24 x 60 x 60)
+      text: 864000
 # TorrentTrader v2-svn


### PR DESCRIPTION
I'm removing `cat=0` and `advanced=1` since they are not present when using the search form, and not doing anything either.

~They seem to use magnet links now for some releases, but sadly the passkey is missing from the announce URL thus they don't work.~ It works after you download first a torrent to generate a passkey on your account.