### PR TITLE
Add FreeBSD-X64 Binary releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -186,7 +186,7 @@ Here's what you need to do to give your pull request the best chance at a timely
     - Remove dead tracker fff
   - Run `dotnet format` from the Package Manager Console (found in `Tools -> NuGet Package Manager` or `View -> Other Windows`)
   - If your branch falls out of sync and has merge conflicts with the Jackett official `master`
-    [rebase](https://mohitgoyal.co/2018/04/18/working-with-git-and-visual-studio-use-git-rebase-inside-visual-studio/) your fix before submission.
+    [rebase](https://mohitgoyal.co/2018/04/18/working-with-git-and-visual-studio-use-git-rebase-inside-visual-studio.html) your fix before submission.
   - If you deleted, moved, or renamed any files/folders, be sure to add the old file/folder path to the appropriate array in `Jacket.Updater/Program.cs`
   - If you added or renamed a tracker, update the README to include the new name
   - [Squash your local commits](https://github.com/spottedmahn/my-blog/issues/26)
@@ -199,3 +199,7 @@ Here's what you need to do to give your pull request the best chance at a timely
   - Include any open tickets this Pull Request should fix in the description. **Do not** put ticket numbers in the title.
 
 We will be by when we can to review your Pull Request.
+
+## FreeBSD-X64 Binary Releases
+
+We now provide FreeBSD-X64 Binary releases to omit the dependency on mono. This allows you to run Jackett natively on FreeBSD without requiring mono. Follow the instructions in the "Setting up your environment" section to get started with FreeBSD-X64 Binary releases.

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -112,6 +112,13 @@ stages:
               runtime: linux-x64
               archiveType: tar
               artifactName: Jackett.Binaries.Mono.tar.gz
+            FreeBSD:
+              buildDescription: FreeBSD
+              imageName: freebsd-12
+              framework: $(netCoreFramework)
+              runtime: freebsd-x64
+              archiveType: tar
+              artifactName: Jackett.Binaries.FreeBSD.tar.gz
         pool:
           vmImage: $(imageName)
         displayName: ${{ variables.buildDescription }}
@@ -440,6 +447,11 @@ stages:
               imageName: ubuntu-22.04
               framework: net462
               runtime: linux-x64
+            FreeBSD:
+              buildDescription: FreeBSD
+              imageName: freebsd-12
+              framework: $(netCoreFramework)
+              runtime: freebsd-x64
         pool:
           vmImage: $(imageName)
         displayName: ${{ variables.buildDescription }}
@@ -537,6 +549,12 @@ stages:
               artifactName: Jackett.Binaries.Mono.tar.gz
               framework: net462
               runtime: linux-x64
+            FreeBSD:
+              buildDescription: FreeBSD
+              imageName: freebsd-12
+              artifactName: Jackett.Binaries.FreeBSD.tar.gz
+              framework: $(netCoreFramework)
+              runtime: freebsd-x64
         pool:
           vmImage: $(imageName)
         displayName: ${{ variables.buildDescription }}
@@ -570,6 +588,7 @@ stages:
                 if [[ "$(artifactName)" == *"Mono"* ]]; then sudo ./install_service_systemd_mono.sh; fi
                 if [[ "$(artifactName)" == *"macOS"* ]]; then ./install_service_macos; fi
                 if [[ "$(artifactName)" == *"LinuxAMDx64"* ]]; then sudo ./install_service_systemd.sh; fi
+                if [[ "$(artifactName)" == *"FreeBSD"* ]]; then sudo ./install_service_systemd.sh; fi
 
           - task: UseDotNet@2
             displayName: Install .NET Core SDK


### PR DESCRIPTION
Related to #15401

Add support for FreeBSD-X64 Binary releases to omit the dependency on mono.

* **azure-pipelines.yml**
  - Add a new job configuration for FreeBSD-X64 in the `Build`, `UnitTest`, and `IntegrationTest` jobs.
  - Add steps to install and configure FreeBSD-X64 in the pipeline.

* **CONTRIBUTING.md**
  - Mention FreeBSD-X64 Binary releases in the "Getting Started" section.

