### PR TITLE
[Bug] 

### DIFF
--- a/src/Jackett.Common/Definitions/torrent9.yml
+++ b/src/Jackett.Common/Definitions/torrent9.yml
@@ -6,6 +6,7 @@ language: fr-FR
 type: public
 encoding: UTF-8
 followredirect: true
+testlinktorrent: false
 links:
   - https://www.torrent9.fm/
   - https://torrent9.unblockninja.com/
@@ -102,7 +103,7 @@ settings:
 
 download:
   selectors:
-    - selector: a[href^="magnet:?"]
+    - selector: a:has(> i[class*="magnet"])
       attribute: href
 
 search:


### PR DESCRIPTION
#### Description
The torrent9 website seems to have changed its torrent/magnet buttons, making Jackett unable to provide the torrent link. It was enough to update the selector as done in my commit.

#### Screenshot (if UI related)
https://www.canardconfit.ch/-/202175b424eca852

#### Issues Fixed or Closed by this PR
---