### PR TITLE
pipelines: update images

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -231,7 +231,7 @@ stages:
 
           - task: CopyFiles@2
             displayName: Copy Mono Specific Scripts
-            condition: and(succeeded(), startsWith(variables['buildDescription'], 'Mono'))
+            condition: and(succeeded(), eq(variables['buildDescription'], 'Mono'))
             inputs:
               SourceFolder: $(Build.SourcesDirectory)
               contents: |
@@ -269,7 +269,7 @@ stages:
           # https://github.com/Jackett/Jackett/issues/3547
           - task: PowerShell@2
             displayName: Patch Mono Build (Mono only)
-            condition: and(succeeded(), startsWith(variables['buildDescription'], 'Mono'))
+            condition: and(succeeded(), eq(variables['buildDescription'], 'Mono'))
             inputs:
               workingDirectory: $(Build.BinariesDirectory)/Jackett
               targetType: inline
@@ -445,6 +445,15 @@ stages:
         steps:
           - checkout: self
 
+          - task: Bash@3
+            displayName: Install Mono (Mono only)
+            condition: and(succeeded(), eq(variables['buildDescription'], 'Mono'))
+            inputs:
+              targetType: inline
+              script: |
+                sudo apt update
+                sudo apt install mono-complete
+
           - task: UseDotNet@2
             displayName: Install .NET Core SDK
             inputs:
@@ -541,6 +550,15 @@ stages:
         displayName: ${{ variables.buildDescription }}
         steps:
           - checkout: self
+
+          - task: Bash@3
+            displayName: Install Mono (Mono only)
+            condition: and(succeeded(), eq(variables['buildDescription'], 'Mono'))
+            inputs:
+              targetType: inline
+              script: |
+                sudo apt update
+                sudo apt install mono-complete
 
           - task: DownloadBuildArtifacts@0
             displayName: Download artifacts for integration tests


### PR DESCRIPTION
#### Description
~For users that require the x86_64 (Intel) environment, we are also introducing a new label to migrate to: `macos-15-intel`. The new label will run on macOS 15 and will be available from now until August 2027. This will be the last available x86_64 image from Actions, and after that date the x86_64 architecture will not be supported on GitHub Actions. - https://github.com/actions/runner-images/issues/13046~

In accordance with our policy to support the n-1 version of OS images, we will initiate the deprecation of macOS 13 Ventura starting 1st September 2025, with plans to retire it by 4th December 2025. Customers currently utilizing macOS-13 in their pipelines are encouraged to transition to macOS-14 or macOS-15 images. - https://devblogs.microsoft.com/devops/upcoming-updates-for-azure-pipelines-agents-images/#mac-os

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
