### PR TITLE
wolfmax4k: Fix multiepisode search when guid doesn't end in /

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/Wolfmax4K.cs
+++ b/src/Jackett.Common/Indexers/Definitions/Wolfmax4K.cs
@@ -396,7 +396,7 @@ namespace Jackett.Common.Indexers.Definitions
                 result += "S" + matchSeason.Groups[1].Value.PadLeft(2, '0');
             }
 
-            var matchEpisode = new Regex(@"/capitulo-(\d+)(-al-(\d+))?/").Match(guid);
+            var matchEpisode = new Regex(@"/capitulo-(\d+)(-al-(\d+))?").Match(guid);
             if (matchSeason.Success && matchEpisode.Success)
             {
                 result += "E" + matchEpisode.Groups[1].Value.PadLeft(2, '0');


### PR DESCRIPTION
#### Description

Fix multiepisode search when guid doesn't end in /


Before fix:
![image](https://github.com/user-attachments/assets/d2ece2aa-ccd1-4bef-9a3a-6e7738630dc4)

After fix
![image](https://github.com/user-attachments/assets/0ef2ed2b-d49e-4d0b-b5f0-2b503231e450)
