### PR TITLE
fix NPE on toXML for releases with missing mandatory attributes

### DIFF
--- a/src/Jackett.Common/Models/ReleaseInfo.cs
+++ b/src/Jackett.Common/Models/ReleaseInfo.cs
@@ -102,5 +102,7 @@ namespace Jackett.Common.Models
         public virtual object Clone() => new ReleaseInfo(this);
 
         public override string ToString() => $"[ReleaseInfo: Title={Title}, Guid={Guid}, Link={Link}, Details={Details}, PublishDate={PublishDate}, Category={Category}, Size={Size}, Files={Files}, Grabs={Grabs}, Description={Description}, RageID={RageID}, TVDBId={TVDBId}, Imdb={Imdb}, TMDb={TMDb}, TVMazeId={TVMazeId}, TraktId={TraktId}, DoubanId={DoubanId}, Seeders={Seeders}, Peers={Peers}, Poster={Poster}, InfoHash={InfoHash}, MagnetUri={MagnetUri}, MinimumRatio={MinimumRatio}, MinimumSeedTime={MinimumSeedTime}, DownloadVolumeFactor={DownloadVolumeFactor}, UploadVolumeFactor={UploadVolumeFactor}, Gain={Gain}]";
+
+        public bool IsValidRelease() => Guid != null && (Link != null || MagnetUri != null);
     }
 }

--- a/src/Jackett.Common/Models/ResultPage.cs
+++ b/src/Jackett.Common/Models/ResultPage.cs
@@ -20,7 +20,14 @@ namespace Jackett.Common.Models
             RegexOptions.Compiled);
 
         private ChannelInfo ChannelInfo { get; }
-        public IEnumerable<ReleaseInfo> Releases { get; set; }
+
+        private IEnumerable<ReleaseInfo> _releases;
+
+        public IEnumerable<ReleaseInfo> Releases
+        {
+            get => _releases.Where(release => release.IsValidRelease());
+            set => _releases = value;
+        }
 
         public ResultPage(ChannelInfo channelInfo)
         {


### PR DESCRIPTION
#### Description
fix NPE on toXML for releases with missing mandatory attributes

because some releases aren't parsed correctly.