### PR TITLE
cardigann: fix captcha relogin

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/Definitions/CardigannIndexer.cs
@@ -750,6 +750,8 @@ namespace Jackett.Common.Indexers.Definitions
                                 input = inputElement.GetAttribute("name");
                             }
                             pairs[input] = CaptchaText.Value;
+                        } else {
+                            throw new ExceptionWithConfigData(string.Format("Login failed: No captcha provided"), configData);
                         }
                     }
                     if (Captcha.Type == "text")
@@ -766,6 +768,8 @@ namespace Jackett.Common.Indexers.Definitions
                                 input = inputElement.GetAttribute("name");
                             }
                             pairs[input] = CaptchaAnswer.Value;
+                        } else {
+                            throw new ExceptionWithConfigData(string.Format("Login failed: No captcha provided"), configData);
                         }
                     }
                 }
@@ -1065,6 +1069,7 @@ namespace Jackett.Common.Indexers.Definitions
             {
                 configData.LastError.Value = "Got captcha during automatic login, please reconfigure manually";
                 logger.Error(string.Format("CardigannIndexer ({0}): Found captcha during automatic login, aborting", Id));
+                landingResultDocument = null;
                 return null;
             }
 


### PR DESCRIPTION
### Description

Fix an issue where Jackett retries login for sites with captcha enabled.

---

### Issues Fixed or Closed by this PR

* Fixes #14726 and many other duplicates (IP ban)

#### To reproduce the issue
1. Add a site with captcha normally (e.g. [hdfans](https://github.com/Jackett/Jackett/blob/5b70c676b3e3ebccf6e01be671699f7f0de4a865/src/Jackett.Common/Definitions/hdfans.yml#L84-L87))
2. Remove the cookie from the config file and restart Jackett (simulates cookie expiration)
3.  Press Test in Jackett UI multiple times and you will see Jackett attempted to relogin

#### Reason for the issue
`landingResultDocument` will not be null after `GetConfigurationForSetup` is called.
https://github.com/Jackett/Jackett/blob/5b70c676b3e3ebccf6e01be671699f7f0de4a865/src/Jackett.Common/Indexers/Definitions/CardigannIndexer.cs#L605-L613

### TODO (Please help!)
The program should discard the captcha code after a login attempt.

(I am not very familiar with C# and this PR is written on Linux, please make additional changes where needed.)