### PR TITLE
Yify sites, proxies, status links updated

### DIFF
--- a/src/Jackett.Common/Definitions/yts.yml
+++ b/src/Jackett.Common/Definitions/yts.yml
@@ -9,15 +9,14 @@ requestDelay: 2.5 # 2.5 requests per second (2 causes problems)
 links:
   # dont forget to update the details, download and poster replace args
   - https://yts.mx/
-  - https://yts.unblockit.dad/
-  - https://yts.unblockninja.com/
-  - https://yts.ninjaproxy1.com/
-  - https://yts.proxyninja.org/
-  - https://yts.torrentbay.st/
-legacylinks:
-  - https://yts.ag/
-  - https://yts.am/
   - https://yts.lt/
+  - https://yts.am/
+  - https://yts.ag/
+  - https://yts.unblockit.dad/
+status_proxylinks:
+  - https://yifystatus.com/
+  - https://ytsproxies.com/
+legacylinks:
   - https://yts.nocensor.art/
   - https://yts.unblockit.bio/
   - https://yts.unblockit.boo/
@@ -36,7 +35,10 @@ legacylinks:
   - https://yts.mrunblock.bond/
   - https://yts.nocensor.cloud/
   - https://yts.unblockit.date/
-
+  - https://yts.unblockninja.com/
+  - https://yts.ninjaproxy1.com/
+  - https://yts.proxyninja.org/
+  - https://yts.torrentbay.st/  
 caps:
   categorymappings:
     # note: the API does not support searching with categories, so these are dummy ones for torznab compatibility

--- a/src/Jackett.Common/Definitions/yts.yml
+++ b/src/Jackett.Common/Definitions/yts.yml
@@ -13,6 +13,11 @@ links:
   - https://yts.am/
   - https://yts.ag/
   - https://yts.unblockit.dad/
+# unofficial proxies below; allowed as meeting requisite criterion.
+  - https://yts.unblockninja.com/
+  - https://yts.ninjaproxy1.com/
+  - https://yts.proxyninja.org/
+  - https://yts.torrentbay.st/
 # official domain list are at https://yifystatus.com/ and  official proxies list are at https://ytsproxies.com/
 legacylinks:
   - https://yts.nocensor.art/
@@ -33,10 +38,6 @@ legacylinks:
   - https://yts.mrunblock.bond/
   - https://yts.nocensor.cloud/
   - https://yts.unblockit.date/
-  - https://yts.unblockninja.com/
-  - https://yts.ninjaproxy1.com/
-  - https://yts.proxyninja.org/
-  - https://yts.torrentbay.st/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/yts.yml
+++ b/src/Jackett.Common/Definitions/yts.yml
@@ -38,7 +38,8 @@ legacylinks:
   - https://yts.unblockninja.com/
   - https://yts.ninjaproxy1.com/
   - https://yts.proxyninja.org/
-  - https://yts.torrentbay.st/  
+  - https://yts.torrentbay.st/
+
 caps:
   categorymappings:
     # note: the API does not support searching with categories, so these are dummy ones for torznab compatibility

--- a/src/Jackett.Common/Definitions/yts.yml
+++ b/src/Jackett.Common/Definitions/yts.yml
@@ -13,9 +13,7 @@ links:
   - https://yts.am/
   - https://yts.ag/
   - https://yts.unblockit.dad/
-status_proxylinks:
-  - https://yifystatus.com/
-  - https://ytsproxies.com/
+# official domain list are at https://yifystatus.com/ and  official proxies list are at https://ytsproxies.com/
 legacylinks:
   - https://yts.nocensor.art/
   - https://yts.unblockit.bio/


### PR DESCRIPTION
As per the yify status & proxies website, these are the only ones which are correct YTS sites. Though. I have kept the yts.unblockit.dad as it is the only other one which seems to be leading to the same certificates as the other yify sites. Moved rest all to legacy links section.
Also, added a section for status & proxy links for future referencing. Please let me know or place it correctly in the file as needed, but keep those 2 links there (status & proxies).