### PR TITLE
Add new link for majomparade.yml

### DIFF
--- a/src/Jackett.Common/Definitions/majomparade.yml
+++ b/src/Jackett.Common/Definitions/majomparade.yml
@@ -8,6 +8,7 @@ encoding: UTF-8
 requestDelay: 2
 links:
   - https://majomparade.eu/
+  - https://majomparade.net/
 
 caps:
   # dont forget to update the path categories in the search block


### PR DESCRIPTION
The domain name for this tracker changed recently.

<img width="566" height="166" alt="Képernyőkép 2026-03-28 092805" src="https://github.com/user-attachments/assets/429008df-d458-485b-bcf7-934ff4673ffd" />

