### PR TITLE
[Enhancement] Update AnimeTorrents.cs to search filename and description

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/AnimeTorrents.cs
+++ b/src/Jackett.Common/Indexers/Definitions/AnimeTorrents.cs
@@ -35,7 +35,7 @@ namespace Jackett.Common.Indexers.Definitions
 
         private string LoginUrl => SiteLink + "login.php";
         private string SearchUrl => SiteLink + "ajax/torrents_data.php";
-        private string SearchUrlReferer => SiteLink + "torrents.php?cat=0&searchin=filename&search=";
+        private string SearchUrlReferer => SiteLink + "torrents.php?cat=0&searchin=filedisc&search=";
 
         private new ConfigurationDataAnimeTorrents configData => (ConfigurationDataAnimeTorrents)base.configData;
 


### PR DESCRIPTION
#### Description
This change searches AnimeTorrents using both filename and description. The default of filename often fails when using Radarr and Sonarr, as the TMDB titles are in English and Japanese (with Japanese characters). While AnimeTorrents provides the filenames in Japanese using Latin characters, the description includes the English and Japanese titles that match TMDB.

#### Screenshot (if UI related)
With previous search:
<img width="981" height="310" alt="image" src="https://github.com/user-attachments/assets/1309aca5-e539-4aaf-bcbd-d796e17d005a" />

With new search:
<img width="978" height="818" alt="image" src="https://github.com/user-attachments/assets/b99b4832-c47b-4675-8039-66955248a162" />


#### Issues Fixed or Closed by this PR

* N/A
