### PR TITLE
bakabt: add freeleech only option

### DIFF
--- a/src/Jackett.Common/Indexers/BakaBT.cs
+++ b/src/Jackett.Common/Indexers/BakaBT.cs
@@ -164,6 +164,14 @@ namespace Jackett.Common.Indexers
 
                 foreach (var row in rows)
                 {
+                    var downloadVolumeFactor = row.QuerySelector("span.freeleech") != null ? 0 : 1;
+
+                    // Skip non-freeleech results when freeleech only is set
+                    if (configData.FreeleechOnly.Value && downloadVolumeFactor != 0)
+                    {
+                        continue;
+                    }
+
                     var qTitleLink = row.QuerySelector("a.title, a.alt_title");
                     if (qTitleLink == null)
                         continue;
@@ -247,7 +255,7 @@ namespace Jackett.Common.Indexers
                         else
                             release.PublishDate = DateTime.ParseExact(dateStr, "dd MMM yy", CultureInfo.InvariantCulture);
 
-                        release.DownloadVolumeFactor = row.QuerySelector("span.freeleech") != null ? 0 : 1;
+                        release.DownloadVolumeFactor = downloadVolumeFactor;
                         release.UploadVolumeFactor = 1;
 
                         releases.Add(release);

--- a/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationDataBakaBT.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationDataBakaBT.cs
@@ -5,12 +5,14 @@ namespace Jackett.Common.Models.IndexerConfig.Bespoke
     [ExcludeFromCodeCoverage]
     internal class ConfigurationDataBakaBT : ConfigurationDataBasicLogin
     {
+        public BoolConfigurationItem FreeleechOnly { get; private set; }
         public BoolConfigurationItem AddRomajiTitle { get; private set; }
         public BoolConfigurationItem AppendSeason { get; private set; }
 
         public ConfigurationDataBakaBT(string instructionMessageOptional = null)
             : base(instructionMessageOptional)
         {
+            FreeleechOnly = new BoolConfigurationItem("Show freeleech only") { Value = false };
             AddRomajiTitle = new BoolConfigurationItem("Add releases for Romaji Title") { Value = true };
             AppendSeason = new BoolConfigurationItem("Append Season for Sonarr Compatibility") { Value = false };
         }


### PR DESCRIPTION
I don't have an account to test, but it's the same idea as AnimeTorrents.

Also according to https://github.com/Prowlarr/Prowlarr/issues/1662#issuecomment-1563624527 there's no query param to filter FL only.