### PR TITLE
assorted nexusphp: update and tidy

### DIFF
--- a/src/Jackett.Common/Definitions/2xfree.yml
+++ b/src/Jackett.Common/Definitions/2xfree.yml
@@ -103,7 +103,6 @@ login:
     trackerssl: yes
   error:
     - selector: td.embedded:has(h2:contains("失败"))
-    - selector: td.embedded:has(h2:contains("Failed"))
   test:
     path: index.php
     selector: a[href="logout.php"]
@@ -213,5 +212,5 @@ search:
       text: 86400
     description:
       selector: td.rowfollow:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP v1.8.0 2023-01-26

--- a/src/Jackett.Common/Definitions/3changtrai.yml
+++ b/src/Jackett.Common/Definitions/3changtrai.yml
@@ -178,5 +178,5 @@ search:
       text: 259200
     description:
       selector: td:nth-child(3)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP 3ChangTrai v3.0 2020-04-30

--- a/src/Jackett.Common/Definitions/52pt.yml
+++ b/src/Jackett.Common/Definitions/52pt.yml
@@ -40,10 +40,6 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
-  - name: info_tpp
-    type: info
-    label: Results Per Page
-    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
   - name: sort
     type: select
     label: Sort requested from site
@@ -96,6 +92,12 @@ search:
     selector: table.torrents > tbody > tr:has(table.torrentname)
 
   fields:
+    category:
+      selector: a[href^="?cat="]
+      attribute: href
+      filters:
+        - name: querystring
+          args: cat
     title_default:
       selector: a[href^="details.php?id="]
     title:
@@ -103,12 +105,6 @@ search:
       attribute: title
       optional: true
       default: "{{ .Result.title_default }}"
-    category:
-      selector: a[href^="?cat="]
-      attribute: href
-      filters:
-        - name: querystring
-          args: cat
     details:
       selector: a[href^="details.php?id="]
       attribute: href
@@ -158,12 +154,12 @@ search:
         img.pro_free2up: 2
         img.pro_2up: 2
         "*": 1
-    description:
-      selector: td:nth-child(2)
-      remove: a, img
     minimumratio:
       text: 1
     minimumseedtime:
       # 1 day (as seconds = 24 x 60 x 60)
       text: 86400
+    description:
+      selector: td:nth-child(2)
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 4

--- a/src/Jackett.Common/Definitions/audiences.yml
+++ b/src/Jackett.Common/Definitions/audiences.yml
@@ -41,10 +41,6 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
-  - name: info_tpp
-    type: info
-    label: Results Per Page
-    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
   - name: sort
     type: select
     label: Sort requested from site
@@ -61,6 +57,10 @@ settings:
     options:
       desc: desc
       asc: asc
+  - name: info_tpp
+    type: info
+    label: Results Per Page
+    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
 
 login:
   method: cookie
@@ -163,5 +163,5 @@ search:
       text: 172800
     description:
       selector: td:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 4

--- a/src/Jackett.Common/Definitions/audiences.yml
+++ b/src/Jackett.Common/Definitions/audiences.yml
@@ -163,5 +163,5 @@ search:
       text: 172800
     description:
       selector: td:nth-child(2)
-      remove: a, b, font, img, span
+      remove: a, img
 # NexusPHP Standard v1.5 Beta 4

--- a/src/Jackett.Common/Definitions/beitai.yml
+++ b/src/Jackett.Common/Definitions/beitai.yml
@@ -163,5 +163,5 @@ search:
         "*": 1
     description:
       selector: td:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 4

--- a/src/Jackett.Common/Definitions/btschool.yml
+++ b/src/Jackett.Common/Definitions/btschool.yml
@@ -150,5 +150,5 @@ search:
       text: 1.0
     description:
       selector: td:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 4

--- a/src/Jackett.Common/Definitions/byrbt.yml
+++ b/src/Jackett.Common/Definitions/byrbt.yml
@@ -38,10 +38,6 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
-  - name: info_tpp
-    type: info
-    label: Results Per Page
-    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
   - name: sort
     type: select
     label: Sort requested from site
@@ -58,6 +54,10 @@ settings:
     options:
       desc: desc
       asc: asc
+  - name: info_tpp
+    type: info
+    label: Results Per Page
+    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
 
 login:
   path: login.php
@@ -76,8 +76,6 @@ login:
     trackerssl: yes
   error:
     - selector: td.embedded:has(h2:contains("失败"))
-    - selector: td.embedded:has(h2:contains("failed!"))
-    - selector: td.embedded:has(h2:contains("Failed"))
   test:
     path: index.php
     selector: a[href^="logout.php?key="]
@@ -169,12 +167,12 @@ search:
         img.pro_free2up: 2
         img.pro_2up: 2
         "*": 1
-    description:
-      selector: td:nth-child(2)
-      remove: a, img
     minimumratio:
       text: 1.0
     minimumseedtime:
       # 1 day (as seconds = 1 x 24 x 60 x 60)
       text: 86400
+    description:
+      selector: td:nth-child(2)
+      remove: a, b, font, img, span
 # NexusPHP v1.5 beta 5 20120707

--- a/src/Jackett.Common/Definitions/carpt.yml
+++ b/src/Jackett.Common/Definitions/carpt.yml
@@ -188,5 +188,5 @@ search:
       text: 86400
     description:
       selector: td.rowfollow:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP v1.7.31 2022-11-14

--- a/src/Jackett.Common/Definitions/ceskeforum.yml
+++ b/src/Jackett.Common/Definitions/ceskeforum.yml
@@ -41,10 +41,6 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
-  - name: info_tpp
-    type: info
-    label: Results Per Page
-    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
   - name: sort
     type: select
     label: Sort requested from site
@@ -61,6 +57,10 @@ settings:
     options:
       desc: desc
       asc: asc
+  - name: info_tpp
+    type: info
+    label: Results Per Page
+    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
 
 login:
   path: takelogin.php
@@ -170,7 +170,7 @@ search:
         "*": 1
     description:
       selector: td.rowfollow:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
     genre:
       selector: table.torrentname > tbody > tr > td:first-child
       remove: a

--- a/src/Jackett.Common/Definitions/chdbits.yml
+++ b/src/Jackett.Common/Definitions/chdbits.yml
@@ -165,5 +165,5 @@ search:
         "*": 1
     description:
       selector: td:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 4

--- a/src/Jackett.Common/Definitions/gainbound.yml
+++ b/src/Jackett.Common/Definitions/gainbound.yml
@@ -150,5 +150,5 @@ search:
       text: 1.0
     description:
       selector: td.rowfollow:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP v1.8.0 2023-01-26

--- a/src/Jackett.Common/Definitions/haitang.yml
+++ b/src/Jackett.Common/Definitions/haitang.yml
@@ -37,10 +37,6 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
-  - name: info_tpp
-    type: info
-    label: Results Per Page
-    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
   - name: sort
     type: select
     label: Sort requested from site
@@ -57,6 +53,10 @@ settings:
     options:
       desc: desc
       asc: asc
+  - name: info_tpp
+    type: info
+    label: Results Per Page
+    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
 
 login:
   path: takelogin.php
@@ -70,7 +70,6 @@ login:
     trackerssl: yes
   error:
     - selector: td.embedded:has(h2:contains("失败"))
-    - selector: td.embedded:has(h2:contains("failed"))
   test:
     path: index.php
     selector: a[href="logout.php"]
@@ -162,12 +161,12 @@ search:
         img.pro_free2up: 2
         img.pro_2up: 2
         "*": 1
-    description:
-      selector: td:nth-child(2)
-      remove: a, img
     minimumratio:
       text: 1
     minimumseedtime:
       # 1 day (as seconds = 24 x 60 x 60)
       text: 86400
+    description:
+      selector: td:nth-child(2)
+      remove: a, b, font, img, span
 # NexusPHP v1.1 2021-10-15

--- a/src/Jackett.Common/Definitions/hd4fans.yml
+++ b/src/Jackett.Common/Definitions/hd4fans.yml
@@ -54,7 +54,7 @@ login:
     ssl: yes
     trackerssl: yes
   error:
-    - selector: td.embedded:has(h2:contains("失败")), td.embedded:has(h2:contains("failed"))
+    - selector: td.embedded:has(h2:contains("失败"))
       message:
         selector: td.text
   test:
@@ -145,5 +145,5 @@ search:
         "*": 1
     description:
       selector: td.rowfollow:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 4

--- a/src/Jackett.Common/Definitions/hdarea.yml
+++ b/src/Jackett.Common/Definitions/hdarea.yml
@@ -47,10 +47,6 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
-  - name: info_tpp
-    type: info
-    label: Results Per Page
-    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
   - name: sort
     type: select
     label: Sort requested from site
@@ -170,5 +166,5 @@ search:
       text: 0.8
     description:
       selector: td:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 4

--- a/src/Jackett.Common/Definitions/hddolby.yml
+++ b/src/Jackett.Common/Definitions/hddolby.yml
@@ -190,5 +190,5 @@ search:
       remove: a, b, font, img, span
       filters:
         - name: replace
-          args: ["剩余时间：", ""]
+          args: [" 剩余时间：", ""]
 # NexusPHP Standard v1.5 Beta 4

--- a/src/Jackett.Common/Definitions/hddolby.yml
+++ b/src/Jackett.Common/Definitions/hddolby.yml
@@ -109,6 +109,8 @@ search:
     search_area: "{{ if .Query.IMDBID }}4{{ else }}{{ end }}{{ if .Query.DoubanID }}1{{ else }}{{ end }}{{ if or .Query.IMDBID .Query.DoubanID }}{{ else }}0{{ end }}"
     # 0=AND, 1=OR, 2=Exact
     search_mode: 0
+    sort: "{{ .Config.sort }}"
+    type: "{{ .Config.type }}"
     notnewword: 1
 
   rows:

--- a/src/Jackett.Common/Definitions/hddolby.yml
+++ b/src/Jackett.Common/Definitions/hddolby.yml
@@ -24,10 +24,9 @@ caps:
 
   modes:
     search: [q]
-    tv-search: [q, season, ep, imdbid]
-    movie-search: [q, imdbid]
+    tv-search: [q, season, ep, imdbid, doubanid]
+    movie-search: [q, imdbid, doubanid]
     music-search: [q]
-    book-search: [q]
 
 settings:
   - name: username
@@ -47,6 +46,22 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
+  - name: sort
+    type: select
+    label: Sort requested from site
+    default: 4
+    options:
+      4: created
+      7: seeders
+      5: size
+      1: title
+  - name: type
+    type: select
+    label: Order requested from site
+    default: desc
+    options:
+      desc: desc
+      asc: asc
   - name: flaresolverr
     type: info
     label: FlareSolverr
@@ -85,13 +100,13 @@ search:
     - path: torrents.php
   inputs:
     $raw: "{{ range .Categories }}cat{{.}}=1&{{end}}"
-    search: "{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}"
+    search: "{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ end }}{{ if or .Query.IMDBID .Query.DoubanID }} {{ else }}{{ .Keywords }}{{ end }}{{ if .Query.DoubanID }}{{ .Query.DoubanID }}{{ else }}{{ end }}"
     # 0=incldead, 1=active, 2=dead
     incldead: 0
     # show promotions: 0=all, 1=normal, 2=free, 3=2x, 4=2xFree, 5=50%, 6=2x50%, 7=30%
     spstate: "{{ if .Config.freeleech }}2{{ else }}0{{ end }}"
     # 0=title, 1=descr, 3=uploader, 4=imdb URL
-    search_area: "{{ if .Query.IMDBID }}4{{ else }}0{{ end }}"
+    search_area: "{{ if .Query.IMDBID }}4{{ else }}{{ end }}{{ if .Query.DoubanID }}1{{ else }}{{ end }}{{ if or .Query.IMDBID .Query.DoubanID }}{{ else }}0{{ end }}"
     # 0=AND, 1=OR, 2=Exact
     search_mode: 0
     notnewword: 1
@@ -100,6 +115,12 @@ search:
     selector: table.torrents > tbody > tr:has(table.torrentname)
 
   fields:
+    category:
+      selector: a[href^="?cat="]
+      attribute: href
+      filters:
+        - name: querystring
+          args: cat
     title_default:
       selector: a[href^="details.php?id="]
     title:
@@ -107,17 +128,17 @@ search:
       attribute: title
       optional: true
       default: "{{ .Result.title_default }}"
-    category:
-      selector: a[href^="?cat="]
-      attribute: href
-      filters:
-        - name: querystring
-          args: cat
     details:
       selector: a[href^="details.php?id="]
       attribute: href
     download:
       selector: a[href^="download.php?id="]
+      attribute: href
+    imdbid:
+      selector: a[href*="imdb.com/title/tt"]
+      attribute: href
+    doubanid:
+      selector: a[href*="movie.douban.com/subject/"]
       attribute: href
     date_elapsed:
       # time type: time elapsed (default)
@@ -166,5 +187,8 @@ search:
       text: 1.2
     description:
       selector: td.rowfollow:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
+      filters:
+        - name: replace
+          args: ["剩余时间：", ""]
 # NexusPHP Standard v1.5 Beta 4

--- a/src/Jackett.Common/Definitions/hdfans.yml
+++ b/src/Jackett.Common/Definitions/hdfans.yml
@@ -52,10 +52,6 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
-  - name: info_tpp
-    type: info
-    label: Results Per Page
-    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
   - name: sort
     type: select
     label: Sort requested from site
@@ -72,6 +68,10 @@ settings:
     options:
       desc: desc
       asc: asc
+  - name: info_tpp
+    type: info
+    label: Results Per Page
+    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
 
 login:
   path: login.php
@@ -188,9 +188,9 @@ search:
         img.pro_free2up: 2
         img.pro_2up: 2
         "*": 1
-    description:
-      selector: td:nth-child(2)
-      remove: a, img
     minimumratio:
       text: 0.81
+    description:
+      selector: td:nth-child(2)
+      remove: a, b, font, img, span
 # NexusPHP v1.8.0 2023-01-20

--- a/src/Jackett.Common/Definitions/hdhome.yml
+++ b/src/Jackett.Common/Definitions/hdhome.yml
@@ -170,5 +170,5 @@ search:
         "*": 1
     description:
       selector: td:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP v2.0 2014-11-24

--- a/src/Jackett.Common/Definitions/hdmayi.yml
+++ b/src/Jackett.Common/Definitions/hdmayi.yml
@@ -169,5 +169,5 @@ search:
       text: 86400
     description:
       selector: td.rowfollow:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP v1.7.29 2022-10-12

--- a/src/Jackett.Common/Definitions/hdsky.yml
+++ b/src/Jackett.Common/Definitions/hdsky.yml
@@ -144,5 +144,5 @@ search:
         "*": 1
     description:
       selector: td:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 5

--- a/src/Jackett.Common/Definitions/hdtime.yml
+++ b/src/Jackett.Common/Definitions/hdtime.yml
@@ -84,7 +84,6 @@ login:
     trackerssl: yes
   error:
     - selector: td.embedded:has(h2:contains("失败"))
-    - selector: td.embedded:has(h2:contains("Failed"))
   test:
     path: index.php
     selector: a[href="logout.php"]
@@ -188,5 +187,5 @@ search:
       text: 0.81
     description:
       selector: td.rowfollow:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP v1.7.33 2023-01-04

--- a/src/Jackett.Common/Definitions/hdu.yml
+++ b/src/Jackett.Common/Definitions/hdu.yml
@@ -40,6 +40,22 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
+  - name: sort
+    type: select
+    label: Sort requested from site
+    default: 4
+    options:
+      4: created
+      7: seeders
+      5: size
+      1: title
+  - name: type
+    type: select
+    label: Order requested from site
+    default: desc
+    options:
+      desc: desc
+      asc: asc
   - name: info_tpp
     type: info
     label: Results Per Page
@@ -84,6 +100,12 @@ search:
     selector: table.torrents > tbody > tr:has(table.torrentname)
 
   fields:
+    category:
+      selector: a[href^="?cat="]
+      attribute: href
+      filters:
+        - name: querystring
+          args: cat
     title_default:
       selector: a[href^="details.php?id="]
     title:
@@ -91,12 +113,6 @@ search:
       attribute: title
       optional: true
       default: "{{ .Result.title_default }}"
-    category:
-      selector: a[href^="?cat="]
-      attribute: href
-      filters:
-        - name: querystring
-          args: cat
     details:
       selector: a[href^="details.php?id="]
       attribute: href
@@ -153,5 +169,5 @@ search:
       text: 259200
     description:
       selector: td.rowfollow:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 4

--- a/src/Jackett.Common/Definitions/hdu.yml
+++ b/src/Jackett.Common/Definitions/hdu.yml
@@ -94,6 +94,8 @@ search:
     search_area: "{{ if .Query.IMDBID }}4{{ else }}0{{ end }}"
     # 0=AND, 1=OR, 2=Exact
     search_mode: 0
+    sort: "{{ .Config.sort }}"
+    type: "{{ .Config.type }}"
     notnewword: 1
 
   rows:

--- a/src/Jackett.Common/Definitions/hdvideo.yml
+++ b/src/Jackett.Common/Definitions/hdvideo.yml
@@ -83,7 +83,6 @@ login:
     trackerssl: yes
   error:
     - selector: td.embedded:has(h2:contains("失败"))
-    - selector: td.embedded:has(h2:contains("Failed"))
   test:
     path: index.php
     selector: a[href="logout.php"]

--- a/src/Jackett.Common/Definitions/hdzone.yml
+++ b/src/Jackett.Common/Definitions/hdzone.yml
@@ -204,5 +204,5 @@ search:
 #       text: 1209600
     description:
       selector: td:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 4

--- a/src/Jackett.Common/Definitions/joyhd.yml
+++ b/src/Jackett.Common/Definitions/joyhd.yml
@@ -71,7 +71,6 @@ login:
     dutime: month
   error:
     - selector: td.embedded:has(h2:contains("失败"))
-    - selector: td.embedded:has(h2:contains("Failed"))
   test:
     path: index.php
     selector: a[href="logout.php"]
@@ -167,9 +166,9 @@ search:
         img.pro_free2up: 2
         img.pro_2up: 2
         "*": 1
-    description:
-      selector: td:nth-child(2)
-      remove: a, img
     minimumratio:
       text: 0.81
+    description:
+      selector: td:nth-child(2)
+      remove: a, b, font, img, span
 # NexusPHP Standard v0.3 2013-10-01

--- a/src/Jackett.Common/Definitions/kamept.yml
+++ b/src/Jackett.Common/Definitions/kamept.yml
@@ -83,7 +83,6 @@ login:
     trackerssl: yes
   error:
     - selector: td.embedded:has(h2:contains("失败"))
-    - selector: td.embedded:has(h2:contains("failed"))
   test:
     path: index.php
     selector: a[href*="usercp.php"]
@@ -179,5 +178,5 @@ search:
       text: 0.9
     description:
       selector: td.rowfollow:nth-child(2)
-      remove: a, img, font, span
+      remove: a, b, font, img, span
 # NexusPHP v1.7.26 2022-09-15

--- a/src/Jackett.Common/Definitions/keepfriends.yml
+++ b/src/Jackett.Common/Definitions/keepfriends.yml
@@ -180,7 +180,7 @@ search:
         "*": 1
     description:
       selector: "{{ if .Result._staff_edit }}td:nth-child(3){{ else }}td:nth-child(2){{ end }}"
-      remove: a, img
+      remove: a, b, font, img, span
     title_english:
       selector: table.torrentname > tbody > tr > td.embedded
     title:

--- a/src/Jackett.Common/Definitions/lemonhd.yml
+++ b/src/Jackett.Common/Definitions/lemonhd.yml
@@ -154,5 +154,5 @@ search:
         "*": 1
     description:
       selector: a[href^="details_"]
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 4 (customised)

--- a/src/Jackett.Common/Definitions/mteamtp.yml
+++ b/src/Jackett.Common/Definitions/mteamtp.yml
@@ -219,5 +219,5 @@ search:
       text: 172800
     description:
       selector: td:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 4

--- a/src/Jackett.Common/Definitions/mteamtp2fa.yml
+++ b/src/Jackett.Common/Definitions/mteamtp2fa.yml
@@ -222,5 +222,5 @@ search:
       text: 172800
     description:
       selector: td:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 4

--- a/src/Jackett.Common/Definitions/nethd.yml
+++ b/src/Jackett.Common/Definitions/nethd.yml
@@ -165,4 +165,7 @@ search:
         "*": 1
     minimumratio:
       text: 0.5
+    description:
+      selector: td:nth-child(3) > div:nth-child(2)
+      remove: a, b, font, img, span
 # NexusPHP 1.0

--- a/src/Jackett.Common/Definitions/nicept.yml
+++ b/src/Jackett.Common/Definitions/nicept.yml
@@ -177,5 +177,5 @@ search:
       remove: a, b, font, img, span
       filters:
         - name: replace
-          args: ["剩余时间：", ""]
+          args: [" 剩余时间：", ""]
 # NexusPHP v1.7.29 2022-10-13

--- a/src/Jackett.Common/Definitions/nicept.yml
+++ b/src/Jackett.Common/Definitions/nicept.yml
@@ -76,7 +76,6 @@ login:
     two_step_code: "{{ .Config.2facode }}"
   error:
     - selector: td.embedded:has(h2:contains("失败"))
-    - selector: td.embedded:has(h2:contains("Failed"))
   test:
     path: index.php
     selector: a[href="logout.php"]
@@ -175,5 +174,8 @@ search:
       text: 259200
     description:
       selector: td.rowfollow:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
+      filters:
+        - name: replace
+          args: ["剩余时间：", ""]
 # NexusPHP v1.7.29 2022-10-13

--- a/src/Jackett.Common/Definitions/opencd.yml
+++ b/src/Jackett.Common/Definitions/opencd.yml
@@ -44,10 +44,6 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
-  - name: info_tpp
-    type: info
-    label: Results Per Page
-    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile. Default is 50.
   - name: sort
     type: select
     label: Sort requested from site
@@ -64,6 +60,10 @@ settings:
     options:
       desc: desc
       asc: asc
+  - name: info_tpp
+    type: info
+    label: Results Per Page
+    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile. Default is 50.
 
 login:
   method: cookie
@@ -183,12 +183,12 @@ search:
         img.pro_free2up: 2
         img.pro_2up: 2
         "*": 1
-    description:
-      selector: td:nth-child(3)
-      remove: a, img
     minimumratio:
       text: 1.0
     minimumseedtime:
       # 36 hours (as seconds = 36 x 60 x 60)
       text: 129600
+    description:
+      selector: td:nth-child(3)
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 4 (customised)

--- a/src/Jackett.Common/Definitions/oshenpt.yml
+++ b/src/Jackett.Common/Definitions/oshenpt.yml
@@ -187,5 +187,5 @@ search:
         "*": 1
     description:
       selector: td:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP v1.8.0 2023-01-11

--- a/src/Jackett.Common/Definitions/ourbits.yml
+++ b/src/Jackett.Common/Definitions/ourbits.yml
@@ -39,6 +39,7 @@ settings:
   - name: freeleech
     type: checkbox
     label: Search freeleech only
+    default: false
   - name: sort
     type: select
     label: Sort requested from site

--- a/src/Jackett.Common/Definitions/ourbits.yml
+++ b/src/Jackett.Common/Definitions/ourbits.yml
@@ -83,6 +83,8 @@ search:
     search_area: "{{ if .Query.IMDBID }}4{{ else }}0{{ end }}"
     # 0=AND, 1=OR, 2=Exact
     search_mode: 0
+    sort: "{{ .Config.sort }}"
+    type: "{{ .Config.type }}"
     notnewword: 1
 
   rows:

--- a/src/Jackett.Common/Definitions/ourbits.yml
+++ b/src/Jackett.Common/Definitions/ourbits.yml
@@ -55,7 +55,6 @@ settings:
     options:
       desc: desc
       asc: asc
-    default: false
   - name: info_tpp
     type: info
     label: Results Per Page

--- a/src/Jackett.Common/Definitions/ourbits.yml
+++ b/src/Jackett.Common/Definitions/ourbits.yml
@@ -169,5 +169,5 @@ search:
       remove: a, b, font, img, span
       filters:
         - name: replace
-          args: ["will end in", ""]
+          args: [" 剩余时间：", ""]
 # Ourbits 1.1.0 (Based on NexusPHP Standard v1.5 Beta 4) 4691022 2023-05-04

--- a/src/Jackett.Common/Definitions/ourbits.yml
+++ b/src/Jackett.Common/Definitions/ourbits.yml
@@ -39,6 +39,22 @@ settings:
   - name: freeleech
     type: checkbox
     label: Search freeleech only
+  - name: sort
+    type: select
+    label: Sort requested from site
+    default: 4
+    options:
+      4: created
+      7: seeders
+      5: size
+      1: title
+  - name: type
+    type: select
+    label: Order requested from site
+    default: desc
+    options:
+      desc: desc
+      asc: asc
     default: false
   - name: info_tpp
     type: info
@@ -150,7 +166,7 @@ search:
       text: 172800
     description:
       selector: td.rowfollow:nth-child(2) > table > tbody > tr > td
-      remove: a, img, b, span
+      remove: a, b, font, img, span
       filters:
         - name: replace
           args: ["will end in", ""]

--- a/src/Jackett.Common/Definitions/pignetwork.yml
+++ b/src/Jackett.Common/Definitions/pignetwork.yml
@@ -177,5 +177,5 @@ search:
       text: 259200
     description:
       selector: td.rowfollow:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP v1.8.0 2023-01-16

--- a/src/Jackett.Common/Definitions/ptchina.yml
+++ b/src/Jackett.Common/Definitions/ptchina.yml
@@ -77,7 +77,6 @@ login:
     trackerssl: yes
   error:
     - selector: td.embedded:has(h2:contains("失败"))
-    - selector: td.embedded:has(h2:contains("Failed"))
   test:
     path: index.php
     selector: a[href="logout.php"]
@@ -185,5 +184,5 @@ search:
       text: 86400
     description:
       selector: td.rowfollow:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP v1.8.2 2023-04-29

--- a/src/Jackett.Common/Definitions/pterclub.yml
+++ b/src/Jackett.Common/Definitions/pterclub.yml
@@ -170,9 +170,9 @@ search:
         img.pro_free2up: 2
         img.pro_2up: 2
         "*": 1
-    description:
-      selector: td:has(table.torrentname)
-      remove: a, b, font, img
     minimumratio:
       text: 0.9
+    description:
+      selector: td:has(table.torrentname)
+      remove: a, b, font, img, span
 # NexusPHP custom v2019.12

--- a/src/Jackett.Common/Definitions/pterclub.yml
+++ b/src/Jackett.Common/Definitions/pterclub.yml
@@ -174,5 +174,5 @@ search:
       text: 0.9
     description:
       selector: td:has(table.torrentname)
-      remove: a, b, font, img, span
+      remove: a, img
 # NexusPHP custom v2019.12

--- a/src/Jackett.Common/Definitions/pthome.yml
+++ b/src/Jackett.Common/Definitions/pthome.yml
@@ -139,5 +139,5 @@ search:
         "*": 1
     description:
       selector: td:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP v3.1 2021-07-05

--- a/src/Jackett.Common/Definitions/pttime.yml
+++ b/src/Jackett.Common/Definitions/pttime.yml
@@ -110,6 +110,8 @@ search:
     search_area: "{{ if .Query.IMDBID }}4{{ else }}{{ end }}{{ if .Query.DoubanID }}5{{ else }}{{ end }}{{ if or .Query.IMDBID .Query.DoubanID }}{{ else }}0{{ end }}"
     # 0 AND, 1 OR, 2 exact
     search_mode: 0
+    sort: "{{ .Config.sort }}"
+    type: "{{ .Config.type }}"
     notnewword: 1
 
   rows:

--- a/src/Jackett.Common/Definitions/pttime.yml
+++ b/src/Jackett.Common/Definitions/pttime.yml
@@ -56,6 +56,22 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
+  - name: sort
+    type: select
+    label: Sort requested from site
+    default: 4
+    options:
+      4: created
+      7: seeders
+      5: size
+      1: title
+  - name: type
+    type: select
+    label: Order requested from site
+    default: desc
+    options:
+      desc: desc
+      asc: asc
   - name: info_tpp
     type: info
     label: Results Per Page
@@ -72,7 +88,6 @@ login:
     ssl: yes
   error:
     - selector: td.embedded:has(h2:contains("失败"))
-    - selector: td.embedded:has(h2:contains("Failed"))
   test:
     path: index.php
     selector: a[href="logout.php"]
@@ -173,6 +188,5 @@ search:
         font.promotion.twouphalfdown: 2
         "*": 1
     description:
-      selector: td:nth-child(2)
-      remove: a, img
+      selector: td:nth-child(2) > font:last-child
 # NexusPHP Standard v1.5 Beta 4

--- a/src/Jackett.Common/Definitions/putao.yml
+++ b/src/Jackett.Common/Definitions/putao.yml
@@ -59,10 +59,6 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
-  - name: info_tpp
-    type: info
-    label: Results Per Page
-    default: For best results, change the <b>每页种子数:每页显示</b><i>(Torrents per page:)</i> setting to <b>100</b> on your account profile.
   - name: sort
     type: select
     label: Sort requested from site
@@ -79,6 +75,10 @@ settings:
     options:
       desc: desc
       asc: asc
+  - name: info_tpp
+    type: info
+    label: Results Per Page
+    default: For best results, change the <b>每页种子数:每页显示</b><i>(Torrents per page:)</i> setting to <b>100</b> on your account profile.
 
 login:
   path: login.php
@@ -118,7 +118,7 @@ search:
     sort: "{{ .Config.sort }}"
     type: "{{ .Config.type }}"
     notnewword: 1
-    # does not return imdb or dubanid in results
+    # does not return imdb or doubanid in results
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)
@@ -196,9 +196,9 @@ search:
         img.pro_2up: 2
         img.pro_free2up: 2
         "*": 1
-    description:
-      selector: td:nth-child(2)
-      remove: a, img
     minimumratio:
       text: 0.7
+    description:
+      selector: td:nth-child(2)
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.0 Beta 2

--- a/src/Jackett.Common/Definitions/spidertk.yml
+++ b/src/Jackett.Common/Definitions/spidertk.yml
@@ -94,10 +94,6 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
-  - name: info_tpp
-    type: info
-    label: Results Per Page
-    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
   - name: sort
     type: select
     label: Sort requested from site
@@ -133,6 +129,10 @@ settings:
     type: checkbox
     label: Replace VOSTFR and SUBFRENCH with ENGLISH
     default: false
+  - name: info_tpp
+    type: info
+    label: Results Per Page
+    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
 
 login:
   path: login.php

--- a/src/Jackett.Common/Definitions/springsunday.yml
+++ b/src/Jackett.Common/Definitions/springsunday.yml
@@ -164,5 +164,5 @@ search:
         "*": 1
     description:
       selector: td:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 4 2010-09-19 (customised)

--- a/src/Jackett.Common/Definitions/tjupt.yml
+++ b/src/Jackett.Common/Definitions/tjupt.yml
@@ -164,9 +164,9 @@ search:
         font.twoupfree: 2
         font.twoup: 2
         "*": 1
-    description:
-      selector: td:nth-child(2)
-      remove: a, img
     minimumratio:
       text: 0.8
+    description:
+      selector: td:nth-child(2)
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 4 (custom ulvf dlvf)

--- a/src/Jackett.Common/Definitions/tlfbits.yml
+++ b/src/Jackett.Common/Definitions/tlfbits.yml
@@ -171,5 +171,5 @@ search:
         "*": 1
     description:
       selector: td:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 4

--- a/src/Jackett.Common/Definitions/torrentccf.yml
+++ b/src/Jackett.Common/Definitions/torrentccf.yml
@@ -46,10 +46,6 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
-  - name: info_tpp
-    type: info
-    label: Results Per Page
-    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
   - name: sort
     type: select
     label: Sort requested from site
@@ -165,9 +161,9 @@ search:
         img.pro_free2up: 2
         img.pro_2up: 2
         "*": 1
-    description:
-      selector: td:nth-child(2)
-      remove: a, img
     minimumratio:
       text: 0.8
+    description:
+      selector: td:nth-child(2)
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 3

--- a/src/Jackett.Common/Definitions/torrentccf.yml
+++ b/src/Jackett.Common/Definitions/torrentccf.yml
@@ -165,5 +165,5 @@ search:
       text: 0.8
     description:
       selector: td:nth-child(2)
-      remove: a, b, font, img, span
+      remove: a, img
 # NexusPHP Standard v1.5 Beta 3

--- a/src/Jackett.Common/Definitions/u2.yml
+++ b/src/Jackett.Common/Definitions/u2.yml
@@ -174,5 +174,5 @@ search:
         "*": 1
     description:
       selector: td:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP U2-Revision Standard v1.5 Beta 4

--- a/src/Jackett.Common/Definitions/ubits.yml
+++ b/src/Jackett.Common/Definitions/ubits.yml
@@ -80,7 +80,6 @@ login:
     trackerssl: yes
   error:
     - selector: td.embedded:has(h2:contains("失败"))
-    - selector: td.embedded:has(h2:contains("failed"))
   test:
     path: index.php
     selector: a[href="logout.php"]

--- a/src/Jackett.Common/Definitions/ultrahd.yml
+++ b/src/Jackett.Common/Definitions/ultrahd.yml
@@ -78,7 +78,6 @@ login:
     trackerssl: yes
   error:
     - selector: td.embedded:has(h2:contains("失败"))
-    - selector: td.embedded:has(h2:contains("failed"))
   test:
     path: index.php
     selector: a[href="logout.php"]

--- a/src/Jackett.Common/Definitions/uploads.yml
+++ b/src/Jackett.Common/Definitions/uploads.yml
@@ -80,7 +80,6 @@ login:
     trackerssl: ""
   error:
     - selector: td.embedded:has(h2:contains("失败"))
-    - selector: td.embedded:has(h2:contains("failed"))
   test:
     path: index.php
     selector: a[href="logout.php"]

--- a/src/Jackett.Common/Definitions/ydypt.yml
+++ b/src/Jackett.Common/Definitions/ydypt.yml
@@ -165,9 +165,9 @@ search:
         font.twoupfree: 2
         font.twoup: 2
         "*": 1
-    description:
-      selector: td:nth-child(2)
-      remove: a, img
     minimumratio:
       text: 0.8
+    description:
+      selector: td:nth-child(2)
+      remove: a, b, font, img, span
 # NexusPHP Standard v1.5 Beta 4 (custom ulvf dlvf)

--- a/src/Jackett.Common/Definitions/zmpt.yml
+++ b/src/Jackett.Common/Definitions/zmpt.yml
@@ -185,5 +185,5 @@ search:
       text: 86400
     description:
       selector: td.rowfollow:nth-child(2)
-      remove: a, img
+      remove: a, b, font, img, span
 # NexusPHP v1.8.1 2023-04-21


### PR DESCRIPTION
Used `remove: a, b, font, img, span` as general clean up for `description` (apart from pttime, because of course there's always one). A few required an additional replace filter. Shouldn't cause any issues when applied to indexers I don't have accounts for, but might as well check.

Removed unused English login errors (Jackett uses default, which is never English).

Updated hddolby.

Added missing sort settings.

Other tidying.