### PR TITLE
Send raw torrent on BencodeParser failure.

### DIFF
--- a/src/Jackett.Server/Controllers/DownloadController.cs
+++ b/src/Jackett.Server/Controllers/DownloadController.cs
@@ -78,11 +78,12 @@ namespace Jackett.Server.Controllers
                     var torrentDictionary = parser.Parse(downloadBytes);
                     sortedDownloadBytes = torrentDictionary.EncodeAsBytes();
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
-                    var content = indexer.Encoding.GetString(downloadBytes);
-                    _logger.Error(content);
-                    throw new Exception("BencodeParser failed", e);
+                    _logger.Warn("Invalid bencode, sending raw torrent");
+
+                    // Fallback: Send the original torrent, even if it doesn't comply
+                    sortedDownloadBytes = downloadBytes;
                 }
 
                 var fileName = StringUtil.MakeValidFileName(file, '_', false) + ".torrent"; // call MakeValidFileName again to avoid any kind of injection attack


### PR DESCRIPTION
Refactor exception handling in DownloadController to log a warning and send raw torrent on BencodeParser failure. 
I don't know if this solution will be accepted, but it works perfectly in my custom Jackett build. Please review this solution.

#### Description
Now I can download any .torrent with an invalid Bencode from old invalid torrents

#### Screenshot 
<img width="625" height="115" alt="Screenshot_2026-03-17_14-12-07" src="https://github.com/user-attachments/assets/191c4f97-1624-4ff4-bfbf-69fbc72f5544" />

#### Issues Fixed or Closed by this PR

* Fixes 
https://github.com/Jackett/Jackett/issues/16492#issuecomment-3761568182
