### PR TITLE
[Update] DocsPedia minimum ratio

### DIFF
--- a/src/Jackett.Common/Definitions/docspedia.yml
+++ b/src/Jackett.Common/Definitions/docspedia.yml
@@ -175,7 +175,7 @@ search:
     date:
       text: "{{ if or .Result.date_day .Result.date_year }}{{ or .Result.date_day .Result.date_year }}{{ else }}now{{ end }}"
     minimumratio:
-      text: 1.0
+      text: 0.4
     minimumseedtime:
       # 2 days (as seconds = 2 x 24 x 60 x 60)
       text: 172800


### PR DESCRIPTION
#### Description
Low ratio may result in severe consequnces, including banning in extreme cases (low ratio <0.4 and more than 25GB downloads).

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
