### PR TITLE
api: filter indexers by state

### DIFF
--- a/src/Jackett.Common/Models/DTO/Indexer.cs
+++ b/src/Jackett.Common/Models/DTO/Indexer.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
+using Jackett.Common.Extensions;
 using Jackett.Common.Indexers;
 
 namespace Jackett.Common.Models.DTO
@@ -41,6 +42,9 @@ namespace Jackett.Common.Models.DTO
         public bool potatoenabled { get; private set; }
 
         [DataMember]
+        public IndexerState state => last_error.IsNotNullOrWhiteSpace() ? IndexerState.Error : IndexerState.Success;
+
+        [DataMember]
         public IEnumerable<Capability> caps { get; private set; }
 
         public Indexer(IIndexer indexer)
@@ -66,5 +70,13 @@ namespace Jackett.Common.Models.DTO
                     Name = c.Name
                 });
         }
+    }
+
+    [DataContract]
+    public enum IndexerState
+    {
+        Unknown,
+        Error,
+        Success
     }
 }

--- a/src/Jackett.Server/Startup.cs
+++ b/src/Jackett.Server/Startup.cs
@@ -61,16 +61,23 @@ namespace Jackett.Server
                         config => config.Filters.Add(
                             new AuthorizeFilter(
                                 new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build())))
-                    .AddJsonOptions(options => options.SerializerSettings.ContractResolver =
-                                        new DefaultContractResolver()); //Web app uses Pascal Case JSON);
+                    .AddJsonOptions(options =>
+                    {
+                        // Web app uses Pascal Case JSON)
+                        options.SerializerSettings.ContractResolver = new DefaultContractResolver();
+                        options.SerializerSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter(new CamelCaseNamingStrategy()));
+                    });
 #else
 
             services.AddControllers(
                         config => config.Filters.Add(
                             new AuthorizeFilter(
                                 new AuthorizationPolicyBuilder().RequireAuthenticatedUser().Build())))
-                    .AddNewtonsoftJson(
-                        options => options.SerializerSettings.ContractResolver = new DefaultContractResolver());
+                    .AddNewtonsoftJson(options =>
+                    {
+                        options.SerializerSettings.ContractResolver = new DefaultContractResolver();
+                        options.SerializerSettings.Converters.Add(new Newtonsoft.Json.Converters.StringEnumConverter(new CamelCaseNamingStrategy()));
+                    });
 #endif
 
             var runtimeSettings = new RuntimeSettings();


### PR DESCRIPTION
#### Description
Adding a new query parameter `state` to `/api/v2.0/indexers` that allows to filtering indexers by:
- state=all (default)
- state=success
- state=error

#### Issues Fixed or Closed by this PR

* Fixes #15546
