### PR TITLE
exttorrents: remove download block

### DIFF
--- a/src/Jackett.Common/Definitions/exttorrents.yml
+++ b/src/Jackett.Common/Definitions/exttorrents.yml
@@ -126,9 +126,12 @@ search:
     details:
       selector: td:nth-child(1) div a
       attribute: href
-    download:
-      selector: td:nth-child(1) a[href^="magnet:?xt="]
+    infohash:
+      selector: a[href^="magnet:?xt="]
       attribute: href
+      filters:
+        - name: regexp
+          args: ([A-F|a-f|0-9]{40})
     size:
       selector: td:nth-child(2)
     files:


### PR DESCRIPTION
#### Description
Someone complained that this tracker adds their site URL to the torrent titles, and I noticed there's a magnet on the search page just without title or trackers. 

Seems to work fine with my qbittorrent, so it should work with other download clients too, right?