### PR TITLE
hdsky: fix localized search and descriptions

### DIFF
--- a/src/Jackett.Common/Definitions/hdsky.yml
+++ b/src/Jackett.Common/Definitions/hdsky.yml
@@ -78,8 +78,6 @@ search:
 
   rows:
     selector: table.torrents > tbody > tr:has(table.torrentname)
-    filters:
-      - name: andmatch
 
   fields:
     category:
@@ -166,6 +164,5 @@ search:
         img.pro_2up: 2
         "*": 1
     description:
-      selector: td:nth-child(2)
-      remove: a, b, font, img, span
+      selector: table.torrentname td.embedded:first-child > span:not(.optiontag)
 # NexusPHP Standard v1.5 Beta 5 (custom)

--- a/src/Jackett.Common/Definitions/hdsky.yml
+++ b/src/Jackett.Common/Definitions/hdsky.yml
@@ -164,5 +164,5 @@ search:
         img.pro_2up: 2
         "*": 1
     description:
-      selector: table.torrentname td.embedded:first-child > span:not(.optiontag)
+      selector: table.torrentname td.embedded:first-child > span:last-child
 # NexusPHP Standard v1.5 Beta 5 (custom)


### PR DESCRIPTION
#### Description
 Fix HDSky parsing for localized descriptions and searches.

  HDSky result rows can use an English release title while keeping the localized title and episode metadata in a separate description
  span. The old parser read the whole title cell and then removed broad elements including `span`, which could drop the useful
  description text.

  Example source:

  ```html
  <td class="embedded">
    <a title="Gimlet Eyes S01E13 2026 1080p WEB-DL AAC H264-HDSWEB"></a>
    <br />
    <span class="optiontag">Official Group</span>
    <span class="optiontag">Mandarin Audio</span>
    <span class="optiontag">Subtitles</span>
    <span>Localized Title / Alternate Title / Customs Office Unit Episode 13 | Cast: Actor One Actor Two Actor Three</span>
  </td>
  ```
  Before:
  ```yaml
  description:
    selector: td:nth-child(2)
    remove: a, b, font, img, span
  ```
  After:
  ```yaml
  description:
    selector: table.torrentname td.embedded:first-child > span:not(.optiontag)
  ```
  This now parses:

  Localized Title / Alternate Title / Customs Office Unit Episode 13 | Cast: Actor One Actor Two Actor Three

  instead of including option tags or losing the description span.



  This also **removes HDSky's andmatch** row filter. HDSky may return valid localized-title matches where the search term appears in the
  description, not in the English release title. Keeping andmatch could reject those rows after the site had already returned them. This
  matches the behavior of other Chinese NexusPHP trackers in Jackett, which generally do not use this extra andmatch restriction.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
