### PR TITLE
hddolby: fix description selector

### DIFF
--- a/src/Jackett.Common/Definitions/hddolby.yml
+++ b/src/Jackett.Common/Definitions/hddolby.yml
@@ -175,9 +175,5 @@ search:
       # 2 days (as seconds = 2 x 24 x 60 x 60)
       text: 172800
     description:
-      selector: td.rowfollow:nth-child(2)
-      remove: a, b, font, img, span.tags
-      filters:
-        - name: re_replace
-          args: ["(?i)\\s*(剩余时间:|剩餘時間：|will end in)\\s*", ""]
+      selector: table.torrentname td.embedded:first-child > span:last-child
 # NexusPHP Standard v1.5 Beta 4


### PR DESCRIPTION
#### Description
Fix HDDolby description parsing by selecting the actual description span in the torrent name cell.

  The previous selector parsed the full title cell and tried to remove unrelated UI text with filters, which could still leave freeleech
  countdown text in the description. The new selector targets the final span that contains the torrent description directly.

like #16771 
#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
