### PR TITLE
winget: change job runner to `ubuntu-latest`

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -6,7 +6,7 @@ permissions:
   contents: read
 jobs:
   publish:
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: vedantmgoyal2009/winget-releaser@v2
         with:


### PR DESCRIPTION
#### Description
Winget Releaser now supports non-Windows runners, and `ubuntu-latest` is generally faster.

