### PR TITLE
Fix postman root path

### DIFF
--- a/src/Jackett.Common/Definitions/postman.yml
+++ b/src/Jackett.Common/Definitions/postman.yml
@@ -52,7 +52,7 @@ settings:
 
 search:
   paths:
-    - path: /
+    - path: /index.php
   allowEmptyInputs: true
   inputs:
     view: Main


### PR DESCRIPTION
#### Description
Postman was having some issues before because the request it would end up creating was 
`http://tracker2.postman.i2p/?view=Main&search=&category=-1&orderby=1&lastactive=-1&lang=-1`, this caused postman to hang. This fixes it so that it creates a request like 
`http://tracker2.postman.i2p/index.php?view=Main&search=&category=-1&orderby=1&lastactive=-1&lang=-1`, and that makes it work as expected.