### PR TITLE
Delay 5 minutes before running winget-releaser

### DIFF
--- a/.github/workflows/winget.yml
+++ b/.github/workflows/winget.yml
@@ -8,6 +8,8 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
+      - run: Start-Sleep -Seconds 300 # 5 minutes
+        shell: pwsh
       - uses: vedantmgoyal2009/winget-releaser@v2
         with:
           identifier: Jackett.Jackett


### PR DESCRIPTION
#### Description

Delay before running winget-releaser action, as discussed in the linked issue.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #13948
