### PR TITLE
httpclient: treat "refresh" as redirect

### DIFF
--- a/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient.cs
@@ -194,10 +194,14 @@ namespace Jackett.Common.Utils.Clients
                                         }
                                     }
                                 }
-                                if (response.Headers.Location != null)
+
+                                var redirectUri = RedirectUri(response);
+
+                                if (redirectUri != null)
                                 {
-                                    result.RedirectingTo = response.Headers.Location.ToString();
+                                    result.RedirectingTo = redirectUri.AbsoluteUri;
                                 }
+
                                 // Mono won't add the baseurl to relative redirects.
                                 // e.g. a "Location: /index.php" header will result in the Uri "file:///index.php"
                                 // See issue #1200

--- a/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
+++ b/src/Jackett.Common/Utils/Clients/HttpWebClient2.cs
@@ -217,10 +217,14 @@ namespace Jackett.Common.Utils.Clients
                     }
                 }
             }
-            if (responseMessage.Headers.Location != null)
+
+            var redirectUri = RedirectUri(responseMessage);
+
+            if (redirectUri != null)
             {
-                result.RedirectingTo = responseMessage.Headers.Location.ToString();
+                result.RedirectingTo = redirectUri.AbsoluteUri;
             }
+
             // Mono won't add the baseurl to relative redirects.
             // e.g. a "Location: /index.php" header will result in the Uri "file:///index.php"
             // See issue #1200

--- a/src/Jackett.Common/Utils/Clients/WebClient.cs
+++ b/src/Jackett.Common/Utils/Clients/WebClient.cs
@@ -5,6 +5,7 @@ using System.Net;
 using System.Net.Http;
 using System.Net.Http.Headers;
 using System.Text;
+using System.Text.RegularExpressions;
 using System.Threading.Tasks;
 using System.Web;
 using com.LandonKey.SocksWebProxy;
@@ -17,6 +18,8 @@ namespace Jackett.Common.Utils.Clients
 {
     public abstract class WebClient : IObserver<ServerConfig>
     {
+        private static readonly Regex _RefreshHeaderRegex = new Regex("^(.*?url)=(.*?)(?:;|$)", RegexOptions.Compiled);
+
         protected IDisposable ServerConfigUnsubscriber;
         protected Logger logger;
         protected IConfigurationService configService;
@@ -262,6 +265,32 @@ namespace Jackett.Common.Utils.Clients
             var content = new ByteArrayContent(data);
             content.Headers.ContentType = new MediaTypeHeaderValue("application/x-www-form-urlencoded");
             return content;
+        }
+
+        protected static Uri RedirectUri(HttpResponseMessage response)
+        {
+            var newUri = response.Headers.Location;
+
+            if (newUri == null && response.Headers.TryGetValues("Refresh", out var refreshHeaders))
+            {
+                var refreshHeader = refreshHeaders.FirstOrDefault();
+
+                if (refreshHeader == null)
+                {
+                    return null;
+                }
+
+                var match = _RefreshHeaderRegex.Match(refreshHeader);
+
+                if (match.Success)
+                {
+                    return new Uri(response.RequestMessage.RequestUri, match.Groups[2].Value);
+                }
+
+                return null;
+            }
+
+            return newUri;
         }
     }
 }

--- a/src/Jackett.Common/Utils/Clients/WebResult.cs
+++ b/src/Jackett.Common/Utils/Clients/WebResult.cs
@@ -74,6 +74,7 @@ namespace Jackett.Common.Utils.Clients
                                   Status == HttpStatusCode.RedirectKeepVerb ||
                                   Status == HttpStatusCode.RedirectMethod ||
                                   Status == HttpStatusCode.Found ||
-                                  Status == HttpStatusCode.MovedPermanently;
+                                  Status == HttpStatusCode.MovedPermanently ||
+                                  Headers.ContainsKey("Refresh");
     }
 }


### PR DESCRIPTION
#### Description
Improve support for redirects that use the `Refresh` header instead of the standard `Location`, and adding a warning about redirects in Cardigann for test login requests.

Doesn't fix the issue at hand as I consider it just bad credentials, but would make it easier to debug in the future for similar cases.

* Towards #15645
