### PR TITLE
build(compose): Test changes in Jackett/Prowlarr

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,6 +162,7 @@ ClientBin/
 *.publishsettings
 node_modules/
 bower_components/
+/.compose
 
 # RIA/Silverlight projects
 Generated_Code/

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,38 @@
+# Development, build, and maintenance tasks:
+
+# Defensive settings for make:
+#     https://tech.davis-hansson.com/p/make/
+SHELL:=bash
+.ONESHELL:
+.SHELLFLAGS:=-eu -o pipefail -c
+.SILENT:
+.DELETE_ON_ERROR:
+MAKEFLAGS+=--warn-undefined-variables
+MAKEFLAGS+=--no-builtin-rules
+PS1?=$$
+
+# Finished with `$(shell)`, echo recipe commands going forward
+.SHELLFLAGS+= -x
+
+
+### Top-level targets:
+
+.PHONY: all
+## The default target.
+all: build
+
+.PHONY: build
+## Set up everything for development from this checkout.
+build:
+
+.PHONY: start
+## Run the local development end-to-end stack services in the background as daemons.
+start: build
+	docker compose up --pull="always" -d
+
+.PHONY: run
+## Run the local development end-to-end stack services in the foreground for debugging.
+run: build
+	$(MAKE) start
+# Scrollback to the container start on a fresh start:
+	docker compose logs -ft --tail="100"

--- a/compose.yaml
+++ b/compose.yaml
@@ -1,0 +1,54 @@
+# https://github.com/linuxserver/docker-jackett?tab=readme-ov-file#docker-compose-recommended-click-here-for-more-info
+#
+# Override `${...:-...}` variables in `./.env` to customize.
+---
+services:
+
+  flaresolverr:
+    # DockerHub mirror flaresolverr/flaresolverr:latest
+    image: "ghcr.io/flaresolverr/flaresolverr:latest"
+    environment:
+      LOG_LEVEL: "${LOG_LEVEL:-debug}"
+      LOG_HTML: "${LOG_HTML:-false}"
+      CAPTCHA_SOLVER: "${CAPTCHA_SOLVER:-none}"
+      TZ: "${TZ:-Etc/UTC}"
+    ports:
+      - "${FLARESOLVERR_PORT:-127.0.0.1:8191}:8191"
+    restart: "unless-stopped"
+
+  jackett:
+    image: "lscr.io/linuxserver/jackett:latest"
+    depends_on:
+      flaresolverr:
+        condition: "service_started"
+    environment:
+      PUID: "${PUID:-1000}"
+      PGID: "${PGID:-1000}"
+      TZ: "${TZ:-Etc/UTC}"
+    volumes:
+      - "./.compose/jackett/config/:/config/"
+      - "./src/Jackett.Common/Definitions/:/app/Jackett/Definitions/"
+    ports:
+      - "${JACKETT_PORT:-127.0.0.1:9117}:9117"
+    restart: "unless-stopped"
+
+  prowlarr:
+    image: "ghcr.io/hotio/prowlarr:release"
+    depends_on:
+      flaresolverr:
+        condition: "service_started"
+    restart: "unless-stopped"
+    ports:
+      - "${PROWLARR_PORT:-127.0.0.1:9696}:9696"
+    environment:
+      PUID: "${PUID:-1000}"
+      PGID: "${PGID:-1000}"
+      UMASK: "${UMASK:-002}"
+      TZ: "${TZ:-Etc/UTC}"
+    volumes:
+      - "./.compose/prowlarr/config/:/config/"
+      - "./:/config/Jackett/"
+      # To test changes to indexer definitions, symlink them into
+      # `./.compose/prowlarr/config/Definitions/Custom/`:
+      #     $ ln -sv ../../Jackett/src/Jackett.Common/Definitions/foo-indexer.yml \
+      #     ./.compose/prowlarr/config/Definitions/Custom/


### PR DESCRIPTION
#### Description

A simple Docker Compose project to test indexer definition changes under both Jackett and Prowlarr.  Helps to avoid bans for multiple auth attempts and other development tasks by submitting both browser and Jackett/Prowlarr requests from the local machine behind a VPN. It's also just smoother development overall using local tools. It could be useful for fostering contributors.
