### PR TITLE
cardigann: ignore disabled or unchecked inputs in login

### DIFF
--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -611,14 +611,14 @@ namespace Jackett.Common.Indexers
                 {
                     var name = input.GetAttribute("name");
 
-                    if (name == null)
+                    if (name == null || input.IsDisabled())
                     {
                         continue;
                     }
 
                     if (input is IHtmlInputElement element &&
                         element.Type.IsOneOf(InputTypeNames.Checkbox, InputTypeNames.Radio) &&
-                        (!input.IsChecked() || input.IsDisabled()))
+                        !input.IsChecked())
                     {
                         continue;
                     }


### PR DESCRIPTION
with fixing learnbits with empty values I discovered that cardigann uses unchecked and even disabled inputs, which aren't used in the sent form body in any real browser.

and it's a BC break in Prowlarr...