### PR TITLE
Updated default torrentday url

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/TorrentDay.cs
+++ b/src/Jackett.Common/Indexers/Definitions/TorrentDay.cs
@@ -25,6 +25,7 @@ namespace Jackett.Common.Indexers.Definitions
         public override string SiteLink { get; protected set; } = "https://tday.love/";
         public override string[] AlternativeSiteLinks => new[]
         {
+            "https://torrentday.com/",
             "https://tday.love/",
             "https://torrentday.cool/",
             "https://secure.torrentday.com/",
@@ -43,7 +44,6 @@ namespace Jackett.Common.Indexers.Definitions
         };
         public override string[] LegacySiteLinks => new[]
         {
-            "https://torrentday.com/",
             "https://tdonline.org/", // redirect to https://www.torrentday.com/
             "https://torrentday.eu/", // redirect to https://www.torrentday.com/
             "https://td-update.com/", // redirect to https://www.torrentday.com/


### PR DESCRIPTION
Updated the default torrentday url per their mirror page details.
all other URLs within the official mirror site redirect to dot-com only. dot com should be the original URL

![image](https://github.com/user-attachments/assets/a67e16df-57f8-4eb4-a127-f1d174288897)

![image](https://github.com/user-attachments/assets/67b36c35-3622-4937-9380-392e1829da12)