### PR TITLE
[Subplease] Fix no results for show with season in their show title

### DIFF
--- a/src/Jackett.Common/Indexers/SubsPlease.cs
+++ b/src/Jackett.Common/Indexers/SubsPlease.cs
@@ -107,7 +107,13 @@ namespace Jackett.Common.Indexers
             {
                 searchTerm = searchTerm.Replace(resMatch.Value, string.Empty);
             }
-
+            // Bug Fix If the show title contains a season SX then query.Season is != 0 leading to different results season S0X
+            if (query.Season != 0 )
+            {
+                searchTerm = searchTerm + $" S{query.Season}";
+                query.Season = 0;
+            }
+            
             var queryParameters = new NameValueCollection
             {
                 { "f", "search" },

--- a/src/Jackett.Common/Indexers/SubsPlease.cs
+++ b/src/Jackett.Common/Indexers/SubsPlease.cs
@@ -108,12 +108,12 @@ namespace Jackett.Common.Indexers
                 searchTerm = searchTerm.Replace(resMatch.Value, string.Empty);
             }
             // Bug Fix If the show title contains a season SX then query.Season is != 0 leading to different results season S0X
-            if (query.Season != 0 )
+            if (query.Season != 0)
             {
                 searchTerm = searchTerm + $" S{query.Season}";
                 query.Season = 0;
             }
-            
+
             var queryParameters = new NameValueCollection
             {
                 { "f", "search" },

--- a/src/Jackett.Common/Indexers/SubsPlease.cs
+++ b/src/Jackett.Common/Indexers/SubsPlease.cs
@@ -107,10 +107,10 @@ namespace Jackett.Common.Indexers
             {
                 searchTerm = searchTerm.Replace(resMatch.Value, string.Empty);
             }
-            // Bug Fix If the show title contains a season SX then query.Season is != 0 leading to different results season S0X
+            // if the season is S1 then skipping filtering, for others seasons addind season number to filtering not to query
             if (query.Season != 0)
             {
-                searchTerm = searchTerm + $" S{query.Season}";
+                searchTerm = query.Season == 1 ? searchTerm : searchTerm + $" S{query.Season}";
                 query.Season = 0;
             }
 

--- a/src/Jackett.Common/Indexers/SubsPlease.cs
+++ b/src/Jackett.Common/Indexers/SubsPlease.cs
@@ -107,7 +107,8 @@ namespace Jackett.Common.Indexers
             {
                 searchTerm = searchTerm.Replace(resMatch.Value, string.Empty);
             }
-            // if the season is S1 then skipping filtering, for others seasons addind season number to filtering not to query
+
+            // Only include season > 1 in searchTerm, format as S2 rather than S02
             if (query.Season != 0)
             {
                 searchTerm = query.Season == 1 ? searchTerm : searchTerm + $" S{query.Season}";


### PR DESCRIPTION

#### Description
Some shows on Subsplease have a season numbering in theirs show title,
for exemple
* https://subsplease.org/shows/shin-no-nakama-s2/
* https://subsplease.org/shows/tsuki-ga-michibiku-isekai-douchuu-s2/

for theses releases Subplease indexer struggle to find results,
at least from a sonarr point of view as it request "show_title S0x" instead of "show_title Sx"

Current Behaviour 
```
2024-03-20 14:44:42	Info	Manual search in SubsPlease for the daily life S4 => Found 36 releases [153ms]
2024-03-20 14:44:36	Info	Manual search in SubsPlease for the daily life S04 => Found 0 releases [308ms]
```

New Behaviour 
``` 
2024-03-20 13:53:37 Info Manual search in SubsPlease for the daily life S04 => Found 36 releases [1094ms]
2024-03-20 13:53:43 Info Manual search in SubsPlease for the daily life S4 => Found 36 releases [82ms]
```

#### Issues Fixed or Closed by this PR


