### PR TITLE
Remove Douban ID search support from HHanClub

### DIFF
--- a/src/Jackett.Common/Definitions/hhanclub.yml
+++ b/src/Jackett.Common/Definitions/hhanclub.yml
@@ -25,8 +25,8 @@ caps:
 
   modes:
     search: [q]
-    tv-search: [q, season, ep, imdbid, doubanid]
-    movie-search: [q, imdbid, doubanid]
+    tv-search: [q, season, ep, imdbid]
+    movie-search: [q, imdbid]
 
 settings:
   - name: username


### PR DESCRIPTION
#### Description
 Removed Douban ID search support from HHanClub because the site itself does not support Douban ID queries. Searches using a Douban ID return no results.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
