### PR TITLE
core: show invalid releases in the interactive search

### DIFF
--- a/src/Jackett.Common/Indexers/AnimeBytes.cs
+++ b/src/Jackett.Common/Indexers/AnimeBytes.cs
@@ -470,6 +470,10 @@ namespace Jackett.Common.Indexers
                         {
                             // Ignore these categories as they'll cause hell with the matcher
                             // TV Special, DVD Special, BD Special
+                            if (groupName == "TV Special" || groupName == "DVD Special" || groupName == "BD Special")
+                            {
+                                continue;
+                            }
 
                             if (groupName == "TV Series" || groupName == "OVA" || groupName == "ONA")
                             {

--- a/src/Jackett.Common/Indexers/BaseIndexer.cs
+++ b/src/Jackett.Common/Indexers/BaseIndexer.cs
@@ -165,7 +165,7 @@ namespace Jackett.Common.Indexers
 
         protected virtual IEnumerable<ReleaseInfo> FilterResults(TorznabQuery query, IEnumerable<ReleaseInfo> results)
         {
-            var filteredResults = results.Where(IsValidRelease).ToList();
+            var filteredResults = results.Where(r => IsValidRelease(r, query.InteractiveSearch)).ToList();
 
             // filter results with wrong categories
             if (query.Categories.Length > 0)
@@ -237,13 +237,19 @@ namespace Jackett.Common.Indexers
             return fixedResults;
         }
 
-        protected virtual bool IsValidRelease(ReleaseInfo release)
+        protected virtual bool IsValidRelease(ReleaseInfo release, bool interactiveSearch)
         {
             if (release.Title.IsNullOrWhiteSpace())
             {
                 logger.Error("[{0}] Invalid Release: '{1}'. No title provided.", Id, release.Details);
 
                 return false;
+            }
+
+            if (interactiveSearch)
+            {
+                // Show releases with issues in the interactive search
+                return true;
             }
 
             if (release.Size == null)

--- a/src/Jackett.Common/Models/TorznabQuery.cs
+++ b/src/Jackett.Common/Models/TorznabQuery.cs
@@ -13,6 +13,7 @@ namespace Jackett.Common.Models
         private static readonly Regex _StandardizeDashesRegex = new Regex(@"\p{Pd}+", RegexOptions.Compiled);
         private static readonly Regex _StandardizeSingleQuotesRegex = new Regex(@"[\u0060\u00B4\u2018\u2019]", RegexOptions.Compiled);
 
+        public bool InteractiveSearch { get; set; }
         public string QueryType { get; set; }
         public int[] Categories { get; set; }
         public int Extended { get; set; }
@@ -167,6 +168,7 @@ namespace Jackett.Common.Models
         {
             var ret = new TorznabQuery
             {
+                InteractiveSearch = InteractiveSearch,
                 QueryType = QueryType,
                 Extended = Extended,
                 ApiKey = ApiKey,
@@ -212,7 +214,7 @@ namespace Jackett.Common.Models
 
         // Some trackers don't support AND logic for search terms resulting in unwanted results.
         // Using this method we can AND filter it within jackett.
-        // With limit we can limit the amount of characters which should be compared (use it if a tracker doesn't return the full title).
+        // With "limit" we can limit the amount of characters which should be compared (use it if a tracker doesn't return the full title).
         public bool MatchQueryStringAND(string title, int? limit = null, string queryStringOverride = null)
         {
             var commonWords = new[] { "and", "the", "an" };

--- a/src/Jackett.Server/Controllers/ResultsController.cs
+++ b/src/Jackett.Server/Controllers/ResultsController.cs
@@ -236,8 +236,8 @@ namespace Jackett.Server.Controllers
 
             var manualResult = new ManualSearchResult();
 
-            var trackers = CurrentIndexer is BaseMetaIndexer
-                ? (CurrentIndexer as BaseMetaIndexer).ValidIndexers
+            var trackers = CurrentIndexer is BaseMetaIndexer metaIndexer
+                ? metaIndexer.ValidIndexers
                 : (new[] { CurrentIndexer });
 
             // Filter current trackers list on Tracker query parameter if available
@@ -245,8 +245,11 @@ namespace Jackett.Server.Controllers
                 trackers = trackers.Where(t => request.Tracker.Contains(t.Id));
             trackers = trackers.Where(t => t.CanHandleQuery(CurrentQuery));
 
+            CurrentQuery.InteractiveSearch = true;
+
             var isMetaIndexer = request.Tracker == null || request.Tracker.Length > 1;
             var tasks = trackers.ToList().Select(t => t.ResultsForQuery(CurrentQuery, isMetaIndexer)).ToList();
+
             try
             {
                 var aggregateTask = Task.WhenAll(tasks);


### PR DESCRIPTION
#### Description
Allow invalid release without size or categories to be shown in the UI search.