### PR TITLE
darkpeers -> 9.1.6 info_hash removed

### DIFF
--- a/src/Jackett.Common/Definitions/darkpeers.yml
+++ b/src/Jackett.Common/Definitions/darkpeers.yml
@@ -120,8 +120,6 @@ search:
       selector: details_link
     download:
       selector: download_link
-    infohash:
-      selector: info_hash
     poster:
       selector: meta.poster
       filters:
@@ -196,4 +194,4 @@ search:
     minimumseedtime:
       # 3 days (as seconds = 3 x 24 x 60 x 60)
       text: 259200
-# json UNIT3D 9.1.5
+# json UNIT3D 9.1.6


### PR DESCRIPTION
#### Description
Updates darkpeers definition for compatibility with Unit3D 9.1.6
