### PR TITLE
totheglory: changes for 2fa

### DIFF
--- a/src/Jackett.Common/Definitions/totheglory.yml
+++ b/src/Jackett.Common/Definitions/totheglory.yml
@@ -1,7 +1,7 @@
 ---
 id: totheglory
 name: ToTheGlory
-description: "ToTheGlory (TTG) A Chinese tracker"
+description: "ToTheGlory (TTG) is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: zh-CN
 type: private
 encoding: UTF-8
@@ -95,13 +95,6 @@ settings:
   - name: password
     type: password
     label: Password
-  - name: 2facode
-    type: text
-    label: 2FA code
-  - name: info_2fa
-    type: info
-    label: "About 2FA code"
-    default: "Only fill in the <b>2FA code</b> box if you have enabled <b>2FA</b> on the TTG Web Site. Otherwise just leave it empty."
   - name: passid
     type: select
     label: Security Question ID
@@ -118,14 +111,14 @@ settings:
   - name: info_passid
     type: info
     label: "About Security ID"
-    default: "Only select the <b>Security Question ID</b> from the pulldown if you have set it on the TTG Web Site. Otherwise just leave it as ignore not set."
+    default: "Only select the <b>Security Question ID</b> from the pulldown if you have set it on the TTG Web Site. Otherwise just leave it as <b>Ignore not set</b>."
   - name: passan
     type: text
     label: Security Question Answer
   - name: info_passan
     type: info
     label: "About Security Question Answer"
-    default: "Only fill in the <b>Security Question Answer</b> box if you have set it on the TTG Web Site. Dont forget to write your answer in the same language you saved it on the TTG Web Site. Otherwise just leave it empty."
+    default: "Only fill in the <b>Security Question Answer</b> box if you have set it on the TTG Web Site. Don't forget to write your answer in the same language you saved it on the TTG Web Site. Otherwise just leave it empty."
 
 login:
   path: login.php?returnto=
@@ -135,7 +128,6 @@ login:
     username: "{{ .Config.username }}"
     password: "{{ .Config.password }}"
     rememberme: yes
-    otp: "{{ .Config.2facode }}"
     passid: "{{ .Config.passid }}"
     passan: "{{ .Config.passan }}"
   error:

--- a/src/Jackett.Common/Definitions/totheglory2fa.yml
+++ b/src/Jackett.Common/Definitions/totheglory2fa.yml
@@ -1,7 +1,7 @@
 ---
-id: totheglorycookie
-name: ToTheGloryCookie
-description: "ToTheGlory (TTG) A Chinese tracker. This uses the cookie method for access"
+id: totheglory2fa
+name: ToTheGlory2FA
+description: "ToTheGlory (TTG) is a CHINESE Private Torrent Tracker for MOVIES / TV / GENERAL. This indexer uses cookie login for 2FA."
 language: zh-CN
 type: private
 encoding: UTF-8

--- a/src/Jackett.Common/Services/IndexerManagerService.cs
+++ b/src/Jackett.Common/Services/IndexerManagerService.cs
@@ -38,39 +38,42 @@ namespace Jackett.Common.Services
         // (the id is used in the torznab/download/search urls and in the indexer configuration file)
         // if the indexer is removed, remove it from this list too
         // use: {"<old id>", "<new id>"}
+        // list alphabetically by the original name
+        // group successive and collective renames, use comments to indicate this
         private readonly Dictionary<string, string> _renamedIndexers = new Dictionary<string, string>
         {
             {"audiobooktorrents", "abtorrents"},
             {"baibako", "rudub"},
             {"broadcastthenet", "broadcasthenet"},
             {"casatorrent", "teamctgame"},
-            {"icetorrent", "speedapp"},
             {"hdzone", "hdfun"},
+            {"icetorrent", "speedapp"}, // v
+            {"scenefz", "speedapp"}, //    |
+            {"xtremezone", "speedapp"}, // ^
             {"kickasstorrent-kathow", "kickasstorrents-ws"},
             {"kisssub", "miobt"},
-            {"legacyhd", "reelflix"},
-            {"reelflix", "reelflix-api"},
+            {"legacyhd", "reelflix"}, //     v
+            {"reelflix", "reelflix-api"}, // ^
             {"magico", "trellas"},
             {"metaliplayro", "romanianmetaltorrents"},
             {"mteamtp2fa", "mteamtp"},
             {"nnm-club", "noname-club"},
-            {"oxtorrent", "torrent911"},
+            {"oxtorrent", "torrent911"}, //     v
+            {"torrent911", "oxtorrent-vip"}, // ^
             {"passtheheadphones", "redacted"},
             {"puntorrent", "puntotorrent"},
             {"rstorrent", "redstartorrent"},
-            {"scenefz", "speedapp"},
             {"seals", "greatposterwall"},
             {"speedcdcookie", "speedcd"},
-            {"tehconnectionme", "anthelion"},
-            {"torrent911", "oxtorrent-vip"},
-            {"anthelion", "anthelion-api"},
+            {"tehconnectionme", "anthelion"}, // v
+            {"anthelion", "anthelion-api"}, //   ^
             {"todotorrents", "dontorrent"},
             {"torrent9clone", "torrent9-tel"},
             {"torrentgalaxyorg", "torrentgalaxy"},
             {"torrentsurf", "xtremebytes"},
-            {"transmithenet", "nebulance"},
-            {"nebulance", "nebulanceapi"},
-            {"xtremezone", "speedapp"},
+            {"totheglorycookie", "totheglory2fa"},
+            {"transmithenet", "nebulance"}, // v
+            {"nebulance", "nebulanceapi"}, //  ^
             {"yourexotic", "exoticaz"}
         };
 

--- a/src/Jackett.Updater/Program.cs
+++ b/src/Jackett.Updater/Program.cs
@@ -679,6 +679,7 @@ namespace Jackett.Updater
                 "Definitions/torrof.yml",
                 "Definitions/torviet.yml",
                 "Definitions/totallykids.yml",
+                "Definitions/totheglorycookie.yml", // renamed totheglory2fa
                 "Definitions/trackeros-api.yml",
                 "Definitions/trackeros.yml", // switch to *-API #12807
                 "Definitions/tspate.yml",


### PR DESCRIPTION
#### Description
2FA now seems to be on a separate page, so short of someone with an account rewriting in C#, change cookie indexer to 2FA. Obviously untested, but there's no `otp` input on the login page, and the log from #15412 shows the redirect to `2fa.php`.

@garfield69 look ok?

@mynameisbogdan a heads up for Prowlarr

Also added some comments to IndexerManagerService.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Relates to #15412
