### PR TITLE
Corrected IPTorrents mirror list

### DIFF
--- a/src/Jackett.Common/Indexers/IPTorrents.cs
+++ b/src/Jackett.Common/Indexers/IPTorrents.cs
@@ -38,8 +38,7 @@ namespace Jackett.Common.Indexers
             "https://ipt.cool/",
             "https://ipt.lol/",
             "https://ipt.world/",
-            "https://ipt.octopus.town/",
-            "https://anyname.octopus.town/"
+            "https://ipt.octopus.town/"
         };
         public override string[] LegacySiteLinks => new[]
         {

--- a/src/Jackett.Common/Indexers/IPTorrents.cs
+++ b/src/Jackett.Common/Indexers/IPTorrents.cs
@@ -51,7 +51,12 @@ namespace Jackett.Common.Indexers
             "http://logan.unusualperson.com/",
             "https://ipt.rocks/",
             "http://baywatch.workisboring.com/",
-            "https://iptorrents.eu/"
+            "https://iptorrents.eu/",
+            "https://ipt.getcrazy.me/",
+            "https://ipt.findnemo.net/",
+            "https://ipt.beelyrics.net/",
+            "https://ipt.venom.global/",
+            "https://ipt.workisboring.net/"
         };
         public override string Language => "en-US";
         public override string Type => "private";

--- a/src/Jackett.Common/Indexers/IPTorrents.cs
+++ b/src/Jackett.Common/Indexers/IPTorrents.cs
@@ -31,15 +31,15 @@ namespace Jackett.Common.Indexers
             "https://www.iptorrents.com/",
             "https://iptorrents.me/",
             "https://nemo.iptorrents.com/",
-            "https://ipt.getcrazy.me/",
-            "https://ipt.findnemo.net/",
-            "https://ipt.beelyrics.net/",
-            "https://ipt.venom.global/",
-            "https://ipt.workisboring.net/",
-            "https://ipt.lol/",
+            "https://ip.findnemo.net/",
+            "https://ip.venom.global/",
+            "https://ip.getcrazy.me/",
+            "https://ip.workisboring.net/",
             "https://ipt.cool/",
+            "https://ipt.lol/",
             "https://ipt.world/",
-            "https://ipt.octopus.town/"
+            "https://ipt.octopus.town/",
+            "https://anyname.octopus.town/"
         };
         public override string[] LegacySiteLinks => new[]
         {


### PR DESCRIPTION
Official mirror list is:
https://ipt.cool
https://ipt.world
https://ipt.lol
https://ip.findnemo.net
https://ip.getcrazy.me
https://ip.venom.global
https://ip.workisboring.net
https://AnyName.octopus.town

Removed any other, as may not be authorized or legitimate, and may expose user credentials. https://ipt.world/topic.php?t=3005848

![image](https://github.com/Jackett/Jackett/assets/60728004/93e21cf8-5132-4b36-80ee-09e9fdc2b380)
