### PR TITLE
Fuzer domain update

### DIFF
--- a/src/Jackett.Common/Definitions/fuzer.yml
+++ b/src/Jackett.Common/Definitions/fuzer.yml
@@ -6,9 +6,9 @@ language: he-IL
 type: private
 encoding: windows-1255
 links:
-  - https://www.fuzer.me/
+  - https://www.fuzer.xyz/
 legacylinks:
-  - https://fuzer.me/
+  - https://fuzer.xyz/
 
 caps:
   categorymappings:

--- a/src/Jackett.Common/Definitions/fuzer.yml
+++ b/src/Jackett.Common/Definitions/fuzer.yml
@@ -8,7 +8,7 @@ encoding: windows-1255
 links:
   - https://www.fuzer.xyz/
 legacylinks:
-  - https://fuzer.xyz/
+  - https://fuzer.me/
 
 caps:
   categorymappings:


### PR DESCRIPTION
#### Description
Fuzer has changed its domain, it is now [fuzer.xyz](url).

#### Issues Fixed or Closed by this PR

* Fixes #13176


(My first PR, hope I did it correctly, tried to follow the contribution guide.)