### PR TITLE
Update Das Unerwartete definition to support API key and TMDb search

### DIFF
--- a/src/Jackett.Common/Definitions/dasunerwartete_api.yml
+++ b/src/Jackett.Common/Definitions/dasunerwartete_api.yml
@@ -4,6 +4,7 @@ name: Das Unerwartete (API)
 description: "Das Unerwartete (D-U) API-only Version for 2FA accounts. Uses /api.php with API Key access."
 language: de-DE
 type: private
+encoding: UTF-8
 links:
   - https://dasunerwartete.biz/
 
@@ -47,7 +48,7 @@ caps:
     - {id: 76, cat: XXX/SD, desc: "XXX > SD"}
     - {id: 73, cat: XXX/x264, desc: "XXX > HD"}
     - {id: 75, cat: XXX/Pack, desc: "XXX > Pack"}
-    - {id: 142, cat: XXX/ImageSet, desc: "XXX > Pics"}
+    - {id: 142, cat: XXX/ImageSet, desc: "XXX > Pic´s"}
     - {id: 129, cat: Movies/SD, desc: "Internal > Film SD"}
     - {id: 128, cat: Movies/HD, desc: "Internal > Film HD"}
     - {id: 131, cat: TV/SD, desc: "Internal > Serien SD"}
@@ -110,7 +111,11 @@ search:
       type: torrent
       filters:
         - name: replace
-          args: ["&amp;", "&"]
+          args:
+            - "&amp;"
+            - "&"
+    poster:
+      selector: cover
     size:
       selector: size
       type: integer
@@ -135,8 +140,11 @@ search:
         - name: contains
           args: "yes"
       optional: true
-    downloadvolumefactor: "{{ if .Result._onlyup }}0{{ else }}1{{ end }}"
-    uploadvolumefactor: 1
-    minimumratio: 1.0
-    minimumseedtime: 129600
-    
+    downloadvolumefactor:
+      text: "{{ if .Result._onlyup }}0{{ else }}1{{ end }}"
+    uploadvolumefactor:
+      text: 1
+    minimumratio:
+      text: 1.0
+    minimumseedtime:
+      text: 129600


### PR DESCRIPTION
Adds support for DasUnerwartete.biz API (API-Key authentication for 2FA accounts). This replaces the previous HTML login with direct XML feed access.

Supports tmdbid searches

Correct category mapping

API Download XML fixed, one-line links for Prowlarr compatibility

Tested on live tracker by Mauerwerk© / DasUnerwartete©

