### PR TITLE
assorted unit3d: remove `None` from genres

### DIFF
--- a/src/Jackett.Common/Definitions/aither-api.yml
+++ b/src/Jackett.Common/Definitions/aither-api.yml
@@ -122,6 +122,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/animeworld-api.yml
+++ b/src/Jackett.Common/Definitions/animeworld-api.yml
@@ -129,6 +129,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Cinema TV)", "Cinema_TV"]
         - name: re_replace
           args: ["(?i)(Ficção científica)", "Ficção_científica"]

--- a/src/Jackett.Common/Definitions/blutopia-api.yml
+++ b/src/Jackett.Common/Definitions/blutopia-api.yml
@@ -122,6 +122,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/cinematik.yml
+++ b/src/Jackett.Common/Definitions/cinematik.yml
@@ -116,6 +116,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/datascene-api.yml
+++ b/src/Jackett.Common/Definitions/datascene-api.yml
@@ -151,6 +151,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(All Sex)", "All_Sex"]
         - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]

--- a/src/Jackett.Common/Definitions/desitorrents-api.yml
+++ b/src/Jackett.Common/Definitions/desitorrents-api.yml
@@ -123,6 +123,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/fearnopeer.yml
+++ b/src/Jackett.Common/Definitions/fearnopeer.yml
@@ -122,6 +122,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/generationfree-api.yml
+++ b/src/Jackett.Common/Definitions/generationfree-api.yml
@@ -169,6 +169,8 @@ search:
     genre:
       selector: meta.genres
       filters:
+        - name: re_replace
+          args: ["(?i)^None$", ""]
         - name: replace
           args: [" & ", "_&_"]
     description:

--- a/src/Jackett.Common/Definitions/hd-unit3d-api.yml
+++ b/src/Jackett.Common/Definitions/hd-unit3d-api.yml
@@ -119,6 +119,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/hdtorrentsit.yml
+++ b/src/Jackett.Common/Definitions/hdtorrentsit.yml
@@ -127,6 +127,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/itatorrents.yml
+++ b/src/Jackett.Common/Definitions/itatorrents.yml
@@ -132,6 +132,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(televisione film)", "televisione_film"]
         - name: replace
           args: [" & ", "_&_"]

--- a/src/Jackett.Common/Definitions/kimoji.yml
+++ b/src/Jackett.Common/Definitions/kimoji.yml
@@ -117,6 +117,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movies)", "TV_Movies"]

--- a/src/Jackett.Common/Definitions/laidbackmanor.yml
+++ b/src/Jackett.Common/Definitions/laidbackmanor.yml
@@ -122,6 +122,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/lastdigitalunderground.yml
+++ b/src/Jackett.Common/Definitions/lastdigitalunderground.yml
@@ -137,6 +137,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/lat-team-api.yml
+++ b/src/Jackett.Common/Definitions/lat-team-api.yml
@@ -141,6 +141,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/lst.yml
+++ b/src/Jackett.Common/Definitions/lst.yml
@@ -126,6 +126,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/mendigosdaweb.yml
+++ b/src/Jackett.Common/Definitions/mendigosdaweb.yml
@@ -127,6 +127,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Ficção científica)", "Ficção_científica"]
         - name: re_replace
           args: ["(?i)(Cinema TV)", "Cinema_TV"]

--- a/src/Jackett.Common/Definitions/monikadesign-api.yml
+++ b/src/Jackett.Common/Definitions/monikadesign-api.yml
@@ -123,6 +123,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: replace
           args: [" & ", "_&_"]

--- a/src/Jackett.Common/Definitions/ntelogo.yml
+++ b/src/Jackett.Common/Definitions/ntelogo.yml
@@ -127,6 +127,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/onlyencodes-api.yml
+++ b/src/Jackett.Common/Definitions/onlyencodes-api.yml
@@ -118,6 +118,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/portugas-api.yml
+++ b/src/Jackett.Common/Definitions/portugas-api.yml
@@ -132,6 +132,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Ficção científica)", "Ficção_científica"]
         - name: re_replace
           args: ["(?i)(Cinema TV)", "Cinema_TV"]

--- a/src/Jackett.Common/Definitions/redbits-api.yml
+++ b/src/Jackett.Common/Definitions/redbits-api.yml
@@ -148,6 +148,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Película de TV)", "Película_de_TV"]
         - name: re_replace
           args: ["(?i)(Ciencia ficción)", "Ciencia_ficción"]

--- a/src/Jackett.Common/Definitions/reelflix-api.yml
+++ b/src/Jackett.Common/Definitions/reelflix-api.yml
@@ -121,6 +121,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/scenelinks.yml
+++ b/src/Jackett.Common/Definitions/scenelinks.yml
@@ -142,6 +142,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/shareisland-api.yml
+++ b/src/Jackett.Common/Definitions/shareisland-api.yml
@@ -156,6 +156,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(televisione film)", "televisione_film"]
         - name: replace
           args: [" & ", "_&_"]

--- a/src/Jackett.Common/Definitions/skipthecommercials-api.yml
+++ b/src/Jackett.Common/Definitions/skipthecommercials-api.yml
@@ -118,6 +118,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]
         - name: replace
           args: [" & ", "_&_"]

--- a/src/Jackett.Common/Definitions/skipthetrailers.yml
+++ b/src/Jackett.Common/Definitions/skipthetrailers.yml
@@ -117,6 +117,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/theoldschool-api.yml
+++ b/src/Jackett.Common/Definitions/theoldschool-api.yml
@@ -173,6 +173,8 @@ search:
     genre:
       selector: meta.genres
       filters:
+        - name: re_replace
+          args: ["(?i)^None$", ""]
         - name: replace
           args: [" & ", "_&_"]
     description:

--- a/src/Jackett.Common/Definitions/therebels-api.yml
+++ b/src/Jackett.Common/Definitions/therebels-api.yml
@@ -130,6 +130,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Ficção científica)", "Ficção_científica"]
         - name: re_replace
           args: ["(?i)(Cinema TV)", "Cinema_TV"]

--- a/src/Jackett.Common/Definitions/theshinning-api.yml
+++ b/src/Jackett.Common/Definitions/theshinning-api.yml
@@ -127,6 +127,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/tocashare.yml
+++ b/src/Jackett.Common/Definitions/tocashare.yml
@@ -129,6 +129,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Ficção científica)", "Ficção_científica"]
         - name: replace
           args: [" & ", "_&_"]

--- a/src/Jackett.Common/Definitions/torrenteros-api.yml
+++ b/src/Jackett.Common/Definitions/torrenteros-api.yml
@@ -120,6 +120,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Ciencia ficción)", "Ciencia_ficción"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/torrentland-api.yml
+++ b/src/Jackett.Common/Definitions/torrentland-api.yml
@@ -153,6 +153,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Ciencia ficción)", "Ciencia_ficción"]
         - name: re_replace
           args: ["(?i)(Película de TV)", "Película_de_TV"]

--- a/src/Jackett.Common/Definitions/uploadcx.yml
+++ b/src/Jackett.Common/Definitions/uploadcx.yml
@@ -111,6 +111,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Science Fiction)", "Science_Fiction"]
         - name: re_replace
           args: ["(?i)(TV Movie)", "TV_Movie"]

--- a/src/Jackett.Common/Definitions/utopia.yml
+++ b/src/Jackett.Common/Definitions/utopia.yml
@@ -121,6 +121,8 @@ search:
       selector: meta.genres
       filters:
         - name: re_replace
+          args: ["(?i)^None$", ""]
+        - name: re_replace
           args: ["(?i)(Екшн і Пригоди)", "Екшн_і_Пригоди"]
         - name: re_replace
           args: ["(?i)(Мильна опера)", "Мильна_опера"]


### PR DESCRIPTION
#### Description
I think this happened somewhere around v6.5.0, with some trackers using it and others not, but it doesn't do any harm to just add it to all.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
