### PR TITLE
fix: New link for YGGtorrent

### DIFF
--- a/src/Jackett.Common/Definitions/yggcookie.yml
+++ b/src/Jackett.Common/Definitions/yggcookie.yml
@@ -8,7 +8,7 @@ encoding: UTF-8
 followredirect: true
 requestDelay: 4
 links:
-  - https://www.yggtorrent.top/
+  - https://www.yggtorrent.org/
 legacylinks:
   - https://www2.yggtorrent.si/
   - https://www.yggtorrent.li/
@@ -25,6 +25,7 @@ legacylinks:
   - https://www3.yggtorrent.qa/
   - https://www3.yggtorrent.cool/
   - https://www.ygg.re/
+  - https://www.yggtorrent.top/
 
 caps:
   # dont forget to update the search fields category case block

--- a/src/Jackett.Common/Definitions/yggtorrent.yml
+++ b/src/Jackett.Common/Definitions/yggtorrent.yml
@@ -8,7 +8,7 @@ encoding: UTF-8
 followredirect: true
 requestDelay: 4
 links:
-  - https://www.yggtorrent.top/
+  - https://www.yggtorrent.org/
 legacylinks:
   - https://www2.yggtorrent.si/
   - https://www.yggtorrent.li/
@@ -25,6 +25,7 @@ legacylinks:
   - https://www3.yggtorrent.qa/
   - https://www3.yggtorrent.cool/
   - https://www.ygg.re/
+  - https://www.yggtorrent.top/
 
 caps:
   # dont forget to update the search fields category case block


### PR DESCRIPTION
#### Description
Updates the Yggtorrent Jackett definitions by switching the primary URL from `yggtorrent.top` to `yggtorrent.org`