### PR TITLE
hdhome: fix metadata parsing

### DIFF
--- a/src/Jackett.Common/Definitions/hdhome.yml
+++ b/src/Jackett.Common/Definitions/hdhome.yml
@@ -163,6 +163,12 @@ search:
     download:
       selector: a[href*="download.php?id="]
       attribute: href
+    imdbid:
+      selector: a[href*="imdb.com/title/tt"]
+      attribute: href
+    doubanid:
+      selector: a[href*="movie.douban.com/subject/"]
+      attribute: href
     size:
       selector: td.rowfollow:nth-child(5)
       optional: true
@@ -215,6 +221,5 @@ search:
         img.pro_2up: 2
         "*": 1
     description:
-      selector: td:nth-child(2)
-      remove: a, b, font, img, span
+      selector: table.torrentname td.embedded:first-child > span:last-child
 # NexusPHP v2.0 2014-11-24


### PR DESCRIPTION
#### Description
This adds missing IMDb and Douban ID extraction from the rating links shown in torrent rows, and updates the description selector to
  target the actual description span inside the torrent name cell. The previous selector parsed the full title cell and removed all
  spans, which could drop the localized description text.
#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
