### PR TITLE
crazyspirits: add a torznab api indexer for v2 resolves #5479

### DIFF
--- a/src/Jackett.Common/Definitions/crazyspirits-api.yml
+++ b/src/Jackett.Common/Definitions/crazyspirits-api.yml
@@ -5,6 +5,7 @@ description: "Crazy Spirits is a FRENCH Private Torrent Tracker for MOVIES / TV 
 language: fr-FR
 type: private
 encoding: UTF-8
+requestDelay: 5
 links:
   - https://crazyspirits.com/
 legacylinks:
@@ -65,6 +66,8 @@ settings:
     label: Replace VOSTFR and SUBFRENCH with ENGLISH
     default: false
 
+# can't test apikey with login as API returns OK with xml "error code": 100 "description": "INVALID API KEY" or "MISSING API KEY"
+
 search:
   paths:
     # docs at https://crazyspirits.com/apps.php
@@ -81,11 +84,6 @@ search:
     ep: "{{ .Query.Ep }}"
     imdbid: "{{ .Query.IMDBID }}"
     limit: 100
-
-#  keywordsfilters:
-    # replace spaces between words with percent wildcard
-#    - name: re_replace
-#      args: ["\\W+", "%"]
 
   rows:
     selector: rss > channel > item


### PR DESCRIPTION
#### Description
crazyspirits on the v2 platform has a torznab api.

* Fixes #5479

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
