### PR TITLE
lacale-api: migrate from passkey to apikey authentication

### DIFF
--- a/src/Jackett.Common/Definitions/lacale-api.yml
+++ b/src/Jackett.Common/Definitions/lacale-api.yml
@@ -5,12 +5,12 @@ description: "La Cale is a FRENCH Private Torrent Tracker for MOVIES / TV / GENE
 language: fr-FR
 type: private
 encoding: UTF-8
-requestDelay: 2.1
+requestDelay: 5.0
 links:
   - https://la-cale.space/
 
 caps:
-  # use https://la-cale.space/api/external/meta?passkey=YOUR-PASSKEY for cat mappings, slug is id, name is desc
+  # use https://la-cale.space/api/external/meta?apikey=YOUR-APIKEY for cat mappings, slug is id, name is desc
   categorymappings:
     # Autres
     - {id: autres, cat: Other, desc: "Autres"}
@@ -64,13 +64,13 @@ caps:
     book-search: [q]
 
 settings:
-  - name: passkey
+  - name: apikey
     type: text
-    label: Passkey
+    label: API key
   - name: info_key
     type: info
-    label: About your Passkey
-    default: "Find your Passkey on your <a href=\"https://la-cale.space/profile\" target=\"_blank\">La Cale profile page</a>."
+    label: About your API key
+    default: "Find your API key on your <a href=\"https://la-cale.space/settings\" target=\"_blank\">La Cale settings page</a>."
   - name: multilang
     type: checkbox
     label: Replace MULTi by another language in release name
@@ -95,14 +95,14 @@ login:
   path: api/external
   method: get
   inputs:
-    passkey: "{{ .Config.passkey }}"
+    apikey: "{{ .Config.apikey }}"
   error:
-    - selector: ":root:contains(\"Passkey invalide\")"
+    - selector: ":root:contains(\"API key invalide\")"
       message:
-        text: "The Passkey was not accepted by {{ .Config.sitelink }}."
-    - selector: ":root:contains(\"Passkey manquant\")"
+        text: "The API key was not accepted by {{ .Config.sitelink }}."
+    - selector: ":root:contains(\"API key manquant\")"
       message:
-        text: "The Passkey was not accepted by {{ .Config.sitelink }}."
+        text: "The API key was not accepted by {{ .Config.sitelink }}."
 
 search:
   paths:
@@ -112,9 +112,9 @@ search:
         type: json
 
   inputs:
-    passkey: "{{ .Config.passkey }}"
+    apikey: "{{ .Config.apikey }}"
     $raw: "{{ range .Categories }}cat={{.}}&{{end}}"
-    q: "{{ .Keywords }}"
+    q: "{{ if .Keywords }}{{ .Keywords }}{{ else }}FRENCH{{ end }}"
     tmdbId: "{{ .Query.TMDBID }}"
 
   rows:
@@ -144,11 +144,10 @@ search:
       text: "{{ .Config.sitelink }}"
     infohash:
       selector: infoHash
-    download:
-      selector: link
       filters:
-        - name: append
-          args: "?passkey={{ .Config.passkey }}"
+        - name: tolower
+    download:
+      text: "/api/torrents/download/{{ .Result.infohash }}?apikey={{ .Config.apikey }}"
     size:
       selector: size
     date:


### PR DESCRIPTION
## Summary
Migrate La Cale indexer from passkey to apikey authentication method.

## Changes
- Changed authentication from `passkey` to `apikey`
- Updated `requestDelay` from 2.1s to 5.0s to respect rate limits (200 req/day, 60/min burst)
- Updated API endpoints and error messages
- Added lowercase filter for infohash
- Updated download link format to use new API endpoint
- Added default "FRENCH" keyword when no keywords provided

## API Rate Limits
- Daily Limit: 200 requests/day
- Burst Limit: 60 requests/min

The increased request delay helps ensure compliance with these limits.

## Testing
- Updated settings reference API key from settings page
- Error messages updated to match new API responses