### PR TITLE
hotfix BJShare indexer

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/BJShare.cs
+++ b/src/Jackett.Common/Indexers/Definitions/BJShare.cs
@@ -278,7 +278,7 @@ namespace Jackett.Common.Indexers.Definitions
             }
 
             searchUrl += "?" + queryCollection.GetQueryString();
-            var results = await RequestWithCookiesAsync(searchUrl, headers: headers);
+            var results = await RequestWithCookiesAsync(searchUrl, configData.Cookie.Value, headers: headers);
             if (IsSessionIsClosed(results))
             {
                 throw new Exception("The user is not logged in. It is possible that the cookie has expired or you " +
@@ -446,7 +446,7 @@ namespace Jackett.Common.Indexers.Definitions
         private async Task<List<ReleaseInfo>> ParseLast24HoursAsync()
         {
             var releases = new List<ReleaseInfo>();
-            var results = await RequestWithCookiesAsync(TodayUrl);
+            var results = await RequestWithCookiesAsync(TodayUrl, configData.Cookie.Value);
             if (IsSessionIsClosed(results))
             {
                 throw new Exception("The user is not logged in. It is possible that the cookie has expired or you " +


### PR DESCRIPTION
Changed to always use the cookie configured by the user, some error cases return a diff cookie forcing the user to update the cookie manually on the UI config page.
