### PR TITLE
hdonly: switch to API

### DIFF
--- a/src/Jackett.Common/Definitions/hdonly-api.yml
+++ b/src/Jackett.Common/Definitions/hdonly-api.yml
@@ -1,6 +1,8 @@
 ---
-id: hdonly
-name: HD-Only
+id: hdonly-api
+replaces:
+  - hdonly
+name: HD-Only (API)
 description: "HD-Only (HD-O) is a FRENCH Private Torrent Tracker for HD MOVIES / TV"
 language: fr-FR
 type: private
@@ -33,19 +35,13 @@ caps:
   allowrawsearch: true
 
 settings:
-  - name: username
+  - name: apikey
     type: text
-    label: Username
-  - name: password
-    type: password
-    label: Password
-  - name: 2fa_code
-    type: text
-    label: 2FA code
-  - name: info_2fa
+    label: API Key
+  - name: info_key
     type: info
-    label: "About 2FA code"
-    default: "Only fill in the <b>2FA code</b> box if you have enabled <b>2FA</b> on the HD-Only Web Site. Otherwise just leave it empty."
+    label: About your API Key
+    default: "Find or Generate a new API Key by accessing your <a href=\"https://hd-only.org/\" target=\"_blank\">HD-Only</a> account <i>Access Settings</i> tab and copy the API Key."
   - name: freeleech
     type: checkbox
     label: Search freeleech only
@@ -93,18 +89,15 @@ settings:
       asc: asc
 
 login:
-  path: login.php
-  method: post
+  path: ajax.php
+  method: get
   inputs:
-    username: "{{ .Config.username }}"
-    password: "{{ .Config.password }}"
-    twofa: "{{ .Config.2fa_code }}"
-    keeplogged: 1
+    action: browse
+    apikey: "{{ .Config.apikey }}"
   error:
-    - selector: form#loginform > span.warning
-  test:
-    path: torrents.php
-    selector: a[href^="logout.php?auth="]
+    - selector: a[href*="login.php"]
+      message:
+        text: "The API key was not accepted by {{ .Config.sitelink }}."
 
 search:
   # https://hd-only.org/ajax.php?filelist=blood+2009&action=browse&group_results=0&order_by=time&order_way=desc&freetorrent=1
@@ -126,6 +119,7 @@ search:
     # 1 freeleech, 0 normal
     freetorrent: "{{ if .Config.freeleech }}1{{ else }}{{ end }}"
     # site does not support imdbid search or display imdb links in results
+    apikey: "{{ .Config.apikey }}"
 
   keywordsfilters:
     # strip season

--- a/src/Jackett.Updater/Program.cs
+++ b/src/Jackett.Updater/Program.cs
@@ -457,6 +457,7 @@ namespace Jackett.Updater
                 "Definitions/hdme.yml",
                 "Definitions/hdmonkey.yml",
                 "Definitions/hdolimpo.yml", // migrated to UNIT3D API
+                "Definitions/hdonly.yml", // renamed to hdonly-api.yml #15855
                 "Definitions/hdplus.yml",
                 "Definitions/hdreactor.yml", // renamed to hdhouse
                 "Definitions/hdspain.yml",


### PR DESCRIPTION
#### Description
Switching to API by using the `apikey` query parameter, generated from Access Settings.