### PR TITLE
torrent-heaven: if searching for season packs switch S0* to seizoen *

### DIFF
--- a/src/Jackett.Common/Definitions/torrent-heaven.yml
+++ b/src/Jackett.Common/Definitions/torrent-heaven.yml
@@ -92,6 +92,12 @@ search:
   paths:
     # https://www.torrentheaven.org/browse.php?search=&cat=0&incldead=1
     - path: browse.php
+  keywordsfilters:
+    # if searching for season packs switch S01 to seizoen 1
+    - name: re_replace
+      args: ["(?i)(S0)(\\d{1,2})$", "seizoen $2"]
+    - name: re_replace
+      args: ["(?i)(S)(\\d{1,3})$", "seizoen $2"]
   inputs:
     $raw: "{{ range .Categories }}c{{.}}=1&{{end}}"
     search: "{{ .Keywords }}"


### PR DESCRIPTION
#### Description
Because Torrent-heaven is dutch the TV shows get uploaded as "seizoen 1" instead of "S01". Sonarr does not like this at all so I fixed it this way.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
