### PR TITLE
g3minitr4ck3r: add option to use freeleech token on download

### DIFF
--- a/src/Jackett.Common/Definitions/g3minitr4ck3r-api.yml
+++ b/src/Jackett.Common/Definitions/g3minitr4ck3r-api.yml
@@ -172,7 +172,7 @@ search:
       selector: download_link
       filters:
         - name: append
-          args: "{{ if .Config.use_fl_tokens }}use_token=1{{ else }}{{ end }}"
+          args: "{{ if .Config.use_fl_tokens }}?use_token=1{{ else }}{{ end }}"
     poster:
       selector: meta.poster
       filters:


### PR DESCRIPTION
#### Description
In response to https://github.com/Prowlarr/Prowlarr/issues/2618 I've prepared this update.
The original update on Prowlarr defines a config option but did not use it on the download section.

I raised this as a PR because I am waiting on a response to a question I raised on the g3minitr4ck3r web site about whether or not we need to provide alternate download links for when users try to use a download with a token when they do not have any.
I may need to amend this indexer further so do not merge.
