### PR TITLE
Update lat-team and f1carreras language to es-419

### DIFF
--- a/src/Jackett.Common/Definitions/f1carreras-api.yml
+++ b/src/Jackett.Common/Definitions/f1carreras-api.yml
@@ -2,7 +2,7 @@
 id: f1carreras-api
 name: F1Carreras (API)
 description: "F1Carreras is a Spanish Private Torrent Tracker for Motor Racing TV Releases"
-language: es-ES
+language: es-419
 type: private
 encoding: UTF-8
 links:

--- a/src/Jackett.Common/Definitions/lat-team-api.yml
+++ b/src/Jackett.Common/Definitions/lat-team-api.yml
@@ -2,7 +2,7 @@
 id: lat-team-api
 name: Lat-Team (API)
 description: "Lat-Team is a SPANISH Private Torrent Tracker for MOVIES / TV"
-language: es-ES
+language: es-419
 type: private
 encoding: UTF-8
 links:


### PR DESCRIPTION
#### Description
Lat-Team and F1Carreras focus on south american content and their language should reflect it to allow users know it.

This pull request updates the language definitions for two torrent trackers that primarily focus on South American Spanish content. Previously, the language was incorrectly set to es-ES (Spanish as spoken in Spain). This has now been changed to es-419, which is the appropriate locale for Latin American Spanish, covering the target audience more accurately.
Changes

    Updated language code from es-ES to es-419 for both trackers.

The trackers serve content for users in Latin America, and es-419 is the correct locale identifier for Spanish used across this region. Using es-ES was a mismatch with the content and audience, as it reflects the variant of Spanish spoken in Spain, which differs from Latin American Spanish in vocabulary, pronunciation, and some grammatical structures.
Impact