### PR TITLE
Update torrent-heaven.yml: new download url

### DIFF
--- a/src/Jackett.Common/Definitions/torrent-heaven.yml
+++ b/src/Jackett.Common/Definitions/torrent-heaven.yml
@@ -79,7 +79,7 @@ download:
       text: "{{ .Config.thankyou }}"
       submit: Opslaan
   selectors:
-    - selector: a[href^="download.php?id="]
+    - selector: a[href^="downloadv1.php?id="]
       attribute: href
 
 search:

--- a/src/Jackett.Common/Definitions/torrent-heaven.yml
+++ b/src/Jackett.Common/Definitions/torrent-heaven.yml
@@ -79,6 +79,8 @@ download:
       text: "{{ .Config.thankyou }}"
       submit: Opslaan
   selectors:
+    - selector: a[href^="download.php?id="]
+      attribute: href
     - selector: a[href^="downloadv1.php?id="]
       attribute: href
 


### PR DESCRIPTION
Torrent Heaven changed the download url.
Before: download.php?id=
Now: downloadv1.php?id=
This wil update the Definition.

#### Description
A few sentences describing the overall goals of the pull request's commits.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
