### PR TITLE
indexers: add configuration item ordering

### DIFF
--- a/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationDataFileList.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/Bespoke/ConfigurationDataFileList.cs
@@ -12,7 +12,7 @@ namespace Jackett.Common.Models.IndexerConfig.Bespoke
             : base("Note this is <b>not</b> your <i>password</i>.<ul><li>Login to the FileList Website</li><li>Click on the <b>Profile</b> link</li><li>Scroll down to the <b>Reset Passkey</b> section</li><li>Copy the <b>passkey</b>.</li><li>Also be aware of not leaving a trailing blank at the end of the passkey after pasting it here.</li></ul>BTW, you will not see your current passkey on your Profile until after you have downloaded your first .torrent")
         {
             Freeleech = new BoolConfigurationItem("Search freeleech only") { Value = false };
-            CatWarning = new DisplayInfoConfigurationItem("CatWarning", "When mapping TV ensure you add category 5000 in addition to 5020, 5030, 5040, 5045.");
+            CatWarning = new DisplayInfoConfigurationItem("Category Warning", "When mapping TV ensure you add category 5000 in addition to 5020, 5030, 5040, 5045.");
         }
     }
 }

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationData.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationData.cs
@@ -1,10 +1,10 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.Json.Serialization;
 using System.Text.RegularExpressions;
 using Jackett.Common.Services.Interfaces;
 using Jackett.Common.Utils;
-
 using Newtonsoft.Json.Linq;
 
 namespace Jackett.Common.Models.IndexerConfig
@@ -66,8 +66,15 @@ namespace Jackett.Common.Models.IndexerConfig
                 .GetProperties()
                 .Where(p => p.CanRead)
                 .Where(p => p.PropertyType.IsSubclassOf(typeof(ConfigurationItem)))
+                .OrderBy(x =>
+                {
+                    var attrib = x.GetCustomAttributes(typeof(JsonPropertyOrderAttribute), true).OfType<JsonPropertyOrderAttribute>().FirstOrDefault();
+
+                    return attrib?.Order ?? int.MaxValue;
+                })
                 .Where(p => p.GetValue(this) != null)
-                .Select(p => (ConfigurationItem)p.GetValue(this)).ToList();
+                .Select(p => (ConfigurationItem)p.GetValue(this))
+                .ToList();
 
             // remove/insert Site Link manualy to make sure it shows up first
             properties.Remove(SiteLink);

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataAPIKey.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataAPIKey.cs
@@ -1,7 +1,10 @@
+using System.Text.Json.Serialization;
+
 namespace Jackett.Common.Models.IndexerConfig
 {
     public class ConfigurationDataAPIKey : ConfigurationData
     {
+        [JsonPropertyOrder(1)]
         public StringConfigurationItem Key { get; private set; }
 
         public ConfigurationDataAPIKey()

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataAPIKeyAndRSSKey.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataAPIKeyAndRSSKey.cs
@@ -1,9 +1,16 @@
+using System.Text.Json.Serialization;
+
 namespace Jackett.Common.Models.IndexerConfig
 {
     public class ConfigurationDataAPIKeyAndRSSKey : ConfigurationData
     {
+        [JsonPropertyOrder(1)]
         public StringConfigurationItem ApiKey { get; private set; }
+
+        [JsonPropertyOrder(2)]
         public StringConfigurationItem RSSKey { get; private set; }
+
+        [JsonPropertyOrder(3)]
         public DisplayInfoConfigurationItem Instructions { get; private set; }
 
         public ConfigurationDataAPIKeyAndRSSKey(string instructionMessageOptional = null)

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataAPILoginWithUserAndPasskeyAndFilter.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataAPILoginWithUserAndPasskeyAndFilter.cs
@@ -1,12 +1,25 @@
+using System.Text.Json.Serialization;
+
 namespace Jackett.Common.Models.IndexerConfig
 {
     public class ConfigurationDataAPILoginWithUserAndPasskeyAndFilter : ConfigurationData
     {
+        [JsonPropertyOrder(1)]
         public DisplayInfoConfigurationItem KeyHint { get; private set; }
+
+        [JsonPropertyOrder(2)]
         public StringConfigurationItem User { get; private set; }
+
+        [JsonPropertyOrder(3)]
         public StringConfigurationItem Key { get; private set; }
+
+        [JsonPropertyOrder(4)]
         public BoolConfigurationItem AddAttributesToTitle { get; private set; }
+
+        [JsonPropertyOrder(5)]
         public DisplayInfoConfigurationItem FilterExample { get; private set; }
+
+        [JsonPropertyOrder(6)]
         public StringConfigurationItem FilterString { get; private set; }
 
         public ConfigurationDataAPILoginWithUserAndPasskeyAndFilter(string filterInstructions)

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataBasicLogin.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataBasicLogin.cs
@@ -1,9 +1,16 @@
+using System.Text.Json.Serialization;
+
 namespace Jackett.Common.Models.IndexerConfig
 {
     public class ConfigurationDataBasicLogin : ConfigurationData
     {
+        [JsonPropertyOrder(1)]
         public StringConfigurationItem Username { get; private set; }
+
+        [JsonPropertyOrder(2)]
         public StringConfigurationItem Password { get; private set; }
+
+        [JsonPropertyOrder(3)]
         public DisplayInfoConfigurationItem Instructions { get; private set; }
 
         public ConfigurationDataBasicLogin(string instructionMessageOptional = null)

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataBasicLoginWith2FA.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataBasicLoginWith2FA.cs
@@ -1,10 +1,19 @@
+using System.Text.Json.Serialization;
+
 namespace Jackett.Common.Models.IndexerConfig
 {
     public class ConfigurationDataBasicLoginWith2FA : ConfigurationData
     {
+        [JsonPropertyOrder(1)]
         public StringConfigurationItem Username { get; private set; }
+
+        [JsonPropertyOrder(2)]
         public StringConfigurationItem Password { get; private set; }
+
+        [JsonPropertyOrder(3)]
         public StringConfigurationItem TwoFactorAuth { get; private set; }
+
+        [JsonPropertyOrder(4)]
         public DisplayInfoConfigurationItem Instructions { get; private set; }
 
         public ConfigurationDataBasicLoginWith2FA(string instructionMessageOptional = null)

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataBasicLoginWithEmail.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataBasicLoginWithEmail.cs
@@ -1,9 +1,16 @@
+using System.Text.Json.Serialization;
+
 namespace Jackett.Common.Models.IndexerConfig
 {
     public class ConfigurationDataBasicLoginWithEmail : ConfigurationData
     {
+        [JsonPropertyOrder(1)]
         public StringConfigurationItem Email { get; private set; }
+
+        [JsonPropertyOrder(2)]
         public StringConfigurationItem Password { get; private set; }
+
+        [JsonPropertyOrder(3)]
         public DisplayInfoConfigurationItem Instructions { get; private set; }
 
         public ConfigurationDataBasicLoginWithEmail(string instructionMessageOptional = null)

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataBasicLoginWithFilter.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataBasicLoginWithFilter.cs
@@ -1,19 +1,30 @@
+using System.Text.Json.Serialization;
+
 namespace Jackett.Common.Models.IndexerConfig
 {
     public class ConfigurationDataBasicLoginWithFilter : ConfigurationData
     {
+        [JsonPropertyOrder(1)]
         public StringConfigurationItem Username { get; private set; }
+
+        [JsonPropertyOrder(2)]
         public StringConfigurationItem Password { get; private set; }
+
+        [JsonPropertyOrder(3)]
         public HiddenStringConfigurationItem LastLoggedInCheck { get; private set; }
+
+        [JsonPropertyOrder(4)]
         public DisplayInfoConfigurationItem FilterExample { get; private set; }
+
+        [JsonPropertyOrder(5)]
         public StringConfigurationItem FilterString { get; private set; }
 
-        public ConfigurationDataBasicLoginWithFilter(string FilterInstructions)
+        public ConfigurationDataBasicLoginWithFilter(string filterInstructions)
         {
             Username = new StringConfigurationItem("Username");
             Password = new StringConfigurationItem("Password");
             LastLoggedInCheck = new HiddenStringConfigurationItem("LastLoggedInCheck");
-            FilterExample = new DisplayInfoConfigurationItem("", FilterInstructions);
+            FilterExample = new DisplayInfoConfigurationItem("", filterInstructions);
             FilterString = new StringConfigurationItem("Filters (optional)");
         }
     }

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataBasicLoginWithPID.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataBasicLoginWithPID.cs
@@ -1,10 +1,19 @@
+using System.Text.Json.Serialization;
+
 namespace Jackett.Common.Models.IndexerConfig
 {
     public class ConfigurationDataBasicLoginWithPID : ConfigurationData
     {
+        [JsonPropertyOrder(1)]
         public StringConfigurationItem Username { get; private set; }
+
+        [JsonPropertyOrder(2)]
         public StringConfigurationItem Password { get; private set; }
+
+        [JsonPropertyOrder(3)]
         public StringConfigurationItem Pid { get; private set; }
+
+        [JsonPropertyOrder(4)]
         public DisplayInfoConfigurationItem Instructions { get; private set; }
 
         public ConfigurationDataBasicLoginWithPID(string instructionMessageOptional = null)

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataCaptchaLogin.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataCaptchaLogin.cs
@@ -1,17 +1,25 @@
+using System.Text.Json.Serialization;
+
 namespace Jackett.Common.Models.IndexerConfig
 {
     internal class ConfigurationDataCaptchaLogin : ConfigurationData
     {
+        [JsonPropertyOrder(1)]
         public StringConfigurationItem Username { get; private set; }
 
+        [JsonPropertyOrder(2)]
         public StringConfigurationItem Password { get; private set; }
 
+        [JsonPropertyOrder(3)]
         public DisplayImageConfigurationItem CaptchaImage { get; private set; }
 
+        [JsonPropertyOrder(4)]
         public StringConfigurationItem CaptchaText { get; private set; }
 
+        [JsonPropertyOrder(5)]
         public HiddenStringConfigurationItem CaptchaCookie { get; private set; }
 
+        [JsonPropertyOrder(6)]
         public DisplayInfoConfigurationItem Instructions { get; private set; }
 
         /// <param name="instructionMessageOptional">Enter any instructions the user will need to setup the tracker</param>

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataCookie.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataCookie.cs
@@ -1,9 +1,16 @@
+using System.Text.Json.Serialization;
+
 namespace Jackett.Common.Models.IndexerConfig
 {
     public class ConfigurationDataCookie : ConfigurationData
     {
+        [JsonPropertyOrder(1)]
         public StringConfigurationItem Cookie { get; private set; }
+
+        [JsonPropertyOrder(2)]
         public DisplayInfoConfigurationItem CookieInstructions { get; private set; }
+
+        [JsonPropertyOrder(3)]
         public DisplayInfoConfigurationItem Instructions { get; private set; }
 
         public ConfigurationDataCookie(string instructionMessageOptional = null)

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataCookieUA.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataCookieUA.cs
@@ -1,11 +1,22 @@
+using System.Text.Json.Serialization;
+
 namespace Jackett.Common.Models.IndexerConfig
 {
     public class ConfigurationDataCookieUA : ConfigurationData
     {
+        [JsonPropertyOrder(1)]
         public StringConfigurationItem Cookie { get; private set; }
+
+        [JsonPropertyOrder(2)]
         public DisplayInfoConfigurationItem CookieInstructions { get; private set; }
+
+        [JsonPropertyOrder(3)]
         public StringConfigurationItem UserAgent { get; private set; }
+
+        [JsonPropertyOrder(4)]
         public DisplayInfoConfigurationItem UserAgentInstructions { get; private set; }
+
+        [JsonPropertyOrder(5)]
         public DisplayInfoConfigurationItem Instructions { get; private set; }
 
         public ConfigurationDataCookieUA(string instructionMessageOptional = null)

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataPasskey.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataPasskey.cs
@@ -1,8 +1,13 @@
+using System.Text.Json.Serialization;
+
 namespace Jackett.Common.Models.IndexerConfig
 {
     public class ConfigurationDataPasskey : ConfigurationData
     {
+        [JsonPropertyOrder(1)]
         public StringConfigurationItem Passkey { get; private set; }
+
+        [JsonPropertyOrder(2)]
         public DisplayInfoConfigurationItem Instructions { get; private set; }
 
         public ConfigurationDataPasskey(string instructionMessageOptional = null)

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataPinNumber.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataPinNumber.cs
@@ -1,7 +1,10 @@
+using System.Text.Json.Serialization;
+
 namespace Jackett.Common.Models.IndexerConfig
 {
     internal class ConfigurationDataPinNumber : ConfigurationDataBasicLogin
     {
+        [JsonPropertyOrder(1)]
         public StringConfigurationItem Pin { get; private set; }
 
         public ConfigurationDataPinNumber(string instructionMessageOptional = null)

--- a/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataUserPasskey.cs
+++ b/src/Jackett.Common/Models/IndexerConfig/ConfigurationDataUserPasskey.cs
@@ -1,9 +1,16 @@
+using System.Text.Json.Serialization;
+
 namespace Jackett.Common.Models.IndexerConfig
 {
     public class ConfigurationDataUserPasskey : ConfigurationData
     {
+        [JsonPropertyOrder(1)]
         public StringConfigurationItem Username { get; private set; }
+
+        [JsonPropertyOrder(2)]
         public StringConfigurationItem Passkey { get; private set; }
+
+        [JsonPropertyOrder(3)]
         public DisplayInfoConfigurationItem Instructions { get; protected set; }
 
         public ConfigurationDataUserPasskey(string instructionMessageOptional = null)


### PR DESCRIPTION
#### Description
Showing the important fields firstly, based on `JsonPropertyOrder`. One side effect is that's going to order the fields in the JSON files for the indexer settings. 

I can create a new custom attribute just for this, but this one is fine to me for it's purpose.

This a common issue with indexers that use inherited configuration data.

#### Screenshot (if UI related)
![Screenshot 2025-12-25](https://github.com/user-attachments/assets/21fe5c57-f00c-49d0-997a-1474ce76127a)
