### PR TITLE
gay-torrents: add Referer header to fix torrent downloads

### DIFF
--- a/src/Jackett.Common/Definitions/gay-torrents.yml
+++ b/src/Jackett.Common/Definitions/gay-torrents.yml
@@ -140,7 +140,7 @@ search:
       args: ["(\\w+)", "+$1"] # prepend + to each word
 
   headers:
-    Referer: ["{{ .Config.sitelink }}"] 
+    Referer: ["{{ .Config.sitelink }}"]
 
   rows:
     selector: ul.TorrentList, ul.Torrent-List


### PR DESCRIPTION
## Summary
- Adds `Referer` header to `search.headers` for the Gay-Torrents.net indexer definition
- Fixes torrent downloads returning 0 bytes

## Problem
Gay-Torrents.net requires a `Referer` header on download requests. Without it, the server returns HTTP 200 with **0 bytes** instead of the actual `.torrent` file.

The Cardigann engine falls back to `search.headers` for download requests when no `download:` block is defined (`Definition.Download?.Headers ?? Definition.Search?.Headers`), so adding the header here covers both search and download.

## Testing
- Verified via direct HTTP requests that GET to the download URL **without** `Referer` returns 0 bytes
- Verified that GET to the download URL **with** `Referer` returns a valid `.torrent` file
- Any `Referer` value works, but using the site's own URL is the correct approach

cc @garfield69 @mynameisbogdan — simple one-line fix, ready for merge.