### PR TITLE
Update emuwarez links from .it to .com

### DIFF
--- a/src/Jackett.Common/Definitions/emuwarez.yml
+++ b/src/Jackett.Common/Definitions/emuwarez.yml
@@ -7,6 +7,8 @@ type: private
 encoding: UTF-8
 links:
   - https://emuwarez.com/
+legacylinks:
+  - https://emuwarez.it/
 
 caps:
   categorymappings:


### PR DESCRIPTION
Due to a change of tracker domain.

We don't have access to the old domain and we haven't registered a new domain.