### PR TITLE
[yggtorrent] Prevent anime compatibility to mess with movies search

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/YggTorrent.cs
+++ b/src/Jackett.Common/Indexers/Definitions/YggTorrent.cs
@@ -628,8 +628,7 @@ namespace Jackett.Common.Indexers.Definitions
         /// </summary>
         private bool IsMovieQuery(TorznabQuery query)
         {
-            if (query.IsMovieSearch) return true;
-            return query.Categories == null ? false : (query.Categories?.Any(cat => IsMovieOnlyCategory(cat)));
+            return query.IsMovieSearch || (query.Categories?.Any(IsMovieOnlyCategory) ?? false);
         }
 
         /// <summary>


### PR DESCRIPTION

#### Description
Add an additionnal check to verify that when anime compatibility is on, the movie search that can contain year remain a year Because with both anime compatibility enables, i have issues , for example "Test Movie 2005" become "Test Movie E2005"

