### PR TITLE
seedpool:  category mapping updates

### DIFF
--- a/src/Jackett.Common/Definitions/seedpool-api.yml
+++ b/src/Jackett.Common/Definitions/seedpool-api.yml
@@ -13,13 +13,17 @@ caps:
     - {id: 2, cat: TV, desc: "TV Show"}
     - {id: 1, cat: Movies, desc: "Movie"}
     - {id: 6, cat: TV/Anime, desc: "Anime"}
+    # for radarr
+    - {id: 6, cat: Movies/Other, desc: "Anime"}
     - {id: 8, cat: TV/Sport, desc: "Sports"}
     - {id: 5, cat: Audio, desc: "Music"}
     - {id: 9, cat: Audio/Audiobook, desc: "Audiobook"}
     - {id: 7, cat: Books/EBook, desc: "E-Books"}
     - {id: 12, cat: Other, desc: "Hobby"}
     - {id: 16, cat: PC, desc: "Software"}
+    # Seedpool has a combined "Games category"
     - {id: 3, cat: Console, desc: "Games"}
+    - {id: 3, cat: PC/Games, desc: "Games"}
     - {id: 21, cat: Other, desc: "Music Production"}
     - {id: 11, cat: Other, desc: "Other"}
 

--- a/src/Jackett.Common/Definitions/seedpool-api.yml
+++ b/src/Jackett.Common/Definitions/seedpool-api.yml
@@ -24,6 +24,9 @@ caps:
     # Seedpool has a combined "Games category"
     - {id: 3, cat: Console, desc: "Games"}
     - {id: 3, cat: PC/Games, desc: "Games"}
+    # Music production can have software and audio samples
+    - {id: 21, cat: PC, desc: "Music Production"}
+    - {id: 21, cat: Audio/Other, desc: "Music Production"}
     - {id: 21, cat: Other, desc: "Music Production"}
     - {id: 11, cat: Other, desc: "Other"}
 

--- a/src/Jackett.Common/Definitions/seedpool-api.yml
+++ b/src/Jackett.Common/Definitions/seedpool-api.yml
@@ -12,22 +12,15 @@ caps:
   categorymappings:
     - {id: 2, cat: TV, desc: "TV Show"}
     - {id: 1, cat: Movies, desc: "Movie"}
-    - {id: 10, cat: Movies/UHD, desc: "4K Movie"}
-    - {id: 13, cat: TV, desc: "TV Boxsets"}
-    - {id: 12, cat: PC/Games, desc: "Linux Game"}
-    - {id: 3, cat: PC/Games, desc: "PC Game"}
-    - {id: 5, cat: Audio/Lossless, desc: "Music"}
     - {id: 6, cat: TV/Anime, desc: "Anime"}
-    - {id: 4, cat: Console/Other, desc: "NSW Game"}
     - {id: 8, cat: TV/Sport, desc: "Sports"}
-    - {id: 7, cat: Books/EBook, desc: "E-Books"}
+    - {id: 5, cat: Audio, desc: "Music"}
     - {id: 9, cat: Audio/Audiobook, desc: "Audiobook"}
-    - {id: 15, cat: Other, desc: "Education"}
-    - {id: 16, cat: PC/0day, desc: "Windows"}
-    - {id: 17, cat: PC, desc: "Linux"}
-    - {id: 18, cat: PC/Mac, desc: "macOS"}
-    - {id: 14, cat: Console/PS4, desc: "PS4"}
-    - {id: 19, cat: Console/XBox, desc: "Xbox"}
+    - {id: 7, cat: Books/EBook, desc: "E-Books"}
+    - {id: 12, cat: Other, desc: "Hobby"}
+    - {id: 16, cat: PC, desc: "Software"}
+    - {id: 3, cat: Console, desc: "Games"}
+    - {id: 21, cat: Other, desc: "Music Production"}
     - {id: 11, cat: Other, desc: "Other"}
 
   modes:


### PR DESCRIPTION
#### Description
Seedpool is reorganizing its categories, this update will match the new category configuration on the tracker. 

Used https://github.com/Jackett/Jackett/wiki/Jackett-Categories as reference for category names

I re-ordered the category list to match the tracker order for easier updates in the future :) 

There are some SP categories that now map to multiple Jackett categories. I believe I have set those correctly, but would appreciate a pair of eyes on that to confirm that the mappings are valid for Jackett. For example, the Music Production category (id 21) is going to have a mix of PC/Audio/Other. I believe I am able to do this mapping, but would like confirmation that its actually valid :) 

Many thanks!

#### Screenshot (if UI related)

