### PR TITLE
Enables RawSearch for YggTorrent

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/YggTorrent.cs
+++ b/src/Jackett.Common/Indexers/Definitions/YggTorrent.cs
@@ -387,7 +387,8 @@ namespace Jackett.Common.Indexers.Definitions
                 },
                 MovieSearchParams = new List<MovieSearchParam> { MovieSearchParam.Q },
                 MusicSearchParams = new List<MusicSearchParam> { MusicSearchParam.Q },
-                BookSearchParams = new List<BookSearchParam> { BookSearchParam.Q }
+                BookSearchParams = new List<BookSearchParam> { BookSearchParam.Q },
+                SupportsRawSearch = true
             };
 
             // Movies/Tv Shows Categories


### PR DESCRIPTION
Enables RawSearch for YggTorrent

#### Description
Enables RawSearch for YggTorrent, allowing Radarr to correctly match movies with special characters (removing those characters results in no matches).