### PR TITLE
assorted unit3d: add missing api to names

### DIFF
--- a/src/Jackett.Common/Definitions/hdtorrentsit.yml
+++ b/src/Jackett.Common/Definitions/hdtorrentsit.yml
@@ -1,6 +1,6 @@
 ---
 id: hdtorrentsit
-name: HDTorrents.it
+name: HDTorrents.it (API)
 description: "HDTorrents.it is an ITALIAN Private PAY2DL site for TV / MOVIES"
 language: it-IT
 type: private

--- a/src/Jackett.Common/Definitions/oldtoonsworld.yml
+++ b/src/Jackett.Common/Definitions/oldtoonsworld.yml
@@ -1,6 +1,6 @@
 ---
 id: oldtoonsworld
-name: Oldtoons
+name: Oldtoons (API)
 description: "Oldtoons is a Private Torrent Tracker for Cartoon MOVIES / TV / GENERAL"
 language: en-US
 type: private

--- a/src/Jackett.Common/Definitions/polishtorrent.yml
+++ b/src/Jackett.Common/Definitions/polishtorrent.yml
@@ -1,6 +1,6 @@
 ---
 id: polishtorrent
-name: Polish Torrent
+name: Polish Torrent (API)
 description: "Polish Torrent (PTT) is a POLISH Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: pl-PL
 type: private

--- a/src/Jackett.Common/Definitions/tocashare.yml
+++ b/src/Jackett.Common/Definitions/tocashare.yml
@@ -1,6 +1,6 @@
 ---
 id: tocashare
-name: Toca Share
+name: Toca Share (API)
 description: "Toca Share is a PORTUGUESE Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: pt-PT
 type: private

--- a/src/Jackett.Common/Definitions/turkseed-api.yml
+++ b/src/Jackett.Common/Definitions/turkseed-api.yml
@@ -1,6 +1,6 @@
 ---
 id: turkseed-api
-name: TurkSeed
+name: TurkSeed (API)
 description: "TurkSeed is a TURKISH Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: tr-TR
 type: private

--- a/src/Jackett.Common/Definitions/uploadcx.yml
+++ b/src/Jackett.Common/Definitions/uploadcx.yml
@@ -1,6 +1,6 @@
 ---
 id: uploadcx
-name: upload.cx
+name: upload.cx (API)
 description: "upload.cx (ULCX) is a Private Torrent Tracker for MOVIES / TV"
 language: en-US
 type: private

--- a/src/Jackett.Common/Definitions/utopia.yml
+++ b/src/Jackett.Common/Definitions/utopia.yml
@@ -1,6 +1,6 @@
 ---
 id: utopia
-name: UTOPIA
+name: UTOPIA (API)
 description: "UTOPIA is a UKRAINIAN Private Tracker for HD MOVIES and TV"
 language: uk-UA
 type: private

--- a/src/Jackett.Common/Definitions/yoinked.yml
+++ b/src/Jackett.Common/Definitions/yoinked.yml
@@ -1,6 +1,6 @@
 ---
 id: yoinked
-name: YOiNKED
+name: YOiNKED (API)
 description: "YOiNKED is a Private Torrent Tracker for MOVIES / TV / MUSIC"
 language: en-US
 type: private


### PR DESCRIPTION
#### Description
Just makes it easier when searching for UNIT3D API indexers. Doesn't affect some older and custom UNIT3D trackers that don't support the API.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
