### PR TITLE
xxxclub: fix search path address

### DIFF
--- a/src/Jackett.Common/Definitions/xxxclub.yml
+++ b/src/Jackett.Common/Definitions/xxxclub.yml
@@ -49,8 +49,8 @@ download:
 
 search:
   paths:
-    # https://xxxclub.to/torrents/browse/2,4/metartx?sort=size&order=asc
-    - path: "torrents/browse/{{ if .Categories }}{{ join .Categories \",\" }}{{ else }}all{{ end }}/{{ .Keywords }}?sort={{ .Config.sort }}&order={{ .Config.type }}"
+    # https://xxxclub.to/torrents/search/2,4/metartx?sort=size&order=asc
+    - path: "torrents/search/{{ if .Categories }}{{ join .Categories \",\" }}{{ else }}all{{ end }}/{{ .Keywords }}?sort={{ .Config.sort }}&order={{ .Config.type }}"
 
   rows:
     selector: div.browsetableinside > ul > li:not(:first-child)


### PR DESCRIPTION
#### Description
The website changed from using https://xxxclub.to/torrents/browse/all/query to https://xxxclub.to/torrents/search/all/query for searches.
https://xxxclub.to/torrents/browse now returns a "static" list based on categories selected.

#### Issues Fixed or Closed by this PR

* Fixes #15581
