### PR TITLE
thepiratebay: attempt to fix release group in titles

### DIFF
--- a/src/Jackett.Common/Definitions/thepiratebay.yml
+++ b/src/Jackett.Common/Definitions/thepiratebay.yml
@@ -164,7 +164,9 @@ search:
       selector: name
       filters:
         - name: re_replace
-          args: [" ?- (\\w+-?\\w*)$", "-$1"]
+          args: ["- (\\w+-?\\w*)$", "-$1"]
+    description:
+      selector: name
     details:
       text: "{{ .Config.sitelink }}description.php?id={{ .Result._id }}"
     infohash:


### PR DESCRIPTION
Replaces last match ` - ` with ` -`. 

https://github.com/TRaSH-/Guides/issues/1288