### PR TITLE
springsunday: add audiobook category, merge anime into tv series category.

### DIFF
--- a/src/Jackett.Common/Definitions/springsunday.yml
+++ b/src/Jackett.Common/Definitions/springsunday.yml
@@ -13,7 +13,6 @@ caps:
     - {id: 501, cat: Movies, desc: "Movies(电影)"}
     - {id: 502, cat: TV, desc: "TV Series(剧集)"}
     - {id: 503, cat: TV/Documentary, desc: "Docs(纪录)"}
-    - {id: 504, cat: TV/Anime, desc: "Animations(动画)"}
     - {id: 505, cat: TV, desc: "TV Shows(综艺)"}
     - {id: 506, cat: TV/Sport, desc: "Sports(体育)"}
     - {id: 507, cat: Audio/Video, desc: "MV(音乐视频)"}

--- a/src/Jackett.Common/Definitions/springsunday.yml
+++ b/src/Jackett.Common/Definitions/springsunday.yml
@@ -19,6 +19,7 @@ caps:
     - {id: 507, cat: Audio/Video, desc: "MV(音乐视频)"}
     - {id: 508, cat: Audio, desc: "Music(音乐)"}
     - {id: 509, cat: Other, desc: "Others(其他)"}
+    - {id: 510, cat: Audio/Audiobook, desc: "Audiobook(有声)"}
 
   modes:
     search: [q]


### PR DESCRIPTION
#### Description
another missing category from prowlarr's warning message. added audiobook support for springsunday.

`[springsunday] Invalid category for value: '510'`

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR
N/A

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
