### PR TITLE
fix(hdbits): Replace periods with spaces

### DIFF
--- a/src/Jackett.Common/Indexers/HDBitsApi.cs
+++ b/src/Jackett.Common/Indexers/HDBitsApi.cs
@@ -135,7 +135,8 @@ namespace Jackett.Common.Indexers
             }
             else if (!string.IsNullOrWhiteSpace(queryString))
             {
-                requestData["search"] = queryString;
+                string modifiedQueryString = queryString.Replace(".", " ");
+                requestData["search"] = modifiedQueryString;
             }
 
             var categories = MapTorznabCapsToTrackers(query);


### PR DESCRIPTION
#### Description
Searching does not work with periods what-so-ever. Names by default have spaces, and if a period is some how present (like in h.264) the search still works.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
