### PR TITLE
piratbit: switch to cookie & UA login, use Windows UA to avoid block

### DIFF
--- a/src/Jackett.Common/Definitions/piratbit.yml
+++ b/src/Jackett.Common/Definitions/piratbit.yml
@@ -5,6 +5,7 @@ description: "PirateBit is a RUSSIAN Public Torrent Tracker for MOVIES / TV / GE
 language: ru-RU
 type: public
 encoding: UTF-8
+requestDelay: 2
 links:
   - https://pb.wtf/
   - https://top.pirat.one/
@@ -679,6 +680,10 @@ search:
       args: ["(?i)\\bE0*(\\d+)\\b", "сери $1"]
     - name: re_replace # S01E02 to сезон 1 сери 2
       args: ["(?i)\\bS0*(\\d+)E0*(\\d+)\\b", "сезон $1 сери $2"]
+
+  headers:
+    # site blocks Jackett's Linux User-Agents, so use Windows instead
+    User-Agent: ["Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36"]
 
   rows:
     selector: tr[id^="tor_"]:not(:has(span[title="закрыто"])):not(:has(span[title="неоформлено"]))

--- a/src/Jackett.Common/Definitions/piratbitl.yml
+++ b/src/Jackett.Common/Definitions/piratbitl.yml
@@ -606,12 +606,20 @@ caps:
     book-search: [q]
 
 settings:
-  - name: username
+  - name: cookie
     type: text
-    label: Username
-  - name: password
-    type: password
-    label: Password
+    label: Cookie
+  - name: info
+    type: info
+    label: How to get the Cookie
+    default: "<ol><li>Login to this tracker with your browser</li><li>Open the <b>DevTools</b> panel by pressing <b>F12</b></li><li>Select the <b>Network</b> tab</li><li>Click on the <b>Doc</b> button (Chrome Browser) or <b>HTML</b> button (FireFox)</li><li>Refresh the page by pressing <b>F5</b></li><li>Click on the first row entry</li><li>Select the <b>Headers</b> tab on the Right panel</li><li>Find <b>'cookie:'</b> in the <b>Request Headers</b> section</li><li><b>Select</b> and <b>Copy</b> the whole cookie string <i>(everything after 'cookie: ')</i> and <b>Paste</b> here.</li></ol>"
+  - name: useragent
+    type: text
+    label: User-Agent
+  - name: info_useragent
+    type: info
+    label: How to get the User-Agent
+    default: "<ol><li>From the same place you fetched the cookie,</li><li>Find <b>'user-agent:'</b> in the <b>Request Headers</b> section</li><li><b>Select</b> and <b>Copy</b> the whole user-agent string <i>(everything after 'user-agent: ')</i> and <b>Paste</b> here.</li></ol>"
   - name: stripcyrillic
     type: checkbox
     label: Strip Cyrillic Letters
@@ -641,14 +649,9 @@ settings:
       1: asc
 
 login:
-  path: login.php
-  method: post
+  method: cookie
   inputs:
-    "login_site_username": "{{ .Config.username }}"
-    "login_password": "{{ .Config.password }}"
-    login: ""
-  error:
-    - selector: table tr td div.alert
+    cookie: "{{ .Config.cookie }}"
   test:
     path: index.php
     selector: li a[href="/login.php?logout=1"]
@@ -692,8 +695,7 @@ search:
       args: ["(?i)\\bS0*(\\d+)E0*(\\d+)\\b", "сезон $1 сери $2"]
 
   headers:
-    # site blocks Jackett's Linux User-Agents, so use Windows instead
-    User-Agent: ["Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36"]
+    User-Agent: ["{{ .Config.useragent }}"]
 
   rows:
     selector: tr[id^="tor_"]:has(a[href^="/dl.php?id="])

--- a/src/Jackett.Common/Definitions/piratbitl.yml
+++ b/src/Jackett.Common/Definitions/piratbitl.yml
@@ -5,6 +5,7 @@ description: "PirateBit is a RUSSIAN Public Torrent Tracker for MOVIES / TV / GE
 language: ru-RU
 type: semi-private
 encoding: UTF-8
+requestDelay: 2
 links:
   - https://pb.wtf/
   - https://top.pirat.one/
@@ -645,9 +646,7 @@ login:
   inputs:
     "login_site_username": "{{ .Config.username }}"
     "login_password": "{{ .Config.password }}"
-    autologin: 1
-    login: Вход
-    redirect: /
+    login: ""
   error:
     - selector: table tr td div.alert
   test:
@@ -691,6 +690,10 @@ search:
       args: ["(?i)\\bE0*(\\d+)\\b", "сери $1"]
     - name: re_replace # S01E02 to сезон 1 сери 2
       args: ["(?i)\\bS0*(\\d+)E0*(\\d+)\\b", "сезон $1 сери $2"]
+
+  headers:
+    # site blocks Jackett's Linux User-Agents, so use Windows instead
+    User-Agent: ["Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/87.0.4280.88 Safari/537.36"]
 
   rows:
     selector: tr[id^="tor_"]:has(a[href^="/dl.php?id="])


### PR DESCRIPTION
#### Description
Jackett's Linux UA causes Cloudflare challenge and 404 page, so switch to Windows UA. Add requestDelay to hopefully avoid further blocks.

Failed login causes captcha challenge, so switch piratbitl to cookie and UA.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
