### PR TITLE
Fixed search on BJShare by displaying portuguese and english results

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/BJShare.cs
+++ b/src/Jackett.Common/Indexers/Definitions/BJShare.cs
@@ -148,8 +148,9 @@ namespace Jackett.Common.Indexers.Definitions
 
         private static string InternationalTitle(string title)
         {
-            var match = Regex.Match(title, @".* \[(.*\/?)\]");
-            return match.Success ? match.Groups[1].Value.Split('/')[0] : title;
+            // Keep the full title including both Portuguese and English versions
+            // This allows searches in both languages to work correctly
+            return title;
         }
 
         private static string StripSearchString(string term, bool isAnime)


### PR DESCRIPTION
#### Description
Previously, results were only appearing when writing in English, but now both Portuguese and English are showing results.
Related to https://github.com/Jackett/Jackett/issues/16574#issuecomment-3910247070