### PR TITLE
ultrabits: add Nordic private tracker. resolves #16783

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,6 +669,7 @@ Prior versions of Jackett are no longer supported.
  * U2 (U2分享園@動漫花園) [![(invite needed)][inviteneeded]](#)
  * UBits
  * UltraHD
+ * Ultrabits
  * UnlimitZ
  * upload.cx (ULCX)
  * Upscale Vault

--- a/src/Jackett.Common/Definitions/ultrabits-api.yml
+++ b/src/Jackett.Common/Definitions/ultrabits-api.yml
@@ -1,0 +1,150 @@
+---
+id: ultrabits-api
+name: Ultrabits (API)
+description: "Ultrabits is a Nordic Private Torrent Tracker for MOVIES / TV / MUSIC / GAMES / APPS / BOOKS"
+language: sv-SE
+type: private
+encoding: UTF-8
+links:
+  - https://ultrabits.org/
+
+caps:
+  categorymappings:
+    - {id: 2010, cat: Movies/Foreign, desc: "Movies Subpack"}
+    - {id: 2040, cat: Movies/HD, desc: "Movies HD"}
+    - {id: 2045, cat: Movies/UHD, desc: "Movies UHD"}
+    - {id: 2050, cat: Movies/BluRay, desc: "Movies BluRay"}
+    - {id: 2070, cat: Movies/DVD, desc: "Movies DVDR"}
+    - {id: 2080, cat: Movies/WEB-DL, desc: "Movies WEB-DL"}
+    - {id: 5010, cat: TV/WEB-DL, desc: "TV WEB-DL"}
+    - {id: 5020, cat: TV/Foreign, desc: "TV Nordisk"}
+    - {id: 5030, cat: TV/SD, desc: "TV SD"}
+    - {id: 5040, cat: TV/HD, desc: "TV HD"}
+    - {id: 5045, cat: TV/UHD, desc: "TV UHD"}
+    - {id: 5060, cat: TV/Sport, desc: "TV Sport"}
+    - {id: 5070, cat: TV/Anime, desc: "TV Anime"}
+    - {id: 5080, cat: TV/Documentary, desc: "TV Documentary"}
+    - {id: 3010, cat: Audio/MP3, desc: "Music MP3"}
+    - {id: 3020, cat: Audio/Video, desc: "Music Video"}
+    - {id: 3030, cat: Audio/Audiobook, desc: "Audiobook / Podcast"}
+    - {id: 3040, cat: Audio/Lossless, desc: "Music FLAC"}
+    - {id: 4010, cat: PC/0day, desc: "Apps 0DAY"}
+    - {id: 4020, cat: PC/ISO, desc: "Apps ISO"}
+    - {id: 4050, cat: PC/Games, desc: "Games PC"}
+    - {id: 4070, cat: PC/Mobile-Android, desc: "Apps Mobile"}
+    - {id: 1090, cat: Console/Other, desc: "Games Switch"}
+    - {id: 1140, cat: Console/XBox One, desc: "Games Xbox"}
+    - {id: 1180, cat: Console/PS4, desc: "Games PlayStation"}
+    - {id: 7010, cat: Books/Mags, desc: "Books Magazine"}
+    - {id: 7020, cat: Books/EBook, desc: "Books eBook"}
+    - {id: 7030, cat: Books/Comics, desc: "Books Comic"}
+
+  modes:
+    search: [q]
+    tv-search: [q, season, ep, imdbid, tmdbid, tvdbid]
+    movie-search: [q, imdbid, tmdbid]
+    music-search: [q]
+    book-search: [q]
+
+settings:
+  - name: apikey
+    type: text
+    label: Passkey or API key
+  - name: info_apikey
+    type: info
+    label: How do I get a key?
+    default: "Paste either your announce passkey (32 hex chars, copied from <a href=\"https://ultrabits.org/profile/settings/account\" target=\"_blank\">/profile/settings/account</a>) OR a personal API key (prefix <code>ubk_</code>, created at <a href=\"https://ultrabits.org/profile/settings/api-keys\" target=\"_blank\">/profile/settings/api-keys</a>). The server detects the format automatically."
+  - name: info_account
+    type: info
+    label: Don't have an account?
+    default: "Ultrabits is invitation-only. Apply at <a href=\"https://ultrabits.org/apply\" target=\"_blank\">/apply</a>; applications are reviewed manually."
+  - name: freeleech
+    type: checkbox
+    label: Search freeleech only
+    default: false
+  - name: sort
+    type: select
+    label: Sort requested from site
+    default: added
+    options:
+      added: created
+      seeders: seeders
+      size: size
+  - name: type
+    type: select
+    label: Order requested from site
+    default: desc
+    options:
+      desc: desc
+      asc: asc
+
+# Ultrabits has no session login — the JSON API takes the apikey as
+# a query parameter on every request. We still issue a 1-result probe
+# at indexer-add time so a bad credential is caught before the user
+# sees empty results from a real search. The error envelope from the
+# server is `{ "error": { "code": ..., "description": "..." } }`,
+# which Cardigann's JSON-to-XML transform exposes as <error><description>...
+login:
+  path: /v1/jackett/search
+  method: get
+  inputs:
+    apikey: "{{ .Config.apikey }}"
+    limit: "1"
+  error:
+    - selector: error
+      message:
+        selector: description
+
+search:
+  paths:
+    - path: /v1/jackett/search
+      response:
+        type: json
+  inputs:
+    q: "{{ .Keywords }}"
+    apikey: "{{ .Config.apikey }}"
+    cat: "{{ join .Categories \",\" }}"
+    imdbid: "{{ .Query.IMDBIDShort }}"
+    tmdbid: "{{ .Query.TMDBID }}"
+    season: "{{ .Query.Season }}"
+    ep: "{{ .Query.Ep }}"
+    freeleech: "{{ if .Config.freeleech }}1{{ else }}{{ end }}"
+    sort: "{{ .Config.sort }}"
+    order: "{{ .Config.type }}"
+    limit: 100
+
+  rows:
+    selector: data
+
+  fields:
+    title:
+      selector: name
+    details:
+      selector: detailsUrl
+    download:
+      selector: downloadUrl
+    category:
+      selector: category
+    size:
+      selector: size
+    seeders:
+      selector: seeders
+    leechers:
+      selector: leechers
+    grabs:
+      selector: grabs
+    date:
+      selector: addedAt
+    infohash:
+      selector: infoHash
+      optional: true
+    imdb:
+      selector: imdb
+      optional: true
+    tmdbid:
+      selector: tmdbId
+      optional: true
+    downloadvolumefactor:
+      selector: downloadvolumefactor
+    uploadvolumefactor:
+      selector: uploadvolumefactor

--- a/src/Jackett.Common/Definitions/ultrabits-api.yml
+++ b/src/Jackett.Common/Definitions/ultrabits-api.yml
@@ -1,7 +1,7 @@
 ---
 id: ultrabits-api
 name: Ultrabits (API)
-description: "Ultrabits is a Nordic Private Torrent Tracker for MOVIES / TV / MUSIC / GAMES / APPS / BOOKS"
+description: "Ultrabits is a NORDIC Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: sv-SE
 type: private
 encoding: UTF-8
@@ -10,20 +10,15 @@ links:
 
 caps:
   categorymappings:
+    - {id: 1090, cat: Console/Other, desc: "Games Switch"}
+    - {id: 1140, cat: Console/XBox One, desc: "Games Xbox"}
+    - {id: 1180, cat: Console/PS4, desc: "Games PlayStation"}
     - {id: 2010, cat: Movies/Foreign, desc: "Movies Subpack"}
     - {id: 2040, cat: Movies/HD, desc: "Movies HD"}
     - {id: 2045, cat: Movies/UHD, desc: "Movies UHD"}
     - {id: 2050, cat: Movies/BluRay, desc: "Movies BluRay"}
     - {id: 2070, cat: Movies/DVD, desc: "Movies DVDR"}
     - {id: 2080, cat: Movies/WEB-DL, desc: "Movies WEB-DL"}
-    - {id: 5010, cat: TV/WEB-DL, desc: "TV WEB-DL"}
-    - {id: 5020, cat: TV/Foreign, desc: "TV Nordisk"}
-    - {id: 5030, cat: TV/SD, desc: "TV SD"}
-    - {id: 5040, cat: TV/HD, desc: "TV HD"}
-    - {id: 5045, cat: TV/UHD, desc: "TV UHD"}
-    - {id: 5060, cat: TV/Sport, desc: "TV Sport"}
-    - {id: 5070, cat: TV/Anime, desc: "TV Anime"}
-    - {id: 5080, cat: TV/Documentary, desc: "TV Documentary"}
     - {id: 3010, cat: Audio/MP3, desc: "Music MP3"}
     - {id: 3020, cat: Audio/Video, desc: "Music Video"}
     - {id: 3030, cat: Audio/Audiobook, desc: "Audiobook / Podcast"}
@@ -32,16 +27,21 @@ caps:
     - {id: 4020, cat: PC/ISO, desc: "Apps ISO"}
     - {id: 4050, cat: PC/Games, desc: "Games PC"}
     - {id: 4070, cat: PC/Mobile-Android, desc: "Apps Mobile"}
-    - {id: 1090, cat: Console/Other, desc: "Games Switch"}
-    - {id: 1140, cat: Console/XBox One, desc: "Games Xbox"}
-    - {id: 1180, cat: Console/PS4, desc: "Games PlayStation"}
+    - {id: 5010, cat: TV/WEB-DL, desc: "TV WEB-DL"}
+    - {id: 5020, cat: TV/Foreign, desc: "TV Nordisk"}
+    - {id: 5030, cat: TV/SD, desc: "TV SD"}
+    - {id: 5040, cat: TV/HD, desc: "TV HD"}
+    - {id: 5045, cat: TV/UHD, desc: "TV UHD"}
+    - {id: 5060, cat: TV/Sport, desc: "TV Sport"}
+    - {id: 5070, cat: TV/Anime, desc: "TV Anime"}
+    - {id: 5080, cat: TV/Documentary, desc: "TV Documentary"}
     - {id: 7010, cat: Books/Mags, desc: "Books Magazine"}
     - {id: 7020, cat: Books/EBook, desc: "Books eBook"}
     - {id: 7030, cat: Books/Comics, desc: "Books Comic"}
 
   modes:
     search: [q]
-    tv-search: [q, season, ep, imdbid, tmdbid, tvdbid]
+    tv-search: [q, season, ep, imdbid, tmdbid]
     movie-search: [q, imdbid, tmdbid]
     music-search: [q]
     book-search: [q]
@@ -49,15 +49,11 @@ caps:
 settings:
   - name: apikey
     type: text
-    label: Passkey or API key
-  - name: info_apikey
+    label: APIKey
+  - name: info_key
     type: info
-    label: How do I get a key?
-    default: "Paste either your announce passkey (32 hex chars, copied from <a href=\"https://ultrabits.org/profile/settings/account\" target=\"_blank\">/profile/settings/account</a>) OR a personal API key (prefix <code>ubk_</code>, created at <a href=\"https://ultrabits.org/profile/settings/api-keys\" target=\"_blank\">/profile/settings/api-keys</a>). The server detects the format automatically."
-  - name: info_account
-    type: info
-    label: Don't have an account?
-    default: "Ultrabits is invitation-only. Apply at <a href=\"https://ultrabits.org/apply\" target=\"_blank\">/apply</a>; applications are reviewed manually."
+    label: About your API key
+    default: "Find or Generate a new API Key by accessing your <a href=\"https://ultrabits.org/profile/settings/api-keys\" target=\"_blank\">Ultrabits</a> account <i>API keys</i> page."
   - name: freeleech
     type: checkbox
     label: Search freeleech only
@@ -77,19 +73,17 @@ settings:
     options:
       desc: desc
       asc: asc
+  - name: info_activity
+    type: info
+    label: Account Inactivity
+    default: "Log in to the website at least every 3 months to avoid account deactivation."
 
-# Ultrabits has no session login — the JSON API takes the apikey as
-# a query parameter on every request. We still issue a 1-result probe
-# at indexer-add time so a bad credential is caught before the user
-# sees empty results from a real search. The error envelope from the
-# server is `{ "error": { "code": ..., "description": "..." } }`,
-# which Cardigann's JSON-to-XML transform exposes as <error><description>...
 login:
-  path: /v1/jackett/search
+  path: v1/jackett/search
   method: get
   inputs:
     apikey: "{{ .Config.apikey }}"
-    limit: "1"
+    limit: 1
   error:
     - selector: error
       message:
@@ -115,6 +109,8 @@ search:
 
   rows:
     selector: data
+    count:
+      selector: total
 
   fields:
     title:
@@ -140,11 +136,15 @@ search:
       optional: true
     imdb:
       selector: imdb
-      optional: true
     tmdbid:
       selector: tmdbId
-      optional: true
     downloadvolumefactor:
       selector: downloadvolumefactor
     uploadvolumefactor:
       selector: uploadvolumefactor
+    minimumratio:
+      text: 1.1
+    minimumseedtime:
+      # 2 days (as seconds = 2 x 24 x 60 x 60)
+      text: 172800
+# json api

--- a/src/Jackett.Common/Definitions/ultrabits-api.yml
+++ b/src/Jackett.Common/Definitions/ultrabits-api.yml
@@ -9,35 +9,45 @@ links:
   - https://ultrabits.org/
 
 caps:
+  # `id` is the site's internal category slug — the JSON search endpoint
+  # echoes it back in each torrent's `category` field, so Cardigann maps
+  # rows 1:1 against what the API returns. `desc` mirrors the labels
+  # users see on ultrabits.org so Sonarr / Radarr / Prowlarr render the
+  # same wording.
   categorymappings:
-    - {id: 1090, cat: Console/Other, desc: "Games Switch"}
-    - {id: 1140, cat: Console/XBox One, desc: "Games Xbox"}
-    - {id: 1180, cat: Console/PS4, desc: "Games PlayStation"}
-    - {id: 2010, cat: Movies/Foreign, desc: "Movies Subpack"}
-    - {id: 2040, cat: Movies/HD, desc: "Movies HD"}
-    - {id: 2045, cat: Movies/UHD, desc: "Movies UHD"}
-    - {id: 2050, cat: Movies/BluRay, desc: "Movies BluRay"}
-    - {id: 2070, cat: Movies/DVD, desc: "Movies DVDR"}
-    - {id: 2080, cat: Movies/WEB-DL, desc: "Movies WEB-DL"}
-    - {id: 3010, cat: Audio/MP3, desc: "Music MP3"}
-    - {id: 3020, cat: Audio/Video, desc: "Music Video"}
-    - {id: 3030, cat: Audio/Audiobook, desc: "Audiobook / Podcast"}
-    - {id: 3040, cat: Audio/Lossless, desc: "Music FLAC"}
-    - {id: 4010, cat: PC/0day, desc: "Apps 0DAY"}
-    - {id: 4020, cat: PC/ISO, desc: "Apps ISO"}
-    - {id: 4050, cat: PC/Games, desc: "Games PC"}
-    - {id: 4070, cat: PC/Mobile-Android, desc: "Apps Mobile"}
-    - {id: 5010, cat: TV/WEB-DL, desc: "TV WEB-DL"}
-    - {id: 5020, cat: TV/Foreign, desc: "TV Nordisk"}
-    - {id: 5030, cat: TV/SD, desc: "TV SD"}
-    - {id: 5040, cat: TV/HD, desc: "TV HD"}
-    - {id: 5045, cat: TV/UHD, desc: "TV UHD"}
-    - {id: 5060, cat: TV/Sport, desc: "TV Sport"}
-    - {id: 5070, cat: TV/Anime, desc: "TV Anime"}
-    - {id: 5080, cat: TV/Documentary, desc: "TV Documentary"}
-    - {id: 7010, cat: Books/Mags, desc: "Books Magazine"}
-    - {id: 7020, cat: Books/EBook, desc: "Books eBook"}
-    - {id: 7030, cat: Books/Comics, desc: "Books Comic"}
+    - {id: Game-NSW, cat: Console/Other, desc: "Console/Switch"}
+    - {id: Game-Xbox, cat: Console/XBox One, desc: "Console/Xbox"}
+    - {id: Game-PS, cat: Console/PS4, desc: "Console/PlayStation"}
+    - {id: Movie-Subpack, cat: Movies/Foreign, desc: "Movies/Subpack"}
+    - {id: Movie-x264, cat: Movies/HD, desc: "Movies/x264"}
+    - {id: Movie-x265, cat: Movies/HD, desc: "Movies/x265"}
+    - {id: Movie-UHD, cat: Movies/UHD, desc: "Movies/UHD"}
+    - {id: Movie-Remux, cat: Movies/UHD, desc: "Movies/Remux"}
+    - {id: Movie-BD, cat: Movies/BluRay, desc: "Movies/BluRay"}
+    - {id: Movie-DVD, cat: Movies/DVD, desc: "Movies/DVDR"}
+    - {id: Movie-WEB, cat: Movies/WEB-DL, desc: "Movies/WEB-DL"}
+    - {id: MP3, cat: Audio/MP3, desc: "Audio/MP3"}
+    - {id: MusicVid, cat: Audio/Video, desc: "Audio/Video"}
+    - {id: Podcast, cat: Audio/Audiobook, desc: "Audio/Podcast"}
+    - {id: AudioBook, cat: Audio/Audiobook, desc: "Books/Audiobook"}
+    - {id: FLAC, cat: Audio/Lossless, desc: "Audio/FLAC"}
+    - {id: MusicDisc, cat: Audio/Lossless, desc: "Audio/Disc"}
+    - {id: "0DAY", cat: PC/0day, desc: "PC/0DAY"}
+    - {id: App-ISO, cat: PC/ISO, desc: "PC/ISO"}
+    - {id: Game-PC, cat: PC/Games, desc: "PC/Games"}
+    - {id: App-Mobile, cat: PC/Mobile-Android, desc: "PC/Mobile"}
+    - {id: TV-WEB, cat: TV/WEB-DL, desc: "TV/WEB-DL"}
+    - {id: TV-Nordic, cat: TV/Foreign, desc: "TV/Nordic"}
+    - {id: TV-DVD, cat: TV/SD, desc: "TV/DVDR"}
+    - {id: TV-x264, cat: TV/HD, desc: "TV/x264"}
+    - {id: TV-x265, cat: TV/HD, desc: "TV/x265"}
+    - {id: TV-UHD, cat: TV/UHD, desc: "TV/UHD"}
+    - {id: TV-Sport, cat: TV/Sport, desc: "TV/Sport"}
+    - {id: TV-Anime, cat: TV/Anime, desc: "TV/Anime"}
+    - {id: TV-Doc, cat: TV/Documentary, desc: "TV/Documentary"}
+    - {id: Magazine, cat: Books/Mags, desc: "Books/Magazine"}
+    - {id: eBook, cat: Books/EBook, desc: "Books/eBook"}
+    - {id: Comic, cat: Books/Comics, desc: "Books/Comic"}
 
   modes:
     search: [q]


### PR DESCRIPTION
#### Description

Adds Ultrabits as a new Cardigann YAML indexer.

Ultrabits is a Swedish-language Nordic private tracker covering scene, P2P and archive content (movies, TV, music, games, apps, books). The indexer talks to the tracker's `/v1/jackett/search` JSON endpoint with query-param auth — same pattern as the UNIT3D-derived definitions (Aither, Anthelion, Blutopia, …).

- Single new file: `src/Jackett.Common/Definitions/ultrabits-api.yml`
- README updated under "Private Trackers" → Ultrabits inserted alphabetically.
- No C# changes.
- 28 categorymappings, all IDs verified against `TorznabCatType.cs` at upstream master so Sonarr/Radarr profile filters land on the expected bucket.
- Auth accepts either the announce passkey (32 hex chars) or a personal API key (prefix `ubk_`); the server detects the format. The login block issues a 1-result probe and surfaces the server's `error.description` on a bad credential.

Tested locally with my own account against the production tracker through Jackett 0.24.1789. Test passes; sample searches return results that resolve correctly back into Sonarr/Radarr.

#### Screenshot (if UI related)

n/a — definition-only change.

#### Issues Fixed or Closed by this PR

Fixes #16783