### PR TITLE
schema: require size, one of category/categorydesc, any of download/infohash/magnet

### DIFF
--- a/src/Jackett.Common/Definitions/schema.json
+++ b/src/Jackett.Common/Definitions/schema.json
@@ -708,7 +708,37 @@
             },
             "required": [
                 "seeders",
+                "size",
                 "title"
+            ],
+            "oneOf": [
+                {
+                    "required": [
+                        "category"
+                    ]
+                },
+                {
+                    "required": [
+                        "categorydesc"
+                    ]
+                }
+            ],
+            "anyOf": [
+                {
+                    "required": [
+                        "download"
+                    ]
+                },
+                {
+                    "required": [
+                        "infohash"
+                    ]
+                },
+                {
+                    "required": [
+                        "magnet"
+                    ]
+                }
             ],
             "title": "FieldsBlock"
         },


### PR DESCRIPTION
#### Description
Can't also require download/infohash/magnet in download block because of [arabtorrents](https://github.com/Jackett/Jackett/blob/2be98aecab78ef02dc6d31122eb1a131556db540/src/Jackett.Common/Definitions/arabtorrents.yml#L143-L148), [hdsky](https://github.com/Jackett/Jackett/blob/2be98aecab78ef02dc6d31122eb1a131556db540/src/Jackett.Common/Definitions/hdsky.yml#L60-L61), and [romanianmetaltorrents](https://github.com/Jackett/Jackett/blob/2be98aecab78ef02dc6d31122eb1a131556db540/src/Jackett.Common/Definitions/romanianmetaltorrents.yml#L98-L104).

Can't require date as audionews and demonoid take it from rows dateheaders instead, and `.Result.dateheaders` is not supported.

Date was missing from [wihd](https://github.com/Jackett/Jackett/commit/e421300dae616620789685dfe106926fc6349527).

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
