### PR TITLE
DonTorrent new domain 23.01.2024

### DIFF
--- a/src/Jackett.Common/Indexers/DonTorrent.cs
+++ b/src/Jackett.Common/Indexers/DonTorrent.cs
@@ -26,10 +26,10 @@ namespace Jackett.Common.Indexers
         public override string Name => "DonTorrent";
         public override string Description => "DonTorrent is a SPANISH public tracker for MOVIES / TV / GENERAL";
         // in the event the redirect is inactive https://t.me/s/dontorrent should have the latest working domain
-        public override string SiteLink { get; protected set; } = "https://dontorrent.capetown/";
+        public override string SiteLink { get; protected set; } = "https://dontorrent.yokohama/";
         public override string[] AlternativeSiteLinks => new[]
         {
-            "https://dontorrent.capetown/",
+            "https://dontorrent.yokohama/",
             "https://todotorrents.org/",
             "https://tomadivx.net/",
             "https://seriesblanco.one/",
@@ -54,6 +54,7 @@ namespace Jackett.Common.Indexers
             "https://dontorrent.nagoya/",
             "https://dontorrent.contact/",
             "https://dontorrent.cymru/",
+            "https://dontorrent.capetown/",
         };
         public override string Language => "es-ES";
         public override string Type => "public";


### PR DESCRIPTION
The new DonTorrent domain is: https://dontorrent.yokohama/

#### Description
Changed as DonTorrent has a new domain now.

TG snapshot from official channel there.
![image](https://github.com/Jackett/Jackett/assets/60728004/b590759b-558b-4d4a-b6c8-2ee8e7b9dbe2)
