### PR TITLE
YggTorrent: Fix missing sub_category parameter in search requests

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/YggTorrent.cs
+++ b/src/Jackett.Common/Indexers/Definitions/YggTorrent.cs
@@ -765,13 +765,18 @@ namespace Jackett.Common.Indexers.Definitions
                 var (rootCat, usesSaison) = GetRootCategory(c);
                 if (rootCat != null)
                 {
-                    var key = $"{rootCat}|";
+                    string subCat = null;
+                    if (rootCat != c.ToString())
+                    {
+                        subCat = c.ToString();
+                    }
+                    var key = $"{rootCat}|{subCat}";
                     if (produced.Add(key))
                     {
                         yield return new SearchRequest
                         {
                             RootCategory = rootCat,
-                            SubCategory = null,
+                            SubCategory = subCat,
                             UseSaisonRewrite = usesSaison
                         };
                     }


### PR DESCRIPTION
#### Description
Fixes YggTorrent sub-category searches (e.g., Manga). 

The previous code was only searching in the "Root" category (e.g. eBooks) and forgetting the sub-category (e.g. Manga). This resulted in getting mostly unrelated results or very few results.

#### Screenshot (if UI related)
N/A

#### Issues Fixed or Closed by this PR
N/A