### PR TITLE
springsunday: fix metadata parsing

### DIFF
--- a/src/Jackett.Common/Definitions/springsunday.yml
+++ b/src/Jackett.Common/Definitions/springsunday.yml
@@ -111,12 +111,10 @@ search:
       selector: a[href*="download.php?id="]
       attribute: href
     imdbid:
-      # site currently only has a badge and rating, the id is not present. just in case a future update.
-      selector: a[href*="imdb.com/title/tt"]
+      selector: a[href$="search_area=4"]
       attribute: href
     doubanid:
-      # site currently only has a badge and rating, the id is not present. just in case a future update.
-      selector: a[href*="movie.douban.com/subject/"]
+      selector: a[href$="search_area=5"]
       attribute: href
     date_elapsed:
       # time type: time elapsed (default)
@@ -162,6 +160,5 @@ search:
         span.torrent-pro-twoup: 2
         "*": 1
     description:
-      selector: td:nth-child(2)
-      remove: a, b, font, img, span
+      selector: div.torrent-smalldescr > span:last-child
 # NexusPHP Standard v1.5 Beta 4 (customised)


### PR DESCRIPTION
#### Description
Fix SpringSunday result metadata parsing.

  SpringSunday exposes IMDb and Douban IDs in internal search links next to the rating badges. The parser now extracts those IDs from
  the `search_area=4` and `search_area=5` links.

  The description selector was also narrowed to the actual small-description span instead of the full torrent title cell.

#### Example

  Source HTML:

  ```html
  <div class="torrent-title">
    <a title="Example.Movie.2001.1080p.Blu-ray.AVC.DTS-HD.MA.5.1-GROUP">
      Example.Movie.2001.1080p.Blu-ray.AVC.DTS-HD.MA.5.1-GROUP
    </a>
    <span class="torrent-pro-icon torrent-pro-free">Free</span>
    <span>(limited time)</span>
  </div>

  <div class="torrent-smalldescr">
    <span class="torrent-tag torrent-team">GROUP</span>
    <span class="torrent-tag torrent-internal">Official</span>
    <span class="torrent-tag torrent-untouched">Untouched</span>
    <span class="torrent-tag torrent-selfpurchase">Self-purchased</span>
    <span title="Localized title | Director: Example Director [disc notes]">
      Localized title | Director: Example Director [disc notes]
    </span>
  </div>

  <div>
    <a href="/torrents.php?search=123456&search_area=4">
      <img src="pic/imdb.png" alt="imdb"> 7.0
    </a>
    <a href="/torrents.php?search=654321&search_area=5">
      <img src="pic/douban.png" alt="douban"> 8.0
    </a>
  </div>
  ```
  Previous behavior could include unrelated UI text from the torrent title cell, such as promotion labels, countdown text, tags, or
  rating controls. IMDb and Douban IDs were also not parsed from the result row.

  New parsed values:

  title: Example.Movie.2001.1080p.Blu-ray.AVC.DTS-HD.MA.5.1-GROUP
  description: Localized title | Director: Example Director [disc notes]
  imdbid: 123456
  doubanid: 654321