### PR TITLE
Update install_service_systemd.sh - 

### DIFF
--- a/install_service_systemd.sh
+++ b/install_service_systemd.sh
@@ -48,7 +48,7 @@ if [ ! -f ./jackett ]; then
 fi
 
 # Check if Jackett's owner is root
-JACKETT_USER="$(stat -c "%U" ./jackett)"
+JACKETT_USER="$(stat -c "%U" ./Jackett)"
 if [ "${JACKETT_USER}" == "root" ] || [ "${JACKETT_USER}" == "UNKNOWN" ] ; then
     echo "${BOLDRED}ERROR${NC}: The owner of Jackett directory is '${JACKETT_USER}'."
     echo "Please, change the owner with the command 'chown <user>:<user> -R \"${JACKETT_DIR}\"'"


### PR DESCRIPTION
Correct capitalization in owner check. Directory is upper case (Jackett not jackett) when created by the installer. Installer fails with below message due to the directory not having an owner since /etc/jackett does not exist.

<img width="781" alt="image" src="https://github.com/Jackett/Jackett/assets/13126662/04dc16b4-1b7d-4299-ba22-fbd9c96a5db1">


#### Description
This PR fixes a capitalization error in the install script for a service on linux.
#### Screenshot (if UI related)
N/A
#### Issues Fixed or Closed by this PR
I did not report this beforehand. 
