### PR TITLE
keepfriends: fix title and metadata parsing

### DIFF
--- a/src/Jackett.Common/Definitions/keepfriends.yml
+++ b/src/Jackett.Common/Definitions/keepfriends.yml
@@ -46,10 +46,6 @@ settings:
     type: checkbox
     label: Search freeleech only
     default: false
-  - name: english_title
-    type: checkbox
-    label: "Use English titles instead of Chinese ones (when available)."
-    default: false
   - name: sort
     type: select
     label: Sort requested from site
@@ -125,8 +121,11 @@ search:
       selector: a[href^="download.php?id="]
       attribute: href
     imdbid:
-      selector: a[href*="imdb.com/title/tt"]
-      attribute: href
+      selector: img[class*="imdb_"]
+      attribute: class
+      filters:
+        - name: regexp
+          args: "imdb_(\\d+)"
     doubanid:
       selector: a[href*="movie.douban.com/subject/"]
       attribute: href
@@ -177,11 +176,16 @@ search:
         img.pro_free2up: 2
         img.pro_2up: 2
         "*": 1
+    title_alt:
+      selector: table.torrentname > tbody > tr > td.embedded:first-child
+      remove: a, b, div, font, img
+    title_raw_has_cjk:
+      text: "{{ .Result.title_raw }}"
+      filters:
+        - name: regexp
+          args: "([\\u4e00-\\u9fff])"
     description:
-      selector: "{{ if .Result._staff_edit }}td:nth-child(3){{ else }}td:nth-child(2){{ end }}"
-      remove: a, b, font, img, span
-    title_english:
-      selector: table.torrentname > tbody > tr > td.embedded
+      text: "{{ if .Result.title_raw_has_cjk }}{{ .Result.title_raw }}{{ else }}{{ .Result.title_alt }}{{ end }}"
     title:
-      text: "{{ if and .Config.english_title .Result.title_english }}{{ .Result.title_english }}{{ else }}{{ .Result.title_raw }}{{ end }}"
+      text: "{{ if .Result.title_raw_has_cjk }}{{ .Result.title_alt }}{{ else }}{{ .Result.title_raw }}{{ end }}"
 # NexusPHP Standard v1.5 Beta 4 (custom title search)


### PR DESCRIPTION
#### Description
 Fix KeepFriends result parsing for title, description, and IMDb ID extraction.

  KeepFriends result rows are inconsistent: some rows put the localized title in the main link title and the English release title after
  `<br>`, while other rows may reverse that relationship. The previous optional "Use English titles instead of Chinese ones" setting was
  not a true swap. When enabled, it could replace the title with the alternate title but lose the original localized title instead of
  preserving it as the description.

  This change removes that setting and always keeps both title candidates by assigning one to `title` and the other to `description`.

**This change removes the existing "Use English titles instead of Chinese ones" setting, so it may affect users who currently rely on that option. I would like to ask for feedback on this part before it is merged. My reasoning is that the new behavior is more consistent in the long term: the release name should remain the English release title when available, while the localized/original title and extra notes should be preserved in the description.**

  #### Parsing Strategy

  The parser now extracts:

  - `title_raw` from the torrent link `title` attribute
  - `_title_alt` from the text after the torrent link inside the torrent name cell
  - `_title_raw_has_cjk` to detect whether `title_raw` contains CJK characters

  If `title_raw` contains CJK characters, it is treated as the localized description and `_title_alt` becomes the release title.

  If `title_raw` does not contain CJK characters, `title_raw` remains the release title and `_title_alt` becomes the description.

  #### Example

  Source HTML:

  ```html
  <td class="embedded browse_td_name_cell">
    <a title="[Localized Movie Title] UHD release notes" href="details.php?id=13118&hit=1">
      <b><span color="Red">[Localized Movie Title] UHD release notes</span></b>
    </a>
    <img class="tag imdb_111161">
    <br />
    <span color="Red">
      The Shawshank Redemption 1994 UHD 2160p x265 10bit HDR mUHD-FRDS
    </span>
  </td>
  ```
  Previous behavior:

  - Enabling the English-title option could make the title English-only.
  - The localized title was not preserved as the description.
  - Rows where the alternate title was wrapped in a <span> could be parsed with an empty title.

  New behavior:

  title: The Shawshank Redemption 1994 UHD 2160p x265 10bit HDR mUHD-FRDS
  description: [Localized Movie Title] UHD release notes
  imdbid: 111161

  #### IMDb ID

  KeepFriends does not expose IMDb result links in these rows, but it does expose the IMDb numeric ID in image classes such as:
  ```html
  <img class="tag imdb_111161">
  ```

  The IMDb parser now extracts that numeric ID directly from the class name.