### PR TITLE
danishbytes-api: add nordicbytes URL and help links

### DIFF
--- a/src/Jackett.Common/Definitions/danishbytes-api.yml
+++ b/src/Jackett.Common/Definitions/danishbytes-api.yml
@@ -6,6 +6,7 @@ language: da-DK
 type: private
 encoding: UTF-8
 links:
+  - https://nordicbytes.org/
   - https://danishbytes.club/
   - https://danishbytes2.org/
   - https://dbytes.org/
@@ -15,14 +16,14 @@ legacylinks:
 
 caps:
   categorymappings:
-    - {id: 1, cat: Movies, desc: "Movies"}
-    - {id: 2, cat: TV, desc: "TV"}
-    - {id: 5, cat: PC/0day, desc: "Apps"}
-    - {id: 4, cat: PC/Games, desc: "Games"}
-    - {id: 3, cat: Audio, desc: "Music"}
-    - {id: 8, cat: Books, desc: "Books"}
-    - {id: 17, cat: Audio/Audiobook, desc: "AudioBooks"}
-    - {id: 19, cat: Audio, desc: "Podcasts"}
+    - { id: 1, cat: Movies, desc: "Movies" }
+    - { id: 2, cat: TV, desc: "TV" }
+    - { id: 5, cat: PC/0day, desc: "Apps" }
+    - { id: 4, cat: PC/Games, desc: "Games" }
+    - { id: 3, cat: Audio, desc: "Music" }
+    - { id: 8, cat: Books, desc: "Books" }
+    - { id: 17, cat: Audio/Audiobook, desc: "AudioBooks" }
+    - { id: 19, cat: Audio, desc: "Podcasts" }
 
   modes:
     search: [q]
@@ -38,14 +39,14 @@ settings:
   - name: info_apikey
     type: info
     label: About your API key
-    default: "Find or Generate a new API Token by accessing your <a href=\"https://danishbytes.club/\" target=\"_blank\">DanishBytes</a> account <i>My Security</i> page and clicking on the <b>API Token</b> tab."
+    default: 'Find or Generate a new API Token by accessing your <a href="https://nordicbytes.org/" target="_blank">NordicBytes</a> account <i>My Security</i> page and clicking on the <b>API Token</b> tab.'
   - name: rsskey
     type: text
     label: RSSKey
   - name: info_rsskey
     type: info
     label: About your RSS key
-    default: "Find or Generate a new RSS key by accessing your <a href=\"https://danishbytes.club/\" target=\"_blank\">DanishBytes</a> account <i>My Security</i> page and clicking on the <b>RSS Key (RID)</b> tab."
+    default: 'Find or Generate a new RSS key by accessing your <a href="https://nordicbytes.org/" target="_blank">NordicBytes</a> account <i>My Security</i> page and clicking on the <b>RSS Key (RID)</b> tab.'
   - name: freeleech
     type: checkbox
     label: Search freeleech only


### PR DESCRIPTION
#### Description
This PR updates the danishbytes-api indexer definition to reflect the tracker rename to NordicBytes.  
It adds https://nordicbytes.org/ to the available base URLs and updates the "About your API key" / "About your RSS key" helper links and text to point to NordicBytes.

#### Screenshot (if UI related)
N/A (definition-only change, no UI changes)
#### Issues Fixed or Closed by this PR
None yet
