### PR TITLE
Fix GGN API empty result

### DIFF
--- a/src/Jackett.Common/Indexers/GazelleGamesAPI.cs
+++ b/src/Jackett.Common/Indexers/GazelleGamesAPI.cs
@@ -240,6 +240,11 @@ namespace Jackett.Common.Indexers
                 {
                     var group = gObj.Value as JObject;
 
+                    if (group["Torrents"].Type == JTokenType.Array && group["Torrents"] is JArray array && array.Count == 0)
+                    {
+                        continue;
+                    }
+
                     foreach (var tObj in JObject.FromObject(group["Torrents"]))
                     {
                         var torrent = tObj.Value as JObject;


### PR DESCRIPTION
Fixes parser error outlined in #13544 

If the result includes games without torrents, the Torrents property on group has value of ```[]``` which is not accepted by the JObject.FromObject on line 248.