### PR TITLE
Use new certificate thumbprint for SceneHD.

### DIFF
--- a/src/Jackett.Common/Indexers/SceneHD.cs
+++ b/src/Jackett.Common/Indexers/SceneHD.cs
@@ -83,7 +83,7 @@ namespace Jackett.Common.Indexers
         {
             base.LoadValuesFromJson(jsonConfig, useProtectionService);
 
-            webclient?.AddTrustedCertificate(new Uri(SiteLink).Host, "3A4090096DD95D31306B14BFDD8F8C98F52A8EA8");
+            webclient?.AddTrustedCertificate(new Uri(SiteLink).Host, "245621438BD9E2E4D99D753CA1F5088072FCB707");
         }
 
         public override async Task<IndexerConfigurationStatus> ApplyConfiguration(JToken configJson)


### PR DESCRIPTION
#### Description
This PR updates the certificate thumbprint used for SceneHD. I believe they updated their cert as a result of a server move that took place in the last couple of days (20-21 August 2023).