### PR TITLE
aither: update timezone to utc to not observe dst

### DIFF
--- a/src/Jackett.Common/Definitions/aither-api.yml
+++ b/src/Jackett.Common/Definitions/aither-api.yml
@@ -152,7 +152,7 @@ search:
       selector: created_at
       filters:
         - name: append
-          args: " +00:00" # UTC - DOES NOT OBSERVE DST
+          args: " +00:00" # UTC
         - name: dateparse
           args: "MM/dd/yyyy HH:mm:ss zzz"
     size:
@@ -188,4 +188,4 @@ search:
     minimumseedtime:
       # 5 days (as seconds = 5 x 24 x 60 x 60)
       text: 432000
-# json UNIT3D 8.3.2 (custom)
+# json UNIT3D 8.3.2

--- a/src/Jackett.Common/Definitions/aither-api.yml
+++ b/src/Jackett.Common/Definitions/aither-api.yml
@@ -152,7 +152,7 @@ search:
       selector: created_at
       filters:
         - name: append
-          args: " -01:00" # EGT
+          args: " +00:00" # UTC - DOES NOT OBSERVE DST
         - name: dateparse
           args: "MM/dd/yyyy HH:mm:ss zzz"
     size:


### PR DESCRIPTION
Aither changed their timezone to UTC rather than EU/London. DST observation has thrown off release pubDates as a result

#### Description
A little over a week ago, Aither changed their timezone to UTC rather than EU/London. This results in not observing DST, which was set in [this commit](https://github.com/Prowlarr/Indexers/commit/7f74ae3c20373f5fff75ef909d29872a14501eac)

Tracker statement below.

```We have changed our timezone to UTC a couple of days ago. Previously, we've had Europe/London as PHP timezone, but that includes DST which we actually do not want. Due to the time change, some releases within that 1-hour timeframe, seem to have been release in the future.```

