### PR TITLE
Remove [PACK] prefix from season packs

### DIFF
--- a/src/Jackett.Common/Definitions/torrentleech-pl.yml
+++ b/src/Jackett.Common/Definitions/torrentleech-pl.yml
@@ -119,20 +119,17 @@ search:
           args: cat
     title_raw:
       selector: a[href^="details.php?id="]
-      filters:
-        - name: replace
-          args: ["[PACK]", ""]
-        - name: trim
     title_stripped:
       selector: a[href^="details.php?id="]
       filters:
-        - name: replace
-          args: ["[PACK]", ""]
         - name: re_replace
           args: ["^(.*/)(.*)$", "$2"]
         - name: trim
     title:
       text: "{{ if .Config.drop_polish_prefix }}{{ .Result.title_stripped }}{{ else }}{{ .Result.title_raw }}{{ end }}"
+      filters:
+        - name: re_replace
+          args: ["(?i)^\\[PACK\\]\\s?", ""]
     details:
       selector: a[href^="details.php?id="]
       attribute: href

--- a/src/Jackett.Common/Definitions/torrentleech-pl.yml
+++ b/src/Jackett.Common/Definitions/torrentleech-pl.yml
@@ -119,9 +119,15 @@ search:
           args: cat
     title_raw:
       selector: a[href^="details.php?id="]
+      filters:
+        - name: replace
+          args: ["[PACK]", ""]
+        - name: trim
     title_stripped:
       selector: a[href^="details.php?id="]
       filters:
+        - name: replace
+          args: ["[PACK]", ""]
         - name: re_replace
           args: ["^(.*/)(.*)$", "$2"]
         - name: trim


### PR DESCRIPTION
#### Description
This tracker add [PACK] prefix to all season packs and sonarr can't process it correctly.
