### PR TITLE
POC: avoid relative time in timeago if using units greater than days

### DIFF
--- a/src/Jackett.Common/Utils/DateTimeUtil.cs
+++ b/src/Jackett.Common/Utils/DateTimeUtil.cs
@@ -50,7 +50,9 @@ namespace Jackett.Common.Utils
             var now = relativeFrom ?? DateTime.Now;
 
             if (str.Contains("now"))
+            {
                 return DateTime.SpecifyKind(now, DateTimeKind.Local);
+            }
 
             str = str.Replace(",", "");
             str = str.Replace("ago", "");
@@ -67,21 +69,42 @@ namespace Jackett.Common.Utils
                 timeAgoMatches = timeAgoMatches.NextMatch();
 
                 if (unit.Contains("sec") || unit == "s")
+                {
                     timeAgo += TimeSpan.FromSeconds(val);
+                }
                 else if (unit.Contains("min") || unit == "m")
+                {
                     timeAgo += TimeSpan.FromMinutes(val);
+                }
                 else if (unit.Contains("hour") || unit.Contains("hr") || unit == "h")
+                {
                     timeAgo += TimeSpan.FromHours(val);
+                }
                 else if (unit.Contains("day") || unit == "d")
+                {
                     timeAgo += TimeSpan.FromDays(val);
+                }
                 else if (unit.Contains("week") || unit.Contains("wk") || unit == "w")
+                {
                     timeAgo += TimeSpan.FromDays(val * 7);
+                }
                 else if (unit.Contains("month") || unit == "mo")
+                {
                     timeAgo += TimeSpan.FromDays(val * 30);
+                }
                 else if (unit.Contains("year") || unit == "y")
+                {
                     timeAgo += TimeSpan.FromDays(val * 365);
+                }
                 else
+                {
                     throw new Exception("TimeAgo parsing failed, unknown unit: " + unit);
+                }
+            }
+
+            if (timeAgo is { TotalDays: > 0, Hours: 0, Minutes: 0, Seconds: 0, Milliseconds: 0 })
+            {
+                now = new DateTime(now.Year, now.Month, now.Day);
             }
 
             return DateTime.SpecifyKind(now - timeAgo, DateTimeKind.Local);

--- a/src/Jackett.Test/Common/Utils/DateTimeUtilTests.cs
+++ b/src/Jackett.Test/Common/Utils/DateTimeUtilTests.cs
@@ -34,16 +34,17 @@ namespace Jackett.Test.Common.Utils
         public void FromTimeAgoTest()
         {
             var now = DateTime.Now;
+            var nowDateOnly = new DateTime(now.Year, now.Month, now.Day, 0, 0, 0, 0);
 
             AssertSimilarDates(now, DateTimeUtil.FromTimeAgo("NOW")); // case insensitive
             AssertSimilarDates(now, DateTimeUtil.FromTimeAgo("now"));
             AssertSimilarDates(now.AddSeconds(-1), DateTimeUtil.FromTimeAgo("1 sec"));
             AssertSimilarDates(now.AddMinutes(-12), DateTimeUtil.FromTimeAgo("12 min ago"));
             AssertSimilarDates(now.AddHours(-20), DateTimeUtil.FromTimeAgo("20 h"));
-            AssertSimilarDates(now.AddDays(-3), DateTimeUtil.FromTimeAgo("3 days"));
-            AssertSimilarDates(now.AddDays(-7), DateTimeUtil.FromTimeAgo("1 week"));
-            AssertSimilarDates(now.AddDays(-60), DateTimeUtil.FromTimeAgo("2 month ago"));
-            AssertSimilarDates(now.AddDays(-365), DateTimeUtil.FromTimeAgo("1 year"));
+            AssertSimilarDates(nowDateOnly.AddDays(-3), DateTimeUtil.FromTimeAgo("3 days"));
+            AssertSimilarDates(nowDateOnly.AddDays(-7), DateTimeUtil.FromTimeAgo("1 week"));
+            AssertSimilarDates(nowDateOnly.AddDays(-60), DateTimeUtil.FromTimeAgo("2 month ago"));
+            AssertSimilarDates(nowDateOnly.AddDays(-365), DateTimeUtil.FromTimeAgo("1 year"));
             AssertSimilarDates(now.AddHours(-20).AddMinutes(-15), DateTimeUtil.FromTimeAgo("20 hours and 15 minutes ago"));
             AssertSimilarDates(now, DateTimeUtil.FromTimeAgo(""));
 


### PR DESCRIPTION
#### Description
A POC that resets time to 00:00:00 if unit used in timeago is greater  than days with 0 hours, 0 minutes, etc.

#### Issues Fixed or Closed by this PR

* Fixes #9165
