### PR TITLE
hdonly: add options to include dubs info to title

### DIFF
--- a/src/Jackett.Common/Definitions/hdonly.yml
+++ b/src/Jackett.Common/Definitions/hdonly.yml
@@ -54,22 +54,9 @@ settings:
     type: checkbox
     label: Include DV/HDR10 in filename when a release has multiple HDR formats.
     default: false
-  - name: add_vff_to_title
+  - name: add_version_francophone_to_title
     type: checkbox
-    label: Include VFF in title if available
-    default: false
-  - name: add_vfq_to_title
-    type: checkbox
-    label: Include VFQ in title if available
-    default: false
-  - name: add_vfi_to_title
-    type: checkbox
-    label: Include VFI in title if available
-    default: false
-  - name: add_vf_to_title
-    type: checkbox
-    label: Include VF in title if available
-    default: false
+    label: Append Version Francophone flags to titles if available (VFF, VFQ, VFI, VF)
   - name: multilang
     type: checkbox
     label: Replace MULTi by another language in release name
@@ -268,13 +255,13 @@ search:
         - name: replace
           args: [".MULTI.MULTI", ".MULTI"]
         - name: append
-          args: "{{ if and (.Config.add_vff_to_title) (eq .Result._vff \"True\") }}.VFF{{ else }}{{ end }}"
+          args: "{{ if and (.Config.add_version_francophone_to_title) (eq .Result._vff \"True\") }}.VFF{{ else }}{{ end }}"
         - name: append
-          args: "{{ if and (.Config.add_vfq_to_title) (eq .Result._vfq \"True\") }}.VFQ{{ else }}{{ end }}"
+          args: "{{ if and (.Config.add_version_francophone_to_title) (eq .Result._vfq \"True\") }}.VFQ{{ else }}{{ end }}"
         - name: append
-          args: "{{ if and (.Config.add_vfi_to_title) (eq .Result._vfi \"True\") }}.VFI{{ else }}{{ end }}"
+          args: "{{ if and (.Config.add_version_francophone_to_title) (eq .Result._vfi \"True\") }}.VFI{{ else }}{{ end }}"
         - name: append
-          args: "{{ if and (.Config.add_vf_to_title) (eq .Result._vf \"True\") }}.VF{{ else }}{{ end }}"
+          args: "{{ if and (.Config.add_version_francophone_to_title) (eq .Result._vf \"True\") }}.VF{{ else }}{{ end }}"
         - name: append
           args: "{{ if eq .Result._vof \"True\" }}.FRENCH{{ else }}{{ end }}"
         - name: re_replace


### PR DESCRIPTION
#### Description
Options to include VFF, VFQ, VFI and VF to titles, disabled by default since it might conflict with `Replace MULTi by this language`
