### PR TITLE
[yggtorrent] Prevent anime compatibility to mess with movies search

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/YggTorrent.cs
+++ b/src/Jackett.Common/Indexers/Definitions/YggTorrent.cs
@@ -521,7 +521,7 @@ namespace Jackett.Common.Indexers.Definitions
 
             rawQuery = NormalizeFrenchSeasonInRawQuery(rawQuery);
 
-            var isMovieQuery = IsMovieQuery(query);
+            var isMovieQuery = IsMovieQuery(query, trackerCats);
 
             var keywords = BuildKeywordsFromRaw(rawQuery, isMovieQuery);
 
@@ -626,9 +626,9 @@ namespace Jackett.Common.Indexers.Definitions
         /// <summary>
         /// Check if the query is a movie query
         /// </summary>
-        private bool IsMovieQuery(TorznabQuery query)
+        private bool IsMovieQuery(TorznabQuery query, List<int> trackerCats)
         {
-            return query.IsMovieSearch || (query.Categories?.Any(IsMovieOnlyCategory) ?? false);
+            return query.IsMovieSearch || (trackerCats?.Any(IsMovieOnlyCategory) ?? false);
         }
 
         /// <summary>


### PR DESCRIPTION
Add an additionnal check to verify that when anime compatibility is on, the movie search that can contain year remain a year Because with both anime compatibility enables, i have issues , for example "Test Movie 2005" become "Test Movie E2005"

EDIT: It seems that the category is passed in the sub_category and not categories, like this for example : https://www.yggtorrent.org/engine/search?do=search&order=desc&sort=publish_date&category=2145&name=%22Alien%22%20%22Romulus%22%20%22E2024%22&sub_category=2183&page=50

So i have modify the IsMovieQuery function to check trackercats that contains all the categories and not only the parent one
