### PR TITLE
[lacale] Fix download URL using expiring token

### DIFF
--- a/src/Jackett.Common/Definitions/lacale-api.yml
+++ b/src/Jackett.Common/Definitions/lacale-api.yml
@@ -142,7 +142,12 @@ search:
     details:
       selector: link
     download:
-      selector: downloadLink
+      selector: infoHash
+      filters:
+        - name: prepend
+          args: "{{ .Config.sitelink }}api/torrents/download/"
+        - name: append
+          args: "?apikey={{ .Config.apikey }}"
     infohash:
       selector: infoHash
     size:


### PR DESCRIPTION
#### Description

The `downloadLink` field returned by La Cale's API contains a temporary token
that expires before *arr apps attempt the download, causing 403 errors.

This constructs the download URL from `infoHash` + `apikey` instead, using
the stable `/api/torrents/download/{infoHash}?apikey=...` endpoint documented
in the [OpenAPI spec](https://la-cale.space/api/external/docs/openapi.yaml).

#### Issues Fixed or Closed by this PR

* Related to Prowlarr/Indexers#821