### PR TITLE
postman: bypass proceed page, add generous requestdelay

### DIFF
--- a/src/Jackett.Common/Definitions/postman.yml
+++ b/src/Jackett.Common/Definitions/postman.yml
@@ -5,6 +5,7 @@ description: Postman is a Public I2P Torrent Tracker for MOVIES / TV / GENERAL
 language: en-US
 type: public
 encoding: UTF-8
+requestDelay: 4
 links:
   - http://tracker2.postman.i2p/
 
@@ -49,6 +50,13 @@ settings:
       1: created
       5: seeders
       7: size
+
+login:
+  path: index.php?view=Main
+  selectorinputs:
+    formtoken:
+      selector: input[name="formtoken"]
+      attribute: value
 
 search:
   paths:


### PR DESCRIPTION
#### Description
Postman have introduced rate limiting. Can return:
- 503 Service unavailable
- timeout
- 'proceed' check button

PR bypasses the latter.

This fine remaining Public? No account is necessary, but couldn't find a way to do this without using 'login'.

Added a generous request delay to avoid us making the site load worse. Didn't add a login test for the same reason, but also because there's nothing really to check here.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
