### PR TITLE
Fix categories for 0daykiev.yml

### DIFF
--- a/src/Jackett.Common/Definitions/0daykiev.yml
+++ b/src/Jackett.Common/Definitions/0daykiev.yml
@@ -20,7 +20,7 @@ caps:
     - {id: 14, cat: Audio, desc: "Музыка / Аудио (Music / Audio)"}
     - {id: 29, cat: TV, desc: "Мультсериалы (TV Series)"}
     - {id: 11, cat: Movies, desc: "Мультфильмы (Cartoons)"}
-    - {id: 28, cat: Movies/HD, desc: "HD / Документальное (HD / Documentary)"}
+    - {id: 28, cat: TV/Documentary, desc: "HD / Документальное (HD / Documentary)"}
     - {id: 18, cat: PC/0day, desc: "Софт / Windows (Software / Windows)"}
     - {id: 19, cat: TV, desc: "TV / Сериалы (TV shows)"}
     - {id: 31, cat: Other, desc: "Прочее (Other)"}

--- a/src/Jackett.Common/Definitions/0daykiev.yml
+++ b/src/Jackett.Common/Definitions/0daykiev.yml
@@ -15,12 +15,12 @@ caps:
     - {id: 10, cat: Movies, desc: "Фильмы (Movies)"}
     - {id: 16, cat: Movies/HD, desc: "HD / Фильмы (HD / Movies)"}
     - {id: 30, cat: TV/HD, desc: "HD / Сериалы (HD / TV Shows)"}
-    - {id: 27, cat: TV/HD, desc: "HD / Мультфильмы (HD / Cartoons)"}
+    - {id: 27, cat: Movies/HD, desc: "HD / Мультфильмы (HD / Cartoons)"}
     - {id: 17, cat: PC/Games, desc: "Игры / ПК (Games / PC)"}
     - {id: 14, cat: Audio, desc: "Музыка / Аудио (Music / Audio)"}
     - {id: 29, cat: TV, desc: "Мультсериалы (TV Series)"}
-    - {id: 11, cat: TV, desc: "Мультфильмы (Cartoons)"}
-    - {id: 28, cat: TV/HD, desc: "HD / Документальное (HD / Documentary)"}
+    - {id: 11, cat: Movies, desc: "Мультфильмы (Cartoons)"}
+    - {id: 28, cat: Movies/HD, desc: "HD / Документальное (HD / Documentary)"}
     - {id: 18, cat: PC/0day, desc: "Софт / Windows (Software / Windows)"}
     - {id: 19, cat: TV, desc: "TV / Сериалы (TV shows)"}
     - {id: 31, cat: Other, desc: "Прочее (Other)"}


### PR DESCRIPTION
#### Description
Fix category mapping for 0day.kiev tracker.

Fixes:
- Cartoons are mapped to Movies instead of TV
- Documentary is mapped to Movies instead of TV
