### PR TITLE
Update pornotorrent.yml

### DIFF
--- a/src/Jackett.Common/Definitions/pornotorrent.yml
+++ b/src/Jackett.Common/Definitions/pornotorrent.yml
@@ -8,6 +8,8 @@ encoding: UTF-8
 testlinktorrent: false
 links:
   - https://pornotorrent.net.br/
+legacylinks:
+  - https://www.pornotorrent.eu/
 
 caps:
   categorymappings:


### PR DESCRIPTION
Replace www.pornotorrent.eu with pornotorrent.net.br

#### Description
www.pornotorrent.eu not supporting searches, so no results are ever returned (not sure how long it has been this way). pornotorrent.net.br supports searching and from what I can tell has identical content.
