### PR TITLE
makingoff: add new Brazilian private tracker. resolves #14834

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,7 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * MaDs Revolution
  * Magico (Trellas) [![(invite needed)][inviteneeded]](#)
  * Majomparádé (TurkDepo)
+ * Making Off
  * Mansão dos Animes (MDAN)
  * MegamixTracker
  * MeseVilág (Fairytale World)

--- a/src/Jackett.Common/Definitions/makingoff.yml
+++ b/src/Jackett.Common/Definitions/makingoff.yml
@@ -1,0 +1,1078 @@
+---
+id: makingoff
+name: Making Off
+description: "Making Off is a BRAZILIAN Private Torrent Tracker for MOVIES / TV / GENERAL"
+language: pt-BR
+type: private
+encoding: iso-8859-1
+requestDelay: 5
+links:
+  - https://makingoff.org/
+
+caps:
+  # commented out categories are discussion-only forums
+  categorymappings:
+    - {id: 23, cat: Movies, desc: "O Verdadeiro Cinema Está Aqui!"}
+    - {id: 461, cat: Movies, desc: "  |-- África", default: true}
+    - {id: 26, cat: Movies, desc: "  |-- América do Norte", default: true}
+    - {id: 24, cat: Movies, desc: "  |-- Asiático", default: true}
+    - {id: 77, cat: Movies, desc: "  |-- Curtas", default: true}
+    - {id: 28, cat: TV/Documentary, desc: "  |-- Documentários", default: true}
+    - {id: 25, cat: Movies, desc: "  |-- Europeu", default: true}
+    - {id: 29, cat: Movies, desc: "  |-- Latino-Americano", default: true}
+    - {id: 27, cat: Movies, desc: "  |-- Nacional", default: true}
+    - {id: 30, cat: Movies, desc: "  |-- Oriente Médio", default: true}
+    - {id: 31, cat: Movies, desc: "  |-- Oceania", default: true}
+    - {id: 15, cat: Audio, desc: "  |-- Trilhas Sonoras", default: true} # mix of DDL and torrents, may cause errors
+    # - {id: 12, cat: Movies, desc: "  |-- Portal"}
+    # - {id: 204, cat: Movies, desc: "  |-- Dossiê Making Off"}
+    # - {id: 573, cat: Movies, desc: "  |-- Festivais e Mostras"}
+    - {id: 173, cat: Movies, desc: "  |-- Prata da Casa", default: true}
+    # - {id: 135, cat: Movies, desc: "  |-- Diretores do Mês"}
+    # - {id: 190, cat: Movies, desc: "  |-- Recomendações do Fórum"}
+    - {id: 36, cat: Movies, desc: "Diretores", default: true}
+    - {id: 460, cat: Movies, desc: "  |-- Africanos"}
+    - {id: 632, cat: Movies, desc: "  |---- Abdellatif Kechiche"}
+    - {id: 679, cat: Movies, desc: "  |---- Abderrahmane Sissako"}
+    - {id: 483, cat: Movies, desc: "  |---- Djibril Diop Mambéty"}
+    - {id: 884, cat: Movies, desc: "  |---- Flora Gomes"}
+    - {id: 885, cat: Movies, desc: "  |---- Gaston Kaboré"}
+    - {id: 745, cat: Movies, desc: "  |---- Henry Barakat"}
+    - {id: 484, cat: Movies, desc: "  |---- Idrissa Ouedraogo"}
+    - {id: 680, cat: Movies, desc: "  |---- Mahamat-Saleh Haroun"}
+    - {id: 886, cat: Movies, desc: "  |---- Merzak Allouache"}
+    - {id: 433, cat: Movies, desc: "  |---- Ousmane Sembène"}
+    - {id: 574, cat: Movies, desc: "  |---- Youssef Chahine"}
+    - {id: 75, cat: Movies, desc: "  |-- Americanos e Canadenses"}
+    - {id: 199, cat: Movies, desc: "  |---- Abel Ferrara"}
+    - {id: 141, cat: Movies, desc: "  |---- Alan Parker"}
+    - {id: 682, cat: Movies, desc: "  |---- Alex Gibney"}
+    - {id: 985, cat: Movies, desc: "  |---- Alex Ross Perry"}
+    - {id: 818, cat: Movies, desc: "  |---- Alexander Payne"}
+    - {id: 681, cat: Movies, desc: "  |---- Allan Dwan"}
+    - {id: 437, cat: Movies, desc: "  |---- Albert e David Maysles"}
+    - {id: 405, cat: Movies, desc: "  |---- Anatole Litvak"}
+    - {id: 419, cat: Movies, desc: "  |---- André de Toth"}
+    - {id: 335, cat: Movies, desc: "  |---- Andrew V. McLaglen"}
+    - {id: 336, cat: Movies, desc: "  |---- Andy Warhol"}
+    - {id: 234, cat: Movies, desc: "  |---- Anthony Mann"}
+    - {id: 746, cat: Movies, desc: "  |---- Arthur Hiller"}
+    - {id: 819, cat: Movies, desc: "  |---- Arthur Lubin"}
+    - {id: 262, cat: Movies, desc: "  |---- Arthur Penn"}
+    - {id: 304, cat: Movies, desc: "  |---- Atom Egoyan"}
+    - {id: 883, cat: Movies, desc: "  |---- Barbara Hammer"}
+    - {id: 438, cat: Movies, desc: "  |---- Barry Levinson"}
+    - {id: 887, cat: Movies, desc: "  |---- Benny & Josh Safdie"}
+    - {id: 820, cat: Movies, desc: "  |---- Bernard Rose"}
+    - {id: 85, cat: Movies, desc: "  |---- Billy Wilder"}
+    - {id: 125, cat: Movies, desc: "  |---- Blake Edwards"}
+    - {id: 747, cat: Movies, desc: "  |---- Bob Fosse"}
+    - {id: 515, cat: Movies, desc: "  |---- Bob Rafelson"}
+    - {id: 142, cat: Movies, desc: "  |---- Brian De Palma"}
+    - {id: 683, cat: Movies, desc: "  |---- Budd Boetticher"}
+    - {id: 821, cat: Movies, desc: "  |---- Busby Berkeley"}
+    - {id: 218, cat: Movies, desc: "  |---- Buster Keaton"}
+    - {id: 888, cat: Movies, desc: "  |---- Byron Haskin"}
+    - {id: 575, cat: Movies, desc: "  |---- Cameron Crowe"}
+    - {id: 257, cat: Movies, desc: "  |---- Cecil B. DeMille"}
+    - {id: 40, cat: Movies, desc: "  |---- Charles Chaplin"}
+    - {id: 533, cat: Movies, desc: "  |---- Charles Vidor"}
+    - {id: 684, cat: Movies, desc: "  |---- Charles Walters"}
+    - {id: 889, cat: Movies, desc: "  |---- Christopher Guest"}
+    - {id: 685, cat: Movies, desc: "  |---- Clarence Brown"}
+    - {id: 88, cat: Movies, desc: "  |---- Clint Eastwood"}
+    - {id: 748, cat: Movies, desc: "  |---- Curtis Bernhardt"}
+    - {id: 822, cat: Movies, desc: "  |---- Curtis Hanson"}
+    - {id: 890, cat: Movies, desc: "  |---- Dan Curtis"}
+    - {id: 439, cat: Movies, desc: "  |---- Daniel Mann"}
+    - {id: 485, cat: Movies, desc: "  |---- Darren Aronofsky"}
+    - {id: 65, cat: Movies, desc: "  |---- David Cronenberg"}
+    - {id: 440, cat: Movies, desc: "  |---- David Fincher"}
+    - {id: 41, cat: Movies, desc: "  |---- David Lynch"}
+    - {id: 441, cat: Movies, desc: "  |---- David Mamet"}
+    - {id: 823, cat: Movies, desc: "  |---- David Miller"}
+    - {id: 602, cat: Movies, desc: "  |---- Delbert Mann"}
+    - {id: 421, cat: Movies, desc: "  |---- Delmer Daves"}
+    - {id: 633, cat: Movies, desc: "  |---- Denis Villeneuve"}
+    - {id: 462, cat: Movies, desc: "  |---- Dennis Hopper"}
+    - {id: 182, cat: Movies, desc: "  |---- Denys Arcand"}
+    - {id: 824, cat: Movies, desc: "  |---- Don Hertzfeldt"}
+    - {id: 891, cat: Movies, desc: "  |---- Don Medford"}
+    - {id: 249, cat: Movies, desc: "  |---- Don Siegel"}
+    - {id: 263, cat: Movies, desc: "  |---- Douglas Sirk"}
+    - {id: 208, cat: Movies, desc: "  |---- D.W. Griffith"}
+    - {id: 406, cat: Movies, desc: "  |---- Edmund Goulding"}
+    - {id: 253, cat: Movies, desc: "  |---- Edward Dmytryk"}
+    - {id: 749, cat: Movies, desc: "  |---- Edgar G. Ulmer "}
+    - {id: 750, cat: Movies, desc: "  |---- Edwin L. Marin"}
+    - {id: 140, cat: Movies, desc: "  |---- Elia Kazan"}
+    - {id: 576, cat: Movies, desc: "  |---- Erich Von Stroheim"}
+    - {id: 231, cat: Movies, desc: "  |---- Ernst Lubitsch"}
+    - {id: 368, cat: Movies, desc: "  |---- Errol Morris"}
+    - {id: 825, cat: Movies, desc: "  |---- Felix E. Feist"}
+    - {id: 91, cat: Movies, desc: "  |---- Francis Ford Coppola"}
+    - {id: 389, cat: Movies, desc: "  |---- Frank Borzage"}
+    - {id: 123, cat: Movies, desc: "  |---- Frank Capra"}
+    - {id: 382, cat: Movies, desc: "  |---- Franklin J. Schaffner"}
+    - {id: 751, cat: Movies, desc: "  |---- Frank Tashlin"}
+    - {id: 369, cat: Movies, desc: "  |---- Fred C. Newmeyer"}
+    - {id: 381, cat: Movies, desc: "  |---- Fred Zinnemann"}
+    - {id: 892, cat: Movies, desc: "  |---- Frederick Wiseman"}
+    - {id: 534, cat: Movies, desc: "  |---- Gene Kelly"}
+    - {id: 383, cat: Movies, desc: "  |---- George A. Romero"}
+    - {id: 250, cat: Movies, desc: "  |---- George Cukor"}
+    - {id: 258, cat: Movies, desc: "  |---- George Roy Hill"}
+    - {id: 407, cat: Movies, desc: "  |---- George Seaton"}
+    - {id: 370, cat: Movies, desc: "  |---- George Sidney"}
+    - {id: 143, cat: Movies, desc: "  |---- George Stevens"}
+    - {id: 893, cat: Movies, desc: "  |---- Gerd Oswald"}
+    - {id: 577, cat: Movies, desc: "  |---- Godfrey Reggio"}
+    - {id: 536, cat: Movies, desc: "  |---- Gordon Douglas"}
+    - {id: 442, cat: Movies, desc: "  |---- Gregg Araki"}
+    - {id: 99, cat: Movies, desc: "  |---- Gus Van Sant"}
+    - {id: 277, cat: Movies, desc: "  |---- Guy Maddin"}
+    - {id: 752, cat: Movies, desc: "  |---- H. C. Potter"}
+    - {id: 408, cat: Movies, desc: "  |---- Hal Ashby"}
+    - {id: 371, cat: Movies, desc: "  |---- Hal Hartley"}
+    - {id: 372, cat: Movies, desc: "  |---- Hal Roach"}
+    - {id: 603, cat: Movies, desc: "  |---- Harmony Korine"}
+    - {id: 373, cat: Movies, desc: "  |---- Henry King"}
+    - {id: 443, cat: Movies, desc: "  |---- Henry Koster"}
+    - {id: 251, cat: Movies, desc: "  |---- Henry Hathaway"}
+    - {id: 826, cat: Movies, desc: "  |---- Henry Levin"}
+    - {id: 486, cat: Movies, desc: "  |---- Herbert Ross"}
+    - {id: 100, cat: Movies, desc: "  |---- Howard Hawks"}
+    - {id: 367, cat: Movies, desc: "  |---- Ida Lupino"}
+    - {id: 753, cat: Movies, desc: "  |---- Irving Pichel"}
+    - {id: 374, cat: Movies, desc: "  |---- J. Lee Thompson"}
+    - {id: 578, cat: Movies, desc: "  |---- Jack Arnold"}
+    - {id: 604, cat: Movies, desc: "  |---- Jack Conway"}
+    - {id: 259, cat: Movies, desc: "  |---- Jacques Tourneur"}
+    - {id: 686, cat: Movies, desc: "  |---- James Benning"}
+    - {id: 687, cat: Movies, desc: "  |---- James Gray"}
+    - {id: 418, cat: Movies, desc: "  |---- Jean Negulesco"}
+    - {id: 975, cat: Movies, desc: "  |---- Jerry Lewis"}
+    - {id: 61, cat: Movies, desc: "  |---- Jim Jarmusch"}
+    - {id: 688, cat: Movies, desc: "  |---- Joe Dante"}
+    - {id: 754, cat: Movies, desc: "  |---- Joe Swanberg"}
+    - {id: 90, cat: Movies, desc: "  |---- Joel & Ethan Coen"}
+    - {id: 894, cat: Movies, desc: "  |---- John Badham"}
+    - {id: 634, cat: Movies, desc: "  |---- John Brahm"}
+    - {id: 375, cat: Movies, desc: "  |---- John Carpenter"}
+    - {id: 189, cat: Movies, desc: "  |---- John Cassavetes"}
+    - {id: 487, cat: Movies, desc: "  |---- John Cromwell"}
+    - {id: 827, cat: Movies, desc: "  |---- John Farrow"}
+    - {id: 101, cat: Movies, desc: "  |---- John Ford"}
+    - {id: 260, cat: Movies, desc: "  |---- John Frankenheimer"}
+    - {id: 895, cat: Movies, desc: "  |---- John Hughes"}
+    - {id: 89, cat: Movies, desc: "  |---- John Huston"}
+    - {id: 898, cat: Movies, desc: "  |---- John Landis"}
+    - {id: 979, cat: Movies, desc: "  |---- John Milius"}
+    - {id: 376, cat: Movies, desc: "  |---- John Sayles"}
+    - {id: 365, cat: Movies, desc: "  |---- John Schlesinger"}
+    - {id: 256, cat: Movies, desc: "  |---- John Sturges"}
+    - {id: 254, cat: Movies, desc: "  |---- John Waters"}
+    - {id: 605, cat: Movies, desc: "  |---- Jonas Mekas"}
+    - {id: 689, cat: Movies, desc: "  |---- Jonathan Demme"}
+    - {id: 378, cat: Movies, desc: "  |---- Josef von Sternberg"}
+    - {id: 755, cat: Movies, desc: "  |---- Joseph H. Lewis"}
+    - {id: 156, cat: Movies, desc: "  |---- Joseph L. Mankiewicz"}
+    - {id: 690, cat: Movies, desc: "  |---- Joseph Sargent"}
+    - {id: 206, cat: Movies, desc: "  |---- Jules Dassin"}
+    - {id: 896, cat: Movies, desc: "  |---- Kathryn Bigelow"}
+    - {id: 828, cat: Movies, desc: "  |---- Kelly Reichardt"}
+    - {id: 463, cat: Movies, desc: "  |---- Kenneth Anger"}
+    - {id: 897, cat: Movies, desc: "  |---- Kevin Smith"}
+    - {id: 444, cat: Movies, desc: "  |---- King Vidor"}
+    - {id: 606, cat: Movies, desc: "  |---- Larry Clark "}
+    - {id: 978, cat: Movies, desc: "  |---- Larry Cohen"}
+    - {id: 366, cat: Movies, desc: "  |---- Lasse Hallström"}
+    - {id: 516, cat: Movies, desc: "  |---- Lawrence Kasdan"}
+    - {id: 417, cat: Movies, desc: "  |---- Leo McCarey"}
+    - {id: 517, cat: Movies, desc: "  |---- Lewis Allen"}
+    - {id: 390, cat: Movies, desc: "  |---- Lewis Milestone"}
+    - {id: 829, cat: Movies, desc: "  |---- Lewis R. Foster"}
+    - {id: 830, cat: Movies, desc: "  |---- M. Night Shyamalan"}
+    - {id: 464, cat: Movies, desc: "  |---- Mark Robson"}
+    - {id: 635, cat: Movies, desc: "  |---- Mark Rydell"}
+    - {id: 488, cat: Movies, desc: "  |---- Mark Sandrich"}
+    - {id: 380, cat: Movies, desc: "  |---- Martin Ritt"}
+    - {id: 45, cat: Movies, desc: "  |---- Martin Scorsese"}
+    - {id: 899, cat: Movies, desc: "  |---- Maya Deren"}
+    - {id: 363, cat: Movies, desc: "  |---- Mel Brooks"}
+    - {id: 385, cat: Movies, desc: "  |---- Mervyn LeRoy"}
+    - {id: 636, cat: Movies, desc: "  |---- Michael Cimino"}
+    - {id: 255, cat: Movies, desc: "  |---- Michael Curtiz"}
+    - {id: 489, cat: Movies, desc: "  |---- Michael Mann"}
+    - {id: 154, cat: Movies, desc: "  |---- Michael Moore"}
+    - {id: 102, cat: Movies, desc: "  |---- Mike Nichols"}
+    - {id: 900, cat: Movies, desc: "  |---- Mitchell Leisen"}
+    - {id: 537, cat: Movies, desc: "  |---- Monte Hellman"}
+    - {id: 607, cat: Movies, desc: "  |---- Neil LaBute"}
+    - {id: 221, cat: Movies, desc: "  |---- Nicholas Ray"}
+    - {id: 637, cat: Movies, desc: "  |---- Noah Baumbach"}
+    - {id: 157, cat: Movies, desc: "  |---- Norman Jewison"}
+    - {id: 901, cat: Movies, desc: "  |---- Norman Z. McLeod"}
+    - {id: 158, cat: Movies, desc: "  |---- Oliver Stone"}
+    - {id: 97, cat: Movies, desc: "  |---- Orson Welles"}
+    - {id: 159, cat: Movies, desc: "  |---- Otto Preminger"}
+    - {id: 691, cat: Movies, desc: "  |---- Paul Mazursky"}
+    - {id: 538, cat: Movies, desc: "  |---- Paul Morrisey"}
+    - {id: 902, cat: Movies, desc: "  |---- Paul Newman"}
+    - {id: 445, cat: Movies, desc: "  |---- Paul Schrader"}
+    - {id: 160, cat: Movies, desc: "  |---- Paul Thomas Anderson"}
+    - {id: 220, cat: Movies, desc: "  |---- Peter Bogdanovich"}
+    - {id: 539, cat: Movies, desc: "  |---- Phil Karlson"}
+    - {id: 638, cat: Movies, desc: "  |---- Philip Kaufman"}
+    - {id: 410, cat: Movies, desc: "  |---- Preston Sturges"}
+    - {id: 235, cat: Movies, desc: "  |---- Quentin Tarantino"}
+    - {id: 756, cat: Movies, desc: "  |---- Ralph Bakshi"}
+    - {id: 362, cat: Movies, desc: "  |---- Ralph Nelson"}
+    - {id: 361, cat: Movies, desc: "  |---- Raoul Walsh"}
+    - {id: 360, cat: Movies, desc: "  |---- Richard Brooks"}
+    - {id: 903, cat: Movies, desc: "  |---- Richard Donner"}
+    - {id: 359, cat: Movies, desc: "  |---- Richard Fleischer"}
+    - {id: 118, cat: Movies, desc: "  |---- Richard Linklater"}
+    - {id: 423, cat: Movies, desc: "  |---- Richard Schickel"}
+    - {id: 757, cat: Movies, desc: "  |---- Richard Thorpe"}
+    - {id: 280, cat: Movies, desc: "  |---- Ridley Scott"}
+    - {id: 831, cat: Movies, desc: "  |---- Rob Reiner"}
+    - {id: 161, cat: Movies, desc: "  |---- Robert Aldrich"}
+    - {id: 184, cat: Movies, desc: "  |---- Robert Altman"}
+    - {id: 832, cat: Movies, desc: "  |---- Robert Benton"}
+    - {id: 904, cat: Movies, desc: "  |---- Robert Florey"}
+    - {id: 409, cat: Movies, desc: "  |---- Robert J. Flaherty"}
+    - {id: 358, cat: Movies, desc: "  |---- Robert Mulligan"}
+    - {id: 692, cat: Movies, desc: "  |---- Robert Rossen"}
+    - {id: 261, cat: Movies, desc: "  |---- Robert Siodmak"}
+    - {id: 357, cat: Movies, desc: "  |---- Robert Stevens"}
+    - {id: 168, cat: Movies, desc: "  |---- Robert Wise"}
+    - {id: 758, cat: Movies, desc: "  |---- Robert Z. Leonard"}
+    - {id: 905, cat: Movies, desc: "  |---- Robert Zemeckis"}
+    - {id: 252, cat: Movies, desc: "  |---- Roger Corman"}
+    - {id: 833, cat: Movies, desc: "  |---- Ron Howard"}
+    - {id: 356, cat: Movies, desc: "  |---- Rouben Mamoulian"}
+    - {id: 355, cat: Movies, desc: "  |---- Rudolph Maté"}
+    - {id: 759, cat: Movies, desc: "  |---- Russ Meyer"}
+    - {id: 834, cat: Movies, desc: "  |---- Sam Mendes"}
+    - {id: 162, cat: Movies, desc: "  |---- Sam Peckinpah"}
+    - {id: 906, cat: Movies, desc: "  |---- Sam Raimi"}
+    - {id: 354, cat: Movies, desc: "  |---- Sam Wood"}
+    - {id: 192, cat: Movies, desc: "  |---- Samuel Fuller"}
+    - {id: 835, cat: Movies, desc: "  |---- Sean Penn"}
+    - {id: 836, cat: Movies, desc: "  |---- Sidney J. Furie"}
+    - {id: 119, cat: Movies, desc: "  |---- Sidney Lumet"}
+    - {id: 608, cat: Movies, desc: "  |---- Sofia Coppola"}
+    - {id: 490, cat: Movies, desc: "  |---- Spike Jonze"}
+    - {id: 121, cat: Movies, desc: "  |---- Spike Lee"}
+    - {id: 353, cat: Movies, desc: "  |---- Stan Brakhage"}
+    - {id: 279, cat: Movies, desc: "  |---- Stanley Donen"}
+    - {id: 333, cat: Movies, desc: "  |---- Stanley Kramer"}
+    - {id: 48, cat: Movies, desc: "  |---- Stanley Kubrick"}
+    - {id: 278, cat: Movies, desc: "  |---- Steven Soderbergh"}
+    - {id: 124, cat: Movies, desc: "  |---- Steven Spielberg"}
+    - {id: 332, cat: Movies, desc: "  |---- Stuart Gordon"}
+    - {id: 907, cat: Movies, desc: "  |---- Stuart Heisler"}
+    - {id: 693, cat: Movies, desc: "  |---- Stuart Rosenberg"}
+    - {id: 163, cat: Movies, desc: "  |---- Sydney Pollack"}
+    - {id: 837, cat: Movies, desc: "  |---- Ted Tetzlaff"}
+    - {id: 422, cat: Movies, desc: "  |---- Terrence Malick"}
+    - {id: 116, cat: Movies, desc: "  |---- Terry Gilliam"}
+    - {id: 117, cat: Movies, desc: "  |---- Tim Burton"}
+    - {id: 838, cat: Movies, desc: "  |---- Tobe Hooper"}
+    - {id: 331, cat: Movies, desc: "  |---- Tod Browning"}
+    - {id: 420, cat: Movies, desc: "  |---- Todd Haynes"}
+    - {id: 110, cat: Movies, desc: "  |---- Todd Solondz"}
+    - {id: 609, cat: Movies, desc: "  |---- Tom DiCillo"}
+    - {id: 465, cat: Movies, desc: "  |---- Victor Fleming"}
+    - {id: 201, cat: Movies, desc: "  |---- Vincente Minnelli"}
+    - {id: 760, cat: Movies, desc: "  |---- Vincent Sherman"}
+    - {id: 839, cat: Movies, desc: "  |---- W. S. Van Dyke"}
+    - {id: 973, cat: Movies, desc: "  |---- Wachowski Brothers"}
+    - {id: 631, cat: Movies, desc: "  |---- Walter Hill "}
+    - {id: 639, cat: Movies, desc: "  |---- Walter Lang"}
+    - {id: 579, cat: Movies, desc: "  |---- Wayne Wang"}
+    - {id: 165, cat: Movies, desc: "  |---- Wes Anderson"}
+    - {id: 761, cat: Movies, desc: "  |---- Wes Craven"}
+    - {id: 762, cat: Movies, desc: "  |---- Whit Stillman"}
+    - {id: 330, cat: Movies, desc: "  |---- William A. Wellman"}
+    - {id: 491, cat: Movies, desc: "  |---- William Castle"}
+    - {id: 329, cat: Movies, desc: "  |---- William Dieterle"}
+    - {id: 328, cat: Movies, desc: "  |---- William Friedkin"}
+    - {id: 166, cat: Movies, desc: "  |---- William Wyler"}
+    - {id: 83, cat: Movies, desc: "  |---- Woody Allen"}
+    - {id: 763, cat: Movies, desc: "  |---- Xavier Dolan"}
+    - {id: 73, cat: Movies, desc: "  |-- Asiáticos"}
+    - {id: 840, cat: Movies, desc: "  |---- Akio Jissôji"}
+    - {id: 37, cat: Movies, desc: "  |---- Akira Kurosawa"}
+    - {id: 283, cat: Movies, desc: "  |---- Ang Lee"}
+    - {id: 580, cat: Movies, desc: "  |---- Anh Hung Tran"}
+    - {id: 411, cat: Movies, desc: "  |---- Apichatpong Weerasethakul"}
+    - {id: 492, cat: Movies, desc: "  |---- Bong Joon-Ho"}
+    - {id: 518, cat: Movies, desc: "  |---- Brillante Mendonza"}
+    - {id: 300, cat: Movies, desc: "  |---- Chan-wook Park"}
+    - {id: 764, cat: Movies, desc: "  |---- Chang Cheh"}
+    - {id: 841, cat: Movies, desc: "  |---- Darezhan Omirbayev"}
+    - {id: 765, cat: Movies, desc: "  |---- Edward Yang"}
+    - {id: 640, cat: Movies, desc: "  |---- Gakuryu Ishii"}
+    - {id: 540, cat: Movies, desc: "  |---- Hayao Miyazaki"}
+    - {id: 610, cat: Movies, desc: "  |---- Hideo Gosha"}
+    - {id: 766, cat: Movies, desc: "  |---- Hideo Nakata"}
+    - {id: 316, cat: Movies, desc: "  |---- Hirokazu Koreeda"}
+    - {id: 541, cat: Movies, desc: "  |---- Hiroshi Inagaki"}
+    - {id: 611, cat: Movies, desc: "  |---- Hiroshi Shimizu"}
+    - {id: 211, cat: Movies, desc: "  |---- Hiroshi Teshigahara"}
+    - {id: 320, cat: Movies, desc: "  |---- Hsiao-hsien Hou"}
+    - {id: 612, cat: Movies, desc: "  |---- Isao Takahata"}
+    - {id: 908, cat: Movies, desc: "  |---- Isao Yukisada"}
+    - {id: 641, cat: Movies, desc: "  |---- Ishirô Honda"}
+    - {id: 301, cat: Movies, desc: "  |---- Ji-woon Kim"}
+    - {id: 694, cat: Movies, desc: "  |---- John Woo"}
+    - {id: 695, cat: Movies, desc: "  |---- Johnnie To"}
+    - {id: 767, cat: Movies, desc: "  |---- Juzo Itami"}
+    - {id: 542, cat: Movies, desc: "  |---- Kaneto Shindô"}
+    - {id: 909, cat: Movies, desc: "  |---- Kazuyoshi Kumakiri"}
+    - {id: 696, cat: Movies, desc: "  |---- Kei Kumai"}
+    - {id: 543, cat: Movies, desc: "  |---- Keisuke Kinoshita"}
+    - {id: 613, cat: Movies, desc: "  |---- Kenji Misumi "}
+    - {id: 614, cat: Movies, desc: "  |---- Kihachi Okamoto"}
+    - {id: 70, cat: Movies, desc: "  |---- Kim Ki-Duk"}
+    - {id: 412, cat: Movies, desc: "  |---- Kiyoshi Kurosawa"}
+    - {id: 202, cat: Movies, desc: "  |---- Kenji Mizoguchi"}
+    - {id: 697, cat: Movies, desc: "  |---- Kinji Fukasaku"}
+    - {id: 476, cat: Movies, desc: "  |---- Kôji Wakamatsu"}
+    - {id: 544, cat: Movies, desc: "  |---- Kon Ichikawa"}
+    - {id: 581, cat: Movies, desc: "  |---- Koreyoshi Kurahara"}
+    - {id: 698, cat: Movies, desc: "  |---- Lav Diaz"}
+    - {id: 699, cat: Movies, desc: "  |---- Lee Chang-dong"}
+    - {id: 910, cat: Movies, desc: "  |---- Makoto Shinkai"}
+    - {id: 642, cat: Movies, desc: "  |---- Mamoru Oshii"}
+    - {id: 911, cat: Movies, desc: "  |---- Mani Kaul"}
+    - {id: 519, cat: Movies, desc: "  |---- Masahiro Shinoda"}
+    - {id: 317, cat: Movies, desc: "  |---- Masaki Kobayashi"}
+    - {id: 318, cat: Movies, desc: "  |---- Mikio Naruse"}
+    - {id: 480, cat: Movies, desc: "  |---- Mira Nair"}
+    - {id: 222, cat: Movies, desc: "  |---- Nagisa Oshima"}
+    - {id: 912, cat: Movies, desc: "  |---- Naoko Ogigami"}
+    - {id: 545, cat: Movies, desc: "  |---- Naomi Kawase"}
+    - {id: 769, cat: Movies, desc: "  |---- Noboru Tanaka"}
+    - {id: 768, cat: Movies, desc: "  |---- Nobuhiko Obayashi"}
+    - {id: 546, cat: Movies, desc: "  |---- Pen-Ek Ratanaruang"}
+    - {id: 700, cat: Movies, desc: "  |---- Rithy Panh"}
+    - {id: 478, cat: Movies, desc: "  |---- Sang-soo Hong"}
+    - {id: 479, cat: Movies, desc: "  |---- Sanjay Leela Bhansali"}
+    - {id: 701, cat: Movies, desc: "  |---- Satoshi Kon"}
+    - {id: 193, cat: Movies, desc: "  |---- Satyajit Ray"}
+    - {id: 493, cat: Movies, desc: "  |---- Seijun Suzuki"}
+    - {id: 770, cat: Movies, desc: "  |---- Shinji Aoyama"}
+    - {id: 273, cat: Movies, desc: "  |---- Shinya Tsukamoto"}
+    - {id: 547, cat: Movies, desc: "  |---- Sion Sono"}
+    - {id: 319, cat: Movies, desc: "  |---- Shohei Imamura"}
+    - {id: 477, cat: Movies, desc: "  |---- Shuji Terayama"}
+    - {id: 615, cat: Movies, desc: "  |---- Shunji Iwai"}
+    - {id: 771, cat: Movies, desc: "  |---- Tadashi Imai"}
+    - {id: 94, cat: Movies, desc: "  |---- Takashi Miike"}
+    - {id: 66, cat: Movies, desc: "  |---- Takeshi Kitano"}
+    - {id: 772, cat: Movies, desc: "  |---- Tetsuya Nakashima"}
+    - {id: 773, cat: Movies, desc: "  |---- Tomu Uchida"}
+    - {id: 105, cat: Movies, desc: "  |---- Tsai Ming-liang"}
+    - {id: 842, cat: Movies, desc: "  |---- Tsui Hark"}
+    - {id: 974, cat: Movies, desc: "  |---- Wang Bing"}
+    - {id: 167, cat: Movies, desc: "  |---- Wong Kar-wai"}
+    - {id: 549, cat: Movies, desc: "  |---- Yasuzô Masumura"}
+    - {id: 548, cat: Movies, desc: "  |---- Yoshishige Yoshida"}
+    - {id: 107, cat: Movies, desc: "  |---- Yasujiro Ozu"}
+    - {id: 120, cat: Movies, desc: "  |---- Yimou Zhang"}
+    - {id: 446, cat: Movies, desc: "  |---- Yôji Yamada"}
+    - {id: 774, cat: Movies, desc: "  |---- Yôjirô Takita"}
+    - {id: 702, cat: Movies, desc: "  |---- Yoshimitsu Morita"}
+    - {id: 520, cat: Movies, desc: "  |---- Zhang Ke Jia"}
+    - {id: 74, cat: Movies, desc: "  |-- Brasileiros"}
+    - {id: 915, cat: Movies, desc: "  |---- Adirley Queirós"}
+    - {id: 981, cat: Movies, desc: "  |---- Agnaldo Siri Azevedo"}
+    - {id: 643, cat: Movies, desc: "  |---- Alfredo Sternheim"}
+    - {id: 703, cat: Movies, desc: "  |---- Alberto Pieralise"}
+    - {id: 704, cat: Movies, desc: "  |---- Alberto Salvá"}
+    - {id: 843, cat: Movies, desc: "  |---- Aloysio Raulino"}
+    - {id: 916, cat: Movies, desc: "  |---- Aly Muritiba"}
+    - {id: 649, cat: Movies, desc: "  |---- Amácio Mazzaropi"}
+    - {id: 241, cat: Movies, desc: "  |---- Ana Carolina"}
+    - {id: 494, cat: Movies, desc: "  |---- André Klotzel"}
+    - {id: 616, cat: Movies, desc: "  |---- André Luís de Oliveira"}
+    - {id: 917, cat: Movies, desc: "  |---- André Novais Oliveira"}
+    - {id: 617, cat: Movies, desc: "  |---- Andrea Tonacci"}
+    - {id: 582, cat: Movies, desc: "  |---- Andrucha Waddington"}
+    - {id: 844, cat: Movies, desc: "  |---- Anna Muylaert"}
+    - {id: 242, cat: Movies, desc: "  |---- Anselmo Duarte"}
+    - {id: 705, cat: Movies, desc: "  |---- Antônio Calmon"}
+    - {id: 706, cat: Movies, desc: "  |---- Antonio Carlos Fontoura"}
+    - {id: 136, cat: Movies, desc: "  |---- Arnaldo Jabor"}
+    - {id: 707, cat: Movies, desc: "  |---- Aurélio Teixeira"}
+    - {id: 918, cat: Movies, desc: "  |---- Bárbara Wagner & Benjamin de Burca"}
+    - {id: 243, cat: Movies, desc: "  |---- Beto Brant"}
+    - {id: 618, cat: Movies, desc: "  |---- Braz Chediak"}
+    - {id: 244, cat: Movies, desc: "  |---- Bruno Barreto"}
+    - {id: 845, cat: Movies, desc: "  |---- Bruno Safadi"}
+    - {id: 619, cat: Movies, desc: "  |---- Cao Guimarães"}
+    - {id: 644, cat: Movies, desc: "  |---- Carlos Alberto Prates Correa"}
+    - {id: 620, cat: Movies, desc: "  |---- Carlos Coimbra"}
+    - {id: 238, cat: Movies, desc: "  |---- Carlos Diegues"}
+    - {id: 550, cat: Movies, desc: "  |---- Carlos Gerbase"}
+    - {id: 551, cat: Movies, desc: "  |---- Carlos Hugo Christensen"}
+    - {id: 435, cat: Movies, desc: "  |---- Carlos Manga"}
+    - {id: 846, cat: Movies, desc: "  |---- Carlos Nader"}
+    - {id: 225, cat: Movies, desc: "  |---- Carlos Reichenbach"}
+    - {id: 847, cat: Movies, desc: "  |---- Cláudio Assis"}
+    - {id: 708, cat: Movies, desc: "  |---- Cláudio Cunha"}
+    - {id: 919, cat: Movies, desc: "  |---- Cristiano Burlan"}
+    - {id: 775, cat: Movies, desc: "  |---- Daniel Filho"}
+    - {id: 621, cat: Movies, desc: "  |---- David Neves"}
+    - {id: 387, cat: Movies, desc: "  |---- Domingos de Oliveira"}
+    - {id: 81, cat: Movies, desc: "  |---- Eduardo Coutinho"}
+    - {id: 622, cat: Movies, desc: "  |---- Eduardo Escorel"}
+    - {id: 848, cat: Movies, desc: "  |---- Eliane Caffé"}
+    - {id: 709, cat: Movies, desc: "  |---- Elyseu Visconti"}
+    - {id: 849, cat: Movies, desc: "  |---- Eryk Rocha"}
+    - {id: 710, cat: Movies, desc: "  |---- Eurípides Ramos"}
+    - {id: 711, cat: Movies, desc: "  |---- Fabio Barreto"}
+    - {id: 712, cat: Movies, desc: "  |---- Fauzi Mansur"}
+    - {id: 713, cat: Movies, desc: "  |---- Fernando de Barros"}
+    - {id: 552, cat: Movies, desc: "  |---- Fernando Meirelles"}
+    - {id: 714, cat: Movies, desc: "  |---- Flávio Tambellini"}
+    - {id: 920, cat: Movies, desc: "  |---- Francisco Cavalcanti"}
+    - {id: 413, cat: Movies, desc: "  |---- Francisco Ramalho Jr."}
+    - {id: 715, cat: Movies, desc: "  |---- Gabriel Mascaro"}
+    - {id: 776, cat: Movies, desc: "  |---- Geraldo Sarno"}
+    - {id: 977, cat: Movies, desc: "  |---- Geraldo Vietri"}
+    - {id: 921, cat: Movies, desc: "  |---- Gerson Tavares"}
+    - {id: 62, cat: Movies, desc: "  |---- Glauber Rocha"}
+    - {id: 623, cat: Movies, desc: "  |---- Guilherme de Almeida Prado"}
+    - {id: 228, cat: Movies, desc: "  |---- Hector Babenco"}
+    - {id: 925, cat: Movies, desc: "  |---- Heitor Dhalia"}
+    - {id: 922, cat: Movies, desc: "  |---- Helena Ignez"}
+    - {id: 647, cat: Movies, desc: "  |---- Helvécio Ratton"}
+    - {id: 583, cat: Movies, desc: "  |---- Hugo Carvana"}
+    - {id: 215, cat: Movies, desc: "  |---- Humberto Mauro"}
+    - {id: 553, cat: Movies, desc: "  |---- Ivan Cardoso"}
+    - {id: 645, cat: Movies, desc: "  |---- J. B. Tanko"}
+    - {id: 191, cat: Movies, desc: "  |---- Jairo Ferreira"}
+    - {id: 646, cat: Movies, desc: "  |---- Jean Garret"}
+    - {id: 850, cat: Movies, desc: "  |---- Jece Valadão"}
+    - {id: 584, cat: Movies, desc: "  |---- João Batista Andrade"}
+    - {id: 923, cat: Movies, desc: "  |---- João Moreira Salles"}
+    - {id: 203, cat: Movies, desc: "  |---- Joaquim Pedro De Andrade"}
+    - {id: 976, cat: Movies, desc: "  |---- Jom Tob Azulay"}
+    - {id: 851, cat: Movies, desc: "  |---- Jorge Durán"}
+    - {id: 155, cat: Movies, desc: "  |---- Jorge Furtado"}
+    - {id: 777, cat: Movies, desc: "  |---- José Carlos Burle"}
+    - {id: 852, cat: Movies, desc: "  |---- José Eduardo Belmonte"}
+    - {id: 436, cat: Movies, desc: "  |---- José Joffily"}
+    - {id: 924, cat: Movies, desc: "  |---- José Miziara"}
+    - {id: 82, cat: Movies, desc: "  |---- José Mojica Marins"}
+    - {id: 853, cat: Movies, desc: "  |---- José Padilha"}
+    - {id: 854, cat: Movies, desc: "  |---- Juliana Rojas"}
+    - {id: 152, cat: Movies, desc: "  |---- Júlio Bressane"}
+    - {id: 554, cat: Movies, desc: "  |---- Karim Aïnouz"}
+    - {id: 555, cat: Movies, desc: "  |---- Kleber Mendonça Filho"}
+    - {id: 239, cat: Movies, desc: "  |---- Leon Hirszman"}
+    - {id: 855, cat: Movies, desc: "  |---- Lírio Ferreira"}
+    - {id: 245, cat: Movies, desc: "  |---- Lucia Murat"}
+    - {id: 466, cat: Movies, desc: "  |---- Luis Sergio Person"}
+    - {id: 585, cat: Movies, desc: "  |---- Luiz Carlos Lacerda"}
+    - {id: 778, cat: Movies, desc: "  |---- Luiz Rosemberg Filho "}
+    - {id: 779, cat: Movies, desc: "  |---- Marcelo Galvão"}
+    - {id: 716, cat: Movies, desc: "  |---- Marcelo Gomes"}
+    - {id: 624, cat: Movies, desc: "  |---- Marcelo Masagão"}
+    - {id: 717, cat: Movies, desc: "  |---- Marcelo Pedroso"}
+    - {id: 718, cat: Movies, desc: "  |---- Marco Altberg  "}
+    - {id: 856, cat: Movies, desc: "  |---- Marcos Farias"}
+    - {id: 926, cat: Movies, desc: "  |---- Maria Augusta Ramos"}
+    - {id: 648, cat: Movies, desc: "  |---- Maurice Capovilla"}
+    - {id: 719, cat: Movies, desc: "  |---- Miguel Borges"}
+    - {id: 556, cat: Movies, desc: "  |---- Miguel Faria Jr."}
+    - {id: 248, cat: Movies, desc: "  |---- Murilo Salles"}
+    - {id: 122, cat: Movies, desc: "  |---- Nelson Pereira dos Santos"}
+    - {id: 720, cat: Movies, desc: "  |---- Neville de Almeida"}
+    - {id: 650, cat: Movies, desc: "  |---- Ody Fraga"}
+    - {id: 927, cat: Movies, desc: "  |---- Olney São Paulo"}
+    - {id: 721, cat: Movies, desc: "  |---- Osvaldo de Oliveira"}
+    - {id: 722, cat: Movies, desc: "  |---- Oswaldo Caldeira"}
+    - {id: 379, cat: Movies, desc: "  |---- Ozualdo Candeias"}
+    - {id: 986, cat: Movies, desc: "  |---- Paula Gaitán"}
+    - {id: 495, cat: Movies, desc: "  |---- Paulo Cesar Saraceni"}
+    - {id: 586, cat: Movies, desc: "  |---- Paulo Thiago"}
+    - {id: 928, cat: Movies, desc: "  |---- Pedro Carlos Rovai"}
+    - {id: 625, cat: Movies, desc: "  |---- Petrus Cariry"}
+    - {id: 723, cat: Movies, desc: "  |---- Reginaldo Faria"}
+    - {id: 557, cat: Movies, desc: "  |---- Renato Tapajós"}
+    - {id: 983, cat: Movies, desc: "  |---- Ricardo Alves Jr."}
+    - {id: 496, cat: Movies, desc: "  |---- Roberto Farias"}
+    - {id: 467, cat: Movies, desc: "  |---- Roberto Pires"}
+    - {id: 626, cat: Movies, desc: "  |---- Roberto Santos"}
+    - {id: 106, cat: Movies, desc: "  |---- Rogério Sganzerla"}
+    - {id: 587, cat: Movies, desc: "  |---- Rosemberg Cariry"}
+    - {id: 108, cat: Movies, desc: "  |---- Ruy Guerra"}
+    - {id: 929, cat: Movies, desc: "  |---- Sandra Kogut"}
+    - {id: 588, cat: Movies, desc: "  |---- Sandra Werneck"}
+    - {id: 384, cat: Movies, desc: "  |---- Sérgio Bianchi"}
+    - {id: 236, cat: Movies, desc: "  |---- Sérgio Rezende"}
+    - {id: 780, cat: Movies, desc: "  |---- Sérgio Ricardo"}
+    - {id: 240, cat: Movies, desc: "  |---- Silvio Tendler"}
+    - {id: 468, cat: Movies, desc: "  |---- Sylvio Back"}
+    - {id: 857, cat: Movies, desc: "  |---- Tata Amaral"}
+    - {id: 724, cat: Movies, desc: "  |---- Tom Payne"}
+    - {id: 497, cat: Movies, desc: "  |---- Toni Venturi"}
+    - {id: 246, cat: Movies, desc: "  |---- Ugo Giorgetti "}
+    - {id: 781, cat: Movies, desc: "  |---- Victor di Mello"}
+    - {id: 558, cat: Movies, desc: "  |---- Victor Lima"}
+    - {id: 247, cat: Movies, desc: "  |---- Vladimir Carvalho"}
+    - {id: 782, cat: Movies, desc: "  |---- Walter Carvalho"}
+    - {id: 164, cat: Movies, desc: "  |---- Walter Hugo Khouri"}
+    - {id: 237, cat: Movies, desc: "  |---- Walter Lima Jr."}
+    - {id: 84, cat: Movies, desc: "  |---- Walter Salles"}
+    - {id: 627, cat: Movies, desc: "  |---- Watson Macedo"}
+    - {id: 982, cat: Movies, desc: "  |---- Wolney Oliveira"}
+    - {id: 628, cat: Movies, desc: "  |---- Xavier de Oliveira"}
+    - {id: 589, cat: Movies, desc: "  |---- Zelito Viana"}
+    - {id: 187, cat: Movies, desc: "  |-- Britânicos"}
+    - {id: 783, cat: Movies, desc: "  |---- Alan Clarke"}
+    - {id: 391, cat: Movies, desc: "  |---- Alberto Cavalcanti"}
+    - {id: 474, cat: Movies, desc: "  |---- Alexander Mackendrick"}
+    - {id: 39, cat: Movies, desc: "  |---- Alfred Hitchcock"}
+    - {id: 559, cat: Movies, desc: "  |---- Anthony Asquith"}
+    - {id: 560, cat: Movies, desc: "  |---- Anthony Minghella"}
+    - {id: 651, cat: Movies, desc: "  |---- Bryan Forbes"}
+    - {id: 268, cat: Movies, desc: "  |---- Carol Reed"}
+    - {id: 284, cat: Movies, desc: "  |---- Danny Boyle"}
+    - {id: 148, cat: Movies, desc: "  |---- David Lean"}
+    - {id: 858, cat: Movies, desc: "  |---- David Mackenzie"}
+    - {id: 285, cat: Movies, desc: "  |---- Derek Jarman"}
+    - {id: 930, cat: Movies, desc: "  |---- Freddie Francis"}
+    - {id: 725, cat: Movies, desc: "  |---- Jack Clayton"}
+    - {id: 286, cat: Movies, desc: "  |---- James Ivory"}
+    - {id: 784, cat: Movies, desc: "  |---- Jim Sheridan"}
+    - {id: 276, cat: Movies, desc: "  |---- John Boorman "}
+    - {id: 931, cat: Movies, desc: "  |---- John Guillermin"}
+    - {id: 219, cat: Movies, desc: "  |---- Joseph Losey"}
+    - {id: 498, cat: Movies, desc: "  |---- Karel Reisz"}
+    - {id: 113, cat: Movies, desc: "  |---- Ken Loach"}
+    - {id: 282, cat: Movies, desc: "  |---- Ken Russell"}
+    - {id: 207, cat: Movies, desc: "  |---- Kenneth Branagh"}
+    - {id: 859, cat: Movies, desc: "  |---- Kevin Macdonald"}
+    - {id: 414, cat: Movies, desc: "  |---- Lewis Gilbert"}
+    - {id: 499, cat: Movies, desc: "  |---- Lindsay Anderson"}
+    - {id: 500, cat: Movies, desc: "  |---- Lynne Ramsay"}
+    - {id: 475, cat: Movies, desc: "  |---- Michael Anderson"}
+    - {id: 287, cat: Movies, desc: "  |---- Michael Powell"}
+    - {id: 958, cat: Movies, desc: "  |---- Michael Radford"}
+    - {id: 150, cat: Movies, desc: "  |---- Michael Winterbottom"}
+    - {id: 652, cat: Movies, desc: "  |---- Mike Figgis"}
+    - {id: 291, cat: Movies, desc: "  |---- Mike Leigh"}
+    - {id: 404, cat: Movies, desc: "  |---- Nicolas Roeg"}
+    - {id: 416, cat: Movies, desc: "  |---- Norman McLaren"}
+    - {id: 653, cat: Movies, desc: "  |---- Peter Brook"}
+    - {id: 96, cat: Movies, desc: "  |---- Peter Greenaway"}
+    - {id: 364, cat: Movies, desc: "  |---- Peter Watkins"}
+    - {id: 288, cat: Movies, desc: "  |---- Peter Yates"}
+    - {id: 281, cat: Movies, desc: "  |---- Richard Attenborough"}
+    - {id: 289, cat: Movies, desc: "  |---- Richard Lester"}
+    - {id: 932, cat: Movies, desc: "  |---- Robert Hamer"}
+    - {id: 726, cat: Movies, desc: "  |---- Robert Stevenson"}
+    - {id: 377, cat: Movies, desc: "  |---- Ronald Neame"}
+    - {id: 727, cat: Movies, desc: "  |---- Roy Ward Baker"}
+    - {id: 130, cat: Movies, desc: "  |---- Stephen Frears"}
+    - {id: 785, cat: Movies, desc: "  |---- Terence Davies"}
+    - {id: 415, cat: Movies, desc: "  |---- Terence Fisher"}
+    - {id: 290, cat: Movies, desc: "  |---- Tony Richardson"}
+    - {id: 72, cat: Movies, desc: "  |-- Europeus (outros)"}
+    - {id: 307, cat: Movies, desc: "  |---- Agnieszka Holland"}
+    - {id: 38, cat: Movies, desc: "  |---- Aki Kaurismäki"}
+    - {id: 501, cat: Movies, desc: "  |---- Alain Tanner"}
+    - {id: 424, cat: Movies, desc: "  |---- Aleksandr Dovzhenko"}
+    - {id: 469, cat: Movies, desc: "  |---- Aleksandr Petrov"}
+    - {id: 171, cat: Movies, desc: "  |---- Aleksandr Sokurov"}
+    - {id: 786, cat: Movies, desc: "  |---- Aleksei German"}
+    - {id: 400, cat: Movies, desc: "  |---- Aleksey Balabanov"}
+    - {id: 521, cat: Movies, desc: "  |---- Alex van Warmerdam"}
+    - {id: 274, cat: Movies, desc: "  |---- Alexander Kluge"}
+    - {id: 860, cat: Movies, desc: "  |---- André Delvaux"}
+    - {id: 453, cat: Movies, desc: "  |---- Andrei Konchalovsky"}
+    - {id: 67, cat: Movies, desc: "  |---- Andrei Tarkovsky"}
+    - {id: 933, cat: Movies, desc: "  |---- Andrey Zvyagintsev"}
+    - {id: 104, cat: Movies, desc: "  |---- Andrzej Wajda"}
+    - {id: 275, cat: Movies, desc: "  |---- Andrzej Zulawski"}
+    - {id: 934, cat: Movies, desc: "  |---- Angela Schanelec"}
+    - {id: 935, cat: Movies, desc: "  |---- Arne Sucksdorff"}
+    - {id: 293, cat: Movies, desc: "  |---- Artavazd Peleshian"}
+    - {id: 728, cat: Movies, desc: "  |---- Baltasar Kormákur"}
+    - {id: 223, cat: Movies, desc: "  |---- Béla Tarr"}
+    - {id: 936, cat: Movies, desc: "  |---- Bert Haanstra"}
+    - {id: 454, cat: Movies, desc: "  |---- Bille August"}
+    - {id: 729, cat: Movies, desc: "  |---- Boris Barnet"}
+    - {id: 170, cat: Movies, desc: "  |---- Carl Theodor Dreyer"}
+    - {id: 401, cat: Movies, desc: "  |---- Chantal Akerman"}
+    - {id: 561, cat: Movies, desc: "  |---- Christian Petzold"}
+    - {id: 590, cat: Movies, desc: "  |---- Christoffer Boe"}
+    - {id: 937, cat: Movies, desc: "  |---- Christoph Hochhäusler"}
+    - {id: 861, cat: Movies, desc: "  |---- Corneliu Porumboiu"}
+    - {id: 137, cat: Movies, desc: "  |---- Costa-Gavras"}
+    - {id: 862, cat: Movies, desc: "  |---- Cristi Puiu"}
+    - {id: 562, cat: Movies, desc: "  |---- Cristian Mungiu"}
+    - {id: 787, cat: Movies, desc: "  |---- Dagur Kári"}
+    - {id: 654, cat: Movies, desc: "  |---- Danis Tanovic"}
+    - {id: 591, cat: Movies, desc: "  |---- Dorota Kedzierzawska"}
+    - {id: 426, cat: Movies, desc: "  |---- Dusan Makavejev"}
+    - {id: 402, cat: Movies, desc: "  |---- Dziga Vertov"}
+    - {id: 788, cat: Movies, desc: "  |---- Elem Klimov"}
+    - {id: 59, cat: Movies, desc: "  |---- Emir Kusturica"}
+    - {id: 789, cat: Movies, desc: "  |---- Evald Schorm"}
+    - {id: 149, cat: Movies, desc: "  |---- Fatih Akin"}
+    - {id: 655, cat: Movies, desc: "  |---- Frantisek Vlácil"}
+    - {id: 502, cat: Movies, desc: "  |---- Fridrik Thor Fridriksson"}
+    - {id: 169, cat: Movies, desc: "  |---- Friedrich Wilhelm Murnau"}
+    - {id: 95, cat: Movies, desc: "  |---- Fritz Lang"}
+    - {id: 297, cat: Movies, desc: "  |---- Georg Wilhelm Pabst"}
+    - {id: 592, cat: Movies, desc: "  |---- Georgi Daneliya"}
+    - {id: 938, cat: Movies, desc: "  |---- Goran Paskaljevic"}
+    - {id: 522, cat: Movies, desc: "  |---- Grigori Kozintsev"}
+    - {id: 205, cat: Movies, desc: "  |---- Harun Farocki"}
+    - {id: 298, cat: Movies, desc: "  |---- Helmut Käutner"}
+    - {id: 730, cat: Movies, desc: "  |---- Henri Storck"}
+    - {id: 42, cat: Movies, desc: "  |---- Ingmar Bergman"}
+    - {id: 312, cat: Movies, desc: "  |---- István Szabó"}
+    - {id: 523, cat: Movies, desc: "  |---- Jan Hrebejk"}
+    - {id: 790, cat: Movies, desc: "  |---- Jan Nemec"}
+    - {id: 731, cat: Movies, desc: "  |---- Jan Troell"}
+    - {id: 132, cat: Movies, desc: "  |---- Jan Svankmajer"}
+    - {id: 791, cat: Movies, desc: "  |---- Jaromil Jires"}
+    - {id: 209, cat: Movies, desc: "  |---- Jean-Pierre & Luc Dardenne"}
+    - {id: 863, cat: Movies, desc: "  |---- Jerzy Kawalerowicz"}
+    - {id: 386, cat: Movies, desc: "  |---- Jerzy Skolimowski"}
+    - {id: 503, cat: Movies, desc: "  |---- Jirí Menzel"}
+    - {id: 864, cat: Movies, desc: "  |---- Joachim Lafosse"}
+    - {id: 563, cat: Movies, desc: "  |---- Johan van der Keuken"}
+    - {id: 939, cat: Movies, desc: "  |---- John Carney"}
+    - {id: 792, cat: Movies, desc: "  |---- Joris Ivens"}
+    - {id: 504, cat: Movies, desc: "  |---- Jos Stelling"}
+    - {id: 793, cat: Movies, desc: "  |---- Juraj Herz "}
+    - {id: 656, cat: Movies, desc: "  |---- Juraj Jakubisko"}
+    - {id: 657, cat: Movies, desc: "  |---- Karel Kachyna"}
+    - {id: 658, cat: Movies, desc: "  |---- Karel Zeman"}
+    - {id: 940, cat: Movies, desc: "  |---- Kira Muratova"}
+    - {id: 732, cat: Movies, desc: "  |---- Konstantin Lopushanskiy"}
+    - {id: 941, cat: Movies, desc: "  |---- Kornél Mundruczó"}
+    - {id: 69, cat: Movies, desc: "  |---- Krzysztof Kieslowski"}
+    - {id: 470, cat: Movies, desc: "  |---- Krzysztof Zanussi"}
+    - {id: 63, cat: Movies, desc: "  |---- Lars Von Trier"}
+    - {id: 659, cat: Movies, desc: "  |---- Lech Majewski"}
+    - {id: 403, cat: Movies, desc: "  |---- Leni Riefenstahl"}
+    - {id: 505, cat: Movies, desc: "  |---- Lev Kuleshov"}
+    - {id: 660, cat: Movies, desc: "  |---- Lucas Belvaux"}
+    - {id: 733, cat: Movies, desc: "  |---- Lucian Pintilie"}
+    - {id: 309, cat: Movies, desc: "  |---- Lukas Moodysson"}
+    - {id: 524, cat: Movies, desc: "  |---- Margarethe von Trotta"}
+    - {id: 734, cat: Movies, desc: "  |---- Martin Sulík"}
+    - {id: 60, cat: Movies, desc: "  |---- Michael Haneke"}
+    - {id: 865, cat: Movies, desc: "  |---- Mika Kaurismäki"}
+    - {id: 272, cat: Movies, desc: "  |---- Miklós Jancsó"}
+    - {id: 506, cat: Movies, desc: "  |---- Mikhail Kalatozov"}
+    - {id: 942, cat: Movies, desc: "  |---- Mikhail Romm"}
+    - {id: 46, cat: Movies, desc: "  |---- Milos Forman"}
+    - {id: 866, cat: Movies, desc: "  |---- Nanouk Leopold"}
+    - {id: 131, cat: Movies, desc: "  |---- Neil Jordan"}
+    - {id: 507, cat: Movies, desc: "  |---- Nicolas Winding Refn"}
+    - {id: 311, cat: Movies, desc: "  |---- Nikita Mikhalkov"}
+    - {id: 564, cat: Movies, desc: "  |---- Ole Christian Madsen"}
+    - {id: 294, cat: Movies, desc: "  |---- Otar Iosseliani"}
+    - {id: 295, cat: Movies, desc: "  |---- Paul Verhoeven"}
+    - {id: 794, cat: Movies, desc: "  |---- Pavel Lungin"}
+    - {id: 943, cat: Movies, desc: "  |---- Piotr Szulkin"}
+    - {id: 867, cat: Movies, desc: "  |---- Radu Jude"}
+    - {id: 47, cat: Movies, desc: "  |---- Rainer Werner Fassbinder"}
+    - {id: 944, cat: Movies, desc: "  |---- Rein Raamat"}
+    - {id: 661, cat: Movies, desc: "  |---- Roy Andersson"}
+    - {id: 795, cat: Movies, desc: "  |---- Rúnar Rúnarsson"}
+    - {id: 735, cat: Movies, desc: "  |---- Sergei Loznitsa"}
+    - {id: 133, cat: Movies, desc: "  |---- Sergei M. Eisenstein"}
+    - {id: 196, cat: Movies, desc: "  |---- Sergei Paradjanov"}
+    - {id: 796, cat: Movies, desc: "  |---- Sergiu Nicolaescu"}
+    - {id: 508, cat: Movies, desc: "  |---- Sharunas Bartas"}
+    - {id: 736, cat: Movies, desc: "  |---- Stefan Uher"}
+    - {id: 455, cat: Movies, desc: "  |---- Susanne Bier"}
+    - {id: 945, cat: Movies, desc: "  |---- Takis Kanellopoulos"}
+    - {id: 868, cat: Movies, desc: "  |---- Tengiz Abuladze"}
+    - {id: 176, cat: Movies, desc: "  |---- Theo Angelopoulos"}
+    - {id: 946, cat: Movies, desc: "  |---- Thomas Arslan"}
+    - {id: 471, cat: Movies, desc: "  |---- Thomas Vinterberg"}
+    - {id: 299, cat: Movies, desc: "  |---- Tom Tykwer"}
+    - {id: 662, cat: Movies, desc: "  |---- Ulrich Seidl"}
+    - {id: 229, cat: Movies, desc: "  |---- Vera Chytilová"}
+    - {id: 310, cat: Movies, desc: "  |---- Victor Sjöström"}
+    - {id: 456, cat: Movies, desc: "  |---- Volker Schlöndorff"}
+    - {id: 869, cat: Movies, desc: "  |---- Vsevolod Pudovkin"}
+    - {id: 663, cat: Movies, desc: "  |---- Walerian Borowczyk"}
+    - {id: 49, cat: Movies, desc: "  |---- Werner Herzog"}
+    - {id: 472, cat: Movies, desc: "  |---- Werner Schroeter"}
+    - {id: 111, cat: Movies, desc: "  |---- Wim Wenders"}
+    - {id: 947, cat: Movies, desc: "  |---- Witold Leszczynski"}
+    - {id: 797, cat: Movies, desc: "  |---- Wladyslaw Starewicz "}
+    - {id: 473, cat: Movies, desc: "  |---- Yevgeni Bauer"}
+    - {id: 948, cat: Movies, desc: "  |---- Yorgos Lanthimos"}
+    - {id: 313, cat: Movies, desc: "  |---- Zoltán Fábri"}
+    - {id: 138, cat: Movies, desc: "  |-- Franceses"}
+    - {id: 565, cat: Movies, desc: "  |---- Abel Gance"}
+    - {id: 200, cat: Movies, desc: "  |---- Agnes Varda"}
+    - {id: 509, cat: Movies, desc: "  |---- Alain Corneau"}
+    - {id: 870, cat: Movies, desc: "  |---- Alain Guiraudie "}
+    - {id: 78, cat: Movies, desc: "  |---- Alain Resnais"}
+    - {id: 430, cat: Movies, desc: "  |---- Alain Robbe-Grillet"}
+    - {id: 798, cat: Movies, desc: "  |---- Alexandre Astruc"}
+    - {id: 871, cat: Movies, desc: "  |---- Alice Guy"}
+    - {id: 338, cat: Movies, desc: "  |---- André Téchiné"}
+    - {id: 799, cat: Movies, desc: "  |---- Anne Fontaine"}
+    - {id: 872, cat: Movies, desc: "  |---- Arnaud Desplechin"}
+    - {id: 339, cat: Movies, desc: "  |---- Barbet Schroeder"}
+    - {id: 593, cat: Movies, desc: "  |---- Benoît Jacquot"}
+    - {id: 395, cat: Movies, desc: "  |---- Bertrand Blier"}
+    - {id: 510, cat: Movies, desc: "  |---- Bertrand Bonello"}
+    - {id: 396, cat: Movies, desc: "  |---- Bertrand Tavernier"}
+    - {id: 427, cat: Movies, desc: "  |---- Bruno Dumont"}
+    - {id: 266, cat: Movies, desc: "  |---- Catherine Breillat"}
+    - {id: 980, cat: Movies, desc: "  |---- Cédric Kahn"}
+    - {id: 447, cat: Movies, desc: "  |---- Cédric Klapisch"}
+    - {id: 232, cat: Movies, desc: "  |---- Chris Marker"}
+    - {id: 340, cat: Movies, desc: "  |---- Christophe Honoré"}
+    - {id: 341, cat: Movies, desc: "  |---- Claire Denis"}
+    - {id: 392, cat: Movies, desc: "  |---- Claude Berri"}
+    - {id: 185, cat: Movies, desc: "  |---- Claude Chabrol"}
+    - {id: 265, cat: Movies, desc: "  |---- Claude Lelouch"}
+    - {id: 594, cat: Movies, desc: "  |---- Claude Sautet"}
+    - {id: 737, cat: Movies, desc: "  |---- Edouard Molinaro"}
+    - {id: 103, cat: Movies, desc: "  |---- Eric Rohmer"}
+    - {id: 448, cat: Movies, desc: "  |---- Eugène Green"}
+    - {id: 129, cat: Movies, desc: "  |---- François Ozon"}
+    - {id: 79, cat: Movies, desc: "  |---- François Truffaut"}
+    - {id: 93, cat: Movies, desc: "  |---- Gaspar Noé"}
+    - {id: 450, cat: Movies, desc: "  |---- Georges Franju"}
+    - {id: 954, cat: Movies, desc: "  |---- Germaine Dulac"}
+    - {id: 342, cat: Movies, desc: "  |---- Guy Debord"}
+    - {id: 566, cat: Movies, desc: "  |---- Henri Verneuil"}
+    - {id: 393, cat: Movies, desc: "  |---- Henri-Georges Clouzot"}
+    - {id: 800, cat: Movies, desc: "  |---- Jacques Audiard"}
+    - {id: 567, cat: Movies, desc: "  |---- Jacques Becker"}
+    - {id: 664, cat: Movies, desc: "  |---- Jacques Demy"}
+    - {id: 665, cat: Movies, desc: "  |---- Jacques Doillon"}
+    - {id: 216, cat: Movies, desc: "  |---- Jacques Rivette"}
+    - {id: 955, cat: Movies, desc: "  |---- Jacques Rozier"}
+    - {id: 217, cat: Movies, desc: "  |---- Jacques Tati"}
+    - {id: 511, cat: Movies, desc: "  |---- Jean Becker"}
+    - {id: 343, cat: Movies, desc: "  |---- Jean Cocteau"}
+    - {id: 397, cat: Movies, desc: "  |---- Jean Epstein"}
+    - {id: 801, cat: Movies, desc: "  |---- Jean Eustache"}
+    - {id: 802, cat: Movies, desc: "  |---- Jean Grémillon"}
+    - {id: 183, cat: Movies, desc: "  |---- Jean Renoir"}
+    - {id: 595, cat: Movies, desc: "  |---- Jean Rollin"}
+    - {id: 227, cat: Movies, desc: "  |---- Jean Rouch"}
+    - {id: 428, cat: Movies, desc: "  |---- Jean Vigo"}
+    - {id: 449, cat: Movies, desc: "  |---- Jean-Claude Brisseau"}
+    - {id: 956, cat: Movies, desc: "  |---- Jean-Claude Rousseau"}
+    - {id: 267, cat: Movies, desc: "  |---- Jean-Jacques Annaud"}
+    - {id: 344, cat: Movies, desc: "  |---- Jean-Jacques Beineix"}
+    - {id: 43, cat: Movies, desc: "  |---- Jean-Luc Godard"}
+    - {id: 388, cat: Movies, desc: "  |---- Jean-Marie Straub e Danièle Huillet"}
+    - {id: 345, cat: Movies, desc: "  |---- Jean-Pierre Jeunet"}
+    - {id: 210, cat: Movies, desc: "  |---- Jean-Pierre Melville"}
+    - {id: 346, cat: Movies, desc: "  |---- Julien Duvivier"}
+    - {id: 666, cat: Movies, desc: "  |---- Laurent Cantet"}
+    - {id: 568, cat: Movies, desc: "  |---- Leos Carax"}
+    - {id: 134, cat: Movies, desc: "  |---- Louis Malle"}
+    - {id: 270, cat: Movies, desc: "  |---- Luc Besson"}
+    - {id: 525, cat: Movies, desc: "  |---- Luc Moullet"}
+    - {id: 347, cat: Movies, desc: "  |---- Marcel Carné"}
+    - {id: 957, cat: Movies, desc: "  |---- Marcel Hanoun"}
+    - {id: 738, cat: Movies, desc: "  |---- Marcel L'Herbier "}
+    - {id: 451, cat: Movies, desc: "  |---- Marguerite Duras"}
+    - {id: 348, cat: Movies, desc: "  |---- Maurice Pialat"}
+    - {id: 349, cat: Movies, desc: "  |---- Max Ophüls"}
+    - {id: 803, cat: Movies, desc: "  |---- Mia Hansen-Love"}
+    - {id: 151, cat: Movies, desc: "  |---- Michel Gondry"}
+    - {id: 350, cat: Movies, desc: "  |---- Olivier Assayas"}
+    - {id: 667, cat: Movies, desc: "  |---- Pascal Aubier"}
+    - {id: 224, cat: Movies, desc: "  |---- Patrice Leconte"}
+    - {id: 873, cat: Movies, desc: "  |---- Paul Vecchiali"}
+    - {id: 874, cat: Movies, desc: "  |---- Philippe de Broca"}
+    - {id: 452, cat: Movies, desc: "  |---- Philippe Garrel"}
+    - {id: 959, cat: Movies, desc: "  |---- Philippe Grandrieux"}
+    - {id: 629, cat: Movies, desc: "  |---- Pierre Étaix "}
+    - {id: 875, cat: Movies, desc: "  |---- Pierre Granier-Deferre"}
+    - {id: 271, cat: Movies, desc: "  |---- Raoul Ruiz"}
+    - {id: 226, cat: Movies, desc: "  |---- René Clair"}
+    - {id: 429, cat: Movies, desc: "  |---- René Clément"}
+    - {id: 109, cat: Movies, desc: "  |---- Robert Bresson"}
+    - {id: 351, cat: Movies, desc: "  |---- Robert Guédiguian"}
+    - {id: 398, cat: Movies, desc: "  |---- Roger Vadim"}
+    - {id: 57, cat: Movies, desc: "  |---- Roman Polanski"}
+    - {id: 352, cat: Movies, desc: "  |---- Tony Gatlif"}
+    - {id: 596, cat: Movies, desc: "  |---- Yves Robert"}
+    - {id: 139, cat: Movies, desc: "  |-- Italianos"}
+    - {id: 526, cat: Movies, desc: "  |---- Alberto Lattuada"}
+    - {id: 804, cat: Movies, desc: "  |---- Antonio Pietrangeli"}
+    - {id: 58, cat: Movies, desc: "  |---- Bernardo Bertolucci"}
+    - {id: 198, cat: Movies, desc: "  |---- Dario Argento"}
+    - {id: 394, cat: Movies, desc: "  |---- Dino Risi"}
+    - {id: 668, cat: Movies, desc: "  |---- Elio Petri"}
+    - {id: 321, cat: Movies, desc: "  |---- Ermanno Olmi"}
+    - {id: 115, cat: Movies, desc: "  |---- Ettore Scola"}
+    - {id: 56, cat: Movies, desc: "  |---- Federico Fellini"}
+    - {id: 597, cat: Movies, desc: "  |---- Ferzan Ozpetek"}
+    - {id: 322, cat: Movies, desc: "  |---- Francesco Rosi"}
+    - {id: 960, cat: Movies, desc: "  |---- Franco Brocani"}
+    - {id: 323, cat: Movies, desc: "  |---- Franco Zeffirelli"}
+    - {id: 569, cat: Movies, desc: "  |---- Gianni Amelio"}
+    - {id: 98, cat: Movies, desc: "  |---- Giuseppe Tornatore"}
+    - {id: 739, cat: Movies, desc: "  |---- Liliana Cavani"}
+    - {id: 457, cat: Movies, desc: "  |---- Lina Wertmüller"}
+    - {id: 68, cat: Movies, desc: "  |---- Luchino Visconti"}
+    - {id: 805, cat: Movies, desc: "  |---- Luciano Salce"}
+    - {id: 598, cat: Movies, desc: "  |---- Lucio Fulci"}
+    - {id: 431, cat: Movies, desc: "  |---- Luigi Comencini"}
+    - {id: 324, cat: Movies, desc: "  |---- Marco Bellocchio"}
+    - {id: 325, cat: Movies, desc: "  |---- Marco Ferreri"}
+    - {id: 197, cat: Movies, desc: "  |---- Mario Bava"}
+    - {id: 740, cat: Movies, desc: "  |---- Mario Matolli"}
+    - {id: 128, cat: Movies, desc: "  |---- Mario Monicelli"}
+    - {id: 876, cat: Movies, desc: "  |---- Mauro Bolognini"}
+    - {id: 64, cat: Movies, desc: "  |---- Michelangelo Antonioni"}
+    - {id: 961, cat: Movies, desc: "  |---- Michele Soavi"}
+    - {id: 174, cat: Movies, desc: "  |---- Nanni Moretti"}
+    - {id: 669, cat: Movies, desc: "  |---- Paolo Sorrentino"}
+    - {id: 806, cat: Movies, desc: "  |---- Paolo Virzi"}
+    - {id: 212, cat: Movies, desc: "  |---- Paolo & Vittorio Taviani"}
+    - {id: 80, cat: Movies, desc: "  |---- Pier Paolo Pasolini"}
+    - {id: 527, cat: Movies, desc: "  |---- Pietro Germi"}
+    - {id: 962, cat: Movies, desc: "  |---- Raffaello Matarazzo"}
+    - {id: 92, cat: Movies, desc: "  |---- Roberto Benigni"}
+    - {id: 175, cat: Movies, desc: "  |---- Roberto Rossellini"}
+    - {id: 327, cat: Movies, desc: "  |---- Sergio Corbucci"}
+    - {id: 112, cat: Movies, desc: "  |---- Sergio Leone"}
+    - {id: 807, cat: Movies, desc: "  |---- Sergio Martino"}
+    - {id: 630, cat: Movies, desc: "  |---- Steno"}
+    - {id: 230, cat: Movies, desc: "  |---- Tinto Brass"}
+    - {id: 326, cat: Movies, desc: "  |---- Valerio Zurlini"}
+    - {id: 963, cat: Movies, desc: "  |---- Vittorio Cottafavi"}
+    - {id: 127, cat: Movies, desc: "  |---- Vittorio de Sica"}
+    - {id: 86, cat: Movies, desc: "  |-- Latino-Americanos"}
+    - {id: 599, cat: Movies, desc: "  |---- Adolfo Aristarain"}
+    - {id: 528, cat: Movies, desc: "  |---- Adrián Caetano"}
+    - {id: 87, cat: Movies, desc: "  |---- Alejandro Jodorowsky"}
+    - {id: 670, cat: Movies, desc: "  |---- Andrés Wood"}
+    - {id: 671, cat: Movies, desc: "  |---- Carlos Enrique Taboada"}
+    - {id: 672, cat: Movies, desc: "  |---- Carlos Reygadas"}
+    - {id: 481, cat: Movies, desc: "  |---- Carlos Sorin"}
+    - {id: 432, cat: Movies, desc: "  |---- Daniel Burman"}
+    - {id: 570, cat: Movies, desc: "  |---- Eliseo Subiela"}
+    - {id: 964, cat: Movies, desc: "  |---- Emilio Fernández"}
+    - {id: 303, cat: Movies, desc: "  |---- Fernando E. Solanas"}
+    - {id: 571, cat: Movies, desc: "  |---- Ismael Rodriguez"}
+    - {id: 965, cat: Movies, desc: "  |---- Leopoldo Torre Nilsson"}
+    - {id: 808, cat: Movies, desc: "  |---- Lisandro Alonso"}
+    - {id: 741, cat: Movies, desc: "  |---- Lucrecia Martel"}
+    - {id: 673, cat: Movies, desc: "  |---- Marcelo Piñeyro"}
+    - {id: 877, cat: Movies, desc: "  |---- Marco Berger"}
+    - {id: 674, cat: Movies, desc: "  |---- Miguel Littin"}
+    - {id: 809, cat: Movies, desc: "  |---- Pablo Larraín"}
+    - {id: 529, cat: Movies, desc: "  |---- Pablo Trapero"}
+    - {id: 302, cat: Movies, desc: "  |---- Santiago Álvarez"}
+    - {id: 572, cat: Movies, desc: "  |---- Tomás Gutiérrez Alea"}
+    - {id: 292, cat: Movies, desc: "  |-- Oceania"}
+    - {id: 810, cat: Movies, desc: "  |---- Bruce Beresford"}
+    - {id: 984, cat: Movies, desc: "  |---- Fred Schepisi"}
+    - {id: 512, cat: Movies, desc: "  |---- Jane Campion"}
+    - {id: 966, cat: Movies, desc: "  |---- Peter Jackson"}
+    - {id: 296, cat: Movies, desc: "  |---- Peter Weir"}
+    - {id: 482, cat: Movies, desc: "  |---- Rolf de Heer"}
+    - {id: 146, cat: Movies, desc: "  |-- Oriente Médio"}
+    - {id: 147, cat: Movies, desc: "  |---- Abbas Kiarostami"}
+    - {id: 315, cat: Movies, desc: "  |---- Amos Gitai"}
+    - {id: 530, cat: Movies, desc: "  |---- Asghar Farhadi"}
+    - {id: 531, cat: Movies, desc: "  |---- Bahman Ghobadi"}
+    - {id: 878, cat: Movies, desc: "  |---- Çagan Irmak"}
+    - {id: 675, cat: Movies, desc: "  |---- Dariush Mehrjui"}
+    - {id: 195, cat: Movies, desc: "  |---- Jafar Panahi"}
+    - {id: 434, cat: Movies, desc: "  |---- Majid Majidi"}
+    - {id: 879, cat: Movies, desc: "  |---- Mohammad Rasoulof"}
+    - {id: 172, cat: Movies, desc: "  |---- Mohsen Makhmalbaf"}
+    - {id: 194, cat: Movies, desc: "  |---- Nuri Bilge Ceylan"}
+    - {id: 600, cat: Movies, desc: "  |---- Reha Erdem"}
+    - {id: 967, cat: Movies, desc: "  |---- Semih Kaponoglu"}
+    - {id: 676, cat: Movies, desc: "  |---- Yilmaz Güney"}
+    - {id: 513, cat: Movies, desc: "  |---- Zeki Demirkubuz"}
+    - {id: 459, cat: Movies, desc: "  |-- Península Ibérica"}
+    - {id: 742, cat: Movies, desc: "  |---- Adolfo Arrieta"}
+    - {id: 968, cat: Movies, desc: "  |---- Agustí Villaronga"}
+    - {id: 305, cat: Movies, desc: "  |---- Alejandro Amenábar"}
+    - {id: 969, cat: Movies, desc: "  |---- Albert Serra"}
+    - {id: 269, cat: Movies, desc: "  |---- Álex de la Iglesia"}
+    - {id: 144, cat: Movies, desc: "  |---- Bigas Luna"}
+    - {id: 186, cat: Movies, desc: "  |---- Carlos Saura"}
+    - {id: 811, cat: Movies, desc: "  |---- Fernando Lopes"}
+    - {id: 514, cat: Movies, desc: "  |---- Fernando Trueba"}
+    - {id: 306, cat: Movies, desc: "  |---- Isabel Coixet"}
+    - {id: 743, cat: Movies, desc: "  |---- João Botelho"}
+    - {id: 264, cat: Movies, desc: "  |---- João César Monteiro"}
+    - {id: 601, cat: Movies, desc: "  |---- João Pedro Rodrigues"}
+    - {id: 812, cat: Movies, desc: "  |---- José Fonseca e Costa"}
+    - {id: 880, cat: Movies, desc: "  |---- José Luis Garci"}
+    - {id: 813, cat: Movies, desc: "  |---- José Luis Guerín"}
+    - {id: 188, cat: Movies, desc: "  |---- Julio Medem"}
+    - {id: 44, cat: Movies, desc: "  |---- Luis Buñuel"}
+    - {id: 881, cat: Movies, desc: "  |---- Luís Filipe Rocha"}
+    - {id: 180, cat: Movies, desc: "  |---- Manoel De Oliveira"}
+    - {id: 814, cat: Movies, desc: "  |---- Manuel Mozos"}
+    - {id: 677, cat: Movies, desc: "  |---- Miguel Gomes"}
+    - {id: 970, cat: Movies, desc: "  |---- Noémia Delgado"}
+    - {id: 815, cat: Movies, desc: "  |---- Paulo Rocha"}
+    - {id: 55, cat: Movies, desc: "  |---- Pedro Almodóvar"}
+    - {id: 308, cat: Movies, desc: "  |---- Pedro Costa"}
+    - {id: 678, cat: Movies, desc: "  |---- Pere Portabella"}
+    - {id: 971, cat: Movies, desc: "  |---- Rita Azevedo Gomes"}
+    - {id: 972, cat: Movies, desc: "  |---- Teresa Villaverde"}
+    - {id: 425, cat: Movies, desc: "  |---- Victor Erice"}
+    # - {id: 6, cat: Movies, desc: "Informações em Geral"}
+    # - {id: 7, cat: Movies, desc: "  |-- Regras e Normas"}
+    # - {id: 9, cat: Movies, desc: "  |-- Críticas e Sugestões"}
+    # - {id: 22, cat: Movies, desc: "  |-- Novidades"}
+    # - {id: 21, cat: Movies, desc: "  |-- Pedidos"}
+    # - {id: 20, cat: Movies, desc: "  |-- Boteco Making Off"}
+    # - {id: 54, cat: Movies, desc: "  |-- Quarentena"}
+    # - {id: 16, cat: Movies, desc: "Tutoriais e Ajuda"}
+    # - {id: 17, cat: Movies, desc: "  |-- Tutoriais em Geral"}
+    # - {id: 18, cat: Movies, desc: "  |-- DivX, XviD e outros formatos"}
+    # - {id: 19, cat: Movies, desc: "  |-- Dúvidas em Geral"}
+    # - {id: 145, cat: Movies, desc: "  |-- O Cinema na Teoria e na Prática"}
+
+  modes:
+    search: [q]
+    tv-search: [q]
+    movie-search: [q]
+    music-search: [q]
+
+settings:
+  - name: username
+    type: text
+    label: Username
+  - name: password
+    type: password
+    label: Password
+  - name: sort
+    type: select
+    label: Sort requested from site
+    default: date
+    options:
+      date: updated
+      title: title
+  - name: type
+    type: select
+    label: Order requested from site
+    default: 0
+    options:
+      0: desc
+      1: asc
+  - name: info_delay
+    type: info
+    label: Delay between searches
+    default: This forum enforces a 20s delay between searches. If no results are returned for a search, wait for 20s and try again.
+
+login:
+  path: forum/index.php
+  method: form
+  form: form#login
+  inputs:
+    referer: https://makingoff.org/forum/index.php
+    ips_username: "{{ .Config.username }}"
+    ips_password: "{{ .Config.password }}"
+    rememberMe: 1
+  selectorinputs:
+    auth_key:
+      selector: input[name="auth_key"]
+      attribute: value
+  error:
+    - selector: p.message.error
+  test:
+    path: forum/index.php
+    selector: a[href*="section=login&do=logout&k="]
+
+search:
+  paths:
+    - path: forum/index.php
+  inputs:
+    $raw: "{{ range .Categories }}search_app_filters[forums][forums][]={{.}}&{{end}}"
+    app: core
+    module: search
+    section: search
+    do: search
+    fromsearch: 1
+    search_app: forums
+    search_term: "{{ if .Keywords }}{{ .Keywords }}{{ else }}{{ .Today.Year }}{{ end }}"
+    search_app: forums
+    andor_type: and
+    # both, titles, content - title only search returns less information
+    search_content: both
+    # 0 posts, 1 topics
+    search_app_filters[forums][noPreview]: 0
+    search_app_filters[forums][sortKey]: "{{ .Config.sort }}"
+    search_app_filters[forums][sortDir]: "{{ .Config.type }}"
+    submit: Pesquisar
+
+  rows:
+    selector: div.post_block:has(a[href*="attach_id="]:has(strong:contains(".torrent")))
+    filters:
+      - name: andmatch
+
+  fields:
+    category:
+      selector: a[href*="index.php?showforum="]
+      attribute: href
+      filters:
+        - name: querystring
+          args: showforum
+    title:
+      selector: div.post.entry-content table tbody tr:nth-child(2) td div:first-child > font[size="2"]
+    details:
+      selector: a[href*="index.php?showtopic="]
+      attribute: href
+    download:
+      selector: a[href*="attach_id="]:has(strong:contains(".torrent"))
+      attribute: href
+    poster:
+      selector: div.post.entry-content table tbody tr:nth-child(4) td:first-child > span[rel="lightbox"] img.bbc_img
+      attribute: src
+    imdbid:
+      selector: a[href*="imdb.com/title/tt"]
+      attribute: href
+    size:
+      selector: div.post.entry-content table tbody tr:nth-child(2) td:nth-child(3) > font[size="2"]
+      filters:
+        - name: regexp
+          args: "(?i)Tamanho: (.+?b)"
+    year:
+      selector: div.post.entry-content table tbody tr:nth-child(2) td:nth-child(2) > font[size="2"]
+      filters:
+        - name: regexp
+          args: "Ano de Lançamento: ((19|20)\\d{2})"
+    seeders:
+      text: 1
+    leechers:
+      text: 1
+    grabs:
+      selector: span:contains("ownloads")
+    date:
+      selector: abbr.published
+      attribute: title
+    downloadvolumefactor:
+      text: 0
+    uploadvolumefactor:
+      text: 1
+    description:
+      selector: div.post.entry-content table tbody tr:nth-child(4) td div:first-child > font[size="2"]
+# engine n/a


### PR DESCRIPTION
#### Description
Alternatively, indexer could use title-only search and not have to use andmatch filter, but it loses a lot of information, like many other forum-based indexers.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #14834
