### PR TITLE
[yggtorrent] Prevent anime compatibility to mess with movies search

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/YggTorrent.cs
+++ b/src/Jackett.Common/Indexers/Definitions/YggTorrent.cs
@@ -147,12 +147,6 @@ namespace Jackett.Common.Indexers.Definitions
 
         #endregion
 
-        #region Is Movie search
-
-        private bool isMovieSearch = false;
-
-        #endregion
-
         #region Configuration Keys
 
         private const string CfgUsername = "username";


### PR DESCRIPTION
Sorry for another one
The search works well but the results still got the "E", so i patched the normalizetitle function
I have modified the code to set a global var, to be easier to access it in normalizetitle function

I'v tested and it works well now, for the search and the title normalization
