### PR TITLE
[New Tracker] Add PandaCD

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Prior versions of Jackett are no longer supported.
  * OneJAV
  * OpenSharing
  * PC-torrent
+ * PandaCD
  * plugintorrent
  * PornoTorrent
  * PornRips

--- a/src/Jackett.Common/Definitions/pandacd.yml
+++ b/src/Jackett.Common/Definitions/pandacd.yml
@@ -1,0 +1,78 @@
+---
+id: pandacd
+name: PandaCD
+description: "PandaCD is a music tracker for Creative Commons and artist-permitted content"
+language: en-US
+type: public
+encoding: UTF-8
+
+links:
+  - https://pandacd.io/
+
+caps:
+  categorymappings:
+    - {id: 3000, cat: Audio, desc: "Audio"}
+    - {id: 3010, cat: Audio/MP3, desc: "MP3"}
+    - {id: 3040, cat: Audio/Lossless, desc: "Lossless"}
+
+  modes:
+    search: [q]
+    music-search: [q, artist, album, genre]
+
+settings:
+  - name: apikey
+    type: text
+    label: API Key (optional)
+    default: ""
+
+search:
+  paths:
+    - path: /api/torznab
+      response:
+        type: xml
+
+  inputs:
+    t: "{{ .Query.Type }}"
+    q: "{{ .Keywords }}"
+    cat: "{{ join .Categories \",\" }}"
+    artist: "{{ .Query.Artist }}"
+    album: "{{ .Query.Album }}"
+    genre: "{{ .Query.Genre }}"
+    apikey: "{{ .Config.apikey }}"
+    limit: 100
+
+  rows:
+    selector: rss > channel > item
+
+  fields:
+    category:
+      selector: "[name=category]"
+      attribute: value
+    title:
+      selector: title
+    details:
+      selector: guid
+    download:
+      selector: enclosure
+      attribute: url
+    date:
+      selector: pubDate
+      filters:
+        - name: dateparse
+          args: "ddd, dd MMM yyyy HH:mm:ss zzz"
+    size:
+      selector: "[name=size]"
+      attribute: value
+    seeders:
+      selector: "[name=seeders]"
+      attribute: value
+    leechers:
+      selector: "[name=leechers]"
+      attribute: value
+    grabs:
+      selector: "[name=grabs]"
+      attribute: value
+    infohash:
+      selector: "[name=infohash]"
+      attribute: value
+# torznab xml

--- a/src/Jackett.Common/Definitions/pandacd.yml
+++ b/src/Jackett.Common/Definitions/pandacd.yml
@@ -11,6 +11,7 @@ links:
 
 caps:
   categorymappings:
+    # https://pandacd.io/api/torznab?t=caps
     - {id: 3000, cat: Audio, desc: "Audio"}
     - {id: 3010, cat: Audio/MP3, desc: "MP3"}
     - {id: 3040, cat: Audio/Lossless, desc: "Lossless"}
@@ -19,11 +20,7 @@ caps:
     search: [q]
     music-search: [q, artist, album, genre]
 
-settings:
-  - name: apikey
-    type: text
-    label: API Key (optional)
-    default: ""
+settings: []
 
 search:
   paths:
@@ -38,7 +35,6 @@ search:
     artist: "{{ .Query.Artist }}"
     album: "{{ .Query.Album }}"
     genre: "{{ .Query.Genre }}"
-    apikey: "{{ .Config.apikey }}"
     limit: 100
 
   rows:
@@ -56,6 +52,7 @@ search:
       selector: enclosure
       attribute: url
     date:
+      # Wed, 15 Apr 2026 02:01:34 +0000
       selector: pubDate
       filters:
         - name: dateparse
@@ -72,7 +69,21 @@ search:
     grabs:
       selector: "[name=grabs]"
       attribute: value
+    files:
+      selector: "[name=files]"
+      attribute: value
     infohash:
       selector: "[name=infohash]"
+      attribute: value
+    genre:
+      selector: "[name=genre]"
+      attribute: value
+    description:
+      text: "{{ .Result.genre }}"
+    downloadvolumefactor:
+      selector: "[name=downloadvolumefactor]"
+      attribute: value
+    uploadvolumefactor:
+      selector: "[name=uploadvolumefactor]"
       attribute: value
 # torznab xml

--- a/src/Jackett.Common/Definitions/pandacd.yml
+++ b/src/Jackett.Common/Definitions/pandacd.yml
@@ -1,7 +1,7 @@
 ---
 id: pandacd
 name: PandaCD
-description: "PandaCD is a music tracker for Creative Commons and artist-permitted content"
+description: "PandaCD is a Public Tracker for MUSIC (Creative Commons and artist-permitted content)"
 language: en-US
 type: public
 encoding: UTF-8
@@ -24,7 +24,7 @@ settings: []
 
 search:
   paths:
-    - path: /api/torznab
+    - path: api/torznab
       response:
         type: xml
 


### PR DESCRIPTION
#### Description
Adds PandaCD. Since https://github.com/Jackett/Jackett/issues/9990 a torznab API has been added. Includes indexer definition and README update.

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
