### PR TITLE
[bwtorrents.yml] Added `andmatch` filter

### DIFF
--- a/src/Jackett.Common/Definitions/bwtorrents.yml
+++ b/src/Jackett.Common/Definitions/bwtorrents.yml
@@ -180,6 +180,8 @@ search:
 
   rows:
     selector: table[width="1200"] > tbody > tr:has(a[href^="download.php/"])
+    filters:
+      - name: andmatch
 
   fields:
     category:


### PR DESCRIPTION
#### Indexer/Tracker

bwtorrents

#### Description

Added `andmatch` filter to improve search accuracy by ensuring only relevant search results are returned.

#### Screenshot (if UI related)

##### Current

![361358476-bcd5a0b3-1df1-4b36-91fe-d5f1fbacad70](https://github.com/user-attachments/assets/c43a114e-b50c-46d5-bb92-d6efa3959ac6)

##### Changes

![361359133-59803b13-5ec7-40e2-8b4d-f0b29353d819](https://github.com/user-attachments/assets/2bc241b0-98d6-4690-add9-d05084d1823e)

#### Issues Fixed or Closed by this PR

* Fixes [#482](https://github.com/Prowlarr/Indexers/pull/482#issue-2486221494)
