### PR TITLE
Add bug report input to weed out timewasters

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,6 +25,13 @@ body:
     options:
       - label: I have read the Contributing Guidelines
         required: true
+- type: input
+  attributes:
+    label: Have you ACTUALLY checked all these?
+    description: Please do not waste our time and yours; these checks are there for a reason, it is not just so you can tick boxes for fun. If you type <b>YES</b> and it is clear you are lying or have put in no effort, your issue will be closed and locked without comment. If you type <b>NO</b> but still open this issue, you will be permanently blocked for timewasting.
+    placeholder: YES or NO
+  validations:
+    required: true
 - type: textarea
   id: environment
   attributes:

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,7 +28,7 @@ body:
 - type: input
   attributes:
     label: Have you ACTUALLY checked all these?
-    description: Please do not waste our time and yours; these checks are there for a reason, it is not just so you can tick boxes for fun. If you type <b>YES</b> and it is clear you are lying or have put in no effort, your issue will be closed and locked without comment. If you type <b>NO</b> but still open this issue, you will be permanently blocked for timewasting.
+    description: Please do not waste our time and yours; these checks are there for a reason, it is not just so you can tick boxes for fun. If you type <b>YES</b> and it is clear you did not or have put in no effort, your issue will be closed and locked without comment. If you type <b>NO</b> but still open this issue, you will be permanently blocked for timewasting.
     placeholder: YES or NO
   validations:
     required: true


### PR DESCRIPTION
A lot of our issues are people not actually reading the wiki, despite saying they have, so we just end up linking them back to it.

I've taken this directly from the FlareSolverr repo, where I grew tired of people not reading and just ticking boxes, so I felt making them type `YES` was enough to make some actually go back and check, and allowed me to guilt-free put as much effort into closing and locking their issue, as they had put into opening it. I'm yet to actually have anyone type anything other than `YES`.

I have made the odd exception where someone clearly doesn't have a clue, or they appear not to speak English.

It may be a bit too blunt for here, so feel free to mellow it out a little 😉 (e.g. maybe it's not locked, but we add a new label `User needs to read Wiki` or something)