### PR TITLE
broadcasthenet: pageable requests

### DIFF
--- a/src/Jackett.Common/Indexers/BaseIndexer.cs
+++ b/src/Jackett.Common/Indexers/BaseIndexer.cs
@@ -39,6 +39,8 @@ namespace Jackett.Common.Indexers
 
         public virtual bool SupportsPagination => false;
 
+        public virtual int PageSize => 0;
+
         public virtual bool IsConfigured { get; protected set; }
         public virtual string[] Tags { get; protected set; }
 
@@ -388,6 +390,9 @@ namespace Jackett.Common.Indexers
             }
         }
 
+        public abstract IIndexerRequestGenerator GetRequestGenerator();
+        public abstract IParseIndexerResponse GetParser();
+
         protected abstract Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query);
     }
 
@@ -601,6 +606,25 @@ namespace Jackett.Common.Indexers
             return result;
         }
 
+        protected async Task<WebResult> RequestWithCookiesAndRetryAsync(WebRequest request)
+        {
+            return await RetryStrategy
+                 .ExecuteAsync(async _ => await RequestWithCookiesAsync(request))
+                 .ConfigureAwait(false);
+        }
+
+        protected virtual async Task<WebResult> RequestWithCookiesAsync(WebRequest request)
+        {
+            request.Encoding = Encoding;
+
+            var result = await webclient.GetResultAsync(request);
+
+            CheckSiteDown(result);
+            UpdateCookieHeader(result.Cookies);
+
+            return result;
+        }
+
         protected async Task<WebResult> RequestLoginAndFollowRedirect(string url, IEnumerable<KeyValuePair<string, string>> data, string cookies, bool returnCookiesFromFirstCall, string redirectUrlOverride = null, string referer = null, bool accumulateCookies = false, Dictionary<string, string> headers = null)
         {
             var request = new WebRequest
@@ -808,6 +832,99 @@ namespace Jackett.Common.Indexers
 
         protected WebClient webclient;
         protected readonly string downloadUrlBase = "";
+
+        public override IIndexerRequestGenerator GetRequestGenerator() => throw new NotImplementedException();
+
+        public override IParseIndexerResponse GetParser() => throw new NotImplementedException();
+
+        protected override Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
+        {
+            return FetchReleasesAsync(g => g.GetSearchRequests(query), query);
+        }
+
+        protected virtual async Task<IEnumerable<ReleaseInfo>> FetchReleasesAsync(Func<IIndexerRequestGenerator, IndexerPageableRequestChain> pageableRequestChainSelector, TorznabQuery query)
+        {
+            var releases = new List<ReleaseInfo>();
+
+            var generator = GetRequestGenerator();
+            var parser = GetParser();
+
+            var pageableRequestChain = pageableRequestChainSelector(generator);
+
+            for (var i = 0; i < pageableRequestChain.Tiers; i++)
+            {
+                var pageableRequests = pageableRequestChain.GetTier(i).ToList();
+
+                foreach (var pageableRequest in pageableRequests)
+                {
+                    var pagedReleases = new List<ReleaseInfo>();
+
+                    var pageSize = PageSize;
+
+                    foreach (var request in pageableRequest)
+                    {
+                        var page = await FetchPageAsync(request, parser);
+
+                        pageSize = pageSize == 1 ? page.Releases.Count : pageSize;
+
+                        pagedReleases.AddRange(page.Releases);
+
+                        if (!IsFullPage(page.Releases, pageSize))
+                        {
+                            break;
+                        }
+                    }
+
+                    releases.AddRange(pagedReleases.Where(r => IsValidRelease(r, query.InteractiveSearch)));
+                }
+
+                if (releases.Any())
+                {
+                    break;
+                }
+            }
+
+            return releases;
+        }
+
+        protected virtual bool IsFullPage(IList<ReleaseInfo> page, int pageSize)
+        {
+            return pageSize != 0 && page.Count >= pageSize;
+        }
+
+        protected virtual async Task<IndexerQueryResult> FetchPageAsync(IndexerRequest request, IParseIndexerResponse parser)
+        {
+            var response = await FetchIndexerResponseAsync(request);
+
+            try
+            {
+                var releases = parser.ParseResponse(response).ToList();
+
+                if (releases.Count == 0)
+                {
+                    logger.Trace("No releases found. Response: {0}", response.Content);
+                }
+
+                return new IndexerQueryResult
+                {
+                    Releases = releases,
+                    Response = response.WebResponse
+                };
+            }
+            catch (Exception ex)
+            {
+                logger.Trace("Unexpected response content ({0} bytes): {1}", response.WebResponse.ContentString.Length, response.WebResponse.ContentString);
+                OnParseError(response.Content, ex);
+                throw;
+            }
+        }
+
+        protected virtual async Task<IndexerResponse> FetchIndexerResponseAsync(IndexerRequest request)
+        {
+            var response = await RequestWithCookiesAndRetryAsync(request.WebRequest);
+
+            return new IndexerResponse(request, response);
+        }
     }
 
     public abstract class BaseCachingWebIndexer : BaseWebIndexer

--- a/src/Jackett.Common/Indexers/BroadcasTheNet.cs
+++ b/src/Jackett.Common/Indexers/BroadcasTheNet.cs
@@ -30,10 +30,9 @@ namespace Jackett.Common.Indexers
 
         public override bool SupportsPagination => true;
 
-        public override TorznabCapabilities TorznabCaps => SetCapabilities();
+        public override int PageSize => 100;
 
-        // based on https://github.com/Prowlarr/Prowlarr/tree/develop/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet
-        private readonly string APIBASE = "https://api.broadcasthe.net";
+        public override TorznabCapabilities TorznabCaps => SetCapabilities();
 
         // TODO: remove ConfigurationDataAPIKey class and use ConfigurationDataPasskey instead
         private new ConfigurationDataAPIKey configData
@@ -51,7 +50,7 @@ namespace Jackett.Common.Indexers
                    cacheService: cs,
                    configData: new ConfigurationDataAPIKey())
         {
-            webclient.requestDelay = 4;
+            webclient.requestDelay = 5;
         }
 
         private TorznabCapabilities SetCapabilities()
@@ -74,6 +73,16 @@ namespace Jackett.Common.Indexers
             caps.Categories.AddCategoryMapping("Portable Device", TorznabCatType.TVSD, "Portable Device");
 
             return caps;
+        }
+
+        public override IIndexerRequestGenerator GetRequestGenerator()
+        {
+            return new BroadcastheNetRequestGenerator(configData, TorznabCaps);
+        }
+
+        public override IParseIndexerResponse GetParser()
+        {
+            return new BroadcastheNetParser(SiteLink, TorznabCaps.Categories);
         }
 
         public override async Task<IndexerConfigurationStatus> ApplyConfiguration(JToken configJson)
@@ -99,8 +108,116 @@ namespace Jackett.Common.Indexers
 
             return IndexerConfigurationStatus.Completed;
         }
+    }
 
-        private string JsonRPCRequest(string method, JArray parameters)
+    public class BroadcastheNetRequestGenerator : IIndexerRequestGenerator
+    {
+        private readonly ConfigurationDataAPIKey _configData;
+        private readonly TorznabCapabilities _torznabCaps;
+
+        // based on https://github.com/Prowlarr/Prowlarr/tree/develop/src/NzbDrone.Core/Indexers/Definitions/BroadcastheNet
+        private const string ApiBase = "https://api.broadcasthe.net";
+
+        public BroadcastheNetRequestGenerator(ConfigurationDataAPIKey configData, TorznabCapabilities torznabCaps)
+        {
+            _configData = configData;
+            _torznabCaps = torznabCaps;
+        }
+
+        public IndexerPageableRequestChain GetSearchRequests(TorznabQuery query)
+        {
+            var pageableRequests = new IndexerPageableRequestChain();
+
+            var searchTerm = query.SearchTerm ?? string.Empty;
+
+            var btnResults = query.Limit;
+            if (btnResults == 0)
+            {
+                btnResults = _torznabCaps.LimitsDefault.GetValueOrDefault(100);
+            }
+
+            var btnOffset = query.Offset;
+
+            var parameters = new BroadcastheNetSearchQuery();
+
+            if (query.IsTvdbQuery)
+            {
+                parameters.Tvdb = query.TvdbID.ToString();
+            }
+
+            if (searchTerm.IsNotNullOrWhiteSpace())
+            {
+                parameters.Search = searchTerm.Replace(" ", "%");
+            }
+
+            // If only the season/episode is searched for then change format to match expected format
+            if (query.Season > 0 && query.Episode.IsNullOrWhiteSpace())
+            {
+                // Search Season
+                parameters.Category = "Season";
+                parameters.Name = $"Season {query.Season}%";
+                pageableRequests.Add(GetPagedRequests(parameters, btnResults, btnOffset));
+
+                parameters = parameters.Clone();
+
+                // Search Episode
+                parameters.Category = "Episode";
+                parameters.Name = $"S{query.Season:00}E%";
+                pageableRequests.Add(GetPagedRequests(parameters, btnResults, btnOffset));
+            }
+            else if (DateTime.TryParseExact($"{query.Season} {query.Episode}", "yyyy MM/dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var showDate))
+            {
+                // Daily Episode
+                parameters.Name = showDate.ToString("yyyy.MM.dd");
+                parameters.Category = "Episode";
+                pageableRequests.Add(GetPagedRequests(parameters, btnResults, btnOffset));
+            }
+            else if (query.Season > 0 && int.TryParse(query.Episode, out var episode) && episode > 0)
+            {
+                // Standard (S/E) Episode
+                parameters.Name = $"S{query.Season:00}E{episode:00}%";
+                parameters.Category = "Episode";
+                pageableRequests.Add(GetPagedRequests(parameters, btnResults, btnOffset));
+            }
+            else if (searchTerm.IsNotNullOrWhiteSpace() && int.TryParse(searchTerm, out _) && query.TvdbID > 0)
+            {
+                // Disable ID-based searches for episodes with absolute episode number
+                return new IndexerPageableRequestChain();
+            }
+            else
+            {
+                // Neither a season only search nor daily nor standard, fall back to query
+                pageableRequests.Add(GetPagedRequests(parameters, btnResults, btnOffset));
+            }
+
+            return pageableRequests;
+        }
+
+        private IEnumerable<IndexerRequest> GetPagedRequests(BroadcastheNetSearchQuery parameters, int results, int offset)
+        {
+            var webRequest = new WebRequest
+            {
+                Url = ApiBase,
+                Type = RequestType.POST,
+                Headers = new Dictionary<string, string>
+                {
+                    { "Accept", "application/json-rpc, application/json" },
+                    { "Content-Type", "application/json-rpc" }
+                },
+                RawBody = JsonRpcRequest("getTorrents", new JArray
+                {
+                    new JValue(_configData.Key.Value),
+                    JObject.FromObject(parameters),
+                    new JValue(results),
+                    new JValue(offset)
+                }),
+                EmulateBrowser = false
+            };
+
+            yield return new IndexerRequest(webRequest);
+        }
+
+        private string JsonRpcRequest(string method, JArray parameters)
         {
             dynamic request = new JObject();
             request["jsonrpc"] = "2.0";
@@ -109,215 +226,189 @@ namespace Jackett.Common.Indexers
             request["id"] = Guid.NewGuid().ToString().Substring(0, 8);
             return request.ToString();
         }
+    }
 
-        protected override async Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query)
+    public class BroadcastheNetParser : IParseIndexerResponse
+    {
+        private readonly string _siteLink;
+        private readonly TorznabCapabilitiesCategories _categories;
+
+        public BroadcastheNetParser(string siteLink, TorznabCapabilitiesCategories categories)
         {
-            var searchTerm = query.SearchTerm ?? string.Empty;
+            _siteLink = siteLink;
+            _categories = categories;
+        }
 
-            var btnResults = query.Limit;
-            if (btnResults == 0)
-            {
-                btnResults = (int)TorznabCaps.LimitsDefault;
-            }
-
-            var btnOffset = query.Offset;
+        public IList<ReleaseInfo> ParseResponse(IndexerResponse indexerResponse)
+        {
             var releases = new List<ReleaseInfo>();
 
-            var parameters = new Dictionary<string, object>();
+            var jsonResponse = JsonConvert.DeserializeObject<BroadcastheNetResponse>(indexerResponse.Content);
 
-            if (query.IsTvdbQuery)
+            if (jsonResponse?.Result?.Torrents == null)
             {
-                parameters["tvdb"] = query.TvdbID;
-            }
-
-            if (searchTerm.IsNotNullOrWhiteSpace())
-            {
-                parameters["search"] = searchTerm.Replace(" ", "%");
-            }
-
-            // If only the season/episode is searched for then change format to match expected format
-            if (query.Season > 0 && query.Episode.IsNullOrWhiteSpace())
-            {
-                parameters["category"] = "Episode";
-                parameters["name"] = $"S{query.Season:00}E%";
-            }
-            else if (DateTime.TryParseExact($"{query.Season} {query.Episode}", "yyyy MM/dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var showDate))
-            {
-                // Daily Episode
-                parameters["name"] = showDate.ToString("yyyy.MM.dd");
-                parameters["category"] = "Episode";
-            }
-            else if (query.Season > 0 && int.TryParse(query.Episode, out var episode) && episode > 0)
-            {
-                // Standard (S/E) Episode
-                parameters["name"] = $"S{query.Season:00}E{episode:00}%";
-                parameters["category"] = "Episode";
-            }
-            else if (searchTerm.IsNotNullOrWhiteSpace() && int.TryParse(searchTerm, out _) && query.TvdbID > 0)
-            {
-                // Disable ID-based searches for episodes with absolute episode number
                 return releases;
             }
 
-            var requestPayload = new JArray
+            foreach (var itemKey in jsonResponse.Result.Torrents)
             {
-                new JValue(configData.Key.Value),
-                JObject.FromObject(parameters),
-                new JValue(btnResults),
-                new JValue(btnOffset)
-            };
+                var btnResult = itemKey.Value;
+                var descriptions = new List<string>();
 
-            var response = await RequestWithCookiesAndRetryAsync(
-                APIBASE, method: RequestType.POST,
-                headers: new Dictionary<string, string>
+                if (btnResult.Series.IsNotNullOrWhiteSpace())
                 {
-                    {"Accept", "application/json-rpc, application/json"},
-                    {"Content-Type", "application/json-rpc"}
-                }, rawbody: JsonRPCRequest("getTorrents", requestPayload), emulateBrowser: false);
-
-            try
-            {
-                var btnResponse = JsonConvert.DeserializeObject<BTNRPCResponse>(response.ContentString);
-
-                if (btnResponse?.Result?.Torrents == null)
-                {
-                    return releases;
+                    descriptions.Add("Series: " + btnResult.Series);
                 }
 
-                foreach (var itemKey in btnResponse.Result.Torrents)
+                if (btnResult.GroupName.IsNotNullOrWhiteSpace())
                 {
-                    var btnResult = itemKey.Value;
-                    var descriptions = new List<string>();
-
-                    if (!string.IsNullOrWhiteSpace(btnResult.Series))
-                    {
-                        descriptions.Add("Series: " + btnResult.Series);
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(btnResult.GroupName))
-                    {
-                        descriptions.Add("Group Name: " + btnResult.GroupName);
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(btnResult.Source))
-                    {
-                        descriptions.Add("Source: " + btnResult.Source);
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(btnResult.Container))
-                    {
-                        descriptions.Add("Container: " + btnResult.Container);
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(btnResult.Codec))
-                    {
-                        descriptions.Add("Codec: " + btnResult.Codec);
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(btnResult.Resolution))
-                    {
-                        descriptions.Add("Resolution: " + btnResult.Resolution);
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(btnResult.Origin))
-                    {
-                        descriptions.Add("Origin: " + btnResult.Origin);
-                    }
-
-                    if (!string.IsNullOrWhiteSpace(btnResult.YoutubeTrailer))
-                    {
-                        descriptions.Add(
-                            "Youtube Trailer: <a href=\"" + btnResult.YoutubeTrailer + "\">" + btnResult.YoutubeTrailer +
-                            "</a>");
-                    }
-
-                    var imdb = ParseUtil.GetImdbId(btnResult.ImdbID);
-                    var link = new Uri(btnResult.DownloadURL);
-                    var details = new Uri($"{SiteLink}torrents.php?id={btnResult.GroupID}&torrentid={btnResult.TorrentID}");
-                    var publishDate = DateTimeUtil.UnixTimestampToDateTime(btnResult.Time);
-
-                    var release = new ReleaseInfo
-                    {
-                        Guid = link,
-                        Details = details,
-                        Link = link,
-                        Title = btnResult.ReleaseName,
-                        Description = string.Join("<br />\n", descriptions),
-                        Category = MapTrackerCatToNewznab(btnResult.Resolution),
-                        InfoHash = btnResult.InfoHash,
-                        Size = btnResult.Size,
-                        Grabs = btnResult.Snatched,
-                        Seeders = btnResult.Seeders,
-                        Peers = btnResult.Seeders + btnResult.Leechers,
-                        PublishDate = publishDate,
-                        TVDBId = btnResult.TvdbID,
-                        RageID = btnResult.TvrageID,
-                        Imdb = imdb,
-                        DownloadVolumeFactor = 0, // ratioless
-                        UploadVolumeFactor = 1,
-                        MinimumRatio = 1,
-                        MinimumSeedTime = btnResult.Category.ToUpperInvariant() == "SEASON" ? 432000 : 86400 // 120 hours for seasons and 24 hours for episodes
-                    };
-
-                    if (!string.IsNullOrEmpty(btnResult.SeriesBanner))
-                    {
-                        release.Poster = new Uri(btnResult.SeriesBanner);
-                    }
-
-                    if (!release.Category.Any()) // default to TV
-                    {
-                        release.Category.Add(TorznabCatType.TV.ID);
-                    }
-
-                    releases.Add(release);
+                    descriptions.Add("Group Name: " + btnResult.GroupName);
                 }
-            }
-            catch (Exception ex)
-            {
-                OnParseError(response.ContentString, ex);
+
+                if (btnResult.Source.IsNotNullOrWhiteSpace())
+                {
+                    descriptions.Add("Source: " + btnResult.Source);
+                }
+
+                if (btnResult.Container.IsNotNullOrWhiteSpace())
+                {
+                    descriptions.Add("Container: " + btnResult.Container);
+                }
+
+                if (btnResult.Codec.IsNotNullOrWhiteSpace())
+                {
+                    descriptions.Add("Codec: " + btnResult.Codec);
+                }
+
+                if (btnResult.Resolution.IsNotNullOrWhiteSpace())
+                {
+                    descriptions.Add("Resolution: " + btnResult.Resolution);
+                }
+
+                if (btnResult.Origin.IsNotNullOrWhiteSpace())
+                {
+                    descriptions.Add("Origin: " + btnResult.Origin);
+                }
+
+                if (btnResult.YoutubeTrailer.IsNotNullOrWhiteSpace())
+                {
+                    descriptions.Add(
+                        "Youtube Trailer: <a href=\"" + btnResult.YoutubeTrailer + "\">" + btnResult.YoutubeTrailer +
+                        "</a>");
+                }
+
+                var imdb = ParseUtil.GetImdbId(btnResult.ImdbID);
+                var link = new Uri(btnResult.DownloadURL);
+                var details = new Uri($"{_siteLink}torrents.php?id={btnResult.GroupID}&torrentid={btnResult.TorrentID}");
+                var publishDate = DateTimeUtil.UnixTimestampToDateTime(btnResult.Time);
+
+                var release = new ReleaseInfo
+                {
+                    Guid = link,
+                    Details = details,
+                    Link = link,
+                    Title = btnResult.ReleaseName,
+                    Description = string.Join("<br />\n", descriptions),
+                    Category = _categories.MapTrackerCatToNewznab(btnResult.Resolution),
+                    InfoHash = btnResult.InfoHash,
+                    Size = btnResult.Size,
+                    Grabs = btnResult.Snatched,
+                    Seeders = btnResult.Seeders,
+                    Peers = btnResult.Seeders + btnResult.Leechers,
+                    PublishDate = publishDate,
+                    TVDBId = btnResult.TvdbID,
+                    RageID = btnResult.TvrageID,
+                    Imdb = imdb,
+                    DownloadVolumeFactor = 0, // ratioless
+                    UploadVolumeFactor = 1,
+                    MinimumRatio = 1,
+                    MinimumSeedTime = btnResult.Category.ToUpperInvariant() == "SEASON" ? 432000 : 86400 // 120 hours for seasons and 24 hours for episodes
+                };
+
+                if (btnResult.SeriesBanner.IsNotNullOrWhiteSpace())
+                {
+                    var posterUrl = btnResult.SeriesBanner;
+
+                    if (posterUrl.StartsWith("//"))
+                    {
+                        posterUrl = "https:" + posterUrl;
+                    }
+
+                    release.Poster = new Uri(posterUrl);
+                }
+
+                if (!release.Category.Any()) // default to TV
+                {
+                    release.Category.Add(TorznabCatType.TV.ID);
+                }
+
+                releases.Add(release);
             }
 
             return releases;
         }
+    }
 
-        public class BTNRPCResponse
-        {
-            public string Id { get; set; }
-            public BTNResultPage Result { get; set; }
-        }
+    public class BroadcastheNetSearchQuery
+    {
+        [JsonProperty("category", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Category { get; set; }
 
-        public class BTNResultPage
-        {
-            public Dictionary<int, BTNResultItem> Torrents { get; set; }
-        }
+        [JsonProperty("name", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Name { get; set; }
 
-        public class BTNResultItem
+        [JsonProperty("search", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Search { get; set; }
+
+        [JsonProperty("tvdb", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Tvdb { get; set; }
+
+        [JsonProperty("tvrage", DefaultValueHandling = DefaultValueHandling.Ignore)]
+        public string Tvrage { get; set; }
+
+        public BroadcastheNetSearchQuery Clone()
         {
-            public int TorrentID { get; set; }
-            public string DownloadURL { get; set; }
-            public string GroupName { get; set; }
-            public int GroupID { get; set; }
-            public int SeriesID { get; set; }
-            public string Series { get; set; }
-            public string SeriesBanner { get; set; }
-            public string SeriesPoster { get; set; }
-            public string YoutubeTrailer { get; set; }
-            public string Category { get; set; }
-            public int? Snatched { get; set; }
-            public int? Seeders { get; set; }
-            public int? Leechers { get; set; }
-            public string Source { get; set; }
-            public string Container { get; set; }
-            public string Codec { get; set; }
-            public string Resolution { get; set; }
-            public string Origin { get; set; }
-            public string ReleaseName { get; set; }
-            public long Size { get; set; }
-            public long Time { get; set; }
-            public int? TvdbID { get; set; }
-            public int? TvrageID { get; set; }
-            public string ImdbID { get; set; }
-            public string InfoHash { get; set; }
+            return MemberwiseClone() as BroadcastheNetSearchQuery;
         }
+    }
+
+    public class BroadcastheNetResponse
+    {
+        public string Id { get; set; }
+        public BroadcastheNetResult Result { get; set; }
+    }
+
+    public class BroadcastheNetResult
+    {
+        public Dictionary<int, BroadcastheNetTorrent> Torrents { get; set; }
+    }
+
+    public class BroadcastheNetTorrent
+    {
+        public int TorrentID { get; set; }
+        public string DownloadURL { get; set; }
+        public string GroupName { get; set; }
+        public int GroupID { get; set; }
+        public int SeriesID { get; set; }
+        public string Series { get; set; }
+        public string SeriesBanner { get; set; }
+        public string SeriesPoster { get; set; }
+        public string YoutubeTrailer { get; set; }
+        public string Category { get; set; }
+        public int? Snatched { get; set; }
+        public int? Seeders { get; set; }
+        public int? Leechers { get; set; }
+        public string Source { get; set; }
+        public string Container { get; set; }
+        public string Codec { get; set; }
+        public string Resolution { get; set; }
+        public string Origin { get; set; }
+        public string ReleaseName { get; set; }
+        public long Size { get; set; }
+        public long Time { get; set; }
+        public int? TvdbID { get; set; }
+        public int? TvrageID { get; set; }
+        public string ImdbID { get; set; }
+        public string InfoHash { get; set; }
     }
 }

--- a/src/Jackett.Common/Indexers/IIndexerRequestGenerator.cs
+++ b/src/Jackett.Common/Indexers/IIndexerRequestGenerator.cs
@@ -1,0 +1,9 @@
+using Jackett.Common.Models;
+
+namespace Jackett.Common.Indexers
+{
+    public interface IIndexerRequestGenerator
+    {
+        IndexerPageableRequestChain GetSearchRequests(TorznabQuery query);
+    }
+}

--- a/src/Jackett.Common/Indexers/IParseIndexerResponse.cs
+++ b/src/Jackett.Common/Indexers/IParseIndexerResponse.cs
@@ -1,0 +1,10 @@
+using System.Collections.Generic;
+using Jackett.Common.Models;
+
+namespace Jackett.Common.Indexers
+{
+    public interface IParseIndexerResponse
+    {
+        IList<ReleaseInfo> ParseResponse(IndexerResponse indexerResponse);
+    }
+}

--- a/src/Jackett.Common/Indexers/IndexerPageableRequest.cs
+++ b/src/Jackett.Common/Indexers/IndexerPageableRequest.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+
+namespace Jackett.Common.Indexers
+{
+    public class IndexerPageableRequest : IEnumerable<IndexerRequest>
+    {
+        private readonly IEnumerable<IndexerRequest> _enumerable;
+
+        public IndexerPageableRequest(IEnumerable<IndexerRequest> enumerable)
+        {
+            _enumerable = enumerable;
+        }
+
+        public IEnumerator<IndexerRequest> GetEnumerator()
+        {
+            return _enumerable.GetEnumerator();
+        }
+
+        IEnumerator IEnumerable.GetEnumerator()
+        {
+            return _enumerable.GetEnumerator();
+        }
+    }
+}

--- a/src/Jackett.Common/Indexers/IndexerPageableRequestChain.cs
+++ b/src/Jackett.Common/Indexers/IndexerPageableRequestChain.cs
@@ -1,0 +1,54 @@
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Jackett.Common.Indexers
+{
+    public class IndexerPageableRequestChain
+    {
+        private List<List<IndexerPageableRequest>> _chains;
+
+        public IndexerPageableRequestChain()
+        {
+            _chains = new List<List<IndexerPageableRequest>>();
+            _chains.Add(new List<IndexerPageableRequest>());
+        }
+
+        public int Tiers => _chains.Count;
+
+        public IEnumerable<IndexerPageableRequest> GetAllTiers()
+        {
+            return _chains.SelectMany(v => v);
+        }
+
+        public IEnumerable<IndexerPageableRequest> GetTier(int index)
+        {
+            return _chains[index];
+        }
+
+        public void Add(IEnumerable<IndexerRequest> request)
+        {
+            if (request == null)
+            {
+                return;
+            }
+
+            _chains.Last().Add(new IndexerPageableRequest(request));
+        }
+
+        public void AddTier(IEnumerable<IndexerRequest> request)
+        {
+            AddTier();
+            Add(request);
+        }
+
+        public void AddTier()
+        {
+            if (_chains.Last().Count == 0)
+            {
+                return;
+            }
+
+            _chains.Add(new List<IndexerPageableRequest>());
+        }
+    }
+}

--- a/src/Jackett.Common/Indexers/IndexerQueryResult.cs
+++ b/src/Jackett.Common/Indexers/IndexerQueryResult.cs
@@ -1,0 +1,17 @@
+using System.Collections.Generic;
+using Jackett.Common.Models;
+using Jackett.Common.Utils.Clients;
+
+namespace Jackett.Common.Indexers
+{
+    public class IndexerQueryResult
+    {
+        public IndexerQueryResult()
+        {
+            Releases = new List<ReleaseInfo>();
+        }
+
+        public IList<ReleaseInfo> Releases { get; set; }
+        public WebResult Response { get; set; }
+    }
+}

--- a/src/Jackett.Common/Indexers/IndexerRequest.cs
+++ b/src/Jackett.Common/Indexers/IndexerRequest.cs
@@ -1,0 +1,21 @@
+using Jackett.Common.Utils.Clients;
+
+namespace Jackett.Common.Indexers
+{
+    public class IndexerRequest
+    {
+        public WebRequest WebRequest { get; private set; }
+
+        public IndexerRequest(string url)
+        {
+            WebRequest = new WebRequest(url);
+        }
+
+        public IndexerRequest(WebRequest webRequest)
+        {
+            WebRequest = webRequest;
+        }
+
+        public string Url => WebRequest.Url;
+    }
+}

--- a/src/Jackett.Common/Indexers/IndexerResponse.cs
+++ b/src/Jackett.Common/Indexers/IndexerResponse.cs
@@ -1,0 +1,24 @@
+using Jackett.Common.Utils.Clients;
+
+namespace Jackett.Common.Indexers
+{
+    public class IndexerResponse
+    {
+        private readonly IndexerRequest _indexerRequest;
+        private readonly WebResult _webResponse;
+
+        public IndexerResponse(IndexerRequest indexerRequest, WebResult webResponse)
+        {
+            _indexerRequest = indexerRequest;
+            _webResponse = webResponse;
+        }
+
+        public IndexerRequest Request => _indexerRequest;
+
+        public WebRequest HttpRequest => _webResponse.Request;
+
+        public WebResult WebResponse => _webResponse;
+
+        public string Content => _webResponse.ContentString;
+    }
+}

--- a/src/Jackett.Test/Common/Models/ResultPageTests.cs
+++ b/src/Jackett.Test/Common/Models/ResultPageTests.cs
@@ -28,6 +28,8 @@ namespace Jackett.Test.Common.Models
 
         public override TorznabCapabilities TorznabCaps { get; protected set; }
         public override Task<IndexerConfigurationStatus> ApplyConfiguration(JToken configJson) => throw new NotImplementedException();
+        public override IIndexerRequestGenerator GetRequestGenerator() => throw new NotImplementedException();
+        public override IParseIndexerResponse GetParser() => throw new NotImplementedException();
         protected override Task<IEnumerable<ReleaseInfo>> PerformQuery(TorznabQuery query) => throw new NotImplementedException();
     }
 


### PR DESCRIPTION
#### Description
Logic similar to Prowlarr that implements a RequestGenerator and Parser for pageable requests, allowing to do multiple requests for BTN to search both season and episode by wildcard when a season search is executed.

One caveat would be that I removed the `OnParseError` call in the parsing.

#### Issues Fixed or Closed by this PR

* Fixes #12972
