### PR TITLE
Fix Category mismatch

### DIFF
--- a/src/Jackett.Common/Definitions/spiritofrevolution.yml
+++ b/src/Jackett.Common/Definitions/spiritofrevolution.yml
@@ -27,7 +27,7 @@ caps:
     - {id: 135, cat: TV/HD, desc: "Serien HD"}
     - {id: 136, cat: TV/SD, desc: "Serien Pack/SD"}
     - {id: 180, cat: TV/HD, desc: "Serien Pack/HD"}
-    - {id: 184, cat: TV/UHD, desc: "Serien Pack/UHD"}
+    - {id: 192, cat: TV/UHD, desc: "Serien Pack/UHD"}
     - {id: 179, cat: TV/Anime, desc: "Serien Anime"}
     - {id: 128, cat: Audio/MP3, desc: "Audio MP3/AAC"}
     - {id: 169, cat: Audio, desc: "Audio Pack"}


### PR DESCRIPTION
TV/UHD is now 192 on Spirit of Revolution

#### Description
I discovered that TV/UHD are no longer recognized.
When you hover over the Category on that tracker, you can see the "cat=192"

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

