### PR TITLE
Prevent .NET runtime from creating debugging fifos/sockets in /tmp

### DIFF
--- a/install_service_systemd.sh
+++ b/install_service_systemd.sh
@@ -73,6 +73,7 @@ Type=simple
 User=${JACKETT_USER}
 Group=${JACKETT_USER}
 WorkingDirectory=${JACKETT_DIR}
+Environment="DOTNET_EnableDiagnostics=0"
 ExecStart=/bin/sh "${JACKETT_DIR}/jackett_launcher.sh"
 TimeoutStopSec=30
 


### PR DESCRIPTION
#### Description
Prevents .NET runtimes from creating debugging fifos/sockets in `/tmp` (which are not necessary for normal operation)

#### Issues Fixed or Closed by this PR
Partial fix for https://github.com/Jackett/Jackett/issues/14774

#### Details
https://learn.microsoft.com/en-us/dotnet/core/runtime-config/debugging-profiling
https://github.com/dotnet/runtime/issues/7204#issuecomment-723204695
