### PR TITLE
Update category mappings for RuTor

### DIFF
--- a/src/Jackett.Common/Definitions/rutor.yml
+++ b/src/Jackett.Common/Definitions/rutor.yml
@@ -29,12 +29,12 @@ caps:
   # albeit you can select a single category in its search options
   # so I've opted not to support categories
   categorymappings:
-      - {id: 1, cat: Movies, desc: "Movies"}
-      - {id: 2, cat: TV, desc: "TV"}
-     # Mapping ID 3 to Movies, TV, and Other simultaneously
-      - {id: 3, cat: Movies, desc: "Movies"}
-      - {id: 3, cat: TV, desc: "TV"}
-      - {id: 3, cat: Other, desc: "Other"}
+    - {id: 1, cat: Movies, desc: "Movies"}
+    - {id: 2, cat: TV, desc: "TV"}
+    # Mapping ID 3 to Movies, TV, and Other simultaneously
+    - {id: 3, cat: Movies, desc: "Movies"}
+    - {id: 3, cat: TV, desc: "TV"}
+    - {id: 3, cat: Other, desc: "Other"}
 
   modes:
     search: [q]


### PR DESCRIPTION
#### Description
We have mapped all three categories of Movies, TV, and Other to a single category because some Movies/TV applications that work with Jackett do not allow you to manually change categories. For example, if we were searching for a TV series or a Movie, it would not work because that application is designed only to search in the Movies and TV categories. RuTor does not display categories anywhere in its search results page, but you can select a single category in its search options, which is why I put them all in one category, now I can find movies and TV series when I search for them.

I hope you approve this pull request, thanks.
