### PR TITLE
torrentleech: add login page form as error selector

### DIFF
--- a/src/Jackett.Common/Definitions/torrentleech.yml
+++ b/src/Jackett.Common/Definitions/torrentleech.yml
@@ -132,6 +132,9 @@ login:
     - selector: .login-container h2:contains("One Time Password")
       message:
         text: "Your TorrentLeech account has 2FA enabled. Please recheck your indexer settings."
+    - selector: form[name="login-form"]
+      message:
+        text: "Login page detected at {{ .Config.sitelink }}."
   test:
     path: /
     selector: a[href="/user/account/logout"]


### PR DESCRIPTION
#### Description
Trying to find some workaround for Cloudflare. Idea borrowed from blutopia, but I think we need an error selector for json in the long run.