### PR TITLE
52bt: domain update

### DIFF
--- a/src/Jackett.Common/Definitions/52bt.yml
+++ b/src/Jackett.Common/Definitions/52bt.yml
@@ -8,13 +8,15 @@ encoding: UTF-8
 requestDelay: 2
 links:
   # Send any content to 52btbtbt@gmail.com to get the latest address. or visit https://521.52btbt.cyou/
-  - https://www.529053.xyz/
-  - https://www.529055.xyz/
+  - https://www.529056.xyz/
+  - https://www.529057.xyz/
 legacylinks:
   - https://529050.xyz/
   - https://529048.xyz/
   - https://529049.xyz/
   - https://www.529052.xyz/
+  - https://www.529053.xyz/
+  - https://www.529055.xyz/
 
 caps:
   categorymappings:


### PR DESCRIPTION
#### Description
This Pull Request updates the address information for 52bt. Due to 52bt changing their official addresses, we need to replace the old addresses with the new ones in the code or documentation. The specific changes are as follows:

- **Old Addresses**:
  - https://www.529053.xyz/
  - https://www.529055.xyz/

- **New Addresses**:
  - https://www.529056.xyz/
  - https://www.529057.xyz/