### PR TITLE
Add PageSize property to TorrentSyndikat

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/TorrentSyndikat.cs
+++ b/src/Jackett.Common/Indexers/Definitions/TorrentSyndikat.cs
@@ -26,6 +26,7 @@ namespace Jackett.Common.Indexers.Definitions
         public override string SiteLink { get; protected set; } = "https://torrent-syndikat.org/";
         public override string Language => "de-DE";
         public override string Type => "private";
+        public override int PageSize => 50;
 
         public override TorznabCapabilities TorznabCaps => SetCapabilities();
 


### PR DESCRIPTION
This pull request makes a small change to the `TorrentSyndikat` indexer definition. The main update is the addition of a `PageSize` property, which specifies the number of results to fetch per page.

* [`src/Jackett.Common/Indexers/Definitions/TorrentSyndikat.cs`](diffhunk://#diff-c84957e17a0ff3ede9d461a6a1db9adc4c09fdb5da194507854d341f59683aafR29): Added an override for `PageSize` to set it to 50.

Why this is needed:
While the API query already explicitly limits the request to 50 results ({"limit", "50"} in the PerformQuery method), the core paginator was not overriding the default PageSize of 100. This mismatch caused the offset for subsequent pages to calculate incorrectly (jumping by 100 instead of 50), completely skipping results 50-99.