### PR TITLE
[enhancement]: support Torznab o=JSON

### DIFF
--- a/src/Jackett.Common/Models/DTO/TorznabRequest.cs
+++ b/src/Jackett.Common/Models/DTO/TorznabRequest.cs
@@ -10,6 +10,7 @@ namespace Jackett.Common.Models.DTO
         public string imdbid { get; set; }
         public string ep { get; set; }
         public string t { get; set; }
+        public string o { get; set; }
         public string extended { get; set; }
         public string limit { get; set; }
         public string offset { get; set; }

--- a/src/Jackett.Common/Models/TorznabQuery.cs
+++ b/src/Jackett.Common/Models/TorznabQuery.cs
@@ -47,6 +47,8 @@ namespace Jackett.Common.Models
 
         public bool IsTest { get; set; }
 
+        public bool IsJson { get; set; }
+
         public string ImdbIDShort => ImdbID?.TrimStart('t');
 
         protected string[] QueryStringParts;


### PR DESCRIPTION
#### Description
Aims to add support for the `o` parameter as described [here](https://torznab.github.io/spec-1.3-draft/external/newznab/api.html?highlight=json), the examples in the standard are only listed for XML, the JSON structure in this PR resembles the XML as closely as possible.

If the parameter is omitted or is not equal to `json`, XML is assumed.

This is my first PR here, if anything looks wrong please let me know and I'll fix it.

#### Issues Fixed or Closed by this PR

* Closes #15018
