### PR TITLE
[Update] reelflix url

### DIFF
--- a/src/Jackett.Common/Definitions/reelflix-api.yml
+++ b/src/Jackett.Common/Definitions/reelflix-api.yml
@@ -9,6 +9,7 @@ language: en-US
 type: private
 encoding: UTF-8
 links:
+  - https://reelflix.cc/
   - https://reelflix.xyz/
 legacylinks:
   - https://legacyhd.org/


### PR DESCRIPTION
#### Description
RFX has added a new domain they will be migrating to. The old one still works until some future announced time so I did not remove it.

