### PR TITLE
Fix search query for rutracker. 

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/RuTracker.cs
+++ b/src/Jackett.Common/Indexers/Definitions/RuTracker.cs
@@ -1534,11 +1534,11 @@ namespace Jackett.Common.Indexers.Definitions
             else // use the normal search
             {
                 searchString = searchString.Replace("-", " ");
-                if (query.Season != 0)
+                if (query.Season.HasValue && query.Season != 0)
                 {
                     searchString += " Сезон: " + query.Season;
                 }
-                if (query.Episode != null)
+                if (!string.IsNullOrWhiteSpace(query.Episode))
                 {
                     searchString += " Серии: " + query.Episode;
                 }


### PR DESCRIPTION
Null check for Season param to don't append "Сезон" to query when it's not requested
