### PR TITLE
torrentleech - replace 2FA with alt2FAToken

### DIFF
--- a/src/Jackett.Common/Definitions/torrentleech.yml
+++ b/src/Jackett.Common/Definitions/torrentleech.yml
@@ -84,13 +84,13 @@ settings:
   - name: password
     type: password
     label: Password
-  - name: 2facode
+  - name: alt2fatoken
     type: text
-    label: 2FA code
-  - name: info_2fa
+    label: Alt 2FA Token
+  - name: info_alt2fatoken
     type: info
-    label: "About 2FA code"
-    default: "Only fill in the <b>2FA code</b> box if you have enabled <b>2FA</b> on the TorrentLeech Web Site. Otherwise just leave it empty."
+    label: "About Alt 2FA Token"
+    default: "(Site Profile => Alt 2FA Token) Only fill in the <b>Alt 2FA Token</b> if you have enabled <b>2FA</b> on the TorrentLeech Web Site. Otherwise just leave it empty."
   - name: freeleech
     type: checkbox
     label: Search freeleech only
@@ -126,7 +126,7 @@ login:
   inputs:
     username: "{{ .Config.username }}"
     password: "{{ .Config.password }}"
-    otpkey: "{{ .Config.2facode }}"
+    alt2FAToken: "{{ .Config.alt2fatoken }}"
   error:
     - selector: p.text-danger
     - selector: .login-container h2:contains("One Time Password")


### PR DESCRIPTION
ref #13772 
reverts #14046

              if the proper 2fa works then lets keep it. The bypass code was an early fix which we did not install in time because C# ;-b

_Originally posted by @garfield69 in https://github.com/Jackett/Jackett/issues/14046#issuecomment-1436133124_

The bypass code is a TL thing, not c#.  2FA works, but provides a poor experience.

Swap to the bypass key given if the creds expire for any reason then the user experience is poor as the user must then go and manually re-configure the tracker with a fresh token.   the bypass key TL provides for all 2FA users should negate this and also meets the original request of #13772.