### PR TITLE
huntorrent: skip extra page before torrent file

### DIFF
--- a/src/Jackett.Common/Definitions/huntorrent.yml
+++ b/src/Jackett.Common/Definitions/huntorrent.yml
@@ -136,6 +136,11 @@ search:
     download:
       selector: a.download-link
       attribute: href
+      filters:
+        - name: replace
+          args: ["please_wait=1&", ""]
+        - name: replace
+          args: ["&please_wait=1", ""]
     genre:
       selector: "span[style=\"font-size: 6pt; font-weight: bold;\"]"
     description:


### PR DESCRIPTION
#### Description
Skip the extra click for downloading the torrent file.
An intermediate page was introduced while downloading torrent file, but that page can be skipped if the URL does not contains the `please_wait=1` argument.
This PR provides a way to remove it from the URL, I know it could be solved with `before` option as well, and likely that is more stable solution (as relies on not URL editing).

Disclaimer I have only tried it with prowlarr (sorry), but that uses the same configuration file.


#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

I haven't opened an issue for this.
