### PR TITLE
flaresolverr: support proxy auth. resolves #15099

### DIFF
--- a/src/Jackett.Common/Jackett.Common.csproj
+++ b/src/Jackett.Common/Jackett.Common.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Autofac" Version="6.5.0" />
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="BencodeNET" Version="4.0.0" />
-    <PackageReference Include="FlareSolverrSharp" Version="3.0.5" />
+    <PackageReference Include="FlareSolverrSharp-fork" Version="3.0.5" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="DotNet4.SocksProxy" Version="1.4.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />

--- a/src/Jackett.Common/Jackett.Common.csproj
+++ b/src/Jackett.Common/Jackett.Common.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="Autofac" Version="6.5.0" />
     <PackageReference Include="AutoMapper" Version="10.1.1" />
     <PackageReference Include="BencodeNET" Version="4.0.0" />
-    <PackageReference Include="FlareSolverrSharp-fork" Version="3.0.5" />
+    <PackageReference Include="FlareSolverrSharp" Version="3.0.6" />
     <PackageReference Include="CommandLineParser" Version="2.9.1" />
     <PackageReference Include="DotNet4.SocksProxy" Version="1.4.0.1" />
     <PackageReference Include="Microsoft.AspNetCore.Http" Version="2.2.2" />

--- a/src/Jackett.Common/Models/Config/ServerConfig.cs
+++ b/src/Jackett.Common/Models/Config/ServerConfig.cs
@@ -94,7 +94,7 @@ namespace Jackett.Common.Models.Config
                 url = $"{authString}@{url}";
 
             // add protocol
-            if (ProxyType == ProxyType.Socks4 || ProxyType == ProxyType.Socks5)
+            if (ProxyType == ProxyType.Socks4 || ProxyType == ProxyType.Socks5 || ProxyType == ProxyType.Http)
             {
                 var protocol = (Enum.GetName(typeof(ProxyType), ProxyType) ?? "").ToLower();
                 if (!string.IsNullOrEmpty(protocol))

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
@@ -84,6 +84,8 @@ namespace Jackett.Common.Utils.Clients
             {
                 clearanceHandlr.MaxTimeout = serverConfig.FlareSolverrMaxTimeout;
                 clearanceHandlr.ProxyUrl = serverConfig.GetProxyUrl(false);
+                clearanceHandlr.ProxyUsername = serverConfig.ProxyUsername;
+                clearanceHandlr.ProxyPassword = serverConfig.ProxyPassword;
                 using (var clientHandlr = new HttpClientHandler
                 {
                     CookieContainer = cookies,

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
@@ -60,7 +60,9 @@ namespace Jackett.Common.Utils.Clients
             clearanceHandlr = new ClearanceHandler(serverConfig.FlareSolverrUrl)
             {
                 MaxTimeout = serverConfig.FlareSolverrMaxTimeout,
-                ProxyUrl = serverConfig.GetProxyUrl(false)
+                ProxyUrl = serverConfig.GetProxyUrl(false),
+                ProxyUsername = serverConfig.ProxyUsername,
+                ProxyPassword = serverConfig.ProxyPassword
             };
             clientHandlr = new HttpClientHandler
             {


### PR DESCRIPTION
#### Description
Temporarily changed to `FlareSolverrSharp-fork` for sake of testing. Will need to merge https://github.com/FlareSolverr/FlareSolverrSharp/pull/25 first and then revert back to `FlareSolverrSharp` with a version bump.

SOCKS4 doesn't support authentication, and Chromium doesn't support SOCKS5 authentication, so it's just HTTP to test here. If you don't have an HTTP proxy with credentials readily available to test, I just used https://www.webshare.io and registered using https://temp-mail.org

Make edits or suggestions.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #15099
