### PR TITLE
Add Torrent Galaxy mirror

### DIFF
--- a/src/Jackett.Common/Definitions/torrentgalaxy.yml
+++ b/src/Jackett.Common/Definitions/torrentgalaxy.yml
@@ -10,6 +10,7 @@ links:
   - https://torrentgalaxy.to/
   - https://torrentgalaxy.mx/
   - https://tgx.rs/
+  - https://tgx.sb/
   - https://torrentgalaxy.unblockit.rsvp/
   - https://torrentgalaxy.unblockninja.com/
 legacylinks:


### PR DESCRIPTION
#### Description

This adds another mirror for Torrent Galaxy, as per https://torrentgalaxy.org/.

The other mirrors listed there are not accessible for me (ISP block) so this extra mirror would be useful for me and others in my position.

#### Screenshot (if UI related)

N/A

#### Issues Fixed or Closed by this PR

N/A