### PR TITLE
core: bump .NET framework to 4.7.2

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,7 +108,7 @@ stages:
             Mono:
               buildDescription: Mono
               imageName: ubuntu-22.04
-              framework: net462
+              framework: net472
               runtime: linux-x64
               archiveType: tar
               artifactName: Jackett.Binaries.Mono.tar.gz
@@ -438,7 +438,7 @@ stages:
             Mono:
               buildDescription: Mono
               imageName: ubuntu-22.04
-              framework: net462
+              framework: net472
               runtime: linux-x64
         pool:
           vmImage: $(imageName)
@@ -535,7 +535,7 @@ stages:
               buildDescription: Mono
               imageName: ubuntu-22.04
               artifactName: Jackett.Binaries.Mono.tar.gz
-              framework: net462
+              framework: net472
               runtime: linux-x64
         pool:
           vmImage: $(imageName)

--- a/src/Jackett.IntegrationTests/Jackett.IntegrationTests.csproj
+++ b/src/Jackett.IntegrationTests/Jackett.IntegrationTests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <IsPackable>false</IsPackable>
     <NoWarn />
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>

--- a/src/Jackett.Server/Helper.cs
+++ b/src/Jackett.Server/Helper.cs
@@ -3,7 +3,7 @@ using Jackett.Common.Models.Config;
 using Jackett.Common.Services.Interfaces;
 using Microsoft.AspNetCore.Hosting;
 using NLog;
-#if !NET462
+#if !NET472
 using Microsoft.Extensions.Hosting;
 #endif
 
@@ -13,7 +13,7 @@ namespace Jackett.Server
     {
         public static IContainer ApplicationContainer { get; set; }
 
-#if NET462
+#if NET472
         public static IApplicationLifetime applicationLifetime;
 #else
         public static IHostApplicationLifetime applicationLifetime;

--- a/src/Jackett.Server/Jackett.Server.csproj
+++ b/src/Jackett.Server/Jackett.Server.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <PackageId>$(MSBuildProjectName)</PackageId>
-    <TargetFrameworks>net8.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <ApplicationIcon>jackett.ico</ApplicationIcon>
     <OutputType>Exe</OutputType>
     <NoWarn></NoWarn>
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <Choose>
-    <When Condition="'$(TargetFramework)' != 'net462' and $(RuntimeIdentifier.Contains('win')) == 'false'">
+    <When Condition="'$(TargetFramework)' != 'net472' and $(RuntimeIdentifier.Contains('win')) == 'false'">
       <PropertyGroup>
         <AssemblyName>jackett</AssemblyName>
       </PropertyGroup>
@@ -40,8 +40,8 @@
     <PackageReference Include="System.Security.Cryptography.ProtectedData" Version="8.0.0" />
   </ItemGroup>
 
-  <!-- Conditionally obtain references for the .NET462 target -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <!-- Conditionally obtain references for the .NET472 target -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="Microsoft.AspNetCore" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.Cookies" Version="2.2.0" />

--- a/src/Jackett.Server/Startup.cs
+++ b/src/Jackett.Server/Startup.cs
@@ -22,7 +22,7 @@ using Microsoft.AspNetCore.Rewrite;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Serialization;
-#if !NET462
+#if !NET472
 using Microsoft.Extensions.Hosting;
 #endif
 
@@ -56,7 +56,7 @@ namespace Jackett.Server
                             options.Cookie.Name = "Jackett";
                         });
 
-#if NET462
+#if NET472
             services.AddMvc(
                         config => config.Filters.Add(
                             new AuthorizeFilter(
@@ -108,7 +108,7 @@ namespace Jackett.Server
         }
 
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.
-#if NET462
+#if NET472
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, IApplicationLifetime applicationLifetime)
         {
             applicationLifetime.ApplicationStarted.Register(OnStarted);

--- a/src/Jackett.Test/Jackett.Test.csproj
+++ b/src/Jackett.Test/Jackett.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <NoWarn />
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors />
@@ -45,8 +45,8 @@
     <ProjectReference Include="..\Jackett.Server\Jackett.Server.csproj" />
   </ItemGroup>
 
-  <!-- Conditionally obtain references for the .NET462 target -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <!-- Conditionally obtain references for the .NET472 target -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
     <Reference Include="System.Web" />
   </ItemGroup>

--- a/src/Jackett.Updater/Jackett.Updater.csproj
+++ b/src/Jackett.Updater/Jackett.Updater.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net462</TargetFrameworks>
+    <TargetFrameworks>net8.0;net472</TargetFrameworks>
     <ApplicationIcon>jackett.ico</ApplicationIcon>
     <AssemblyName>JackettUpdater</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -13,8 +13,8 @@
     <DefineConstants Condition="'$(RuntimeIdentifier)' == 'linux-musl-x64' or '$(RuntimeIdentifier)' == 'linux-musl-arm' or '$(RuntimeIdentifier)' == 'linux-musl-arm64'">ISLINUXMUSL</DefineConstants>
   </PropertyGroup>
 
-  <!-- Conditionally obtain references for the .NET462 target -->
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net462' ">
+  <!-- Conditionally obtain references for the .NET472 target -->
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net472' ">
     <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
   </ItemGroup>
 


### PR DESCRIPTION
#### Description
According to https://en.wikipedia.org/wiki/.NET_Framework_version_history it should only require a newer version of win10 compared to 4.6.2.
