### PR TITLE
pterclub: fix description selector

### DIFF
--- a/src/Jackett.Common/Definitions/pterclub.yml
+++ b/src/Jackett.Common/Definitions/pterclub.yml
@@ -187,6 +187,5 @@ search:
     minimumratio:
       text: 0.9
     description:
-      selector: td:has(table.torrentname)
-      remove: a, img
+      selector: td:has(table.torrentname) span:last-child
 # NexusPHP prod#60d2fdc724a 2023-05-10


### PR DESCRIPTION
#### Description
 Fix PTerClub result description parsing.

  The previous selector used the full torrent title cell and removed only links/images. That could leave unrelated UI text in the parsed
  description, such as promotion countdowns or other title-cell metadata.

  This change narrows the description selector to the final span in the torrent name cell, which is where PTerClub places the localized
  title/description text.

  #### Example

  Source HTML:
```html

  <td class="embedded">
    <div>
      <div>
        <a title="Example.Movie.2025.1080p.Blu-ray.AVC.DTS-HD.MA.5.1-GROUP">
          <b>Example.Movie.2025.1080p.Blu-ray.AVC.DTS-HD.MA.5.1-GROUP</b>
        </a>
        <img class="pro_free" alt="Free">
        remaining time: <b><span>14h 12m</span></b>
      </div>
      <div>
        <span>Localized title | Alternate title | 2025 | Extra aliases</span>
      </div>
    </div>
  </td>
```

  Previous behavior could include text from the full title cell, including promotion information.

  New parsed values:

  title: Example.Movie.2025.1080p.Blu-ray.AVC.DTS-HD.MA.5.1-GROUP
  description: Localized title | Alternate title | 2025 | Extra aliases