### PR TITLE
Add imdb, tvdb and tvmaze to feed base release

### DIFF
--- a/src/Jackett.Common/Indexers/Feeds/BaseNewznabIndexer.cs
+++ b/src/Jackett.Common/Indexers/Feeds/BaseNewznabIndexer.cs
@@ -65,6 +65,9 @@ namespace Jackett.Common.Indexers.Feeds
                 categoryids = new List<int> { int.Parse(categories.Last(e => !string.IsNullOrEmpty(e.Value)).Value) };
             else
                 categoryids = new List<int> { int.Parse(attributes.First(e => e.Attribute("name").Value == "category").Attribute("value").Value) };
+            var imdbId = long.TryParse(ReadAttribute(attributes, "imdbid"), out longVal) ? (long?)longVal : null;
+            var tvdbId = long.TryParse(ReadAttribute(attributes, "tvdbid"), out longVal) ? (long?)longVal : null;
+            var tvmazeId = long.TryParse(ReadAttribute(attributes, "tvmazeid"), out longVal) ? (long?)longVal : null;
 
             var release = new ReleaseInfo
             {
@@ -82,7 +85,10 @@ namespace Jackett.Common.Indexers.Feeds
                 Peers = peers,
                 InfoHash = attributes.First(e => e.Attribute("name").Value == "infohash").Attribute("value").Value,
                 DownloadVolumeFactor = downloadvolumefactor,
-                UploadVolumeFactor = uploadvolumefactor
+                UploadVolumeFactor = uploadvolumefactor,
+                Imdb = imdbId,
+                TVDBId = tvdbId,
+                TVMazeId = tvmazeId
             };
             if (magneturi != null)
                 release.MagnetUri = magneturi;

--- a/src/Jackett.Common/Indexers/Feeds/BaseNewznabIndexer.cs
+++ b/src/Jackett.Common/Indexers/Feeds/BaseNewznabIndexer.cs
@@ -65,9 +65,7 @@ namespace Jackett.Common.Indexers.Feeds
                 categoryids = new List<int> { int.Parse(categories.Last(e => !string.IsNullOrEmpty(e.Value)).Value) };
             else
                 categoryids = new List<int> { int.Parse(attributes.First(e => e.Attribute("name").Value == "category").Attribute("value").Value) };
-            var imdbId = long.TryParse(ReadAttribute(attributes, "imdbid"), out longVal) ? (long?)longVal : null;
-            var tvdbId = long.TryParse(ReadAttribute(attributes, "tvdbid"), out longVal) ? (long?)longVal : null;
-            var tvmazeId = long.TryParse(ReadAttribute(attributes, "tvmazeid"), out longVal) ? (long?)longVal : null;
+            var imdbId = long.TryParse(ReadAttribute(attributes, "imdb"), out longVal) ? (long?)longVal : null;
 
             var release = new ReleaseInfo
             {
@@ -86,16 +84,14 @@ namespace Jackett.Common.Indexers.Feeds
                 InfoHash = attributes.First(e => e.Attribute("name").Value == "infohash").Attribute("value").Value,
                 DownloadVolumeFactor = downloadvolumefactor,
                 UploadVolumeFactor = uploadvolumefactor,
-                Imdb = imdbId,
-                TVDBId = tvdbId,
-                TVMazeId = tvmazeId
+                Imdb = imdbId
             };
             if (magneturi != null)
                 release.MagnetUri = magneturi;
             return release;
         }
 
-        private string ReadAttribute(IEnumerable<XElement> attributes, string attributeName)
+        protected string ReadAttribute(IEnumerable<XElement> attributes, string attributeName)
         {
             var attribute = attributes.FirstOrDefault(e => e.Attribute("name").Value == attributeName);
             if (attribute == null)

--- a/src/Jackett.Common/Indexers/Feeds/BaseNewznabIndexer.cs
+++ b/src/Jackett.Common/Indexers/Feeds/BaseNewznabIndexer.cs
@@ -65,7 +65,13 @@ namespace Jackett.Common.Indexers.Feeds
                 categoryids = new List<int> { int.Parse(categories.Last(e => !string.IsNullOrEmpty(e.Value)).Value) };
             else
                 categoryids = new List<int> { int.Parse(attributes.First(e => e.Attribute("name").Value == "category").Attribute("value").Value) };
-            var imdbId = long.TryParse(ReadAttribute(attributes, "imdb"), out longVal) ? (long?)longVal : null;
+            var imdb = long.TryParse(ReadAttribute(attributes, "imdb"), out longVal) ? (long?)longVal : null;
+            var imdbId = ReadAttribute(attributes, "imdbid");
+            if (imdb == null && imdbId.StartsWith("tt"))
+                imdb = long.TryParse(imdbId.Substring(2), out longVal) ? (long?)longVal : null;
+            var rageId = long.TryParse(ReadAttribute(attributes, "rageid"), out longVal) ? (long?)longVal : null;
+            var tvdbId = long.TryParse(ReadAttribute(attributes, "tvdbid"), out longVal) ? (long?)longVal : null;
+            var tvMazeid = long.TryParse(ReadAttribute(attributes, "tvmazeid"), out longVal) ? (long?)longVal : null;
 
             var release = new ReleaseInfo
             {
@@ -84,7 +90,10 @@ namespace Jackett.Common.Indexers.Feeds
                 InfoHash = attributes.First(e => e.Attribute("name").Value == "infohash").Attribute("value").Value,
                 DownloadVolumeFactor = downloadvolumefactor,
                 UploadVolumeFactor = uploadvolumefactor,
-                Imdb = imdbId
+                Imdb = imdb,
+                RageID = rageId,
+                TVDBId = tvdbId,
+                TVMazeId = tvMazeid
             };
             if (magneturi != null)
                 release.MagnetUri = magneturi;

--- a/src/Jackett.Common/Indexers/Feeds/MoreThanTVAPI.cs
+++ b/src/Jackett.Common/Indexers/Feeds/MoreThanTVAPI.cs
@@ -138,11 +138,6 @@ namespace Jackett.Common.Indexers.Feeds
                 var enclosureUrl = enclosure.Attribute("url").Value;
                 release.Link = new Uri(enclosureUrl);
             }
-            // custom provider IDs
-            var attributes = item.Descendants().Where(e => e.Name.LocalName == "attr");
-            release.TVDBId = long.TryParse(ReadAttribute(attributes, "tvdbid"), out var longVal) ? (long?)longVal : null;
-            release.TVMazeId = long.TryParse(ReadAttribute(attributes, "tvmazeid"), out longVal) ? (long?)longVal : null;
-
             // add some default values if none returned by feed
             release.Seeders = release.Seeders > 0 ? release.Seeders : 0;
             release.Peers = release.Peers > 0 ? release.Peers : 0;

--- a/src/Jackett.Common/Indexers/Feeds/MoreThanTVAPI.cs
+++ b/src/Jackett.Common/Indexers/Feeds/MoreThanTVAPI.cs
@@ -138,6 +138,11 @@ namespace Jackett.Common.Indexers.Feeds
                 var enclosureUrl = enclosure.Attribute("url").Value;
                 release.Link = new Uri(enclosureUrl);
             }
+            // custom provider IDs
+            var attributes = item.Descendants().Where(e => e.Name.LocalName == "attr");
+            release.TVDBId = long.TryParse(ReadAttribute(attributes, "tvdbid"), out var longVal) ? (long?)longVal : null;
+            release.TVMazeId = long.TryParse(ReadAttribute(attributes, "tvmazeid"), out longVal) ? (long?)longVal : null;
+
             // add some default values if none returned by feed
             release.Seeders = release.Seeders > 0 ? release.Seeders : 0;
             release.Peers = release.Peers > 0 ? release.Peers : 0;


### PR DESCRIPTION
#### Description

MTV uses the BaseFeedIndexer. So now imdb, tvdb and tvmaze IDs gets added to MTV releases.
