### PR TITLE
[Update] HDT minimum ratio

### DIFF
--- a/src/Jackett.Common/Definitions/hdtorrents.yml
+++ b/src/Jackett.Common/Definitions/hdtorrents.yml
@@ -183,7 +183,7 @@ search:
         img[src$="no_ratio.png"]: 0
         "*": 1
     minimumratio:
-      text: 1.0
+      text: 0.7
     minimumseedtime:
       # 2 days (as seconds = 2 x 24 x 60 x 60)
       text: 172800


### PR DESCRIPTION
#### Description
If you have a combined download total in excess of 50 GB and your ratio is below 0.70, you will receive two consecutive 3-day warnings. Failure to act upon the warnings and increase your ratio above 0.70 within those 6 days will get your account disabled.
Also from FAQ: There is no Hit & Run rule here. You can stop a torrent immediately after downloading it or even before that, no matter the % you already downloaded. Don't forget that the 0.70 overall ratio requirement though.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
