### PR TITLE
feat(matrix): Add Matrix Hungarian private tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Prior versions of Jackett are no longer supported.
  * Making Off
  * Mansão dos Animes (MDAN)
  * Malayabits
+ * Matrix
  * MegamixTracker
  * MeseVilág (Fairytale World)
  * MetalGuru [![(invite needed)][inviteneeded]](#)

--- a/src/Jackett.Common/Definitions/matrix.yml
+++ b/src/Jackett.Common/Definitions/matrix.yml
@@ -121,7 +121,14 @@ search:
         - name: querystring
           args: cat
     title:
-      selector: a.torrent-link b
+      # titles can be abbreviated so using the name from DL
+      selector: a[href^="download.php?id="]
+      attribute: href
+      filters:
+        - name: querystring
+          args: name
+        - name: replace
+          args: [".torrent", ""]
     details:
       selector: a[href^="details.php?id="]
       attribute: href

--- a/src/Jackett.Common/Definitions/matrix.yml
+++ b/src/Jackett.Common/Definitions/matrix.yml
@@ -156,7 +156,7 @@ search:
       selector: td:nth-child(7)
       filters:
         - name: regexp
-          args: "([0-9]+\\.?[0-9]* *[kKmMgGtTpP]i?[bB])"
+          args: "(.+?B)"
     seeders:
       selector: td:nth-child(8)
     leechers:

--- a/src/Jackett.Common/Definitions/matrix.yml
+++ b/src/Jackett.Common/Definitions/matrix.yml
@@ -145,9 +145,9 @@ search:
       selector: td:contains("Feltöltve:")
       filters:
         - name: regexp
-          args: "Feltöltve: *([0-9]{4}-[0-9]{2}-[0-9]{2} +[0-9]{2}:[0-9]{2}:[0-9]{2})"
+          args: "Feltöltve: (.+?)(\\(|$)"
         - name: append
-          args: " +01:00" # Europe/Budapest, CET
+          args: " +01:00" # CET
         - name: dateparse
           args: "yyyy-MM-dd HH:mm:ss zzz"
     grabs:

--- a/src/Jackett.Common/Definitions/matrix.yml
+++ b/src/Jackett.Common/Definitions/matrix.yml
@@ -1,0 +1,184 @@
+---
+id: matrix
+name: Matrix
+description: "M.A.T.R.I.X is a HUNGARIAN Private Tracker for MOVIES / TV / GENERAL"
+language: hu-HU
+type: private
+encoding: UTF-8
+links:
+  - https://matrixworld.info/
+
+caps:
+  categorymappings:
+    - {id: 23, cat: Movies/Other, desc: "Animációk"}
+    - {id: 61, cat: Movies/Other, desc: "Cam/EN"}
+    - {id: 60, cat: Movies/Other, desc: "Cam/HU"}
+    - {id: 45, cat: Books/EBook, desc: "eBook/EN"}
+    - {id: 40, cat: Books/EBook, desc: "eBook/HU"}
+    - {id: 20, cat: Movies/DVD, desc: "Film/DVD9"}
+    - {id: 48, cat: Movies/HD, desc: "Film/EN/1080p"}
+    - {id: 32, cat: Movies/HD, desc: "Film/EN/720p"}
+    - {id: 38, cat: Movies/BluRay, desc: "Film/EN/Blu-ray"}
+    - {id: 27, cat: Movies/DVD, desc: "Film/EN/DVD-R"}
+    - {id: 24, cat: Movies/SD, desc: "Film/EN/SD"}
+    - {id: 34, cat: Movies/HD, desc: "Film/HU/1080p"}
+    - {id: 31, cat: Movies/HD, desc: "Film/HU/720p"}
+    - {id: 35, cat: Movies/BluRay, desc: "Film/HU/Blu-ray"}
+    - {id: 26, cat: Movies/DVD, desc: "Film/HU/DVD-R"}
+    - {id: 5, cat: Movies/SD, desc: "Film/HU/SD"}
+    - {id: 4, cat: PC/Games, desc: "Játékok/ISO"}
+    - {id: 39, cat: PC/Games, desc: "Játékok/Rip/Dox"}
+    - {id: 47, cat: Other, desc: "Klippek"}
+    - {id: 30, cat: Audio/Lossless, desc: "Lossless/EN"}
+    - {id: 29, cat: Audio/Lossless, desc: "Lossless/HU"}
+    - {id: 25, cat: Audio/MP3, desc: "MP3/EN"}
+    - {id: 6, cat: Audio/MP3, desc: "MP3/HU"}
+    - {id: 33, cat: PC, desc: "Program/egyéb"}
+    - {id: 1, cat: PC/ISO, desc: "Program/ISO"}
+    - {id: 36, cat: TV/HD, desc: "Sorozat/EN/HD"}
+    - {id: 49, cat: TV/SD, desc: "Sorozat/EN/SD"}
+    - {id: 28, cat: TV/HD, desc: "Sorozat/HU/HD"}
+    - {id: 7, cat: TV/SD, desc: "Sorozat/HU/SD"}
+    - {id: 9, cat: XXX, desc: "XXX"}
+    - {id: 44, cat: XXX/x264, desc: "XXX/HD"}
+    - {id: 43, cat: XXX/SD, desc: "XXX/SD"}
+
+  modes:
+    search: [q]
+    tv-search: [q, season, ep, imdbid]
+    movie-search: [q, imdbid]
+    book-search: [q]
+    music-search: [q]
+
+settings:
+  - name: username
+    type: text
+    label: Username
+  - name: password
+    type: password
+    label: Password
+  - name: freeleech
+    type: checkbox
+    label: Filter freeleech only
+    default: false
+  - name: sort
+    type: select
+    label: Sort requested from site
+    default: 0
+    options:
+      0: created
+      1: title
+      4: size
+      6: seeders
+  - name: type
+    type: select
+    label: Order requested from site
+    default: desc
+    options:
+      desc: desc
+      asc: asc
+  - name: info_tpp
+    type: info
+    label: Results Per Page
+    default: For best results, change the <b>Torrents per page:</b> setting to <b>100</b> on your account profile.
+  - name: info_activity
+    type: info
+    label: Account Inactivity
+    default: "If you do not log in to the site for 6 months, the system will automatically delete it!"
+
+login:
+  path: takelogin.php
+  method: post
+  inputs:
+    username: "{{ .Config.username }}"
+    password: "{{ .Config.password }}"
+    logout: ""
+  error:
+    - selector: td.embedded:contains("Sikertelen bejelentkezés")
+  test:
+    path: /
+    selector: a[href$="logout.php"]
+
+search:
+  paths:
+    - path: browse.php
+  inputs:
+    $raw: "{{ range .Categories }}c{{.}}=1&{{end}}"
+    search: "{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}"
+    # 0 active only, 1 include dead, 2 only dead
+    incldead: 1
+    sort: "{{ .Config.sort }}"
+    type: "{{ .Config.type }}"
+
+  rows:
+    selector: "table.mainouter > tbody > tr > td > table tr:has(a[href^=\"download.php?id=\"]){{ if .Config.freeleech }}:has(img[src$=\"/pic/ingyentorrent.gif\"]){{ else }}{{ end }}"
+
+  fields:
+    category:
+      selector: a[href^="browse.php?cat="]
+      attribute: href
+      filters:
+        - name: querystring
+          args: cat
+    title:
+      selector: a.torrent-link b
+    _id:
+      selector: a[href^="download.php?id="]
+      attribute: href
+      filters:
+        - name: querystring
+          args: id
+    details:
+      text: "details.php?id={{ .Result._id }}"
+    download:
+      selector: a[href^="download.php?id="]
+      attribute: href
+    poster:
+      selector: a.torrent-link
+      attribute: data-cover
+    imdbid:
+      selector: a[href*="imdb.com/title/tt"]
+      attribute: href
+    files:
+      selector: td:nth-child(5) a
+    date:
+      selector: td:contains("Feltöltve:")
+      filters:
+        - name: regexp
+          args: "Feltöltve: *([0-9]{4}-[0-9]{2}-[0-9]{2} +[0-9]{2}:[0-9]{2}:[0-9]{2})"
+        - name: append
+          args: " +01:00" # Europe/Budapest, CET
+        - name: dateparse
+          args: "yyyy-MM-dd HH:mm:ss zzz"
+    grabs:
+      selector: td:nth-child(7) b
+    size:
+      selector: td:nth-child(7)
+      filters:
+        - name: regexp
+          args: "([0-9]+\\.?[0-9]* *[kKmMgGtTpP]i?[bB])"
+    seeders:
+      selector: td:nth-child(8)
+    leechers:
+      selector: td:nth-child(9)
+    genre:
+      selector: td:nth-child(2) > div > i > i
+      filters:
+        - name: regexp
+          args: "\\((.+)\\)"
+    description:
+      text: "{{ .Result.genre }}"
+    downloadvolumefactor:
+      case:
+        img[src$="/pic/ingyentorrent.gif"]: 0
+        "*": 1
+    uploadvolumefactor:
+      case:
+        img[src$="/pic/x2.gif"]: 2
+        "*": 1
+    minimumratio:
+      text: 1.0
+    minimumseedtime:
+      # 2 days (as seconds = 2 x 24 x 60 x 60)
+      text: 172800
+# TBDev

--- a/src/Jackett.Common/Definitions/matrix.yml
+++ b/src/Jackett.Common/Definitions/matrix.yml
@@ -122,14 +122,12 @@ search:
           args: cat
     title:
       selector: a.torrent-link b
-    _id:
-      selector: a[href^="download.php?id="]
+    details:
+      selector: a[href^="details.php?id="]
       attribute: href
       filters:
-        - name: querystring
-          args: id
-    details:
-      text: "details.php?id={{ .Result._id }}"
+        - name: re_replace
+          args: ["&hit=1.+", ""]
     download:
       selector: a[href^="download.php?id="]
       attribute: href


### PR DESCRIPTION
#### Description

This is my first new indexer definition. This tracker has no explicit software type attribution in the footer nor elsewhere in the `/browse.php` page source. The only software type reference I can find is `<script
src="https://matrixworld.info/js/tbdev_hun.js"></script>`, so TBDev is my best guess.  I started with a few of the most recently added and modified definitions tagged with `# TBDev...` at the bottom and copied one.

I modified it as seemed most correct supplemented with [the Prowlarr Cardigann YML Definition docs](https://wiki.servarr.com/en/prowlarr/cardigann-yml-definition) and various `$ git grep ...` searches for relevant bits. For things like the categories and sort fields, I copied the relevant HTML from the indexer web UI and transformed it with editor tools into the corresponding indexer definition YAML, so they should be complete.

Finally, I tested the new definition in the Prowlarr UI:

- the edit form looks correct and saves successfully
- the view indexer modal looks correct and the indexer web UI link works
- searching with an empty query yields the same 100 results as the indexer web UI:
  - I found different examples for each of the fields/columns to demonstrate each is extracting real data
  - the details link works
  - the grab button works and adds the torrent to the client
  - the search XHR response JSON also looks correct and as complete as I can make it from the indexer HTML
- searching with a simple query returns the same result as in the indexer's web UI
- searching by a category also looks correct

I can't think of anything else to test, but LMK if there's more. I'd like to get this as correct as I reasonably can to save time on the indexer definition PRs I intend to be submitting next.
