### PR TITLE
assorted unit3d 8.0: use filename for single files

### DIFF
--- a/src/Jackett.Common/Definitions/blutopia-api.yml
+++ b/src/Jackett.Common/Definitions/blutopia-api.yml
@@ -34,6 +34,10 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
+  - name: single_file_release_use_filename
+    type: checkbox
+    label: Use filename as title for single file releases
+    default: true
   - name: sort
     type: select
     label: Sort requested from site
@@ -99,7 +103,7 @@ search:
   fields:
     category:
       selector: category_id
-    title:
+    title_optional:
       selector: name
     details:
       selector: details_link
@@ -169,4 +173,9 @@ search:
     minimumseedtime:
       # 7 day (as seconds = 7 x 24 x 60 x 60)
       text: 604800
+    title_filename:
+      selector: "files[0].name"
+      optional: true
+    title:
+      text: "{{ if and (.Config.single_file_release_use_filename) (eq .Result.files \"1\") (.Result.title_filename) }}{{ .Result.title_filename }}{{ else }}{{ .Result.title_optional }}{{ end }}"
 # json UNIT3D 8.0.0b

--- a/src/Jackett.Common/Definitions/cinematik.yml
+++ b/src/Jackett.Common/Definitions/cinematik.yml
@@ -32,6 +32,10 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
+  - name: single_file_release_use_filename
+    type: checkbox
+    label: Use filename as title for single file releases
+    default: true
   - name: sort
     type: select
     label: Sort requested from site
@@ -97,7 +101,7 @@ search:
   fields:
     category:
       selector: category_id
-    title:
+    title_optional:
       selector: name
     details:
       selector: details_link
@@ -167,4 +171,9 @@ search:
     minimumseedtime:
       # 7 days (as seconds = 7 x 24 x 60 x 60)
       text: 604800
+    title_filename:
+      selector: "files[0].name"
+      optional: true
+    title:
+      text: "{{ if and (.Config.single_file_release_use_filename) (eq .Result.files \"1\") (.Result.title_filename) }}{{ .Result.title_filename }}{{ else }}{{ .Result.title_optional }}{{ end }}"
 # json UNIT3D 8.0.0


### PR DESCRIPTION
#### Description
I noticed UNIT3D 8.0 contains the list of files now and considering their renaming of release titles, I grabbed the same logic I implemented to ANT to use filename for single files. 

Should we add it as an option or always on?