### PR TITLE
Fix login redirect for reverse proxy.

### DIFF
--- a/src/Jackett.Server/Startup.cs
+++ b/src/Jackett.Server/Startup.cs
@@ -22,6 +22,7 @@ using Microsoft.AspNetCore.Rewrite;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Newtonsoft.Json.Serialization;
+using System.Threading.Tasks;
 #if !NET462
 using Microsoft.Extensions.Hosting;
 #endif
@@ -54,6 +55,11 @@ namespace Jackett.Server
                             options.AccessDeniedPath = new PathString("/UI/Login");
                             options.LogoutPath = new PathString("/UI/Logout");
                             options.Cookie.Name = "Jackett";
+                            options.Events.OnRedirectToLogin = context =>
+                            {
+                                context.Response.Redirect("/UI/Login");
+                                return Task.CompletedTask;
+                            };
                         });
 
 #if NET462


### PR DESCRIPTION
Issue first mentioned here https://github.com/Jackett/Jackett/issues/12954#issuecomment-1305773552

#### Description
When redirecting to the login page, the default behavior uses an absolute location for the redirect. If using a reverse proxy, the host tag is used instead of the x-forwarded-host information. It manifested in a way that wasn't clear for me. The above comment made me suspect of the login page specifically, but I wasn't sure their issue (that I don't think is the same issue as the thread's OP) was my issue at first.

I created the handler attempting to debug though the response generation ensure that what I was seeing was coming from the server jackett itself and not something else in my setup before filing a new issue. Adding the event handler completely overrides the default behavior resulting in no redirect with an empty handler. So I wasn't debugging the default response generation as I intended, but if I have total control over the response and can manually send one that I know for a fact doesn't is relative... presto problem diagnosed and solved all at once.

