### PR TITLE
1337x.yml => filtered apostrophe into blank

### DIFF
--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -218,6 +218,8 @@ search:
           args: ["-([\\w]+(?:[\\[\\]\\(\\)\\w]+)?)$", "~$1"]
         - name: replace
           args: ["-", " "]
+        - name: replace
+          args: ["'", " "]
         - name: re_replace
           args: ["~([\\w]+(?:[\\[\\]\\(\\)\\w]+)?)$", "-$1"]
         - name: replace


### PR DESCRIPTION
#### Description
"The queen's gambit" doesn't show up when indexed but "The queens gambit" does show up when indexed

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
