### PR TITLE
rutor: 6tor.org is an up-to-date address

### DIFF
--- a/src/Jackett.Common/Definitions/rutor.yml
+++ b/src/Jackett.Common/Definitions/rutor.yml
@@ -8,6 +8,7 @@ encoding: UTF-8
 links:
   - https://rutor.info/
   - https://rutor.is/
+  - http://6tor.org/ # IPv6-only
 legacylinks:
   - https://rutor.uk-unblock.xyz/
   - https://rutor.ind-unblock.xyz/
@@ -17,7 +18,6 @@ legacylinks:
   - https://rutor.root.yt/
   - https://rutor.unblocked.rest/
   - https://rutor.unblocked.monster/
-  - http://6tor.org/
   - https://rutor.mrunblock.bond/ # for magnet only
   - https://rutor.nocensor.cloud/
   - http://new-rutor.org/ # Oops. Something went wrong, try reloading the page


### PR DESCRIPTION
#### Description

6tor.org is an up-to-date IPv6-only address for Rutor and shouldn’t be in legacylinks.

See also http://6tor.org/torrent/472 or http://rutor.info/torrent/472.

#### Screenshot (if UI related)

n/a

#### Issues Fixed or Closed by this PR

n/a