### PR TITLE
retromoviesclub-api: remove tv-search from caps

### DIFF
--- a/src/Jackett.Common/Definitions/retromoviesclub-api.yml
+++ b/src/Jackett.Common/Definitions/retromoviesclub-api.yml
@@ -14,7 +14,6 @@ caps:
 
   modes:
     search: [q]
-    tv-search: [q, season, ep, imdbid, tvdbid, tmdbid]
     movie-search: [q, imdbid, tmdbid]
   allowtvsearchimdb: true
 

--- a/src/Jackett.Common/Definitions/retromoviesclub-api.yml
+++ b/src/Jackett.Common/Definitions/retromoviesclub-api.yml
@@ -15,7 +15,6 @@ caps:
   modes:
     search: [q]
     movie-search: [q, imdbid, tmdbid]
-  allowtvsearchimdb: true
 
 settings:
   - name: apikey

--- a/src/Jackett.Common/Definitions/retromoviesclub-api.yml
+++ b/src/Jackett.Common/Definitions/retromoviesclub-api.yml
@@ -74,14 +74,10 @@ search:
     Authorization: ["Bearer {{ .Config.apikey }}"]
 
   inputs:
-  # if we have an id based search, add Season and Episode as query in name for UNIT3D < v6.  Else pass S/E Params for UNIT3D >= v6
     $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
     name: "{{ .Keywords }}"
-    seasonNumber: "{{ .Query.Season }}"
-    episodeNumber: "{{ .Query.Ep }}"
     imdbId: "{{ .Query.IMDBIDShort }}"
     tmdbId: "{{ .Query.TMDBID }}"
-    tvdbId: "{{ .Query.TVDBID }}"
     "free[]": "{{ if .Config.freeleech }}100{{ else }}{{ end }}"
     sortField: "{{ .Config.sort }}"
     sortDirection: "{{ .Config.type }}"


### PR DESCRIPTION
#### Description
Forgot to strip the tv-search from the template in the initial PR. RMC is a movies-only tracker, so this just removes the TV caps to prevent Sonarr from trying to use it.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
