### PR TITLE
[Feature] Disable use of filename as title

### DIFF
--- a/src/Jackett.Common/Definitions/locadora.yml
+++ b/src/Jackett.Common/Definitions/locadora.yml
@@ -1,7 +1,7 @@
 ---
 id: locadora
 name: Locadora
-description: "Locadora is a BRAZILIAN Private Tracker for MOVIES and TV"
+description: "Locadora is a BRAZILIAN Private Tracker for MOVIES, TV and ANIME"
 language: pt-BR
 type: private
 encoding: UTF-8
@@ -38,7 +38,7 @@ settings:
   - name: single_file_release_use_filename
     type: checkbox
     label: Use filename as title for single file releases
-    default: true
+    default: false
   - name: sort
     type: select
     label: Sort requested from site


### PR DESCRIPTION
This change disables the use of filename as title by default and updates the tracker's description.

#### Description
In addition to the release name we also add the audio language to the API, which allows our users to make better use of Profiles on Sonarr/Radarr. Showing the file name instead of the API response is not ideal for us.

Thank you


