### PR TITLE
Lostfilm: Relax parsePlayEpisodeRegex to support arbitrary-length ser…

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/LostFilm.cs
+++ b/src/Jackett.Common/Indexers/Definitions/LostFilm.cs
@@ -51,7 +51,7 @@ namespace Jackett.Common.Indexers.Definitions
 
         public override TorznabCapabilities TorznabCaps => SetCapabilities();
 
-        private static readonly Regex parsePlayEpisodeRegex = new Regex("PlayEpisode\\('(?<id>\\d{1,3})(?<season>\\d{3})(?<episode>\\d{3})'\\)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        private static readonly Regex parsePlayEpisodeRegex = new Regex(@"PlayEpisode\('(?<id>\d+)(?<season>\d{3})(?<episode>\d{3})'\)", RegexOptions.Compiled | RegexOptions.IgnoreCase);
         private static readonly Regex parseReleaseDetailsRegex = new Regex("Видео:\\ (?<quality>.+).\\ Размер:\\ (?<size>.+).\\ Перевод", RegexOptions.Compiled | RegexOptions.IgnoreCase);
 
         private string LoginUrl => SiteLink + "login";


### PR DESCRIPTION
#### Description

Changed the “id” capture from `\d{1,3}` to `\d+` so we no longer fail to match when LostFilm ever emits IDs longer than three digits.

#### Screenshot (if UI related)

<img width="1007" height="741" alt="Screenshot 2025-07-19 at 13 57 45" src="https://github.com/user-attachments/assets/176e3067-82c1-40ee-91dc-a0beb6fc8fb4" />


#### Issues Fixed or Closed by this PR

* Fixes #16074
