### PR TITLE
[Fix] remove unsupported search parameters from seedpool definition

### DIFF
--- a/src/Jackett.Common/Definitions/seedpool-api.yml
+++ b/src/Jackett.Common/Definitions/seedpool-api.yml
@@ -193,4 +193,4 @@ search:
     minimumseedtime:
       # 10 days (as seconds = 10 x 24 x 60 x 60)
       text: 864000
-# json UNIT3D 8.2.0
+# json UNIT3D 8.2.0 (custom)

--- a/src/Jackett.Common/Definitions/seedpool-api.yml
+++ b/src/Jackett.Common/Definitions/seedpool-api.yml
@@ -13,7 +13,7 @@ caps:
     - {id: 2, cat: TV, desc: "TV Show"}
     - {id: 1, cat: Movies, desc: "Movie"}
     - {id: 10, cat: Movies/UHD, desc: "4K Movie"}
-    - {id: 13, cat: Movies, desc: "BoxSet"}
+    - {id: 13, cat: TV, desc: "TV Boxsets"}
     - {id: 12, cat: PC/Games, desc: "Linux Game"}
     - {id: 3, cat: PC/Games, desc: "PC Game"}
     - {id: 5, cat: Audio/Lossless, desc: "Music"}
@@ -32,8 +32,8 @@ caps:
 
   modes:
     search: [q]
-    tv-search: [q, season, ep, imdbid, tvdbid, tmdbid]
-    movie-search: [q, imdbid, tmdbid]
+    tv-search: [q, season, ep, tmdbid]
+    movie-search: [q, tmdbid]
     music-search: [q]
     book-search: [q]
 
@@ -96,9 +96,7 @@ search:
     name: "{{ .Keywords }}"
     seasonNumber: "{{ .Query.Season }}"
     episodeNumber: "{{ .Query.Ep }}"
-    imdbId: "{{ .Query.IMDBIDShort }}"
     tmdbId: "{{ .Query.TMDBID }}"
-    tvdbId: "{{ .Query.TVDBID }}"
     "free[]": "{{ if .Config.freeleech }}100{{ else }}{{ end }}"
     sortField: "{{ .Config.sort }}"
     sortDirection: "{{ .Config.type }}"
@@ -135,12 +133,8 @@ search:
       filters:
         - name: replace
           args: ["https://via.placeholder.com/90x135", ""]
-    imdbid:
-      selector: imdb_id
     tmdbid:
       selector: tmdb_id
-    tvdbid:
-      selector: tvdb_id
     genre:
       selector: meta.genres
       filters:


### PR DESCRIPTION
#### Description
Updates the seedpool indexer definition to fix searches.

- Remove unsupported `tvdbid` search parameter
- Remove unsupported `imdbid` search parameter
- Use correct search category for BoxSets (TV Season packs, not Movies)

These fixes have been tested by running jackett locally and performing searches against the seedpool api

I have read the the contributing guide, but this is the first patch I've submitted to Jackett, so I apologize in advance if I missed something. Willing to work or change things as needed to make sure this works :) 

#### Screenshot (if UI related)


#### Issues Fixed or Closed by this PR

* Fixes #15733
