### PR TITLE
Fixing status of TOS & GF

### DIFF
--- a/src/Jackett.Common/Definitions/generationfree-api.yml
+++ b/src/Jackett.Common/Definitions/generationfree-api.yml
@@ -3,7 +3,7 @@ id: generationfree-api
 name: Generation-Free (API)
 description: "Generation-Free (GF-Free) is a FRENCH Semi-Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: fr-FR
-type: private
+type: semi-private
 encoding: UTF-8
 links:
   - https://generation-free.org/

--- a/src/Jackett.Common/Definitions/theoldschool-api.yml
+++ b/src/Jackett.Common/Definitions/theoldschool-api.yml
@@ -3,7 +3,7 @@ id: theoldschool-api
 name: The Old School (API)
 description: "The Old School (TOS) is a FRENCH Semi-Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: fr-FR
-type: private
+type: semi-private
 encoding: UTF-8
 links:
   - https://theoldschool.cc/


### PR DESCRIPTION
#### Description
These tracker cannot be classified as Private trackers anymore as they have recently opened applications, and since then cannot be considered invite only.

The PR is made to fix their definitions in Jackett and all the software that pull their definition from there, i-e Prowlarr for example
