### PR TITLE
core: fix cookies removal when using subfolders as path

### DIFF
--- a/src/Jackett.Common/Utils/CookieUtil.cs
+++ b/src/Jackett.Common/Utils/CookieUtil.cs
@@ -49,17 +49,43 @@ namespace Jackett.Common.Utils
         {
             var table = (Hashtable)cookieJar
                                    .GetType()
-                                   .InvokeMember("m_domainTable", BindingFlags.NonPublic | BindingFlags.GetField |
-                                                                  BindingFlags.Instance, null, cookieJar, Array.Empty<object>());
-            foreach (var key in table.Keys)
+                                   .InvokeMember("m_domainTable", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance, null, cookieJar, Array.Empty<object>());
+
+            foreach (var tableKey in table.Keys)
             {
-                var domain = (string)key;
+                var domain = (string)tableKey;
+
                 if (domain.StartsWith("."))
+                {
                     domain = domain.Substring(1);
+                }
+
+                var list = (SortedList)table[tableKey]
+                                        .GetType()
+                                        .InvokeMember("m_list", BindingFlags.NonPublic | BindingFlags.GetField | BindingFlags.Instance, null, table[tableKey], Array.Empty<object>());
+
+                foreach (var listKey in list.Keys)
+                {
+                    foreach (Cookie cookie in cookieJar.GetCookies(new Uri($"http://{domain}{listKey}")))
+                    {
+                        cookie.Expired = true;
+                    }
+
+                    foreach (Cookie cookie in cookieJar.GetCookies(new Uri($"https://{domain}{listKey}")))
+                    {
+                        cookie.Expired = true;
+                    }
+                }
+
                 foreach (Cookie cookie in cookieJar.GetCookies(new Uri($"http://{domain}")))
+                {
                     cookie.Expired = true;
+                }
+
                 foreach (Cookie cookie in cookieJar.GetCookies(new Uri($"https://{domain}")))
+                {
                     cookie.Expired = true;
+                }
             }
         }
 

--- a/src/Jackett.Test/Common/Utils/CookieUtilTests.cs
+++ b/src/Jackett.Test/Common/Utils/CookieUtilTests.cs
@@ -117,5 +117,28 @@ namespace Jackett.Test.Common.Utils
             Assert.AreEqual(0, cookiesContainer.GetCookies(domainHttp).Count);
             Assert.AreEqual(0, cookiesContainer.GetCookies(domainHttps).Count);
         }
+
+        [Test]
+        public void RemoveAllCookiesWithPaths()
+        {
+            var cookiesContainer = new CookieContainer();
+
+            var domainHttp = new Uri("http://testdomain1.com/path");
+            var domainHttps = new Uri("https://testdomain2.com/path");
+
+            cookiesContainer.Add(domainHttp, new Cookie("cookie1", "value1", "/"));
+            cookiesContainer.Add(domainHttps, new Cookie("cookie2", "value2", "/"));
+            cookiesContainer.Add(domainHttp, new Cookie("cookie3", "value3", "/path"));
+            cookiesContainer.Add(domainHttps, new Cookie("cookie4", "value4", "/path"));
+            cookiesContainer.Add(domainHttp, new Cookie("cookie5", "value5", "/path", ".testdomain1.com"));
+            cookiesContainer.Add(domainHttps, new Cookie("cookie6", "value6", "/path", ".testdomain2.com"));
+
+            Assert.AreEqual(3, cookiesContainer.GetCookies(domainHttp).Count);
+            Assert.AreEqual(3, cookiesContainer.GetCookies(domainHttps).Count);
+
+            CookieUtil.RemoveAllCookies(cookiesContainer);
+            Assert.AreEqual(0, cookiesContainer.GetCookies(domainHttp).Count);
+            Assert.AreEqual(0, cookiesContainer.GetCookies(domainHttps).Count);
+        }
     }
 }


### PR DESCRIPTION
#### Description
Apparently `RemoveAllCookies` doesn't remove cookies that are using subfolders as path, eg. `/forum` for pornolab.