### PR TITLE
Remove IMDB, season, and episode from KrazyZone

### DIFF
--- a/src/Jackett.Common/Definitions/krazyzone.yml
+++ b/src/Jackett.Common/Definitions/krazyzone.yml
@@ -61,7 +61,7 @@ caps:
 
   modes:
     search: [q]
-    tv-search: [q]
+    tv-search: [q, season, ep]
     movie-search: [q]
     music-search: [q]
     book-search: [q]
@@ -120,7 +120,7 @@ search:
     - path: torrents-search.php
   inputs:
     $raw: "{{ range .Categories }}c{{.}}=1&{{end}}"
-    search: "{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}" # for dashboard imdbid search
+    search: "{{ .Keywords }}"
     # 0 active, 1 incldead, 2 onlydead
     incldead: 1
     # 0 all, 1 notfree, 2 onlyfree

--- a/src/Jackett.Common/Definitions/krazyzone.yml
+++ b/src/Jackett.Common/Definitions/krazyzone.yml
@@ -61,8 +61,8 @@ caps:
 
   modes:
     search: [q]
-    tv-search: [q, season, ep, imdbid]
-    movie-search: [q, imdbid]
+    tv-search: [q]
+    movie-search: [q]
     music-search: [q]
     book-search: [q]
 


### PR DESCRIPTION
#### Description
KrazyZone does not support these lookups; confirmed in their shoutbox, and discussed at https://krazyzone.net/forums.php?action=viewtopic&topicid=351 and https://krazyzone.net/forums.php?action=viewtopic&topicid=476

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #16088 
