### PR TITLE
[POC] torznab: support for `freetorrent`

### DIFF
--- a/src/Jackett.Common/Indexers/BaseIndexer.cs
+++ b/src/Jackett.Common/Indexers/BaseIndexer.cs
@@ -182,6 +182,11 @@ namespace Jackett.Common.Indexers
                 ).ToList();
             }
 
+            if (query.FreeTorrent)
+            {
+                filteredResults = filteredResults.Where(release => release.DownloadVolumeFactor == 0.0).ToList();
+            }
+
             // eliminate excess results
             if (query.Limit > 0)
             {

--- a/src/Jackett.Common/Indexers/Definitions/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/Definitions/CardigannIndexer.cs
@@ -1444,6 +1444,11 @@ namespace Jackett.Common.Indexers.Definitions
             variables[".Query.IsTvdbQuery"] = query.IsTvdbQuery ? "True" : null;
             variables[".Query.IsTvmazeQuery"] = query.IsTvmazeQuery ? "True" : null;
 
+            if (query.FreeTorrent)
+            {
+                variables[".Config.freeleech"] = "True";
+            }
+
             var mappedCategories = MapTorznabCapsToTrackers(query);
             if (mappedCategories.Count == 0)
             {

--- a/src/Jackett.Common/Indexers/Definitions/FileList.cs
+++ b/src/Jackett.Common/Indexers/Definitions/FileList.cs
@@ -51,8 +51,10 @@ namespace Jackett.Common.Indexers.Definitions
 
         private new ConfigurationDataFileList configData => (ConfigurationDataFileList)base.configData;
 
+        private bool SearchFreeleech(TorznabQuery query) => query.FreeTorrent || configData.Freeleech.Value;
+
         public FileList(IIndexerConfigurationService configService, WebClient wc, Logger l, IProtectionService ps,
-            ICacheService cs)
+                        ICacheService cs)
             : base(configService: configService,
                    client: wc,
                    logger: l,
@@ -163,7 +165,7 @@ namespace Jackett.Common.Indexers.Definitions
                     var isFreeleech = row.FreeLeech;
 
                     // skip non-freeleech results when freeleech only is set
-                    if (configData.Freeleech.Value && !isFreeleech)
+                    if (SearchFreeleech(query) && !isFreeleech)
                     {
                         continue;
                     }
@@ -215,7 +217,7 @@ namespace Jackett.Common.Indexers.Definitions
                 {"category", string.Join(",", MapTorznabCapsToTrackers(query))}
             };
 
-            if (configData.Freeleech.Value)
+            if (SearchFreeleech(query))
             {
                 queryCollection.Set("freeleech", "1");
             }

--- a/src/Jackett.Common/Models/DTO/TorznabRequest.cs
+++ b/src/Jackett.Common/Models/DTO/TorznabRequest.cs
@@ -33,72 +33,144 @@ namespace Jackett.Common.Models.DTO
         public string publisher { get; set; }
         public string configured { get; set; }
 
+        public string freetorrent { get; set; }
+
         public static TorznabQuery ToTorznabQuery(TorznabRequest request)
         {
-            var query = new TorznabQuery()
+            var query = new TorznabQuery
             {
                 QueryType = "search",
                 SearchTerm = request.q,
                 ImdbID = request.imdbid,
-                Episode = request.ep,
+                Episode = request.ep
             };
-            if (request.t != null)
-                query.QueryType = request.t;
-            if (!string.IsNullOrWhiteSpace(request.extended))
-                query.Extended = ParseUtil.CoerceInt(request.extended);
-            if (!string.IsNullOrWhiteSpace(request.limit))
-                query.Limit = ParseUtil.CoerceInt(request.limit);
-            if (!string.IsNullOrWhiteSpace(request.offset))
-                query.Offset = ParseUtil.CoerceInt(request.offset);
 
-            if (bool.TryParse(request.cache, out var _cache))
-                query.Cache = _cache;
+            if (request.t != null)
+            {
+                query.QueryType = request.t;
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.extended))
+            {
+                query.Extended = ParseUtil.CoerceInt(request.extended);
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.limit))
+            {
+                query.Limit = ParseUtil.CoerceInt(request.limit);
+            }
+
+            if (!string.IsNullOrWhiteSpace(request.offset))
+            {
+                query.Offset = ParseUtil.CoerceInt(request.offset);
+            }
+
+            if (bool.TryParse(request.cache, out var cache))
+            {
+                query.Cache = cache;
+            }
 
             if (request.cat != null)
+            {
                 query.Categories = request.cat.Split(',').Where(s => !string.IsNullOrWhiteSpace(s)).Select(int.Parse).ToArray();
+            }
             else
             {
                 if (query.QueryType == "movie" && !string.IsNullOrWhiteSpace(request.imdbid))
+                {
                     query.Categories = new[] { TorznabCatType.Movies.ID };
+                }
                 else
+                {
                     query.Categories = Array.Empty<int>();
+                }
             }
 
             if (!string.IsNullOrWhiteSpace(request.season))
+            {
                 query.Season = int.Parse(request.season);
+            }
+
             if (!string.IsNullOrWhiteSpace(request.rid))
+            {
                 query.RageID = int.Parse(request.rid);
+            }
+
             if (!string.IsNullOrWhiteSpace(request.tvdbid))
+            {
                 query.TvdbID = int.Parse(request.tvdbid);
+            }
+
             if (!string.IsNullOrWhiteSpace(request.tvmazeid))
+            {
                 query.TvmazeID = int.Parse(request.tvmazeid);
+            }
 
             if (!string.IsNullOrWhiteSpace(request.tmdbid))
+            {
                 query.TmdbID = int.Parse(request.tmdbid);
+            }
+
             if (!string.IsNullOrWhiteSpace(request.traktid))
+            {
                 query.TraktID = int.Parse(request.traktid);
+            }
+
             if (!string.IsNullOrWhiteSpace(request.doubanid))
+            {
                 query.DoubanID = int.Parse(request.doubanid);
+            }
 
             if (!string.IsNullOrWhiteSpace(request.album))
+            {
                 query.Album = request.album;
+            }
+
             if (!string.IsNullOrWhiteSpace(request.artist))
+            {
                 query.Artist = request.artist;
+            }
+
             if (!string.IsNullOrWhiteSpace(request.label))
+            {
                 query.Label = request.label;
+            }
+
             if (!string.IsNullOrWhiteSpace(request.track))
+            {
                 query.Track = request.track;
+            }
+
             if (!string.IsNullOrWhiteSpace(request.year))
+            {
                 query.Year = int.Parse(request.year);
+            }
+
             if (!string.IsNullOrWhiteSpace(request.genre))
+            {
                 query.Genre = request.genre;
+            }
 
             if (!string.IsNullOrWhiteSpace(request.title))
+            {
                 query.Title = request.title;
+            }
+
             if (!string.IsNullOrWhiteSpace(request.author))
+            {
                 query.Author = request.author;
+            }
+
             if (!string.IsNullOrWhiteSpace(request.publisher))
+            {
                 query.Author = request.publisher;
+            }
+
+            if ((bool.TryParse(request.freetorrent, out var freeTorrent) && freeTorrent) ||
+                (int.TryParse(request.freetorrent, out var freeTorrentInt) && freeTorrentInt == 1))
+            {
+                query.FreeTorrent = true;
+            }
 
             return query;
         }

--- a/src/Jackett.Common/Models/TorznabQuery.cs
+++ b/src/Jackett.Common/Models/TorznabQuery.cs
@@ -46,6 +46,8 @@ namespace Jackett.Common.Models
         public string Title { get; set; }
         public string Publisher { get; set; }
 
+        public bool FreeTorrent { get; set; }
+
         public bool IsTest { get; set; }
 
         public string ImdbIDShort => ImdbID?.TrimStart('t');
@@ -194,7 +196,8 @@ namespace Jackett.Common.Models
                 TvmazeID = TvmazeID,
                 TraktID = TraktID,
                 DoubanID = DoubanID,
-                Cache = Cache
+                Cache = Cache,
+                FreeTorrent = FreeTorrent
             };
             if (Categories?.Length > 0)
             {
@@ -227,7 +230,9 @@ namespace Jackett.Common.Models
                 if (limit != null && limit > 0)
                 {
                     if (limit > queryString.Length)
+                    {
                         limit = queryString.Length;
+                    }
 
                     queryString = queryString.Substring(0, (int)limit);
                 }
@@ -244,13 +249,19 @@ namespace Jackett.Common.Models
         public string GetEpisodeSearchString()
         {
             if (Season == 0)
+            {
                 return string.Empty;
+            }
 
             string episodeString;
             if (DateTime.TryParseExact($"{Season} {Episode}", "yyyy MM/dd", CultureInfo.InvariantCulture, DateTimeStyles.None, out var showDate))
+            {
                 episodeString = showDate.ToString("yyyy.MM.dd");
+            }
             else if (string.IsNullOrEmpty(Episode))
+            {
                 episodeString = $"S{Season:00}";
+            }
             else
             {
                 try


### PR DESCRIPTION
#### Description
Since Jackett doesn't have support for multiple instances of the same indexer, I was thinking of adding support for `freetorrent` according to the [Torznab spec](https://torznab.github.io/spec-1.3-draft/torznab/Specification-v1.3.html), but can't find it anymore. 😬

Works fine with all Cardigann indexers that use `freeleech` key for the config, and FL only for now as a POC.