### PR TITLE
assorted nexusphp: add Chinese names

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,6 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * NNTT
  * NoNaMe Club (NNM-Club)
  * Nyaa.si
- * OKPT
  * OneJAV
  * ParnuXi
  * PC-torrent
@@ -256,10 +255,10 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * AudioNews (AN)
  * Aussierul.es [![(invite needed)][inviteneeded]](#)
  * AvistaZ (AsiaTorrents)
- * Azusa [![(invite needed)][inviteneeded]](#)
+ * Azusa (梓喵) [![(invite needed)][inviteneeded]](#)
  * Back-ups
  * BakaBT
- * BeiTai
+ * BeiTai (备胎)
  * Beload
  * Best-Core
  * BeyondHD (BHD)
@@ -359,7 +358,7 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * GreatPosterWall (GPW)
  * GreekDiamond
  * HaiDan
- * Haitang
+ * Hǎitáng (海棠PT)
  * HappyFappy
  * Hares Club (白兔俱乐部) [![(invite needed)][inviteneeded]](#)
  * Hawke-uno
@@ -374,15 +373,15 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * HDArea (HDA)
  * HDAtmos
  * HDBits [![(invite needed)][inviteneeded]](#)
- * HDC (HDCiTY) [![(invite needed)][inviteneeded]](#)
+ * HDCiTY (HDC) [![(invite needed)][inviteneeded]](#)
  * HDFans
  * HDFun (HDZone)
  * HDHome (HDBigger) [![(invite needed)][inviteneeded]](#)
- * HDMaYi
- * HDPT [![(invite needed)][inviteneeded]](#)
+ * HDMaYi (小蚂蚁PT站)
+ * HDPT (明教) [![(invite needed)][inviteneeded]](#)
  * HDRoute [![(invite needed)][inviteneeded]](#)
  * HDSky [![(invite needed)][inviteneeded]](#)
- * HDTime
+ * HDtime
  * HDTorrents.it [![(invite needed)][inviteneeded]](#)
  * HDTurk
  * HDU
@@ -395,7 +394,7 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * House of Devil
  * HQMusic
  * iAnon
- * ICC2022
+ * ICC2022 (冰淇淋)
  * ImmortalSeed (iS)
  * Immortuos
  * Indietorrents [![(invite needed)][inviteneeded]](#)
@@ -458,6 +457,7 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * NorBits
  * NORDiCHD
  * Ntelogo
+ * OKPT
  * Old Greek Tracker
  * Old Toons World
  * OpenCD [![(invite needed)][inviteneeded]](#)
@@ -472,7 +472,7 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * PassThePopcorn (PTP)
  * Peeratiko
  * Peers.FM
- * PigNetwork
+ * PigNetwork (猪猪网)
  * PixelCove (Ultimate Gamer)
  * PiXELHD (PxHD) [![(invite needed)][inviteneeded]](#)
  * PolishSource (PS)
@@ -485,17 +485,17 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * ProAudioTorrents (PAT)
  * PT GTK
  * PT分享站 (itzmx)
- * PTCafe
+ * PTCafe (咖啡)
  * PTChina (铂金学院)
- * PTerClub
+ * PTerClub (PT之友俱乐部)
  * PTFiles (PTF)
  * PThome [![(invite needed)][inviteneeded]](#)
  * PTLSP
- * PTSBAO
+ * PTSBAO (烧包)
  * PTtime
  * Punk's Horror Tracker
  * PuntoTorrent
- * PuTao
+ * PuTao (葡萄)
  * PWTorrents (PWT)
  * R3V WTF!
  * Racing4Everyone (R4E)
@@ -504,7 +504,7 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * Red Star Torrent (RST) [![(invite needed)][inviteneeded]](#)
  * Redacted (PassTheHeadphones)
  * RedBits
- * Red Leaves [![(invite needed)][inviteneeded]](#)
+ * Red Leaves (红叶) [![(invite needed)][inviteneeded]](#)
  * ReelFlix
  * Resurrect The Net [![(invite needed)][inviteneeded]](#)
  * RetroFlix
@@ -529,7 +529,7 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * SkipTheTrailers
  * slosoul
  * SnowPT (SSPT)
- * SoulVoice
+ * SoulVoice (聆音Club)
  * SpeedApp (SceneFZ, XtreMeZone / MYXZ, ICE Torrent)
  * SpeedCD
  * Speedmaster HD [![(invite needed)][inviteneeded]](#)
@@ -565,7 +565,7 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * TheRebels
  * TheScenePlace (TSP)
  * Thor's Land
- * TJUPT
+ * TJUPT (北洋园PT)
  * TLFBits [![(invite needed)][inviteneeded]](#)
  * TmGHuB
  * Toca Share
@@ -615,7 +615,7 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * WinterSakura
  * World-In-HD [![(invite needed)][inviteneeded]](#)
  * World-of-Tomorrow
- * Wukong
+ * Wukong (悟空问道)
  * x-ite.me (XM)
  * xBytesV2
  * Xider-Torrent
@@ -624,7 +624,7 @@ A third-party Golang SDK for Jackett is available from [webtor-io/go-jackett](ht
  * XtremeBytes
  * XWT-Classics
  * XWTorrents (XWT)
- * YDYPT
+ * YDYPT (伊甸园PT)
  * Zamunda.net
  * Zelka.org
  * ZmPT (织梦)

--- a/src/Jackett.Common/Definitions/azusa.yml
+++ b/src/Jackett.Common/Definitions/azusa.yml
@@ -1,7 +1,7 @@
 ---
 id: azusa
-name: Azusa
-description: "Azusa is a CHINESE Torrent Tracker focusing on Comics"
+name: Azusa (梓喵)
+description: "Azusa (梓喵) is a CHINESE Private Torrent Tracker focusing on Comics"
 language: zh-CN
 type: private
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/beitai.yml
+++ b/src/Jackett.Common/Definitions/beitai.yml
@@ -1,7 +1,7 @@
 ---
 id: beitai
-name: BeiTai
-description: "BeiTai is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
+name: BeiTai (备胎)
+description: "BeiTai (备胎) is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
 language: zh-CN
 type: private
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/dajiao.yml
+++ b/src/Jackett.Common/Definitions/dajiao.yml
@@ -1,6 +1,6 @@
 ---
 id: dajiao
-name: Dajiao
+name: Dajiao (打胶)
 description: "Dajiao (打胶) is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: zh-CN
 type: private

--- a/src/Jackett.Common/Definitions/freefarm.yml
+++ b/src/Jackett.Common/Definitions/freefarm.yml
@@ -1,6 +1,6 @@
 ---
 id: freefarm
-name: Free Farm
+name: Free Farm (自由农场)
 description: "Free Farm (自由农场) is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: zh-CN
 type: private

--- a/src/Jackett.Common/Definitions/gamera.yml
+++ b/src/Jackett.Common/Definitions/gamera.yml
@@ -1,6 +1,6 @@
 ---
 id: gamera
-name: Gamera
+name: Gamera (駕瞑羅)
 description: "Gamera (駕瞑羅) is a CHINESE Private Torrent Tracker for Japanese Monster and Superhero MOVIES / TV"
 language: zh-CN
 type: private

--- a/src/Jackett.Common/Definitions/haitang.yml
+++ b/src/Jackett.Common/Definitions/haitang.yml
@@ -1,7 +1,7 @@
 ---
 id: haitang
-name: Haitang
-description: "海棠PT (Hǎitáng PT) is a CHINESE Private Torrent Tracker for OPERA / CROSSTALK"
+name: Hǎitáng (海棠PT)
+description: "Hǎitáng (海棠PT) is a CHINESE Private Torrent Tracker for OPERA / CROSSTALK"
 language: zh-CN
 type: private
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/haresclub.yml
+++ b/src/Jackett.Common/Definitions/haresclub.yml
@@ -1,6 +1,6 @@
 ---
 id: haresclub
-name: Hares Club
+name: Hares Club (白兔俱乐部)
 description: "Hares Club (白兔俱乐部) is a CHINESE site that focuses on 4K media."
 language: zh-CN
 type: private

--- a/src/Jackett.Common/Definitions/haresclub.yml
+++ b/src/Jackett.Common/Definitions/haresclub.yml
@@ -1,7 +1,7 @@
 ---
 id: haresclub
 name: Hares Club (白兔俱乐部)
-description: "Hares Club (白兔俱乐部) is a CHINESE site that focuses on 4K media."
+description: "Hares Club (白兔俱乐部) is a CHINESE Private site that focuses on 4K media."
 language: zh-CN
 type: private
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/hdc.yml
+++ b/src/Jackett.Common/Definitions/hdc.yml
@@ -1,7 +1,7 @@
 ---
 id: hdc
-name: HDC
-description: "HDC (HDCiTY) is a CHINESE Private Torrent Tracker for HD MOVIES / TV / GENERAL"
+name: HDCiTY
+description: "HDCiTY (HDC) is a CHINESE Private Torrent Tracker for HD MOVIES / TV / GENERAL"
 language: zh-CN
 type: private
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/hdmayi.yml
+++ b/src/Jackett.Common/Definitions/hdmayi.yml
@@ -1,6 +1,6 @@
 ---
 id: hdmayi
-name: HDMaYi
+name: HDMaYi (小蚂蚁PT站)
 description: "HDMaYi (小蚂蚁PT站) is a CHINESE Private Torrent Tracker for HD MOVIES / TV / GENERAL"
 language: zh-CN
 type: private

--- a/src/Jackett.Common/Definitions/hdpt.yml
+++ b/src/Jackett.Common/Definitions/hdpt.yml
@@ -1,7 +1,7 @@
 ---
 id: hdpt
-name: HDPT
-description: "HDPT is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL"
+name: HDPT (明教)
+description: "HDPT (明教) is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: zh-CN
 type: private
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/icc2022.yml
+++ b/src/Jackett.Common/Definitions/icc2022.yml
@@ -1,6 +1,6 @@
 ---
 id: icc2022
-name: ICC2022
+name: ICC2022 (冰淇淋)
 description: "ICC2022 (冰淇淋) is a CHINESE Private Torrent Tracker for HD MOVIES / TV / GENERAL"
 language: zh-CN
 type: private

--- a/src/Jackett.Common/Definitions/kufei.yml
+++ b/src/Jackett.Common/Definitions/kufei.yml
@@ -1,6 +1,6 @@
 ---
 id: kufei
-name: Kufei
+name: Kufei (库非)
 description: "Kufei (库非) is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: zh-CN
 type: private

--- a/src/Jackett.Common/Definitions/pignetwork.yml
+++ b/src/Jackett.Common/Definitions/pignetwork.yml
@@ -1,6 +1,6 @@
 ---
 id: pignetwork
-name: PigNetwork
+name: PigNetwork (猪猪网)
 description: "PigNetwork (猪猪网) is a CHINESE Private Torrent Tracker for HD MOVIES / TV / GENERAL"
 language: zh-CN
 type: private

--- a/src/Jackett.Common/Definitions/ptcafe.yml
+++ b/src/Jackett.Common/Definitions/ptcafe.yml
@@ -1,6 +1,6 @@
 ---
 id: ptcafe
-name: PTCafe
+name: PTCafe (咖啡)
 description: "PTCafe (咖啡) is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: zh-CN
 type: private

--- a/src/Jackett.Common/Definitions/ptchina.yml
+++ b/src/Jackett.Common/Definitions/ptchina.yml
@@ -1,6 +1,6 @@
 ---
 id: ptchina
-name: PTChina
+name: PTChina (铂金学院)
 description: "PTChina (铂金学院) is a CHINESE Private site for MOVIES / TV"
 language: zh-CN
 type: private

--- a/src/Jackett.Common/Definitions/pterclub.yml
+++ b/src/Jackett.Common/Definitions/pterclub.yml
@@ -1,7 +1,7 @@
 ---
 id: pterclub
-name: PTerClub
-description: "PTerClub is a CHINESE Private Torrent Tracker for HD MUSIC VIDEOS, MOVIES, TV & ANIME"
+name: PTerClub (PT之友俱乐部)
+description: "PTerClub (PT之友俱乐部) is a CHINESE Private Torrent Tracker for HD MUSIC VIDEOS, MOVIES, TV & ANIME"
 language: zh-CN
 type: private
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/ptitzmx.yml
+++ b/src/Jackett.Common/Definitions/ptitzmx.yml
@@ -1,6 +1,6 @@
 ---
 id: ptitzmx
-name: PT分享站
+name: PT分享站 (itzmx)
 description: "PT分享站 (itzmx) is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: zh-CN
 type: private

--- a/src/Jackett.Common/Definitions/ptsbao.yml
+++ b/src/Jackett.Common/Definitions/ptsbao.yml
@@ -1,7 +1,7 @@
 ---
 id: ptsbao
-name: PTSBAO
-description: "PTSBAO is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
+name: PTSBAO (烧包)
+description: "PTSBAO (烧包) is a CHINESE Private Torrent Tracker for HD MOVIES / TV"
 language: zh-CN
 type: private
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/putao.yml
+++ b/src/Jackett.Common/Definitions/putao.yml
@@ -1,7 +1,7 @@
 ---
 id: putao
-name: PuTao
-description: "葡萄 (PuTao) is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL"
+name: PuTao (葡萄)
+description: "PuTao (葡萄) is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: zh-CN
 type: private
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/redleaves.yml
+++ b/src/Jackett.Common/Definitions/redleaves.yml
@@ -1,6 +1,6 @@
 ---
 id: redleaves
-name: Red Leaves
+name: Red Leaves (红叶)
 description: "Red Leaves (红叶) is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: zh-CN
 type: private

--- a/src/Jackett.Common/Definitions/shadowflow.yml
+++ b/src/Jackett.Common/Definitions/shadowflow.yml
@@ -1,6 +1,6 @@
 ---
 id: shadowflow
-name: Shadowflow
+name: Shadowflow (影)
 description: "Shadowflow (影) is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: zh-CN
 type: private

--- a/src/Jackett.Common/Definitions/soulvoice.yml
+++ b/src/Jackett.Common/Definitions/soulvoice.yml
@@ -1,7 +1,7 @@
 ---
 id: soulvoice
-name: SoulVoice
-description: "SoulVoice is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL"
+name: SoulVoice (聆音Club)
+description: "SoulVoice (聆音Club) is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: zh-CN
 type: private
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/tjupt.yml
+++ b/src/Jackett.Common/Definitions/tjupt.yml
@@ -1,7 +1,7 @@
 ---
 id: tjupt
-name: TJUPT
-description: "TJUPT is a CHINESE Private Torrent Tracker for GENERAL"
+name: TJUPT (北洋园PT)
+description: "TJUPT (北洋园PT) is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: zh-CN
 type: private
 encoding: UTF-8

--- a/src/Jackett.Common/Definitions/wukong.yml
+++ b/src/Jackett.Common/Definitions/wukong.yml
@@ -1,6 +1,6 @@
 ---
 id: wukong
-name: Wukong
+name: Wukong (悟空问道)
 description: "Wukong (悟空问道) is a CHINESE Private Torrent Tracker for E-LEARNING"
 language: zh-CN
 type: private

--- a/src/Jackett.Common/Definitions/ydypt.yml
+++ b/src/Jackett.Common/Definitions/ydypt.yml
@@ -1,7 +1,7 @@
 ---
 id: ydypt
-name: YDYPT
-description: "YDYPT is a CHINESE Private Torrent Tracker for MOVIES / TV / 3X"
+name: YDYPT (伊甸园PT)
+description: "YDYPT (伊甸园PT) is a CHINESE Private Torrent Tracker for MOVIES / TV / 3X"
 language: zh-CN
 type: private
 encoding: UTF-8


### PR DESCRIPTION
#### Description
Given most people using the indexers will be Chinese, include Chinese name. However, as Jackett is currently only available in English, use English name first (exception being ptitzmx, as there isn't an English name, itzmx is just taken from the domain).

Some other minor description fixes.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
