### PR TITLE
Add option to disable root privileges nag

### DIFF
--- a/src/Jackett.Server/Services/ServerService.cs
+++ b/src/Jackett.Server/Services/ServerService.cs
@@ -274,7 +274,7 @@ namespace Jackett.Server.Services
 
             try
             {
-                if (Environment.UserName == "root" && !Boolean.TryParse(Environment.GetEnvironmentVariable("DisableRootWarning"), out bool result))
+                if (Environment.UserName == "root" && (!bool.TryParse(Environment.GetEnvironmentVariable("DisableRootWarning"), out var disableRootWarning) || !disableRootWarning))
                 {
                     var notice = "Jackett is running with root privileges. You should run Jackett as an unprivileged user.";
                     notices.Add(notice);

--- a/src/Jackett.Server/Services/ServerService.cs
+++ b/src/Jackett.Server/Services/ServerService.cs
@@ -274,7 +274,7 @@ namespace Jackett.Server.Services
 
             try
             {
-                if (Environment.UserName == "root")
+                if (Environment.UserName == "root" && !Boolean.TryParse(Environment.GetEnvironmentVariable("DisableRootWarning"), out bool result))
                 {
                     var notice = "Jackett is running with root privileges. You should run Jackett as an unprivileged user.";
                     notices.Add(notice);


### PR DESCRIPTION
Recently, an "external access" warning was introduced, and @garfield69 implemented a button to dismiss the warning. As [pointed out here](https://github.com/Jackett/Jackett/issues/15066#issuecomment-1953129520), it is the user's responsibility to understand and accept the consequences of ignoring said warning.

In the same light, I would like to introduce a way to dismiss the warning about running with root privileges. The user has been warned of the risks and they should be able to dismiss the warning under their responsibility.