### PR TITLE
Use params IMDBID, TVDBID, TVMAZEID and TMDBID with json response

### DIFF
--- a/src/Jackett.Common/Models/DTO/ApiSearch.cs
+++ b/src/Jackett.Common/Models/DTO/ApiSearch.cs
@@ -9,6 +9,10 @@ namespace Jackett.Common.Models.DTO
         public string Query { get; set; }
         public int[] Category { get; set; }
         public string[] Tracker { get; set; }
+        public string ImdbId { get; set; }
+        public int TvdbId { get; set; }
+        public int TmdbId { get; set; }
+        public int TvMazeId { get; set; }
 
         public static TorznabQuery ToTorznabQuery(ApiSearch request)
         {
@@ -50,6 +54,10 @@ namespace Jackett.Common.Models.DTO
 
             stringQuery.SearchTerm = queryStr;
             stringQuery.Categories = request.Category ?? Array.Empty<int>();
+            stringQuery.TmdbID = request.TmdbId;
+            stringQuery.TvdbID = request.TvdbId;
+            stringQuery.ImdbID = request.ImdbId;
+            stringQuery.TvmazeID = request.TvMazeId;
 
             // try to build an IMDB Query (tt plus 6 to 8 digits)
             if (stringQuery.SanitizedSearchTerm.StartsWith("tt") && stringQuery.SanitizedSearchTerm.Length <= 10)
@@ -66,6 +74,9 @@ namespace Jackett.Common.Models.DTO
                     };
                 }
             }
+
+
+
 
             return stringQuery;
         }

--- a/src/Jackett.Server/Controllers/ResultsController.cs
+++ b/src/Jackett.Server/Controllers/ResultsController.cs
@@ -221,19 +221,16 @@ namespace Jackett.Server.Controllers
                 if (t.Key == "tmdbid")
                 {
                     request.TmdbId = Int32.Parse(t.Value.ToString());
-                    Console.WriteLine(request.TmdbId);
                 }
 
                 if (t.Key == "tvdbid")
                 {
                     request.TvdbId = Int32.Parse(t.Value.ToString());
-                    Console.WriteLine(request.TmdbId);
                 }
 
                 if (t.Key == "tvmazeid")
                 {
                     request.TvMazeId = Int32.Parse(t.Value.ToString());
-                    Console.WriteLine(request.TmdbId);
                 }
             }
 

--- a/src/Jackett.Server/Controllers/ResultsController.cs
+++ b/src/Jackett.Server/Controllers/ResultsController.cs
@@ -212,6 +212,29 @@ namespace Jackett.Server.Controllers
                 {
                     request.Query = t.Value.ToString();
                 }
+
+                if (t.Key == "imdbid")
+                {
+                    request.ImdbId = t.Value.ToString();
+                }
+
+                if (t.Key == "tmdbid")
+                {
+                    request.TmdbId = Int32.Parse(t.Value.ToString());
+                    Console.WriteLine(request.TmdbId);
+                }
+
+                if (t.Key == "tvdbid")
+                {
+                    request.TvdbId = Int32.Parse(t.Value.ToString());
+                    Console.WriteLine(request.TmdbId);
+                }
+
+                if (t.Key == "tvmazeid")
+                {
+                    request.TvMazeId = Int32.Parse(t.Value.ToString());
+                    Console.WriteLine(request.TmdbId);
+                }
             }
 
             var manualResult = new ManualSearchResult();


### PR DESCRIPTION
#### Description
As discussed here https://github.com/Jackett/Jackett/issues/15009 the params for json response only works with a few params.

Implemented so IMDBID, TVDBID, TVMAZEID and TMDBID params are supported with the API json response

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX

IMDBID -tested with valid, invalid id
TVDBID - tested with valid, invalid id
TMDBID - tested with valid, invalid id
TVMAZEID - uanble to test as the only site i know that uses tvmaze is BIThdtv but its not a supported param for the site. ```http://localhost:9117/api/v2.0/indexers/bithdtv/results/torznab/api?apikey=<API_KEY>&t=caps```


I will add the other params that is supported by torznab once i know know this will be merged. 

Note if the site does not support the search param that the latest torrents are returned but that is the same behavior as torznab. I will put in a test that search only happens with supported params when i have time.