### PR TITLE
nyaa: fix sonarr compatibility conflict with radarr year compability

### DIFF
--- a/src/Jackett.Common/Definitions/nyaasi.yml
+++ b/src/Jackett.Common/Definitions/nyaasi.yml
@@ -197,7 +197,7 @@ search:
       text: "{{ or (.Result.title_phase1) (.Result.title_default) }}"
       filters:
         - name: re_replace
-          args: ["^(\\[.+?\\] ?)?(\\[.+?\\] ?)?(.+?)(\\[)", "$1$2$3{{ if .Config.radarr_compatibility }} {{ .Result.title_keyword_year }} $4{{ else }}$4{{ end }}"]
+          args: ["^(\\[.+?\\] ?)?(\\[.+?\\] ?)?(.+?)(\\[)", "$1$2$3{{ if and (.Config.radarr_compatibility) (.Result.title_keyword_year) }} {{ .Result.title_keyword_year }} $4{{ else }}$4{{ end }}"]
     title_phase3:
       text: "{{ .Result.title_phase2 }}"
       filters:
@@ -229,6 +229,9 @@ search:
           args: ["(?i)\\b(?:S\\s|Seasons?\\s?)(\\d+(?:-\\d+)?)\\b(?!(?:-\\d+)?\\s(?:EP|Episodes?)?\\s?(?:\\d+(?:-\\d+)?)?\\s?S\\d+(?:E\\d+(?:-\\d+)?)?)", "$0 S$1"]
         - name: re_replace
           args: ["(?i)\\b(?:EP|Episodes?)\\s?(\\d+(?:-\\d+)?)\\b(?!(?:-\\d+)?\\sS\\d+(?:-\\d+)?(?:E\\d+(?:-\\d+)?)?)", "$0 S01E$1"]
+        - name: re_replace
+          args: ["\\s+", " "]
+        - name: trim
     title_has_season:
       text: "{{ .Result.title_phase3 }}"
       filters:


### PR DESCRIPTION
#### Description
When Radarr compatibility is enabled it adds some extra spaces even if there's no year to add, seen here:

https://github.com/Jackett/Jackett/blob/fc0934125e5e99071d654f3a63c7e7f91cef1782/src/Jackett.Common/Definitions/nyaasi.yml#L200

Which breaks the episode detection with Sonarr compatibility enabled, seen here:

https://github.com/Jackett/Jackett/blob/fc0934125e5e99071d654f3a63c7e7f91cef1782/src/Jackett.Common/Definitions/nyaasi.yml#L249

My solution is check if there's really a year to add, and to replace multiple spaces with a single one just to be safe.