### PR TITLE
1337x: Fix multi-episode ranges without leading whitespace

### DIFF
--- a/src/Jackett.Common/Definitions/1337x.yml
+++ b/src/Jackett.Common/Definitions/1337x.yml
@@ -219,7 +219,7 @@ search:
         - name: re_replace # EP 3 4 to E3-4
           args: ["(?i)\\sEP\\s(\\d{1,2})\\s(E?\\s?\\d{1,2})\\s", " E$1-$2 "]
         - name: re_replace # S02E04 05 to S02E04-05
-          args: ["(?i)S(\\d{1,2})\\s?E\\s?(\\d{1,2})\\s(E?\\s?\\d{1,2})\\s", " S$1E$2-$3 "]
+          args: ["(?i)([-_. ])S(\\d{1,2})\\s?E\\s?(\\d{1,2})\\s(E?\\s?\\d{1,2})([-_. ])", "$1S$2E$3-$4$5"]
         - name: re_replace
           args: ["(?i)AC3\\s?(\\d)\\s(\\d)", "AC3 $1.$2"]
         - name: re_replace


### PR DESCRIPTION
#### Description
Current filter RegEx requires a whitespace before a multi-episode range, e.g. `Series.Name S01E01 E04`. This, along with the preceding filters, means that a release title like `Series.Name.S01E01-E04` would be converted to `Series.Name.S01E01 E04`, breaking parsing for Sonarr. 

First reported in https://github.com/Prowlarr/Prowlarr/issues/2638

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes https://github.com/Prowlarr/Prowlarr/issues/2638
