### PR TITLE
readme: better linux install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -848,7 +848,7 @@ For modern ARM-based systems (Raspberry Pi, etc.)
 
    ```bash
    cd /opt
-   sudo wget -O - -o /dev/stderr https://github.com/Jackett/Jackett/releases/latest/download/Jackett.Binaries.LinuxARM32.tar.gz | sudo tar -xz
+   wget -O - -o /dev/stderr https://github.com/Jackett/Jackett/releases/latest/download/Jackett.Binaries.LinuxARM32.tar.gz | sudo tar -xz
    ```
 
 2. Install as a service:


### PR DESCRIPTION
#### Description
Make the Linux (AMD64 + ARM) install commands in `README.md` pipe `wget`'s output directly to the `tar` extract command, instead of saving to a file, extracting, then removing the file.

`-o /dev/stderr` was necessary, otherwise wget would save the progress indicator to a new `wget-log` file.

Tested on Debian 13 (trixie). `/opt/` only had the `Jackett` dir afterwards (and `containerd`, but that's unrelated)

sorry if that's an unwanted change, I think it's preferable because it makes the install commands shorter, and makes decompression and extraction happen at the same time as the download instead of after it.

#### Screenshot (if UI related)
<img width="695" height="436" alt="image" src="https://github.com/user-attachments/assets/75227d7d-f594-480b-8fe9-59474c549627" />
<img width="419" height="84" alt="image" src="https://github.com/user-attachments/assets/8825e648-7732-48e6-8126-d2caeb84e922" />

#### Issues Fixed or Closed by this PR
N/A