### PR TITLE
Fix Audiences login check

### DIFF
--- a/src/Jackett.Common/Definitions/audiences.yml
+++ b/src/Jackett.Common/Definitions/audiences.yml
@@ -72,7 +72,7 @@ login:
     cookie: "{{ .Config.cookie }}"
   test:
     path: index.php
-    selector: a[href="logout.php"]
+    selector: a[href*="usercp.php"]
 
 search:
   paths:


### PR DESCRIPTION
#### Description

 Fix Audiences cookie login detection after a recent page layout update.

  Audiences no longer exposes `logout.php` as a normal logout anchor in the parsed DOM, so the previous login test fails.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
