### PR TITLE
[FIX] Update limetorrents URL

### DIFF
--- a/src/Jackett.Common/Definitions/limetorrents.yml
+++ b/src/Jackett.Common/Definitions/limetorrents.yml
@@ -15,11 +15,11 @@ links:
   - https://limetorrents.torrentbay.st/
   - https://limetorrents.torrentsbay.org/
 legacylinks:
-  - https://www.limetorrents.lol/
   - https://limetorrents.mrunblock.bond/
   - https://limetorrents.nocensor.cloud/
   - https://limetorrents.abcproxy.org/
   - https://limetorrents.unblockit.download/
+  - https://www.limetorrents.lol/
 
 caps:
   categorymappings:


### PR DESCRIPTION
#### Description
`limetorrents.lol` is now being redirected to `limetorrents.fun`, which is causing Jackett to fail with this error
``` 
Jackett.Common.IndexerException: Exception (limetorrents): Got redirected to another domain. Try changing the indexer URL to https://www.limetorrents.fun/.
```
