### PR TITLE
Update YggTorrent login URL to /auth/process_login

### DIFF
--- a/src/Jackett.Common/Definitions/yggtorrent.yml
+++ b/src/Jackett.Common/Definitions/yggtorrent.yml
@@ -167,7 +167,7 @@ settings:
 
 login:
   method: form
-  path: /auth/login
+  path: /auth/process_login
   form: form.login-form
   inputs:
     id: "{{ .Config.username }}"


### PR DESCRIPTION
#### Description
The YggTorrent site updated its login endpoint on the morning of July 18, 2025. This commit updates the yggtorrent.yml definition to replace /auth/login with /auth/process_login as the new form submission URL. This ensures proper authentication and restores compatibility with the updated site.


#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
