### PR TITLE
cinecalidad: change base url

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/Cinecalidad.cs
+++ b/src/Jackett.Common/Indexers/Definitions/Cinecalidad.cs
@@ -97,13 +97,12 @@ namespace Jackett.Common.Indexers.Definitions
         {
             var releases = new List<ReleaseInfo>();
 
-            var templateUrl = SiteLink;
-            templateUrl += "{0}?s="; // placeholder for page
+            var templateUrl = $"{SiteLink}{{0}}?s="; // placeholder for page
 
             var maxPages = MaxLatestPageLimit; // we scrape only 3 pages for recent torrents
 
-            var recent = !string.IsNullOrWhiteSpace(query.GetQueryString());
-            if (recent)
+            var isSearch = !string.IsNullOrWhiteSpace(query.GetQueryString());
+            if (isSearch)
             {
                 templateUrl += WebUtilityHelpers.UrlEncode(query.GetQueryString(), Encoding.UTF8);
                 maxPages = MaxSearchPageLimit;
@@ -112,7 +111,7 @@ namespace Jackett.Common.Indexers.Definitions
             var lastPublishDate = DateTime.Now;
             for (var page = 1; page <= maxPages; page++)
             {
-                var pageParam = page > 1 ? $"page/{page}/" : "";
+                var pageParam = page > 1 ? $"page/{page}/" : string.Empty;
                 var searchUrl = string.Format(templateUrl, pageParam);
                 var response = await RequestWithCookiesAndRetryAsync(searchUrl);
                 var pageReleases = ParseReleases(response, query);
@@ -125,7 +124,7 @@ namespace Jackett.Common.Indexers.Definitions
                 }
                 releases.AddRange(pageReleases);
 
-                if (pageReleases.Count < 1 && recent)
+                if (pageReleases.Count < 1 && isSearch)
                 {
                     // this is the last page
                     break;
@@ -146,7 +145,9 @@ namespace Jackett.Common.Indexers.Definitions
                 using var dom = await parser.ParseDocumentAsync(results.ContentString);
 
                 var is4K = link.Query.Contains("type=4k");
-                var hrefDownloadLinks = dom.QuerySelectorAll("#sbss > a:not([href*='acortalink'])");                if (hrefDownloadLinks.Length > 0)
+                var hrefDownloadLinks = dom.QuerySelectorAll("#sbss > a:not([href*='acortalink'])");
+
+                if (hrefDownloadLinks.Length > 0)
                 {
                     var selected = hrefDownloadLinks.FirstOrDefault(a => a.TextContent.IndexOf("uTorrent", StringComparison.OrdinalIgnoreCase) >= 0);
                     selected ??= is4K
@@ -178,7 +179,7 @@ namespace Jackett.Common.Indexers.Definitions
                     }
                 }
 
-                var downloadLink = link.Query.Contains("type=4k")
+                var downloadLink = is4K
                     ? dom.QuerySelector("ul.links a:contains('Bittorrent 4K')")
                     : dom.QuerySelector("ul.links a:contains('Torrent')");
 
@@ -216,141 +217,152 @@ namespace Jackett.Common.Indexers.Definitions
             return null;
         }
 
-private List<ReleaseInfo> ParseReleases(WebResult response, TorznabQuery query)
-{
-    var releases = new List<ReleaseInfo>();
-
-    try
-    {
-        var parser = new HtmlParser();
-        using var dom = parser.ParseDocument(response.ContentString);
-
-        // Get all movie items - updated selector to match the actual structure
-        var movieItems = dom.QuerySelectorAll("article, div[class*='post-']");
-
-        foreach (var item in movieItems)
+        private List<ReleaseInfo> ParseReleases(WebResult response, TorznabQuery query)
         {
-            var seltText = item.QuerySelector("div.selt")?.TextContent?.Trim();
-            if (!string.IsNullOrEmpty(seltText) && seltText.IndexOf("Series", StringComparison.OrdinalIgnoreCase) >= 0)
-                continue;
-
-            var titleElement = item.QuerySelector(".in_title") ?? item.QuerySelector("h3") ?? item.QuerySelector("h2") ?? item.QuerySelector(".entry-title");
-            var linkElement = item.QuerySelector("a[href*='/ver-pelicula/']") ??
-                             item.QuerySelector("a[href*='/pelicula/']") ??
-                             item.QuerySelector("h3 a[href]") ??
-                             item.QuerySelector("h2 a[href]") ??
-                             item.QuerySelector(".entry-title a[href]");
-
-            var imgElement = item.QuerySelector("img.lazy") ??
-                            item.QuerySelector("img[data-src]") ??
-                            item.QuerySelector("img[src]");
-
-            // Try to find year in various places
-            var yearElement = item.QuerySelector("span.year") ??
-                             item.QuerySelector(".year") ??
-                             item.QuerySelector(".date") ??
-                             item.QuerySelector("time") ??
-                             item.QuerySelector(".entry-meta");
-
-            if (titleElement == null || linkElement == null)
-                continue;
-
-            var title = titleElement.TextContent.Trim();
-            var year = yearElement?.TextContent.Trim();
-
-            // Extract year if it's in format like (2023) or [2023]
-            if (!string.IsNullOrEmpty(year))
-            {
-                var yearMatch = System.Text.RegularExpressions.Regex.Match(year, @"\(?(\d{4})\)?");
-                if (yearMatch.Success)
-                {
-                    year = yearMatch.Groups[1].Value;
-                    title = $"{title.Trim()} ({year})";
-                }
-            }
-
-            if (!CheckTitleMatchWords(query.GetQueryString(), title))
-                continue;
-
-            var posterUrl = imgElement?.GetAttribute("data-src") ??
-                           imgElement?.GetAttribute("src");
-
-            var detailsUrl = linkElement.GetAttribute("href");
-
-            if (string.IsNullOrEmpty(detailsUrl) ||
-                detailsUrl.Contains("wp-json") ||
-                detailsUrl.Contains("wp-admin"))
-                continue;
-
-            // Skip if it's not a movie URL
-            if (!detailsUrl.Contains("/ver-pelicula/") && !detailsUrl.Contains("/pelicula/"))
-                continue;
+            var releases = new List<ReleaseInfo>();
 
             try
             {
-                var poster = !string.IsNullOrEmpty(posterUrl) ?
-                    new Uri(GetAbsoluteUrl(posterUrl)) : null;
-                var link = new Uri(detailsUrl);
+                var parser = new HtmlParser();
+                using var dom = parser.ParseDocument(response.ContentString);
 
-                // Check for 4K version
-                var is4K = item.TextContent.IndexOf("4K", StringComparison.OrdinalIgnoreCase) >= 0 ||
-                           item.TextContent.IndexOf("2160p", StringComparison.OrdinalIgnoreCase) >= 0 ||
-                           detailsUrl.IndexOf("4k", StringComparison.OrdinalIgnoreCase) >= 0;
+                // Get all movie items - updated selector to match the actual structure
+                var movieItems = dom.QuerySelectorAll("article, div[class*='post-']");
 
-                // Add HD version (1080p)
-                releases.Add(new ReleaseInfo
+                foreach (var item in movieItems)
                 {
-                    Guid = link,
-                    Details = link,
-                    Link = link,
-                    Title = $"{title} MULTi/LATiN SPANiSH 1080p BDRip x264",
-                    Category = new List<int> { TorznabCatType.MoviesHD.ID },
-                    Poster = poster,
-                    Size = 2147483648, // 2 GB
-                    Files = 1,
-                    Seeders = 1,
-                    Peers = 2,
-                    DownloadVolumeFactor = 0,
-                    UploadVolumeFactor = 1,
-                    PublishDate = DateTime.Today
-                });
-
-                // Add 4K version if available
-                if (is4K)
-                {
-                    var link4K = link.AddQueryParameter("type", "4k");
-                    releases.Add(new ReleaseInfo
+                    var seltText = item.QuerySelector("div.selt")?.TextContent?.Trim();
+                    if (!string.IsNullOrEmpty(seltText) && seltText.IndexOf("Series", StringComparison.OrdinalIgnoreCase) >= 0)
                     {
-                        Guid = link4K,
-                        Details = link,
-                        Link = link4K,
-                        Title = $"{title} MULTi/LATiN SPANiSH 2160p BDRip x265",
-                        Category = new List<int> { TorznabCatType.MoviesUHD.ID },
-                        Poster = poster,
-                        Size = 10737418240, // 10 GB
-                        Files = 1,
-                        Seeders = 1,
-                        Peers = 2,
-                        DownloadVolumeFactor = 0,
-                        UploadVolumeFactor = 1,
-                        PublishDate = DateTime.Today
-                    });
+                        continue;
+                    }
+
+                    var titleElement = item.QuerySelector(".in_title") ?? item.QuerySelector("h3") ?? item.QuerySelector("h2") ?? item.QuerySelector(".entry-title");
+                    var linkElement = item.QuerySelector("a[href*='/ver-pelicula/']") ??
+                                     item.QuerySelector("a[href*='/pelicula/']") ??
+                                     item.QuerySelector("h3 a[href]") ??
+                                     item.QuerySelector("h2 a[href]") ??
+                                     item.QuerySelector(".entry-title a[href]");
+
+                    var imgElement = item.QuerySelector("img.lazy") ??
+                                    item.QuerySelector("img[data-src]") ??
+                                    item.QuerySelector("img[src]");
+
+                    // Try to find year in various places
+                    var yearElement = item.QuerySelector("span.year") ??
+                                     item.QuerySelector(".year") ??
+                                     item.QuerySelector(".date") ??
+                                     item.QuerySelector("time") ??
+                                     item.QuerySelector(".entry-meta");
+
+                    if (titleElement == null || linkElement == null)
+                    {
+                        continue;
+                    }
+
+                    var title = titleElement.TextContent.Trim();
+                    var year = yearElement?.TextContent.Trim();
+
+                    // Extract year if it's in format like (2023) or [2023]
+                    if (!string.IsNullOrEmpty(year))
+                    {
+                        var yearMatch = Regex.Match(year, @"\(?(\d{4})\)?");
+                        if (yearMatch.Success)
+                        {
+                            year = yearMatch.Groups[1].Value;
+                            title = $"{title.Trim()} ({year})";
+                        }
+                    }
+
+                    if (!CheckTitleMatchWords(query.GetQueryString(), title))
+                    {
+                        continue;
+                    }
+
+                    var posterUrl = imgElement?.GetAttribute("data-src") ??
+                                   imgElement?.GetAttribute("src");
+
+                    var detailsUrl = linkElement.GetAttribute("href");
+
+                    if (string.IsNullOrEmpty(detailsUrl) ||
+                        detailsUrl.Contains("wp-json") ||
+                        detailsUrl.Contains("wp-admin"))
+                    {
+                        continue;
+                    }
+
+                    // Skip if it's not a movie URL
+                    if (!detailsUrl.Contains("/ver-pelicula/") && !detailsUrl.Contains("/pelicula/"))
+                    {
+                        continue;
+                    }
+
+                    try
+                    {
+                        var poster = !string.IsNullOrEmpty(posterUrl)
+                            ? new Uri(GetAbsoluteUrl(posterUrl))
+                            : null;
+                        var link = new Uri(detailsUrl);
+
+                        // Check for 4K version
+                        var is4K = item.TextContent.IndexOf("4K", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                                   item.TextContent.IndexOf("2160p", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                                   detailsUrl.IndexOf("4k", StringComparison.OrdinalIgnoreCase) >= 0;
+
+                        // Add HD version (1080p)
+                        releases.Add(new ReleaseInfo
+                        {
+                            Guid = link,
+                            Details = link,
+                            Link = link,
+                            Title = $"{title} MULTi/LATiN SPANiSH 1080p BDRip x264",
+                            Category = new List<int> { TorznabCatType.MoviesHD.ID },
+                            Poster = poster,
+                            Size = 2147483648, // 2 GB
+                            Files = 1,
+                            Seeders = 1,
+                            Peers = 2,
+                            DownloadVolumeFactor = 0,
+                            UploadVolumeFactor = 1,
+                            PublishDate = DateTime.Today
+                        });
+
+                        // Add 4K version if available
+                        if (is4K)
+                        {
+                            var link4K = link.AddQueryParameter("type", "4k");
+                            releases.Add(new ReleaseInfo
+                            {
+                                Guid = link4K,
+                                Details = link,
+                                Link = link4K,
+                                Title = $"{title} MULTi/LATiN SPANiSH 2160p BDRip x265",
+                                Category = new List<int> { TorznabCatType.MoviesUHD.ID },
+                                Poster = poster,
+                                Size = 10737418240, // 10 GB
+                                Files = 1,
+                                Seeders = 1,
+                                Peers = 2,
+                                DownloadVolumeFactor = 0,
+                                UploadVolumeFactor = 1,
+                                PublishDate = DateTime.Today
+                            });
+                        }
+                    }
+                    catch (Exception)
+                    {
+                        // Skip this item if there's an error with URL parsing
+                        continue;
+                    }
                 }
             }
             catch (Exception ex)
             {
-                // Skip this item if there's an error with URL parsing
-                continue;
+                OnParseError(response.ContentString, ex);
             }
-        }
-    }
-    catch (Exception ex)
-    {
-        OnParseError(response.ContentString, ex);
-    }
 
-    return releases;
-}
+            return releases;
+        }
 
         // TODO: merge this method with query.MatchQueryStringAND
         private static bool CheckTitleMatchWords(string queryStr, string title)
@@ -382,11 +394,10 @@ private List<ReleaseInfo> ParseReleases(WebResult response, TorznabQuery query)
             return url;
         }
 
-        private string Base64Decode(string base64EncodedData)
+        private static string Base64Decode(string base64EncodedData)
         {
             var base64EncodedBytes = Convert.FromBase64String(base64EncodedData);
             return Encoding.UTF8.GetString(base64EncodedBytes);
         }
     }
-
 }


### PR DESCRIPTION
This pull request updates the Cinecalidad indexer to improve compatibility with recent changes on the site and enhance the robustness of movie parsing and download link extraction. The main changes include updating the primary site URL, improving the logic for extracting movie releases (including 4K versions), and making the download method more resilient to site structure changes.

**Site URL and Legacy Links Update**
* Changed the main `SiteLink` to `"https://www.cinecalidad.ec/"` and added the previous URL (`"https://www.cinecalidad.vg/"`) to `LegacySiteLinks` for backward compatibility. [[1]](diffhunk://#diff-e306adeafb763e614868fdd4a0b04da9c2a6b4b05298343a888de5bf688e0b73L28-R28) [[2]](diffhunk://#diff-e306adeafb763e614868fdd4a0b04da9c2a6b4b05298343a888de5bf688e0b73R46)

**Movie Parsing Improvements**
* Refactored the `ParseReleases` method to use more flexible selectors, allowing it to parse both old and new site structures. Now supports extracting movie titles, years, posters, and links more reliably, and skips non-movie items and invalid URLs.
* Improved logic to detect and add 4K versions of releases, ensuring both HD and 4K releases are included when available. [[1]](diffhunk://#diff-e306adeafb763e614868fdd4a0b04da9c2a6b4b05298343a888de5bf688e0b73L242-L248) [[2]](diffhunk://#diff-e306adeafb763e614868fdd4a0b04da9c2a6b4b05298343a888de5bf688e0b73L262-R357)

**Download Link Extraction Enhancements**
* Enhanced the `Download` method to handle multiple download link formats, prioritize uTorrent and 4K links, and follow redirects to magnet links when necessary. This increases reliability for both HD and 4K downloads.
* Improved handling of magnet link extraction from protected pages and download pages, making the process more robust against site changes.

**General Code Improvements**
* Updated variable names and logic for clarity (e.g., `recent` to `isSearch`, empty string usage), and made utility methods static where appropriate. [[1]](diffhunk://#diff-e306adeafb763e614868fdd4a0b04da9c2a6b4b05298343a888de5bf688e0b73L99-R105) [[2]](diffhunk://#diff-e306adeafb763e614868fdd4a0b04da9c2a6b4b05298343a888de5bf688e0b73L114-R114) [[3]](diffhunk://#diff-e306adeafb763e614868fdd4a0b04da9c2a6b4b05298343a888de5bf688e0b73L127-R127) [[4]](diffhunk://#diff-e306adeafb763e614868fdd4a0b04da9c2a6b4b05298343a888de5bf688e0b73L305-L311)