### PR TITLE
[Enhancement] Fix missed reference in AnimeTorrents.cs for Japanese matching

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/AnimeTorrents.cs
+++ b/src/Jackett.Common/Indexers/Definitions/AnimeTorrents.cs
@@ -130,7 +130,7 @@ namespace Jackett.Common.Indexers.Definitions
                 { "total", "146" }, // Assuming the total number of pages
                 { "cat", MapTorznabCapsToTrackers(query).FirstIfSingleOrDefault("0") },
                 { "page", page.ToString() },
-                { "searchin", "filename" },
+                { "searchin", "filedisc" },
                 { "search", searchString }
             };
 


### PR DESCRIPTION
#### Description
Recently got around to testing out the changes I made from #16098, and the debug logs showed that it was using a different line to set up the search. This PR changes that line to match the query style from before.
