### PR TITLE
Updated new official homepage for 1337X

### DIFF
--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -7,12 +7,12 @@ type: public
 encoding: UTF-8
 requestDelay: 2
 links:
-  - https://1337x.to/
-  - https://1337x.st/
+  - https://x1337x.cc/
   - https://x1337x.ws/
   - https://x1337x.eu/
   - https://x1337x.se/
-  - https://1337x.so/
+  - https://1337x.to/
+  - https://1337x.st/
   - https://1337x.unblockninja.com/
   - https://1337x.ninjaproxy1.com/
   - https://1337x.proxyninja.org/
@@ -20,6 +20,7 @@ links:
   - https://1337x.torrentbay.st/
   - https://1337x.torrentsbay.org/
 legacylinks:
+  - https://1337x.so/
   - https://1337x.is/
   - https://1337x.gd/
   - https://1337x.mrunblock.life/

--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -7,12 +7,12 @@ type: public
 encoding: UTF-8
 requestDelay: 2
 links:
-  - https://x1337x.cc/
+  - https://1337x.to/
+  - https://1337x.st/
   - https://x1337x.ws/
   - https://x1337x.eu/
   - https://x1337x.se/
-  - https://1337x.to/
-  - https://1337x.st/
+  - https://x1337x.cc/
   - https://1337x.unblockninja.com/
   - https://1337x.ninjaproxy1.com/
   - https://1337x.proxyninja.org/
@@ -20,7 +20,6 @@ links:
   - https://1337x.torrentbay.st/
   - https://1337x.torrentsbay.org/
 legacylinks:
-  - https://1337x.so/
   - https://1337x.is/
   - https://1337x.gd/
   - https://1337x.mrunblock.life/
@@ -41,6 +40,7 @@ legacylinks:
   - https://1337x.unblockit.ong/ # 502
   - https://1337x.unblockit.black/ # 502
   - https://1337x.abcproxy.org/
+  - https://1337x.so/
 
 caps:
   categorymappings:


### PR DESCRIPTION
Per official .so page:
Domain 1337x.so expired by mistake and is no longer controlled by us. Stop using this domain.
New alternative domain is https://x1337x.cc/