### PR TITLE
assorted C#: removed old cert exceptions

### DIFF
--- a/src/Jackett.Common/Indexers/AniDUB.cs
+++ b/src/Jackett.Common/Indexers/AniDUB.cs
@@ -44,7 +44,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataAniDub())
         {
-            webclient.AddTrustedCertificate(new Uri(SiteLink).Host, "392E98CE1447B59CA62BAB8824CA1EEFC2ED3D37");
         }
 
         private TorznabCapabilities SetCapabilities()

--- a/src/Jackett.Common/Indexers/LostFilm.cs
+++ b/src/Jackett.Common/Indexers/LostFilm.cs
@@ -33,6 +33,7 @@ namespace Jackett.Common.Indexers
             "https://www.lostfilm.win/",
             "https://www.lostfilm.tw/",
             "https://www.lostfilmtv2.site/",
+            "https://www.lostfilmtv3.site/",
             "https://www.lostfilmtv5.site/",
             "https://www.lostfilm.uno/"
         };
@@ -122,7 +123,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataCaptchaLogin())
         {
-            webclient.AddTrustedCertificate(new Uri(SiteLink).Host, "98D43B6E740B42C02A9BD1A9D1A813E4350BE332"); // for *.win expired 26/Mar/22
             webclient.AddTrustedCertificate(new Uri(SiteLink).Host, "34287FB53A58EC6AE590E7DD7E03C70C0263CADC"); // for *.tw  expired 01/Apr/21
         }
 

--- a/src/Jackett.Common/Indexers/TorrentHeaven.cs
+++ b/src/Jackett.Common/Indexers/TorrentHeaven.cs
@@ -47,8 +47,6 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataCaptchaLogin())
         {
-            // incomplete CA chain
-            wc.AddTrustedCertificate(new Uri(SiteLink).Host, "8612e46b2abd418b6398dbf2382ebcf44b10f378");
         }
 
         private TorznabCapabilities SetCapabilities()


### PR DESCRIPTION
Follow up to https://github.com/Jackett/Jackett/pull/14235. Forgot about C# indexers.

Also added another LostFilm mirror. *tv1.site exists too, but fails with parsing errors.