### PR TITLE
bump macOS runner version to 13

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -51,14 +51,14 @@ stages:
               artifactName: Jackett.Binaries.Windows.zip
             macOS:
               buildDescription: macOS
-              imageName: macOS-12
+              imageName: macOS-13
               framework: $(netCoreFramework)
               runtime: osx-x64
               archiveType: tar
               artifactName: Jackett.Binaries.macOS.tar.gz
             macOSARM64:
               buildDescription: macOS ARM64
-              imageName: macOS-12
+              imageName: macOS-13
               framework: $(netCoreFramework)
               runtime: osx-arm64
               archiveType: tar
@@ -427,7 +427,7 @@ stages:
               runtime: win-x86
             macOS:
               buildDescription: macOS
-              imageName: macOS-12
+              imageName: macOS-13
               framework: $(netCoreFramework)
               runtime: osx-x64
             LinuxAMDx64:
@@ -521,7 +521,7 @@ stages:
               runtime: win-x86
             macOS:
               buildDescription: macOS
-              imageName: macOS-12
+              imageName: macOS-13
               artifactName: Jackett.Binaries.macOS.tar.gz
               framework: $(netCoreFramework)
               runtime: osx-x64


### PR DESCRIPTION
#### Description
Bump due to `A brownout will take place on November 4, 14:00 UTC - November 5, 00:00 UTC to raise awareness of the upcoming macOS-12 environment removal. For more details, see https://github.com/actions/runner-images/issues/10721`