### PR TITLE
nonameclub: fix episode and title ordering for shows

### DIFF
--- a/src/Jackett.Common/Definitions/noname-club.yml
+++ b/src/Jackett.Common/Definitions/noname-club.yml
@@ -869,7 +869,7 @@ search:
         - name: re_replace
           args: ["^[\\s&,\\.!\\?\\+\\-_\\|\\/':]+", ""]
         - name: re_replace
-          args: ["^(.*?)(\\((?:20|19)\\d{2}\\))(.*?)(.*?)\\((\\bS\\d{1,2}E\\d{1,3}(?:-\\d{1,3})?(?:\\s+of\\s+\\d+)?\\b)\\)(.*)", "$1 / $5 $2$4$6"]
+          args: ["^(.*?)(\\((?:(?:20|19)\\d{2}-?)+\\))(.*?)(.*?)\\((\bS\\d{1,2}E\\d{1,3}(?:-\\d{1,3})?(?:\\s+of\\s+[?0-9]+)?)\\)(.*)", "$1 / $5 $2$4$6"]
         - name: append
           args: "{{ if and (ne .Result.category_id \"913\") (.Config.addrussiantotitle) }} RUS{{ else }}{{ end }}"
     details:

--- a/src/Jackett.Common/Definitions/noname-club.yml
+++ b/src/Jackett.Common/Definitions/noname-club.yml
@@ -868,6 +868,8 @@ search:
           args: ["[\\[\\(\\{<«][\\s\\W]*[\\]\\)\\}>»]", ""]
         - name: re_replace
           args: ["^[\\s&,\\.!\\?\\+\\-_\\|\\/':]+", ""]
+        - name: re_replace
+          args: ["^(.*?)(\\((?:20|19)\\d{2}\\))(.*?)(.*?)\\((\\bS\\d{1,2}E\\d{1,3}(?:-\\d{1,3})?(?:\\s+of\\s+\\d+)?\\b)\\)(.*)", "$1 / $5 $2$4$6"]
         - name: append
           args: "{{ if and (ne .Result.category_id \"913\") (.Config.addrussiantotitle) }} RUS{{ else }}{{ end }}"
     details:

--- a/src/Jackett.Common/Definitions/noname-clubl.yml
+++ b/src/Jackett.Common/Definitions/noname-clubl.yml
@@ -897,6 +897,8 @@ search:
           args: ["[\\[\\(\\{<«][\\s\\W]*[\\]\\)\\}>»]", ""]
         - name: re_replace
           args: ["^[\\s&,\\.!\\?\\+\\-_\\|\\/':]+", ""]
+        - name: re_replace
+          args: ["^(.*?)(\\((?:20|19)\\d{2}\\))(.*?)(.*?)\\((\\bS\\d{1,2}E\\d{1,3}(?:-\\d{1,3})?(?:\\s+of\\s+\\d+)?\\b)\\)(.*)", "$1 / $5 $2$4$6"]
         - name: append
           args: "{{ if and (ne .Result.category_id \"913\") (.Config.addrussiantotitle) }} RUS{{ else }}{{ end }}"
     details:

--- a/src/Jackett.Common/Definitions/noname-clubl.yml
+++ b/src/Jackett.Common/Definitions/noname-clubl.yml
@@ -898,7 +898,7 @@ search:
         - name: re_replace
           args: ["^[\\s&,\\.!\\?\\+\\-_\\|\\/':]+", ""]
         - name: re_replace
-          args: ["^(.*?)(\\((?:20|19)\\d{2}\\))(.*?)(.*?)\\((\\bS\\d{1,2}E\\d{1,3}(?:-\\d{1,3})?(?:\\s+of\\s+\\d+)?\\b)\\)(.*)", "$1 / $5 $2$4$6"]
+          args: ["^(.*?)(\\((?:(?:20|19)\\d{2}-?)+\\))(.*?)(.*?)\\((\bS\\d{1,2}E\\d{1,3}(?:-\\d{1,3})?(?:\\s+of\\s+[?0-9]+)?)\\)(.*)", "$1 / $5 $2$4$6"]
         - name: append
           args: "{{ if and (ne .Result.category_id \"913\") (.Config.addrussiantotitle) }} RUS{{ else }}{{ end }}"
     details:


### PR DESCRIPTION
#### Description
NoNameClub TV show releases include additional metadata between the last slash-separated title and the `SxxExx` block, e.g.:
```
Пацаны / The Boys / WEB-DL [H.265/2160p] [4K, SDR, 8-bit] S5E1-4 of 8 ...
```

Sonarr’s parser has a specific regex that correctly handles:
```
Title1 / Title2 / SxxExx ...
```
but fails when any tokens appear between the last / and SxxExx, causing the entire segment (including WEB-DL ...) to be captured as part of the title. This breaks series matching.

#### Solution
This pull request adds a regex which transforms:
```
Пацаны / The Boys (2026) WEB-DL [H.265/2160p] [4K, SDR, 8-bit] (S5E1-4 of 8) ...
```
into:
```
Пацаны / The Boys / S5E1-4 of 8 (2026) WEB-DL [H.265/2160p] [4K, SDR, 8-bit] ...
```
which matches Sonarr’s expected pattern and restores correct series detection.