### PR TITLE
Fix search for Demain nous appartient (tommorow is ours).

### DIFF
--- a/src/Jackett.Common/Definitions/yggcookie.yml
+++ b/src/Jackett.Common/Definitions/yggcookie.yml
@@ -392,6 +392,8 @@ search:
         # Replace French date dd-mm-yyyy to yyyy.mm.dd
         - name: re_replace
           args: ["\\b(\\d{2})[\\-_\\.](\\d{2})[\\-_\\.](\\d{4})\\b", "$3.$2.$1"]
+        - name: re_replace
+          args: ["(?i)Demain Nous Appartient S(\\d{1,2})E(\\d{1,})", "Demain Nous Appartient E{{ add $1 8 }}$2"]
     title_filtered:
       text: "{{ .Result.title_normal }}"
       filters:

--- a/src/Jackett.Common/Definitions/yggtorrent.yml
+++ b/src/Jackett.Common/Definitions/yggtorrent.yml
@@ -396,6 +396,8 @@ search:
         # Replace French date dd-mm-yyyy to yyyy.mm.dd
         - name: re_replace
           args: ["\\b(\\d{2})[\\-_\\.](\\d{2})[\\-_\\.](\\d{4})\\b", "$3.$2.$1"]
+        - name: re_replace
+          args: ["(?i)Demain Nous Appartient S(\\d{1,2})E(\\d{1,})", "Demain Nous Appartient E{{ add $1 8 }}$2"]
     title_filtered:
       text: "{{ .Result.title_normal }}"
       filters:


### PR DESCRIPTION
Currently, the search from sonarr to Jackett is done this way:
Demain Nous Appartient S07E81
Demain Nous Appartient S07E82
Demain Nous Appartient S07E83
...
Demain Nous Appartient S07E99

However, on yggtorent they are named like this:
Demain Nous Appartient E1581
Demain Nous Appartient E1582
Demain Nous Appartient E1583
...
Demain Nous Appartient E1599

So I added a filter rule so that they appear in jackett. I anticipated season 8:
Demain Nous Appartient S08E01 => Demain Nous Appartient E1601
....
Demain Nous Appartient S08E99 => Demain Nous Appartient E1699