### PR TITLE
thepiratebay: add search by `season x`

### DIFF
--- a/src/Jackett.Common/Definitions/thepiratebay.yml
+++ b/src/Jackett.Common/Definitions/thepiratebay.yml
@@ -146,9 +146,6 @@ search:
       args: ["([\\p{IsCJKUnifiedIdeographs}\\W]+)", "."]
     # search for both S01 and Season 01
     - name: re_replace
-      args: ["(?i)\\b(S0?(\\d{1}))\\b", "$1|\"Season.0$2\""]
-    # search for both S10 and Season 10
-    - name: re_replace
       args: ["(?i)\\b(S(\\d{2,3}))\\b", "$1|\"Season.$2\""]
     # currently, the only uploader for General Hospital puts a space between season and episode
     # this filter searches both formats, so 'General Hospital S01E02' becomes 'General Hospital S01E02|"S01 E02"'


### PR DESCRIPTION
#### Description
For Doctor Who looks to be more results with Season x than Sxx. I noticed the workaround for General Hospital so I improvised based on that format. 

Downsides:
- Works only for full season searches
- Searches with `Season x` tend to return many unrelated season results.