### PR TITLE
[Indexer] Update zetorrents download hash selector for current indexer dom

### DIFF
--- a/src/Jackett.Common/Definitions/zetorrents.yml
+++ b/src/Jackett.Common/Definitions/zetorrents.yml
@@ -65,7 +65,7 @@ settings:
 download:
   infohash:
     hash:
-      selector: a[href^="/get_torrent/"]
+      selector: a[href^="/download/"]
       attribute: href
       filters:
         - name: regexp


### PR DESCRIPTION
#### Description

Change the zetorrents yml config to find the download link properly.

 #### Changes

* Change download hash selector from selector: `a[href^="/get_torrent/"])` to selector: `a[href^="/download/"]`