### PR TITLE
[BJshare] Search match national titles without changing displayed release titles

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/BJShare.cs
+++ b/src/Jackett.Common/Indexers/Definitions/BJShare.cs
@@ -441,11 +441,7 @@ namespace Jackett.Common.Indexers.Definitions
                         }
 
                         // check for previously stripped search terms
-                        var matchesReleaseTitle = query.MatchQueryStringAND(release.Title, null, searchTerm);
-                        var matchesNationalTitle = !matchesReleaseTitle &&
-                                                   query.MatchQueryStringAND(nationalTitle, null, searchTerm);
-
-                        if (!matchesReleaseTitle && !matchesNationalTitle)
+                        if (!query.MatchQueryStringAND(release.Title, null, searchTerm) && !query.MatchQueryStringAND(nationalTitle, null, searchTerm))
                         {
                             continue;
                         }


### PR DESCRIPTION
#### Description
A proper fix for PR #16595

Match national titles without changing displayed release titles

Extend BJShare matching to accept national-title searches while always returning the international title in results.


#### Screenshot (if UI related)

Jackett english:
<img width="1232" height="498" alt="image" src="https://github.com/user-attachments/assets/f87177ab-26f5-497d-9309-cff47c5388b4" />


Jackett pt-br:
<img width="1234" height="502" alt="image" src="https://github.com/user-attachments/assets/4dce83ed-2205-4ecc-9833-4cc7c333cd56" />


#### Issues Fixed or Closed by this PR

* Fixes #16595
