### PR TITLE
nyaasi: New domain 

### DIFF
--- a/src/Jackett.Common/Definitions/nyaasi.yml
+++ b/src/Jackett.Common/Definitions/nyaasi.yml
@@ -7,9 +7,10 @@ type: public
 encoding: UTF-8
 requestDelay: 2
 links:
-  - https://nyaa.mom/
+  - https://nyaa.si/
   - https://nyaa.iss.ink/
   - https://nyaa.land/
+  - https://nyaa.mom/
   - https://nyaa.unblockninja.com/ # for magnets only
 legacylinks:
   - https://nyaa.black-mirror.xyz/


### PR DESCRIPTION
#### Description
Nyaa.si looks to have moved to Nyaa.mom: https://github.com/Prowlarr/Indexers/issues/799

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes https://github.com/Prowlarr/Indexers/issues/799
