### PR TITLE
assorted yml: use default: statement for optional fields

### DIFF
--- a/src/Jackett.Common/Definitions/amigosshare.yml
+++ b/src/Jackett.Common/Definitions/amigosshare.yml
@@ -297,10 +297,11 @@ search:
         "[src$=\"/Scripts.png\"]": 128
         "[src$=\"/Vetores.png\"]": 124
         "[src$=\"/outros2.png\"]": 130
-    date_optional:
+    date:
       selector: p:contains("Lançado:")
       # auto adjusted by site account profile
       optional: true
+      default: now
       filters:
         - name: regexp
           args: "Lançado: (.+?)$"
@@ -308,8 +309,6 @@ search:
           args: [" (\\d:)", " 0$1"]
         - name: dateparse
           args: "dd/MM/yy HH:mm:ss"
-    date:
-      text: "{{ if .Result.date_optional }}{{ .Result.date_optional }}{{ else }}now{{ end }}"
     size:
       selector: div.list-group-item-content p.m-0 span.badge-info
     seeders:

--- a/src/Jackett.Common/Definitions/anime-free.yml
+++ b/src/Jackett.Common/Definitions/anime-free.yml
@@ -88,10 +88,11 @@ search:
     selector: article
 
   fields:
-    category_optional:
-      optional: true
+    category:
       selector: a[href*="category="]
       attribute: href
+      optional: true
+      default: 54
       case:
         a[href$="3d_hentai"]: 51
         a[href$="3dcg_game"]: 55
@@ -110,8 +111,6 @@ search:
         a[href$="original_hentai"]: 48
         a[href$="rus-game"]: 57
         a[href$="uncensored"]: 45
-    category:
-      text: "{{ if .Result.category_optional }}{{ .Result.category_optional }}{{ else }}54{{ end }}"
     title:
       selector: h2.title a
     details:

--- a/src/Jackett.Common/Definitions/beyond-hd.yml
+++ b/src/Jackett.Common/Definitions/beyond-hd.yml
@@ -87,15 +87,14 @@ search:
     selector: div.table-torrents > table > tbody > tr[id^="torrentposter"]
 
   fields:
-    category_optional:
+    category:
       selector: a[href*="/categories/"]
-      optional: true
       attribute: href
+      optional: true
+      default: 1
       filters:
         - name: regexp
           args: "/categories/.*?\\.(\\d+)"
-    category:
-      text: "{{ if .Result.category_optional }}{{ .Result.category_optional }}{{ else }}1{{ end }}"
     title:
       selector: a.torrent-name
     details:

--- a/src/Jackett.Common/Definitions/bibliotik.yml
+++ b/src/Jackett.Common/Definitions/bibliotik.yml
@@ -80,14 +80,13 @@ search:
         div[title="Comics"]: 4
         div[title="Ebooks"]: 5
         div[title="Magazines"]: 7
-    author_optional:
-      selector: .authorLink
-      optional: true
     _editor:
       selector: .editorLink
       optional: true
     author:
-      text: "{{ or .Result.author_optional .Result._editor }}"
+      selector: .authorLink
+      optional: true
+      default: "{{ .Result._editor }}"
     year:
       selector: .torYear
       optional: true

--- a/src/Jackett.Common/Definitions/byrutor.yml
+++ b/src/Jackett.Common/Definitions/byrutor.yml
@@ -391,6 +391,7 @@ search:
     size_rus:
       selector: div.shor_subtitles span:nth-child(2):contains("Б")
       optional: true
+      default: "0 B"
       filters:
         - name: replace
           args: ["ТБ", "TB"]
@@ -400,11 +401,10 @@ search:
           args: ["МБ", "MB"]
         - name: replace
           args: ["КБ", "KB"]
-    size_eng:
+    size:
       selector: div.shor_subtitles span:nth-child(2):contains("B")
       optional: true
-    size:
-      text: "{{ if or .Result.size_rus .Result.size_eng }}{{ or .Result.size_rus .Result.size_eng }}{{ else }}0 B{{ end }}"
+      default: "{{ .Result.size_rus }}"
     downloadvolumefactor:
       text: 0
     uploadvolumefactor:

--- a/src/Jackett.Common/Definitions/extremlymtorrents.yml
+++ b/src/Jackett.Common/Definitions/extremlymtorrents.yml
@@ -149,6 +149,8 @@ search:
       filters:
         - name: regexp
           args: "src=(.+?) "
+        - name: replace
+          args: ["/pic/uploadimage.jpg", ""]
     date:
       selector: td:nth-last-child(1)
       # auto adjusted by site account profile
@@ -167,7 +169,7 @@ search:
         "*": 1
     uploadvolumefactor:
       text: 1
-    genre_optional:
+    genre:
       # Drama, Romance | N/A | 2022 | 112 min | N/A
       # Drama:Family:Romance
       selector: td:nth-child(2)
@@ -175,11 +177,10 @@ search:
       filters:
         - name: split
           args: ["|", 0]
-    genre:
-      # if its VIP then do not keep genre
-      text: "{{ if .Result._vip }}{{ else }}{{ .Result.genre_optional }}{{ end }}"
+        - name: re_replace
+          args: ["\\bn\\\\a\\b", ""]
     description:
-      text: "{{ if .Result._vip }}VIP ONLY{{ else }}{{ .Result.genre }}{{ end }}"
+      text: "{{ .Result.genre }}{{ if .Result._vip }}</br>VIP ONLY{{ else }}{{ end }}"
     minimumratio:
       text: 1.0
     minimumseedtime:

--- a/src/Jackett.Common/Definitions/femdomcult.yml
+++ b/src/Jackett.Common/Definitions/femdomcult.yml
@@ -116,16 +116,15 @@ search:
           args: ["/static/common/noartwork/noimage.png", ""]
     files:
       selector: td:nth-child(3)
-    date_optional:
+    date:
       selector: td:nth-child(5) > span
       attribute: title
       # auto adjusted by site account profile
       optional: true
+      default: "20 years ago" # some torrents have "Never" date
       filters:
         - name: dateparse
           args: "MMM dd yyyy, HH:mm"
-    date: # some torrents have "Never" date
-      text: "{{ if .Result.date_optional }}{{ .Result.date_optional }}{{ else }}20 years ago{{ end }}"
     size:
       selector: td:nth-child(6)
     grabs:

--- a/src/Jackett.Common/Definitions/nipponsei.yml
+++ b/src/Jackett.Common/Definitions/nipponsei.yml
@@ -42,14 +42,13 @@ search:
     download:
       selector: a
       attribute: href
-    date_optional:
-      optional: true
+    date:
       selector: td.date
+      optional: true
+      default: now
       filters:
         - name: dateparse
           args: "yyyy-MM-dd HH:mm"
-    date:
-      text: "{{ if .Result.date_optional }}{{ .Result.date_optional }}{{ else }}now{{ end }}"
     size:
       selector: td.bytes
       optional: true

--- a/src/Jackett.Common/Definitions/parnuxi.yml
+++ b/src/Jackett.Common/Definitions/parnuxi.yml
@@ -229,18 +229,17 @@ search:
       selector: span.leech
     grabs:
       selector: span.complet
-    date_optional:
+    date:
       # (09.03.2020)
       selector: a.topictitle
       optional: true
+      default: now
       # do not append TZ else text {{if}} will not work if date not found
       filters:
         - name: regexp
           args: (\d{2}\.\d{2}\.\d{4})
         - name: dateparse
           args: "dd.MM.yyyy"
-    date:
-      text: "{{ if .Result.date_optional }}{{ .Result.date_optional }}{{ else }}now{{ end }}"
     downloadvolumefactor:
       text: 0
     uploadvolumefactor:

--- a/src/Jackett.Common/Definitions/sktorrent.yml
+++ b/src/Jackett.Common/Definitions/sktorrent.yml
@@ -183,16 +183,9 @@ search:
     details:
       selector: a[href^="details.php?name="]
       attribute: href
-    poster_default:
+    poster:
       selector: img[class="lozad"]
       attribute: data-src
-      optional: true
-    poster_optional:
-      selector: img[src="//cdn.sktorrent.eu/obrazky/xXx.jpg"]
-      attribute: src
-      optional: true
-    poster:
-      text: "{{ if .Result.poster_optional }}{{ .Result.poster_optional }}{{ else }}{{ .Result.poster_default }}{{ end }}"
     download:
       selector: a[href^="details.php?name="]
       attribute: href

--- a/src/Jackett.Common/Definitions/thefallingangels.yml
+++ b/src/Jackett.Common/Definitions/thefallingangels.yml
@@ -154,14 +154,13 @@ search:
       attribute: href
     download_default:
       selector: a[href^="download.php?torrent="]
-      optional: true
       attribute: href
-    download_ssl:
-      selector: a[href^="download_ssl.php?torrent="]
       optional: true
-      attribute: href
     download:
-      text: "{{ if .Result.download_ssl }}{{ .Result.download_ssl }}{{ else }}{{ .Result.download_default }}{{ end }}"
+      selector: a[href^="download_ssl.php?torrent="]
+      attribute: href
+      optional: true
+      default: "{{ .Result.download_default }}"
     poster:
       selector: div[id^="details"] img
       attribute: src

--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -170,14 +170,13 @@ search:
     download:
       selector: td:nth-child(1) a
       attribute: href
-    date_optional:
-      optional: true
+    date:
       selector: td:nth-child(2):contains("/")
+      optional: true
+      default: now
       filters:
         - name: dateparse
           args: "dd/MM/yyyy"
-    date:
-      text: "{{ if .Result.date_optional }}{{ .Result.date_optional }}{{ else }}now{{ end }}"
     size:
       selector: "{{ if .Keywords }}td:nth-child(3){{ else }}td:nth-child(2){{ end }}"
       filters:

--- a/src/Jackett.Common/Definitions/tribalmixes.yml
+++ b/src/Jackett.Common/Definitions/tribalmixes.yml
@@ -105,14 +105,14 @@ search:
       filters:
         - name: regexp
           args: "Size: (.+?)<"
-    files_optional:
+    files:
       selector: a[href^="/download.php?id="]
       attribute: title
+      optional: true
+      default: 1
       filters:
         - name: regexp
           args: "\\((\\d+) files\\)"
-    files:
-      text: "{{ if .Result.files_optional }}{{ .Result.files_optional }}{{ else }}1{{ end }}"
     seeders:
       selector: a[href^="/download.php?id="]
       attribute: title


### PR DESCRIPTION
A few more. Double-check in case there's a reason not use `default:` with any of them.

Also tidied extremlymtorrents and removed unnecessary optional poster from sktorrent.

Only remaining indexers with `_optional:` fields are:
- 1337x & torrent9 - `title` https://github.com/Jackett/Jackett/commit/0f9f173cc5c691dacb2e633991eee01f856c0cc7
- nyaasi - `download` https://github.com/Jackett/Jackett/commit/80691060ea030e869084209b63285061a3f06da8
- torrenthr - 2 optional `title` fields and a default, all different selectors

puntotorrent has a `title_vose:` field which serves the same function, but different filters are being applied to `_default` and `_vose`.