### PR TITLE
[Update] HHD Add minimum ratio

### DIFF
--- a/src/Jackett.Common/Definitions/hhd-api.yml
+++ b/src/Jackett.Common/Definitions/hhd-api.yml
@@ -193,6 +193,8 @@ search:
         True: 2 # double
     uploadvolumefactor:
       text: "{{ if .Result._featured }}2{{ else }}{{ .Result.uploadvolumefactor_double_upload }}{{ end }}"
+    minimumratio:
+      text: 0.4
     minimumseedtime:
       # 7 days (as seconds = 7 x 24 x 60 x 60)
       text: 604800

--- a/src/Jackett.Common/Definitions/hhd-api.yml
+++ b/src/Jackett.Common/Definitions/hhd-api.yml
@@ -193,8 +193,9 @@ search:
         True: 2 # double
     uploadvolumefactor:
       text: "{{ if .Result._featured }}2{{ else }}{{ .Result.uploadvolumefactor_double_upload }}{{ end }}"
-    minimumratio:
-      text: 0.4
+# global MR is 0.4 but torrents must be seeded for 7 days regardless of ratio
+#    minimumratio:
+#      text: 0.4
     minimumseedtime:
       # 7 days (as seconds = 7 x 24 x 60 x 60)
       text: 604800


### PR DESCRIPTION
#### Description
You must keep a ratio of at least 0.4 otherwise your download privileges will be revoked. Your buffer at the top of the page shows how much you can download without falling below 0.4.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
