### PR TITLE
Add chown to linux install script

### DIFF
--- a/README.md
+++ b/README.md
@@ -742,7 +742,7 @@ On most operating systems all the required dependencies will already be present.
 ### Install as service
 A) Command to download and install the latest package and run the Jackett service:
 
-`cd /opt && f=Jackett.Binaries.LinuxAMDx64.tar.gz && sudo wget -Nc https://github.com/Jackett/Jackett/releases/latest/download/"$f" && sudo tar -xzf "$f" && sudo rm -f "$f" && cd Jackett* && sudo ./install_service_systemd.sh && systemctl status jackett.service && cd - && echo -e "\nVisit http://127.0.0.1:9117"`
+`cd /opt && f=Jackett.Binaries.LinuxAMDx64.tar.gz && sudo wget -Nc https://github.com/Jackett/Jackett/releases/latest/download/"$f" && sudo tar -xzf "$f" && sudo rm -f "$f" && cd Jackett* && sudo chown $(whoami):$(whoami) -R "/opt/Jackett" && sudo ./install_service_systemd.sh && systemctl status jackett.service && cd - && echo -e "\nVisit http://127.0.0.1:9117"`
 
 B) Or manually:
 

--- a/README.md
+++ b/README.md
@@ -742,7 +742,7 @@ On most operating systems all the required dependencies will already be present.
 ### Install as service
 A) Command to download and install the latest package and run the Jackett service:
 
-`cd /opt && f=Jackett.Binaries.LinuxAMDx64.tar.gz && sudo wget -Nc https://github.com/Jackett/Jackett/releases/latest/download/"$f" && sudo tar -xzf "$f" && sudo rm -f "$f" && cd Jackett* && sudo chown $(whoami):$(whoami) -R "/opt/Jackett" && sudo ./install_service_systemd.sh && systemctl status jackett.service && cd - && echo -e "\nVisit http://127.0.0.1:9117"`
+`cd /opt && f=Jackett.Binaries.LinuxAMDx64.tar.gz && sudo wget -Nc https://github.com/Jackett/Jackett/releases/latest/download/"$f" && sudo tar -xzf "$f" && sudo rm -f "$f" && cd Jackett* && sudo chown $(whoami):$(id -g) -R "/opt/Jackett" && sudo ./install_service_systemd.sh && systemctl status jackett.service && cd - && echo -e "\nVisit http://127.0.0.1:9117"`
 
 B) Or manually:
 


### PR DESCRIPTION
`install_service_systemd.sh` throws this error:
```
ERROR: The owner of Jackett directory is 'UNKNOWN'.
Please, change the owner with the command 'chown <user>:<user> -R "/opt/Jackett"'
The user <user> will be used to run Jackett.
```
but runing `sudo chown $(whoami):$(id -g) -R "/opt/Jackett"` and then re-running the install command deletes and overwrites the directory making the chown moot.
Is there any reason not to include this in the script? It worked for me