### PR TITLE
(fix) movie query type not supported by `nekoBT` Torznab API

### DIFF
--- a/src/Jackett.Common/Definitions/nekobt.yml
+++ b/src/Jackett.Common/Definitions/nekobt.yml
@@ -82,7 +82,7 @@ search:
         type: xml
 
   inputs:
-    t: "{{ re_replace .Query.Type \"^movie$\" \"movie-search\" }}"
+    t: "search"
     q: "{{ .Keywords }}"
     apikey: "{{ .Config.apikey }}"
     tvdbid: "{{ .Query.TVDBID }}"


### PR DESCRIPTION
#### Description
Following my previous PR [16373](https://github.com/Jackett/Jackett/pull/16373)
I noticed intermittent warnings in Prowlarr.

`movie`  does not work, while the following are supported :

```
search
tv-search
tvsearch
movie-search
moviesearch
```

`https://nekobt.to/api/torznab/api?t=moviesearch&sub_lang=fr&hardsub=false&limit=100`

This PR fixes the query type to avoid warnings and ensure proper compatibility with the nekoBT Torznab API.
Apologies for the oversight
