### PR TITLE
[Feature] Option to enable season number parsing for Anilibria

### DIFF
--- a/src/Jackett.Common/Definitions/anilibria.yml
+++ b/src/Jackett.Common/Definitions/anilibria.yml
@@ -23,6 +23,10 @@ settings:
     type: checkbox
     label: Strip Cyrillic Letters
     default: false
+  - name: compatibilitymod
+    type: checkbox
+    label: Remove Russian/alternative names and try to parse season numbers to ensure compatibility with Sonarr/Radarr.
+    default: false
   - name: addrussiantotitle
     type: checkbox
     label: Add RUS to end of all titles to improve language detection by Sonarr and Radarr. Will cause English-only results to be misidentified.
@@ -60,6 +64,58 @@ search:
       selector: ..names.ru
     title_en:
       selector: ..names.en
+    title_en_parsed:
+      selector: ..names.en
+      filters:
+        - name: re_replace
+          args: ["(?i)\\bPart\\s*1\\b", "Part One"]
+        - name: re_replace
+          args: ["(?i)\\bPart\\s*2\\b", "Part Two"]
+        - name: re_replace
+          args: ["(?i)\\bPart\\s*3\\b", "Part Three"]
+        - name: re_replace
+          args: ["(?i)\\bPart\\s*4\\b", "Part Four"]
+        - name: re_replace
+          args: ["(?i)\\bPart\\s*5\\b", "Part Five"]
+        - name: re_replace
+          args: ["(?i)\\bPart\\s*6\\b", "Part Six"]
+        - name: re_replace
+          args: ["(?i)\\bPart\\s*7\\b", "Part Seven"]
+        - name: re_replace
+          args: ["(?i)\\bPart\\s*8\\b", "Part Eight"]
+        - name: re_replace
+          args: ["(?i)\\bPart\\s*9\\b", "Part Nine"]
+        - name: re_replace
+          args: ["(?i)\\bseason\\s*(\\d+)\\b", ""]
+        - name: re_replace
+          args: ["(?i)\\b(\\d+)(st|nd|rd|th)\\s*season[\\s\\.]*", ""]
+        - name: re_replace
+          args: ["(?i)\\b(\\d+)\\s*season\\b[\\s\\.]*", ""]
+        - name: re_replace
+          args: ["(?i)\\bseason\\s*([IVXLCDM]+)\\b", ""]
+        - name: re_replace
+          args: ["\\bI$", ""]
+        - name: re_replace
+          args: ["\\bII$", ""]
+        - name: re_replace
+          args: ["\\bIII$", ""]
+        - name: re_replace
+          args: ["\\bIV$", ""]
+        - name: re_replace
+          args: ["\\bV$", ""]
+        - name: re_replace
+          args: ["\\bVI$", ""]
+        - name: re_replace
+          args: ["\\bVII$", ""]
+        - name: re_replace
+          args: ["\\bVIII$", ""]
+        - name: re_replace
+          args: ["\\bIX$", ""]
+        - name: re_replace
+          args: ["\\bX$", ""]
+        - name: re_replace
+          args: ["(?i)\\b(\\d+)(?:st|nd|rd|th)?\\b", ""]
+        - name: trim
     title_alternative:
       selector: ..names.alternative
       optional: true
@@ -72,19 +128,142 @@ search:
           args: ["^[\\s&,\\.!\\?\\+\\-_\\|\\/':]+", ""]
         - name: re_replace
           args: ["^OVA$", ""]
+    _season_number_en:
+      selector: ..names.en
+      filters:
+        - name: re_replace
+          args: ["(?i)\\bPart\\s*\\d+\\s*$", ""]
+        - name: re_replace
+          args: ["(?i)(^.*\\bseason\\s*(\\d+)\\b\\s*$)", "S$2"]
+        - name: re_replace
+          args: ["(?i)(^.*\\b(\\d+)(st|nd|rd|th)\\s*season\\b.*$)", "S$2"]
+        - name: re_replace
+          args: ["(?i)(^.*\\b(\\d+)\\s*season\\b.*$)", "S$2"]
+        - name: re_replace
+          args: ["(?i)(^.*\\bseason\\s*([IVXLCDM]+)\\b\\s*$)", "$1"]
+        - name: re_replace
+          args: ["(^.*X$)", "S10"]
+        - name: re_replace
+          args: ["(^.*IX$)", "S9"]
+        - name: re_replace
+          args: ["(^.*VIII$)", "S8"]
+        - name: re_replace
+          args: ["(^.*VII$)", "S7"]
+        - name: re_replace
+          args: ["(^.*VI$)", "S6"]
+        - name: re_replace
+          args: ["(^.*V$)", "S5"]
+        - name: re_replace
+          args: ["(^.*IV$)", "S4"]
+        - name: re_replace
+          args: ["(^.*III$)", "S3"]
+        - name: re_replace
+          args: ["(^.*II$)", "S2"]
+        - name: re_replace
+          args: ["(^.*I$)", "S1"]
+        - name: re_replace
+          args: ["(?i)(^.*\\b(\\d+)(?:st|nd|rd|th)?\\b\\s*$)", "S$2"]
+        - name: re_replace
+          args: ["(?i)^(?!S\\d+).*", ""]
+    _season_number_alternative:
+      selector: ..names.alternative
+      filters:
+        - name: re_replace
+          args: ["(?i)\\bPart\\s*\\d+\\s*$", ""]
+        - name: re_replace
+          args: ["(?i)(^.*\\bseason\\s*(\\d+)\\b\\s*$)", "S$2"]
+        - name: re_replace
+          args: ["(?i)(^.*\\b(\\d+)(st|nd|rd|th)\\s*season\\b\\s*$)", "S$2"]
+        - name: re_replace
+          args: ["(?i)(^.*\\b(\\d+)\\s*season\\b\\s*$)", "S$2"]
+        - name: re_replace
+          args: ["(?i)(^.*\\bseason\\s*([IVXLCDM]+)\\b\\s*$)", "$1"]
+        - name: re_replace
+          args: ["(^.*X$)", "S10"]
+        - name: re_replace
+          args: ["(^.*IX$)", "S9"]
+        - name: re_replace
+          args: ["(^.*VIII$)", "S8"]
+        - name: re_replace
+          args: ["(^.*VII$)", "S7"]
+        - name: re_replace
+          args: ["(^.*VI$)", "S6"]
+        - name: re_replace
+          args: ["(^.*V$)", "S5"]
+        - name: re_replace
+          args: ["(^.*IV$)", "S4"]
+        - name: re_replace
+          args: ["(^.*III$)", "S3"]
+        - name: re_replace
+          args: ["(^.*II$)", "S2"]
+        - name: re_replace
+          args: ["(^.*I$)", "S1"]
+        - name: re_replace
+          args: ["(?i)(^.*\\b(\\d+)(?:st|nd|rd|th)?\\b\\s*$)", "S$2"]
+        - name: re_replace
+          args: ["(?i)^(?!S\\d+).*", ""]
+    _season_number:
+      text: "{{ .Result._season_number_en }}"
+      filters:
+        - name: append
+          args: "{{ .Result._season_number_alternative }}"
+        - name: re_replace
+          args: ["^S1S1$", "S1"]
+        - name: re_replace
+          args: ["^S1(.+)$", "$1"]
+        - name: re_replace
+          args: ["^(S\\d+).*$", "$1"]
+        - name: re_replace
+          args: ["^$", "S1"]
     year:
       selector: ..season.year
     _quality:
       selector: quality.string
-    title:
+    _quality_type:
+      selector: quality.type
+    _quality_resolution:
+      selector: quality.resolution
+    _quality_encoder:
+      selector: quality.encoder
+      filters:
+        - name: re_replace
+          args: ["(?i)^h", "x"]
+    title_parsed:
+      text: "{{ if .Config.stripcyrillic }}{{ else }}{{ .Result.title_ru }} / {{ end }}{{ .Result.title_en_parsed }} {{ .Result._season_number}}E{{ .Result._episodes }} [{{ .Result._quality_type }}.{{ .Result._quality_resolution }}.{{ .Result._quality_encoder }}]"
+      filters:
+        - name: re_replace
+          args: ["\\bS\\d+EФильм\\b", "({{ .Result.year }}) MOVIE"]
+        - name: re_replace
+          args: ["\\bS\\d+EOVA\\b", "({{ .Result.year }}) OVA"]
+        - name: re_replace
+          args: ["\\bS\\d+EONA\\b", "({{ .Result.year }}) ONA"]
+        - name: re_replace
+          args: ["\\bS\\d+EMovie\\b", "({{ .Result.year }}) MOVIE"]
+        - name: re_replace
+          args: ["\\bS\\d+EП/м фильм\\b", "({{ .Result.year }}) MOVIE"]
+        - name: re_replace
+          args: ["\\bS\\d+EРекап\\b", "({{ .Result.year }}) RECAP"]
+        - name: re_replace
+          args: ["\\bS\\d+ETV-Special\\b", "({{ .Result.year }}) SPECIAL"]
+        - name: append
+          args: "{{ if .Config.addrussiantotitle }} - RUS{{ else }}{{ end }}"
+    title_old:
       text: "{{ if .Config.stripcyrillic }}{{ else }}{{ .Result.title_ru }} / {{ end }}{{ .Result.title_en }}{{ if .Result.title_alternative }} / AKA {{ .Result.title_alternative }}{{ else }}{{ end }} ({{ .Result.year }}) [{{ .Result._quality }}]{{ if .Result._episodes }} - E{{ .Result._episodes }}{{ else }}{{ end }}"
       filters:
         - name: re_replace
           args: [" - \\bEФильм\\b", " - MOVIE"]
         - name: re_replace
+          args: [" - \\bEMovie\\b", " - MOVIE"]
+        - name: re_replace
+          args: [" - \\bEП/м фильм\\b", " - MOVIE"]
+        - name: re_replace
           args: [" - \\bEOVA\\b", " - OVA"]
+        - name: re_replace
+          args: [" - \\bEONA\\b", " - ONA"]
         - name: append
           args: "{{ if .Config.addrussiantotitle }} - RUS{{ else }}{{ end }}"
+    title:
+      text: "{{ if .Config.compatibilitymod }}{{ .Result.title_parsed }}{{ else }}{{ .Result.title_old }}{{ end }}"
     _code:
       selector: ..code
     details:

--- a/src/Jackett.Common/Definitions/anilibria.yml
+++ b/src/Jackett.Common/Definitions/anilibria.yml
@@ -23,9 +23,9 @@ settings:
     type: checkbox
     label: Strip Cyrillic Letters
     default: false
-  - name: compatibilitymod
+  - name: sonarr_compatibility
     type: checkbox
-    label: Remove Russian/alternative names and try to parse season numbers to ensure compatibility with Sonarr/Radarr.
+    label: Improve Sonarr compatibility by trying to better parse Season information in release titles.
     default: false
   - name: addrussiantotitle
     type: checkbox
@@ -229,7 +229,7 @@ search:
         - name: re_replace
           args: ["(?i)^h", "x"]
     title_parsed:
-      text: "{{ if .Config.stripcyrillic }}{{ else }}{{ .Result.title_ru }} / {{ end }}{{ .Result.title_en_parsed }} {{ .Result._season_number}}E{{ .Result._episodes }} [{{ .Result._quality_type }}.{{ .Result._quality_resolution }}.{{ .Result._quality_encoder }}]"
+      text: "{{ if .Config.stripcyrillic }}{{ else }}{{ .Result.title_ru }} / {{ end }}{{ .Result.title_en_parsed }} {{ .Result._season_number}}E{{ .Result._episodes }} [{{ .Result._quality_type }} {{ .Result._quality_resolution }} {{ .Result._quality_encoder }}]"
       filters:
         - name: re_replace
           args: ["\\bS\\d+EФильм\\b", "({{ .Result.year }}) MOVIE"]
@@ -247,7 +247,7 @@ search:
           args: ["\\bS\\d+ETV-Special\\b", "({{ .Result.year }}) SPECIAL"]
         - name: append
           args: "{{ if .Config.addrussiantotitle }} - RUS{{ else }}{{ end }}"
-    title_old:
+    title_original:
       text: "{{ if .Config.stripcyrillic }}{{ else }}{{ .Result.title_ru }} / {{ end }}{{ .Result.title_en }}{{ if .Result.title_alternative }} / AKA {{ .Result.title_alternative }}{{ else }}{{ end }} ({{ .Result.year }}) [{{ .Result._quality }}]{{ if .Result._episodes }} - E{{ .Result._episodes }}{{ else }}{{ end }}"
       filters:
         - name: re_replace
@@ -263,7 +263,7 @@ search:
         - name: append
           args: "{{ if .Config.addrussiantotitle }} - RUS{{ else }}{{ end }}"
     title:
-      text: "{{ if .Config.compatibilitymod }}{{ .Result.title_parsed }}{{ else }}{{ .Result.title_old }}{{ end }}"
+      text: "{{ if .Config.sonarr_compatibility }}{{ .Result.title_parsed }}{{ else }}{{ .Result.title_original }}{{ end }}"
     _code:
       selector: ..code
     details:


### PR DESCRIPTION
Added the option to enable season number parsing for better compatibility with Sonarr.
Edgecases are taken from dozens of the most problematic titles found at random.
In addition, several problems with non-standard release classifications have been fixed. (Recaps, specials, etc.)

(I have no experience with this Cardigann, so that the approach may be suboptimal. The concept of calling this regex hell a "simple indexer" makes me glee.)

May be related to #10973 