### PR TITLE
Fixed a bug that caused time information parsing to fail when fetching from mikanani.me.

### DIFF
--- a/src/Jackett.Common/Definitions/mikan.yml
+++ b/src/Jackett.Common/Definitions/mikan.yml
@@ -50,7 +50,7 @@ search:
           args: ["今天", "Today"]
         - name: fuzzytime
     date_year:
-      selector: td:nth-child(3):not(:has(a))
+      selector: td:not(:has(a)):matches("^\s*(\d{4}/\d{1,2}/\d{1,2})\s+(\d{1,2}:\d{2})\s*$") # match like "2026/1/28 14:30"
       optional: true
       filters:
         - name: append


### PR DESCRIPTION
#### Description
Fixed a bug that caused time information parsing to fail when fetching from mikanani.me.

I encountered the following error when using Jackett.
```
01-29 03:59:23 Error CardigannIndexer (mikan): Error while parsing row '
<tr class="js-search-results-row" data-itemindex="915" style="display:none;">
 <td>
  <input type="checkbox" class="js-episode-select" data-magnet="magnet:?xt=urn:btih:0ccd163f40ba65e2eba04ccc15b894fb6637cd20&amp;tr=http%3a%2f%2ft.nyaatracker.com%2fannounce&amp;tr=http%3a%2f%2ftracker.kamigami.org%3a2710%2fannounce&amp;tr=http%3a%2f%2fshare.camoe.cn%3a8080%2fannounce&amp;tr=http%3a%2f%2fopentracker.acgnx.se%2fannounce&amp;tr=http%3a%2f%2fanidex.moe%3a6969%2fannounce&amp;tr=http%3a%2f%2ft.acg.rip%3a6699%2fannounce&amp;tr=https%3a%2f%2ftr.bangumi.moe%3a9696%2fannounce&amp;tr=udp%3a%2f%2ftr.bangumi.moe%3a6969%2fannounce&amp;tr=http%3a%2f%2fopen.acgtracker.com%3a1096%2fannounce&amp;tr=udp%3a%2f%2ftracker.opentrackr.org%3a1337%2fannounce" aria-label="选择此行">
 </td>
 <td>
  <a href="/Home/Episode/0ccd163f40ba65e2eba04ccc15b894fb6637cd20" target="_blank" class="magnet-link-wrap">【喵萌奶茶屋】★04月新番★[间谍过家家/间谍家家酒/SPYxFAMILY][08][1080p][繁日双语][招募翻译]</a>
  <a data-clipboard-text="magnet:?xt=urn:btih:0ccd163f40ba65e2eba04ccc15b894fb6637cd20&amp;tr=http%3a%2f%2ft.nyaatracker.com%2fannounce&amp;tr=http%3a%2f%2ftracker.kamigami.org%3a2710%2fannounce&amp;tr=http%3a%2f%2fshare.camoe.cn%3a8080%2fannounce&amp;tr=http%3a%2f%2fopentracker.acgnx.se%2fannounce&amp;tr=http%3a%2f%2fanidex.moe%3a6969%2fannounce&amp;tr=http%3a%2f%2ft.acg.rip%3a6699%2fannounce&amp;tr=https%3a%2f%2ftr.bangumi.moe%3a9696%2fannounce&amp;tr=udp%3a%2f%2ftr.bangumi.moe%3a6969%2fannounce&amp;tr=http%3a%2f%2fopen.acgtracker.com%3a1096%2fannounce&amp;tr=udp%3a%2f%2ftracker.opentrackr.org%3a1337%2fannounce" class="js-magnet magnet-link">[复制磁连]</a>
 </td>
 <td>459.53 MB</td>
 <td>2022/06/02 07:13</td>
 <td>
  <a href="/Download/20220602/0ccd163f40ba65e2eba04ccc15b894fb6637cd20.torrent">
   <img src="/images/download_icon_blue.svg" style="margin-left: 2px;width: 20px;height:15px;">
  </a>
 </td>
 <td>
  <a target="_blank" href="https://keepshare.org/rclukaia/magnet%3A%3Fxt%3Durn%3Abtih%3A0ccd163f40ba65e2eba04ccc15b894fb6637cd20">
   <i class="fa fa-play-circle" style="color: #47c1c5; margin-left: 4px; font-size: 18px;"></i>
  </a>
 </td>
</tr>':
System.Exception: Error while parsing field=date, selector=, value=459.53 MB +08:00: DateTime parsing failed for "459.53 MB +08:00": System.Exception: FromFuzzyTime parsing failed
   at Jackett.Common.Utils.DateTimeUtil.FromFuzzyTime(String str, String format) in ./Jackett.Common/Utils/DateTimeUtil.cs:line 102
   at Jackett.Common.Utils.DateTimeUtil.FromUnknown(String str, String format, Nullable`1 relativeFrom) in ./Jackett.Common/Utils/DateTimeUtil.cs:line 221
 ---> System.Exception: DateTime parsing failed for "459.53 MB +08:00": System.Exception: FromFuzzyTime parsing failed
   at Jackett.Common.Utils.DateTimeUtil.FromFuzzyTime(String str, String format) in ./Jackett.Common/Utils/DateTimeUtil.cs:line 102
   at Jackett.Common.Utils.DateTimeUtil.FromUnknown(String str, String format, Nullable`1 relativeFrom) in ./Jackett.Common/Utils/DateTimeUtil.cs:line 221
   at Jackett.Common.Utils.DateTimeUtil.FromUnknown(String str, String format, Nullable`1 relativeFrom) in ./Jackett.Common/Utils/DateTimeUtil.cs:line 225
   at Jackett.Common.Indexers.Definitions.CardigannIndexer.ParseFields(String value, String FieldName, ReleaseInfo release, List`1 FieldModifiers, Uri searchUrlUri) in ./Jackett.Common/Indexers/Definitions/CardigannIndexer.cs:line 2308
   at Jackett.Common.Indexers.Definitions.CardigannIndexer.PerformQuery(TorznabQuery query) in ./Jackett.Common/Indexers/Definitions/CardigannIndexer.cs:line 1853
   --- End of inner exception stack trace ---
   at Jackett.Common.Indexers.Definitions.CardigannIndexer.PerformQuery(TorznabQuery query) in ./Jackett.Common/Indexers/Definitions/CardigannIndexer.cs:line 1876
01-29 03:59:23 Error CardigannIndexer (mikan): Error while parsing row '
```

It appears the error was caused by changes to the page; after fixing it, the expected content was retrieved correctly.
