### PR TITLE
[enhancement] Move resolution search terms from name to tags in json (nebulance.io)

### DIFF
--- a/src/Jackett.Common/Indexers/NebulanceAPI.cs
+++ b/src/Jackett.Common/Indexers/NebulanceAPI.cs
@@ -34,6 +34,8 @@ namespace Jackett.Common.Indexers
         protected virtual string APIUrl => SiteLink + "api.php";
         protected virtual int KeyLength => 32;
 
+        private readonly string[] _moveToTags = { "720p", "1080p", "2160p", "4k" };
+
         // TODO: remove ConfigurationDataAPIKey class and use ConfigurationDataPasskey instead
         private new ConfigurationDataAPIKey configData
         {
@@ -170,7 +172,16 @@ namespace Jackett.Common.Indexers
 
             var searchString = query.GetQueryString();
             if (!string.IsNullOrWhiteSpace(searchString))
+            {
+                var searchTerms = Regex.Split(searchString, "\\s+").ToList();
+                var movingToTags = searchTerms.Intersect(_moveToTags, StringComparer.OrdinalIgnoreCase).ToList();
+                movingToTags.ForEach(
+                    tag => searchTerms.RemoveAll(searchTerm => searchTerm.Equals(tag, StringComparison.OrdinalIgnoreCase)));
+
+                searchString = searchTerms.Join(" ");
+                searchParam["tags"] = new JArray(movingToTags);
                 searchParam["name"] = "%" + Regex.Replace(searchString, "[\\W]+", "%").Trim() + "%";
+            }
 
             if (query.IsTvmazeQuery && query.TvmazeID.HasValue)
             {

--- a/src/Jackett.Common/Indexers/NebulanceAPI.cs
+++ b/src/Jackett.Common/Indexers/NebulanceAPI.cs
@@ -246,7 +246,10 @@ namespace Jackett.Common.Indexers
                     }
                     var tags = string.Join(",", item.Value<JArray>("tags"));
                     var releaseGenres = validList.Intersect(tags.ToLower().Split(delimiters, StringSplitOptions.RemoveEmptyEntries)).ToList();
-                    descriptions.Add("Genre: " + string.Join(",", releaseGenres));
+                    if (releaseGenres.Count >= 1)
+                    {
+                        descriptions.Add("Genre: " + string.Join(",", releaseGenres));
+                    }
                     var releaseCats = validCats.Intersect(tags.ToLower().Split(delimiters, StringSplitOptions.RemoveEmptyEntries)).ToList();
 
                     var release = new ReleaseInfo

--- a/src/Jackett.Common/Indexers/NebulanceAPI.cs
+++ b/src/Jackett.Common/Indexers/NebulanceAPI.cs
@@ -246,7 +246,7 @@ namespace Jackett.Common.Indexers
                     }
                     var tags = string.Join(",", item.Value<JArray>("tags"));
                     var releaseGenres = validList.Intersect(tags.ToLower().Split(delimiters, StringSplitOptions.RemoveEmptyEntries)).ToList();
-                    descriptions.Add("Tags: " + string.Join(",", releaseGenres));
+                    descriptions.Add("Genre: " + string.Join(",", releaseGenres));
                     var releaseCats = validCats.Intersect(tags.ToLower().Split(delimiters, StringSplitOptions.RemoveEmptyEntries)).ToList();
 
                     var release = new ReleaseInfo


### PR DESCRIPTION
#### Description
Currently searching nebulance.io by resolution (1080p, 2160p,...) returns no results because resolution should be sent as tags, not as part of name. This PR fixes that. 






