### PR TITLE
superbits: add alternative link

### DIFF
--- a/src/Jackett.Common/Definitions/superbits.yml
+++ b/src/Jackett.Common/Definitions/superbits.yml
@@ -7,6 +7,7 @@ type: private
 encoding: UTF-8
 links:
   - https://superbits.org/
+  - https://superbits.cc/
 
 caps:
   categorymappings:


### PR DESCRIPTION
They're currently having issues with their .org domain and recommend using the .cc one instead.
