### PR TITLE
Updated 1337X links

### DIFF
--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -16,7 +16,6 @@ links:
   - https://1337x.ninjaproxy1.com/
   - https://1337x.proxyninja.org/
   - https://1337x.torrentbay.st/
-  - l337xdarkkaqfwzntnfk5bmoaroivtl6xsbatabvlb52umg6v3ch44yd.onion
 legacylinks:
   - https://1337x.is/
   - https://1337x.gd/

--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -13,6 +13,8 @@ links:
   - https://x1337x.eu/
   - https://x1337x.se/
   - https://1337x.so/
+  - https://1337x.unblockit.africa/
+  - https://1337x.unblockninja.com/
   - https://1337x.ninjaproxy1.com/
   - https://1337x.proxyninja.org/
   - https://1337x.torrentbay.st/
@@ -38,8 +40,6 @@ legacylinks:
   - https://1337x.mrunblock.bond/
   - https://1337x.unblockit.date/
   - https://1337x.unblockit.dad/
-  - https://1337x.unblockit.africa/
-  - https://1337x.unblockninja.com/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -13,11 +13,10 @@ links:
   - https://x1337x.eu/
   - https://x1337x.se/
   - https://1337x.so/
-  - https://1337x.unblockit.africa/
-  - https://1337x.unblockninja.com/
   - https://1337x.ninjaproxy1.com/
   - https://1337x.proxyninja.org/
   - https://1337x.torrentbay.st/
+  - l337xdarkkaqfwzntnfk5bmoaroivtl6xsbatabvlb52umg6v3ch44yd.onion
 legacylinks:
   - https://1337x.is/
   - https://1337x.gd/
@@ -40,6 +39,8 @@ legacylinks:
   - https://1337x.mrunblock.bond/
   - https://1337x.unblockit.date/
   - https://1337x.unblockit.dad/
+  - https://1337x.unblockit.africa/
+  - https://1337x.unblockninja.com/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/yts.yml
+++ b/src/Jackett.Common/Definitions/yts.yml
@@ -9,10 +9,11 @@ requestDelay: 2.5 # 2.5 requests per second (2 causes problems)
 links:
   # if the primary domain changes then don't forget to update the details, download and poster replace args
   - https://yts.mx/
-# official domain list are at https://yifystatus.com/ and  official proxies list are at https://ytsproxies.com/
+# official domain list are at https://yifystatus.com/ and  official proxies list are at https://ytsproxies.com/ (this site is off and shows account suspended)
   - https://yts.lt/
   - https://yts.am/
   - https://yts.ag/
+  - https://www3.yts.nz/
   - https://yts.unblockit.africa/
   - https://yts.unblockninja.com/
   - https://yts.ninjaproxy1.com/


### PR DESCRIPTION
Added onion v3 (beta) link, and removed the 2 non-working proxy links. Those 2 have been giving 502, 404, and various errors for almost 5 days now.
Added: l337xdarkkaqfwzntnfk5bmoaroivtl6xsbatabvlb52umg6v3ch44yd.onion
Removed: https://1337x.unblockit.africa/ & https://1337x.unblockninja.com/

1337X Status: https://1337x-status.org/

@garfield69 how to add onion links to the files? I removed it as Jackett check was failing, but if you can add it, it will be helpful.