### PR TITLE
assorted: simplify use of sitelink for results fields

### DIFF
--- a/src/Jackett.Common/Definitions/anilibria.yml
+++ b/src/Jackett.Common/Definitions/anilibria.yml
@@ -89,11 +89,10 @@ search:
       selector: ..code
     details:
       text: "{{ .Config.sitelink }}release/{{ .Result._code }}.html"
-    download:
+    download_url:
       selector: url
-      filters:
-        - name: prepend
-          args: "{{ .Config.sitelink }}"
+    download:
+      text: "{{ .Config.sitelink }}{{ .Result.download_url }}"
     magnet:
       selector: magnet
     poster:

--- a/src/Jackett.Common/Definitions/animetime.yml
+++ b/src/Jackett.Common/Definitions/animetime.yml
@@ -41,7 +41,7 @@ search:
     title:
       selector: div.flex.flex-wrap ~ p
     details:
-      text: "{{ .Config.sitelink }}search?query={{ .Result.title }}"
+      text: "{{ .Config.sitelink }}"
     download:
       selector: a[href*="/download/"]
       attribute: href

--- a/src/Jackett.Common/Definitions/animetime.yml
+++ b/src/Jackett.Common/Definitions/animetime.yml
@@ -41,7 +41,7 @@ search:
     title:
       selector: div.flex.flex-wrap ~ p
     details:
-      text: "{{ .Config.sitelink }}"
+      text: /
     download:
       selector: a[href*="/download/"]
       attribute: href

--- a/src/Jackett.Common/Definitions/bangumi-moe.yml
+++ b/src/Jackett.Common/Definitions/bangumi-moe.yml
@@ -50,7 +50,7 @@ search:
     title:
       selector: title
     details:
-      text: "{{ .Config.sitelink }}"
+      text: /
     infohash:
       selector: infoHash
     poster:

--- a/src/Jackett.Common/Definitions/danishbytes-api.yml
+++ b/src/Jackett.Common/Definitions/danishbytes-api.yml
@@ -107,9 +107,9 @@ search:
     title:
       selector: name
     details:
-      text: "{{ .Config.sitelink }}torrents/{{ .Result._id }}"
+      text: "/torrents/{{ .Result._id }}"
     download:
-      text: "{{ .Config.sitelink }}torrent/download/{{ .Result._id }}.{{ .Config.rsskey }}"
+      text: "/torrent/download/{{ .Result._id }}.{{ .Config.rsskey }}"
     infohash:
       selector: info_hash
     poster:

--- a/src/Jackett.Common/Definitions/digitalcore.yml
+++ b/src/Jackett.Common/Definitions/digitalcore.yml
@@ -137,9 +137,9 @@ search:
     _id:
       selector: id
     details:
-      text: "{{ .Config.sitelink }}torrent/{{ .Result._id }}/"
+      text: "/torrent/{{ .Result._id }}/"
     download:
-      text: "{{ .Config.sitelink }}api/v1/torrents/download/{{ .Result._id }}"
+      text: "/api/v1/torrents/download/{{ .Result._id }}"
     imdbid:
       selector: imdbid2
     imdbid_full:
@@ -150,7 +150,7 @@ search:
       selector: firstpic
     poster_imdb:
       optional: true
-      text: "{{ if .Result.imdbid }}{{ .Config.sitelink }}img/imdb/{{ .Result.imdbid_full }}.jpg{{ else }}{{ end }}"
+      text: "{{ if .Result.imdbid }}/img/imdb/{{ .Result.imdbid_full }}.jpg{{ else }}{{ end }}"
     poster:
       text: "{{ if .Result.poster_imdb }}{{ .Result.poster_imdb }}{{ else }}{{ .Result.poster_normal }}{{ end }}"
     date:

--- a/src/Jackett.Common/Definitions/hebits.yml
+++ b/src/Jackett.Common/Definitions/hebits.yml
@@ -112,9 +112,9 @@ search:
     title:
       text: "{{ if .Result.title_notenglish }}{{ .Result.title_notenglish }}{{ else }}{{ .Result.title_english }}{{ end }}"
     details:
-      text: "{{ .Config.sitelink }}torrents.php?torrentid={{ .Result._id }}"
+      text: "/torrents.php?torrentid={{ .Result._id }}"
     download:
-      text: "{{ .Config.sitelink }}torrents.php?action=download&id={{ .Result._id }}"
+      text: "/torrents.php?action=download&id={{ .Result._id }}"
     poster:
       selector: ..cover
     imdbid:

--- a/src/Jackett.Common/Definitions/milkie.yml
+++ b/src/Jackett.Common/Definitions/milkie.yml
@@ -61,13 +61,13 @@ search:
     title:
       selector: releaseName
     details:
-      text: "{{ .Config.sitelink }}browse/{{ .Result._id }}"
+      text: "/browse/{{ .Result._id }}"
     _apikey:
       text: "{{ .Config.apikey }}"
       filters:
         - name: urlencode
     download:
-      text: "{{ .Config.sitelink }}api/v1/torrents/{{ .Result._id }}/torrent?key={{ .Result._apikey }}"
+      text: "/api/v1/torrents/{{ .Result._id }}/torrent?key={{ .Result._apikey }}"
     date:
       selector: createdAt
     size:

--- a/src/Jackett.Common/Definitions/nipponsei.yml
+++ b/src/Jackett.Common/Definitions/nipponsei.yml
@@ -38,7 +38,7 @@ search:
         - name: replace
           args: ["[Nipponsei] ", ""]
     details:
-      text: "{{ .Config.sitelink }}"
+      text: /
     download:
       selector: a
       attribute: href

--- a/src/Jackett.Common/Definitions/showrss.yml
+++ b/src/Jackett.Common/Definitions/showrss.yml
@@ -40,7 +40,7 @@ search:
     title:
       selector: raw_title
     details:
-      text: "{{ .Config.sitelink }}"
+      text: /
     date:
       selector: pubDate
     download:

--- a/src/Jackett.Common/Definitions/superbits.yml
+++ b/src/Jackett.Common/Definitions/superbits.yml
@@ -140,7 +140,7 @@ search:
       selector: customcover
     poster_imdb:
       optional: true
-      text: "{{ if .Result.imdbid }}{{ .Config.sitelink }}img/imdb/{{ .Result.imdbid_full }}.jpg{{ else }}{{ end }}"
+      text: "{{ if .Result.imdbid }}/img/imdb/{{ .Result.imdbid_full }}.jpg{{ else }}{{ end }}"
     poster:
       text: "{{ if .Result.poster_imdb }}{{ .Result.poster_imdb }}{{ else }}{{ .Result.poster_normal }}{{ end }}"
     date:

--- a/src/Jackett.Common/Definitions/superbits.yml
+++ b/src/Jackett.Common/Definitions/superbits.yml
@@ -127,9 +127,9 @@ search:
     _id:
       selector: id
     details:
-      text: "{{ .Config.sitelink }}torrent/{{ .Result._id }}/"
+      text: "/torrent/{{ .Result._id }}/"
     download:
-      text: "{{ .Config.sitelink }}api/v1/torrents/download/{{ .Result._id }}"
+      text: "/api/v1/torrents/download/{{ .Result._id }}"
     imdbid:
       selector: imdbid2
     imdbid_full:

--- a/src/Jackett.Common/Definitions/torrentleech.yml
+++ b/src/Jackett.Common/Definitions/torrentleech.yml
@@ -174,9 +174,9 @@ search:
     _filename:
       selector: filename
     details:
-      text: "{{ .Config.sitelink }}torrent/{{ .Result._id }}"
+      text: "/torrent/{{ .Result._id }}"
     download:
-      text: "{{ .Config.sitelink }}download/{{ .Result._id }}/{{ .Result._filename }}"
+      text: "/download/{{ .Result._id }}/{{ .Result._filename }}"
     genre:
       selector: tags
       filters:

--- a/src/Jackett.Common/Definitions/torrentmasters.yml
+++ b/src/Jackett.Common/Definitions/torrentmasters.yml
@@ -137,7 +137,7 @@ search:
         - name: regexp
           args: (\d+)
     download:
-      text: "{{ .Config.sitelink }}download/{{ .Result._id }}/"
+      text: "/download/{{ .Result._id }}/"
     title_hungarian:
       selector: a[href^="/details/"]
       attribute: title

--- a/src/Jackett.Common/Definitions/torrentz2eu.yml
+++ b/src/Jackett.Common/Definitions/torrentz2eu.yml
@@ -94,8 +94,7 @@ search:
       # some tv have category as video() which can also be movies, so we look for the SxxExx to tag TV
       text: "{{ if .Result.category_is_tv_show }}Video(TV shows){{ else }}{{ .Result.category_provided }}{{ end }}"
     details:
-      # there is no details page so we use the sitelink
-      text: "{{ .Config.sitelink }}"
+      text: /
     download:
       selector: a[href^="magnet:?"]
       attribute: href

--- a/src/Jackett.Common/Definitions/yggcookie.yml
+++ b/src/Jackett.Common/Definitions/yggcookie.yml
@@ -437,7 +437,7 @@ search:
     category:
       selector: td:nth-child(1) > div.hidden
     download:
-      text: "{{ .Config.sitelink }}engine/download_torrent?id={{ .Result._id }}"
+      text: "/engine/download_torrent?id={{ .Result._id }}"
     date:
       # unix
       selector: td:nth-child(5) > div.hidden

--- a/src/Jackett.Common/Definitions/yggtorrent.yml
+++ b/src/Jackett.Common/Definitions/yggtorrent.yml
@@ -441,7 +441,7 @@ search:
     category:
       selector: td:nth-child(1) > div.hidden
     download:
-      text: "{{ .Config.sitelink }}engine/download_torrent?id={{ .Result._id }}"
+      text: "/engine/download_torrent?id={{ .Result._id }}"
     date:
       # unix
       selector: td:nth-child(5) > div.hidden


### PR DESCRIPTION
#### Description
Assuming this is intentional:
- a leading `/` uses search path domain, e.g. `https://www.example.com/` (i.e. the sitelink, unless search path is different, e.g. `https://api.example.com/`)
- no leading `/` uses full search path, e.g. `https://www.example.com/search/path/`

Remaining uses for `.Config.sitelink` in results fields are API indexers for which the search path differs from sitelink - anilibria, xthor, polishtracker, tpb/apibay.

Confirmed working in Prowlarr too.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
