### PR TITLE
restore yggcookie.yml from 0.24.504

### DIFF
--- a/src/Jackett.Common/Definitions/yggcookie.yml
+++ b/src/Jackett.Common/Definitions/yggcookie.yml
@@ -1,7 +1,7 @@
 ---
-id: yggcookie
-name: YGG cookie
-description: "YggTorrent (YGG) is a FRENCH Private Torrent Tracker for MOVIES / TV / GENERAL. This indexer uses cookie login."
+id: yggcookie-turbo
+name: YGG cookie (Turbo)
+description: "YggTorrent (YGG) is a FRENCH Private Torrent Tracker for MOVIES / TV / GENERAL. This indexer uses cookie login. This indexer is only for users with Turbo Mode access (Uploaders and donors)."
 language: fr-FR
 type: private
 encoding: UTF-8
@@ -112,6 +112,10 @@ settings:
     label: User-Agent
   - name: info_useragent
     type: info_useragent
+  - name: info_turbo
+    type: info
+    label: Turbo Mode
+    default: This indexer is only for users with Turbo Mode access (Uploaders and donors). This indexer does not bypass site requirements.
   - name: multilang
     type: checkbox
     label: Replace MULTi by another language in release name


### PR DESCRIPTION
This indexer is fully functional, as a complement to the YggTorrent (Turbo) indexer.

#### Description
This pull request was created because authentication using only username and password does not always work reliably with the YggTorrent (Turbo) indexer. To address this issue, this PR reintroduces YggCookie, which has proven to work very well and provides a more stable authentication method.
The goal is to improve reliability while keeping compatibility with the existing YggTorrent (Turbo) indexer.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
