### PR TITLE
totheglory: add category for anime bluray bdmv

### DIFF
--- a/src/Jackett.Common/Definitions/totheglory.yml
+++ b/src/Jackett.Common/Definitions/totheglory.yml
@@ -48,7 +48,7 @@ caps:
     MiniVideo: Other # MiniVideo
     补充音轨: Audio # Supplemental audio tracks
     iPhone/iPad视频: PC/Mobile-Other # IPhone / iPad video
-    动漫原盘: Movies/BluRay # Anime BluRay Original disc
+    动漫原盘: Movies/Other # Anime BluRay Original disc
     # 单机游戏
     PC: PC/Games # Games - PC
     MAC: PC/Mac # Games - MAC

--- a/src/Jackett.Common/Definitions/totheglory.yml
+++ b/src/Jackett.Common/Definitions/totheglory.yml
@@ -48,6 +48,7 @@ caps:
     MiniVideo: Other # MiniVideo
     补充音轨: Audio # Supplemental audio tracks
     iPhone/iPad视频: PC/Mobile-Other # IPhone / iPad video
+    动漫原盘: Movies/BluRay # Anime BluRay Original disc
     # 单机游戏
     PC: PC/Games # Games - PC
     MAC: PC/Mac # Games - MAC

--- a/src/Jackett.Common/Definitions/totheglory2fa.yml
+++ b/src/Jackett.Common/Definitions/totheglory2fa.yml
@@ -50,6 +50,7 @@ caps:
     MiniVideo: Other # MiniVideo
     补充音轨: Audio # Supplemental audio tracks
     iPhone/iPad视频: PC/Mobile-Other # IPhone / iPad video
+    动漫原盘: Movies/BluRay # Anime BluRay Original disc
     # 单机游戏
     PC: PC/Games # Games - PC
     MAC: PC/Mac # Games - MAC

--- a/src/Jackett.Common/Definitions/totheglory2fa.yml
+++ b/src/Jackett.Common/Definitions/totheglory2fa.yml
@@ -50,7 +50,7 @@ caps:
     MiniVideo: Other # MiniVideo
     补充音轨: Audio # Supplemental audio tracks
     iPhone/iPad视频: PC/Mobile-Other # IPhone / iPad video
-    动漫原盘: Movies/BluRay # Anime BluRay Original disc
+    动漫原盘: Movies/Other # Anime BluRay Original disc
     # 单机游戏
     PC: PC/Games # Games - PC
     MAC: PC/Mac # Games - MAC


### PR DESCRIPTION
#### Description
ttg has a category for anime bdmv. but it seems the indexer doesn't cover this yet, and will output warning in prowlarr due to unable to parse.

`[totheglory2fa] Invalid category for value: '动漫原盘'`

note: this category actually has BDMV for both anime series and movies, but looks like it's better to put this under 'Movies/Bluray' as here's no suitable category like `Movies/Anime`.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR
N/A

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
