### PR TITLE
fix(freefarm): Captcha/flaresolverr fail -> cookie

### DIFF
--- a/src/Jackett.Common/Definitions/freefarm.yml
+++ b/src/Jackett.Common/Definitions/freefarm.yml
@@ -49,19 +49,11 @@ caps:
     book-search: [q]
 
 settings:
-  - name: username
+  - name: cookie
     type: text
-    label: Username
-  - name: password
-    type: password
-    label: Password
-  - name: 2facode
-    type: text
-    label: 2FA code
-  - name: info_2fa
-    type: info
-    label: "About 2FA code"
-    default: "Only fill in the <b>2FA code</b> box if you have enabled <b>2FA</b> on the Free Farm Web Site. Otherwise just leave it empty."
+    label: Cookie
+  - name: info_cookie
+    type: info_cookie
   - name: freeleech
     type: checkbox
     label: Search freeleech only
@@ -94,24 +86,12 @@ settings:
     default: "Cherish your user account. Inactive accounts would be deleted based on the following rules:<ol><li>Veteran User or above would never be deleted.</li><li>Elite User or above would never be deleted if parked (at User CP).</li><li>Parked accounts would be deleted if users have not logged in for more than 400 days in a row.</li><li>Unparked accounts would be deleted if users have not logged in for more than 150 days in a row.</li><li>Accounts with both uploaded and downloaded amount being 0 would be deleted if users have not logged in for more than 100 days in a row.</li></ol>"
 
 login:
-  path: login.php
-  method: form
-  form: form[action="takelogin.php"]
-  captcha:
-    type: image
-    selector: img[alt="CAPTCHA"]
-    input: imagestring
+  # using cookie method because takelogin.php fails:
+  #     HTTP request failed:
+  #     [500:InternalServerError] [POST] at [http://flaresolverr:8191/v1]
+  method: cookie
   inputs:
-    secret: ""
-    username: "{{ .Config.username }}"
-    password: "{{ .Config.password }}"
-    two_step_code: "{{ .Config.2facode }}"
-    logout: ""
-    securelogin: ""
-    ssl: yes
-    trackerssl: yes
-  error:
-    - selector: td.embedded:has(h2:contains("失败"))
+    cookie: "{{ .Config.cookie }}"
   test:
     path: index.php
     selector: a[href="logout.php"]


### PR DESCRIPTION
#### Description

For some time, the Prowlarr edit form for this definition fails to load the captcha. Trying to save the form fails with:

    HTTP request failed: [500:InternalServerError] [POST] at
    [http://flaresolverr:8191/v1]

This happens whether or not the indexer is tagged with the tag on "FlareSolverr" under "Indexer Proxies". Regardless, reverting to cookie authentication allows the edit form to be saved successfully and the resulting indexer also then successfully returns results in the Prowlarr search UI.
