### PR TITLE
Update danishbytes-api.yml definition, added missing s in download torrents

### DIFF
--- a/src/Jackett.Common/Definitions/danishbytes-api.yml
+++ b/src/Jackett.Common/Definitions/danishbytes-api.yml
@@ -113,7 +113,7 @@ search:
     details:
       text: "/torrents/{{ .Result._id }}"
     download:
-      text: "/torrent/download/{{ .Result._id }}.{{ .Config.rsskey }}"
+      text: "/torrents/download/{{ .Result._id }}.{{ .Config.rsskey }}"
     infohash:
       selector: info_hash
     poster:


### PR DESCRIPTION
#### Description
Download url missing s in torrentS. Letter added to download definition.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR
