### PR TITLE
springsunday: fix support for doubanid search

### DIFF
--- a/src/Jackett.Common/Definitions/springsunday.yml
+++ b/src/Jackett.Common/Definitions/springsunday.yml
@@ -71,7 +71,7 @@ search:
     - path: torrents.php
   inputs:
     $raw: "{{ range .Categories }}cat{{.}}=1&{{end}}"
-    search: "{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ .Keywords }}{{ end }}"
+    search: "{{ if .Query.IMDBID }}{{ .Query.IMDBID }}{{ else }}{{ end }}{{ if and .Query.DoubanID (eq .Query.IMDBID .False) }}{{ .Query.DoubanID }}{{ else }}{{ end }}{{ if and (eq .Query.IMDBID .False) (eq .Query.DoubanID .False) }}{{ .Keywords }}{{ else }}{{ end }}"
     # 0 incldead, 1 active, 2 onlydead
     incldead: 0
     # 0 all, 1 normal, 2 free, 3 2x, 4 2xFree, 5 50%, 6 2x50%, 7 30%
@@ -79,7 +79,7 @@ search:
     # 0 all, 1 popular, 2 classic, 3 recomended, 4 2+3
     pick: 0
     # 0 title, 3 uploader, 4 imdb URL, 5 douban URL
-    search_area: "{{ if or .Query.IMDBID .Query.DoubanID }}{{ else }}0{{ end }}{{ if .Query.IMDBID }}4{{ else }}{{ end }}{{ if .Query.DoubanID }}5{{ else }}{{ end }}"
+    search_area: "{{ if .Query.IMDBID }}4{{ else }}{{ end }}{{ if and .Query.DoubanID (eq .Query.IMDBID .False) }}5{{ else }}{{ end }}{{ if and (eq .Query.IMDBID .False) (eq .Query.DoubanID .False) }}0{{ else }}{{ end }}"
     # 0 AND, 1 OR, 2 Exact
     search_mode: 0
     sort: "{{ .Config.sort }}"


### PR DESCRIPTION
#### Description
Fix SpringSunday support for Douban ID search. When an IMDb ID is available, it takes priority; otherwise a Douban ID is used, and keyword search is used as a fallback. 

All three search modes have been tested and are working.


#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
