### PR TITLE
amigosshare: remove possible leading spaces

### DIFF
--- a/src/Jackett.Common/Definitions/amigosshare.yml
+++ b/src/Jackett.Common/Definitions/amigosshare.yml
@@ -152,7 +152,7 @@ search:
   keywordsfilters:
     # drop the year from searches since site titles do not include year
     - name: re_replace
-      args: ["(\\b((19|20)\\d{2})\\b)", ""]
+      args: ["(\\s*\\b((19|20)\\d{2})\\b)", ""]
 
   rows:
     selector: "div#fancy-list-group ul.list-group li.list-group-item{{ if .Config.freeleech }}:has(span.badge-success:contains(\"FREE\")){{ else }}{{ end }}"


### PR DESCRIPTION
#### Description
Can you check this? I don't have an account, but responding to a report on Prowlarr's Discord.

Problem seems to be caused by a search like `test 720p 2025`, where `keywordsfilters` removes the year but leaves a trailing space, and then `re_replace .Keywords` replaces that space with `%`, which then breaks the search apparently.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
