### PR TITLE
fix(abnormal-api): use correct numeric values for downloadvolumefactor

### DIFF
--- a/src/Jackett.Common/Definitions/abnormal-api.yml
+++ b/src/Jackett.Common/Definitions/abnormal-api.yml
@@ -163,8 +163,8 @@ search:
     downloadvolumefactor:
       selector: freeleech
       case:
-        False: "{{ .False }}"
-        True: "{{ .True }}"
+        False: 1 # not free
+        True: 0 # freeleech
     uploadvolumefactor:
       text: 1
     minimumratio:


### PR DESCRIPTION
#### Description

The `downloadvolumefactor` field in the ABnormal (API) definition expects a numeric value (between `0` and `1`), but the current case values return booleans instead. This causes all torrents to always show the Freeleech flag, even when they are not freeleech.

Fixed by replacing with the correct numeric values: `1` (not free) and `0` (freeleech).

#### Issues Fixed or Closed by this PR
* Fixes #13506
