### PR TITLE
fix: Remove num_files from thepiratebay.yml

### DIFF
--- a/src/Jackett.Common/Definitions/thepiratebay.yml
+++ b/src/Jackett.Common/Definitions/thepiratebay.yml
@@ -203,6 +203,9 @@ search:
       selector: added
     size:
       selector: size
+    files:
+      selector: num_files
+      optional: true
     seeders:
       selector: seeders
     leechers:


### PR DESCRIPTION
#### Description

Piratebay fields apparently changed so requests are failing:
```
Error Jackett.Common.IndexerException: Exception (thepiratebay): Selector "num_files" didn't match {"id": ...
```

Removing the `files` field from the yaml seems to fix the issue

#### Screenshot (if UI related)

Before:
<img width="482" height="166" alt="Screenshot 2025-12-16 at 14 50 46" src="https://github.com/user-attachments/assets/ecad9856-fe95-4040-a955-8faf2c561e48" />

After:
<img width="502" height="271" alt="Screenshot 2025-12-16 at 14 51 29" src="https://github.com/user-attachments/assets/3d187bff-b17d-490d-8f32-f61338e95af2" />
