### PR TITLE
Add setting remove_seasoninfo to nyaasi definition

### DIFF
--- a/src/Jackett.Common/Definitions/nyaasi.yml
+++ b/src/Jackett.Common/Definitions/nyaasi.yml
@@ -89,6 +89,10 @@ settings:
     type: checkbox
     label: Improve Radarr compatibility by removing year information from keywords and adding it to Release Titles
     default: false
+  - name: remove_seasoninfo
+    type: checkbox
+    label: Improve results by removing Season Information from keywords
+    default: false
   - name: filter-id
     type: select
     label: Filter
@@ -151,6 +155,8 @@ search:
   keywordsfilters:
     - name: re_replace
       args: [" *\\b((?:19|20)\\d{2})\\b", "{{ if .Config.radarr_compatibility }}{{ else }} $1{{ end }}"]
+    - name: re_replace
+      args: ["(?i)(S[0-9][0-9]E)", "{{ if .Config.remove_seasoninfo }}{{ else }} $1{{ end }}"]
 
   rows:
     selector: tr.default,tr.danger,tr.success


### PR DESCRIPTION
Added the option to remove season information from the search keywords, as most anime are numbered continuously.

#### Description
Added the option to remove season information from the search keywords, as most anime are numbered continuously.
TMDB TV shows use the same method, and there are no results when querying e.g. _SomeAnime_ S01E45, but there are when querying _SomeAnime_ 45.

