### PR TITLE
[Fix] Allow to search multiple words in Wolfmax4K

### DIFF
--- a/src/Jackett.Common/Indexers/Wolfmax4K.cs
+++ b/src/Jackett.Common/Indexers/Wolfmax4K.cs
@@ -213,7 +213,7 @@ namespace Jackett.Common.Indexers
             // replace punctuation symbols with spaces
             // searchTerm = Marco Polo 2014
             searchTerm = Regex.Replace(searchTerm, @"[-._\(\)@/\\\[\]\+\%]", " ");
-            searchTerm = Regex.Replace(searchTerm, @"\s+", " ");
+            searchTerm = Regex.Replace(searchTerm, @"\s+", "+");
             searchTerm = searchTerm.Trim();
 
             // we parse the year and remove it from search


### PR DESCRIPTION
#### Description
When searching with multiple word in Wolfmax4K, no results were returned, as it didn't support spaces on the query string.
Changing spaces to `+` fixes the issue, and now multiple words can be used to search with this tracker.

