### PR TITLE
Fix Audiences description selector

### DIFF
--- a/src/Jackett.Common/Definitions/audiences.yml
+++ b/src/Jackett.Common/Definitions/audiences.yml
@@ -174,6 +174,6 @@ search:
       # 2 days (as seconds = 2 x 24 x 60 x 60)
       text: 172800
     description:
-      selector: td:nth-child(2)
-      remove: a, img
+      selector: tr[data-description]
+      attribute: data-description
 # NexusPHP Standard v1.5 Beta 4 (custom)


### PR DESCRIPTION
#### Description
 The Audiences indexer previously extracted description from the whole second table cell:
  ```yaml
  description:
    selector: td:nth-child(2)
    remove: a, img
  ```
  That cell contains more than the actual torrent description. For promoted or freeleech torrents, it can also include UI-only text such
  as promotion countdowns, display tags, and other page decorations.

  Example HTML:
  ```html
  <tr data-description="Episode 18 | Genre: Drama Mystery Crime | Cast: Actor A Actor B Actor C | Alternate Title A / Alternate Title B
  *Streaming Platform*">
    <td class="rowfollow torrents-box">
      <a href="details.php?id=655436">
        <b>Gimlet Eyes S01E18 2026 2160p WEB-DL H265 AAC-ADWeb</b>
      </a>
      <img class="pro_free" src="pic/trans.gif" />
      &nbsp;Time remaining:<b><span>23h44m</span></b>
      <br />
      <span class="tags tgf">Official</span>
      <span class="tags tgy">Mandarin</span>
      <span class="tags tzz">Subtitles</span>
      <span>Episode 18 | Genre: Drama Mystery Crime | Cast: Actor A Actor B Actor C | Alternate Title A / Alternate Title B *Streaming
  Platform*</span>
    </td>
  </tr>
  ```
  With the old selector, the parsed description could become:

  Time remaining:23h44mOfficialMandarinSubtitlesEpisode 18 | Genre: Drama Mystery Crime | Cast: Actor A Actor B Actor C | Alternate
  Title A / Alternate Title B *Streaming Platform*

  The new selector reads the dedicated row attribute instead:

  description:
    selector: tr[data-description]
    attribute: data-description

  With the same HTML, the parsed description is now:

  Episode 18 | Genre: Drama Mystery Crime | Cast: Actor A Actor B Actor C | Alternate Title A / Alternate Title B *Streaming Platform*

  This keeps the release description focused on the actual torrent metadata and prevents UI-only text from leaking into Torznab results

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
