### PR TITLE
cardigann: [multiSearchPath] ignore searchPath exception if other result is releases

### DIFF
--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -1423,7 +1423,7 @@ namespace Jackett.Common.Indexers
             var SearchPaths = Search.Paths;
 
             Exception SearchPathException = null;
-            String SearchPathExceptionResult = null;
+            string SearchPathExceptionResult = null;
             foreach (var SearchPath in SearchPaths)
             {
                 variables[".Categories"] = mappedCategories;
@@ -1882,11 +1882,11 @@ namespace Jackett.Common.Indexers
                         {
                             SearchPathException = ex;
                             SearchPathExceptionResult = results;
-                        }                       
+                        }
                     }
                 }
             }
-            if(SearchPathException != null && releases.Count == 0)
+            if (SearchPathException != null && releases.Count == 0)
             {
                 OnParseError(SearchPathExceptionResult, SearchPathException);
             }

--- a/src/Jackett.Common/Indexers/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/CardigannIndexer.cs
@@ -1421,6 +1421,9 @@ namespace Jackett.Common.Indexers
 
             // TODO: prepare queries first and then send them parallel
             var SearchPaths = Search.Paths;
+
+            Exception SearchPathException = null;
+            String SearchPathExceptionResult = null;
             foreach (var SearchPath in SearchPaths)
             {
                 variables[".Categories"] = mappedCategories;
@@ -1875,11 +1878,18 @@ namespace Jackett.Common.Indexers
                     }
                     catch (Exception ex)
                     {
-                        OnParseError(results, ex);
+                        if (SearchPathException == null)
+                        {
+                            SearchPathException = ex;
+                            SearchPathExceptionResult = results;
+                        }                       
                     }
                 }
             }
-
+            if(SearchPathException != null && releases.Count == 0)
+            {
+                OnParseError(SearchPathExceptionResult, SearchPathException);
+            }
             if (query.Limit > 0)
                 releases = releases.Take(query.Limit).ToList();
 


### PR DESCRIPTION

#### Description
When multiple searchPath are available and one of them fails and other succeeds entire request is considered failed. This changes throws exceptions only if we couldn't get any release from all searchPaths, and throws first search path exception


#### Issues Fixed 

Fixes exttorrents query result in only one page result
eg : api/v2.0/indexers/exttorrents/results/torznab/api?t=tvsearch&cat=5000&extended=1&apikey=<key>&offset=0&limit=100&q=Witcher%20US&season=3&ep=1

