### PR TITLE
[Nyaa.si] Update url

### DIFF
--- a/src/Jackett.Common/Definitions/nyaasi.yml
+++ b/src/Jackett.Common/Definitions/nyaasi.yml
@@ -7,11 +7,12 @@ type: public
 encoding: UTF-8
 requestDelay: 2
 links:
-  - https://nyaa.si/
+  - https://nyaa.mom/
   - https://nyaa.iss.ink/
   - https://nyaa.land/
   - https://nyaa.unblockninja.com/ # for magnets only
 legacylinks:
+  - https://nyaa.si/
   - https://nyaa.black-mirror.xyz/
   - https://nyaa.unblocked.casa/
   - https://nyaa.proxyportal.fun/

--- a/src/Jackett.Common/Definitions/nyaasi.yml
+++ b/src/Jackett.Common/Definitions/nyaasi.yml
@@ -7,12 +7,12 @@ type: public
 encoding: UTF-8
 requestDelay: 2
 links:
+  - https://nyaa.si/
   - https://nyaa.mom/
   - https://nyaa.iss.ink/
   - https://nyaa.land/
   - https://nyaa.unblockninja.com/ # for magnets only
 legacylinks:
-  - https://nyaa.si/
   - https://nyaa.black-mirror.xyz/
   - https://nyaa.unblocked.casa/
   - https://nyaa.proxyportal.fun/


### PR DESCRIPTION
#### Description
 - Nyaa moved from `.si` to `.mom` domain.

#### Screenshot (if UI related)
![nyaa](https://github.com/user-attachments/assets/5e2c781a-2d10-4fb1-baa1-9e32dc058a7a)

