### PR TITLE
[Update] Rastastugan minimum seedtime

### DIFF
--- a/src/Jackett.Common/Definitions/rastastugan-api.yml
+++ b/src/Jackett.Common/Definitions/rastastugan-api.yml
@@ -191,9 +191,8 @@ search:
         True: 2 # double
     uploadvolumefactor:
       text: "{{ if .Result._featured }}2{{ else }}{{ .Result.uploadvolumefactor_double_upload }}{{ end }}"
-# global MR is 0.8 but torrents must be seeded for 7 days regardless of ratio
-#    minimumratio:
-#      text: 0.8
+    minimumratio:
+      text: 1.0
     minimumseedtime:
       # 2 days (as seconds = 2 x 24 x 60 x 60)
       text: 172800

--- a/src/Jackett.Common/Definitions/rastastugan-api.yml
+++ b/src/Jackett.Common/Definitions/rastastugan-api.yml
@@ -195,6 +195,6 @@ search:
 #    minimumratio:
 #      text: 0.8
     minimumseedtime:
-      # 5 days (as seconds = 5 x 24 x 60 x 60)
-      text: 432000
+      # 2 days (as seconds = 2 x 24 x 60 x 60)
+      text: 172800
 # json UNIT3D 9.1.7


### PR DESCRIPTION
#### Description
You are required to seed all torrents to a 1:1 ratio or for at least 2 days (48 hours) before removing them from your client .

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
