### PR TITLE
unit3d: move api key auth in headers

### DIFF
--- a/src/Jackett.Common/Definitions/aither-api.yml
+++ b/src/Jackett.Common/Definitions/aither-api.yml
@@ -60,8 +60,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -75,9 +73,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/animetracker.yml
+++ b/src/Jackett.Common/Definitions/animetracker.yml
@@ -62,8 +62,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -77,9 +75,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/animeworld-api.yml
+++ b/src/Jackett.Common/Definitions/animeworld-api.yml
@@ -65,8 +65,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -80,9 +78,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/blutopia-api.yml
+++ b/src/Jackett.Common/Definitions/blutopia-api.yml
@@ -54,8 +54,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -69,9 +67,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/brsociety-api.yml
+++ b/src/Jackett.Common/Definitions/brsociety-api.yml
@@ -55,8 +55,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -70,8 +68,10 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     "free[]": "{{ if .Config.freeleech }}100{{ else }}{{ end }}"

--- a/src/Jackett.Common/Definitions/danishbytes-api.yml
+++ b/src/Jackett.Common/Definitions/danishbytes-api.yml
@@ -68,8 +68,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -81,8 +79,10 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     search: "{{ .Keywords }}"
     imdb: "{{ .Query.IMDBIDShort }}"

--- a/src/Jackett.Common/Definitions/datascene-api.yml
+++ b/src/Jackett.Common/Definitions/datascene-api.yml
@@ -61,8 +61,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -76,9 +74,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/desitorrents-api.yml
+++ b/src/Jackett.Common/Definitions/desitorrents-api.yml
@@ -54,8 +54,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -69,9 +67,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/generationfree-api.yml
+++ b/src/Jackett.Common/Definitions/generationfree-api.yml
@@ -84,8 +84,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -99,9 +97,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/hawke-uno.yml
+++ b/src/Jackett.Common/Definitions/hawke-uno.yml
@@ -50,8 +50,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -65,8 +63,10 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     imdbId: "{{ .Query.IMDBIDShort }}"

--- a/src/Jackett.Common/Definitions/hd-unit3d-api.yml
+++ b/src/Jackett.Common/Definitions/hd-unit3d-api.yml
@@ -53,8 +53,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -68,9 +66,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/hdolimpo-api.yml
+++ b/src/Jackett.Common/Definitions/hdolimpo-api.yml
@@ -56,8 +56,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -73,7 +71,6 @@ search:
 
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/itatorrents.yml
+++ b/src/Jackett.Common/Definitions/itatorrents.yml
@@ -59,8 +59,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -74,9 +72,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/jme-reunit3d-api.yml
+++ b/src/Jackett.Common/Definitions/jme-reunit3d-api.yml
@@ -61,8 +61,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -76,9 +74,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/lat-team-api.yml
+++ b/src/Jackett.Common/Definitions/lat-team-api.yml
@@ -65,8 +65,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -80,9 +78,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/locadora.yml
+++ b/src/Jackett.Common/Definitions/locadora.yml
@@ -55,8 +55,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -70,9 +68,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/lst.yml
+++ b/src/Jackett.Common/Definitions/lst.yml
@@ -59,8 +59,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -74,9 +72,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/monikadesign-api.yml
+++ b/src/Jackett.Common/Definitions/monikadesign-api.yml
@@ -58,8 +58,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -73,9 +71,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/ntelogo.yml
+++ b/src/Jackett.Common/Definitions/ntelogo.yml
@@ -60,8 +60,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -75,9 +73,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/portugas-api.yml
+++ b/src/Jackett.Common/Definitions/portugas-api.yml
@@ -59,8 +59,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -74,9 +72,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/racing4everyone-api.yml
+++ b/src/Jackett.Common/Definitions/racing4everyone-api.yml
@@ -83,8 +83,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -98,9 +96,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/rareshare2.yml
+++ b/src/Jackett.Common/Definitions/rareshare2.yml
@@ -69,8 +69,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -84,9 +82,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/redbits-api.yml
+++ b/src/Jackett.Common/Definitions/redbits-api.yml
@@ -57,8 +57,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -72,9 +70,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/reelflix-api.yml
+++ b/src/Jackett.Common/Definitions/reelflix-api.yml
@@ -53,8 +53,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -68,9 +66,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/shareisland-api.yml
+++ b/src/Jackett.Common/Definitions/shareisland-api.yml
@@ -61,8 +61,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -76,9 +74,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/skipthecommercials-api.yml
+++ b/src/Jackett.Common/Definitions/skipthecommercials-api.yml
@@ -49,8 +49,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -64,9 +62,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/skipthetrailers.yml
+++ b/src/Jackett.Common/Definitions/skipthetrailers.yml
@@ -49,8 +49,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -64,9 +62,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/tellytorrent-api.yml
+++ b/src/Jackett.Common/Definitions/tellytorrent-api.yml
@@ -61,8 +61,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -76,9 +74,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/thedarkcommunity-api.yml
+++ b/src/Jackett.Common/Definitions/thedarkcommunity-api.yml
@@ -50,8 +50,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -65,9 +63,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/theoldschool-api.yml
+++ b/src/Jackett.Common/Definitions/theoldschool-api.yml
@@ -83,8 +83,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -98,9 +96,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/theshinning-api.yml
+++ b/src/Jackett.Common/Definitions/theshinning-api.yml
@@ -63,8 +63,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -78,9 +76,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/torrenteros-api.yml
+++ b/src/Jackett.Common/Definitions/torrenteros-api.yml
@@ -56,8 +56,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -71,9 +69,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"

--- a/src/Jackett.Common/Definitions/torrentseeds-api.yml
+++ b/src/Jackett.Common/Definitions/torrentseeds-api.yml
@@ -63,8 +63,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -78,8 +76,10 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     imdbId: "{{ .Query.IMDBIDShort }}"

--- a/src/Jackett.Common/Definitions/utopia.yml
+++ b/src/Jackett.Common/Definitions/utopia.yml
@@ -50,8 +50,6 @@ settings:
 login:
   path: /api/torrents
   method: get
-  inputs:
-    api_token: "{{ .Config.apikey }}"
   error:
     - selector: a[href*="/login"]
       message:
@@ -65,9 +63,11 @@ search:
       response:
         type: json
 
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
   inputs:
   # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
-    api_token: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"


### PR DESCRIPTION
#### Description
Moving the api keys to headers, thus making the URLs with credentials another thing not to worry about.