### PR TITLE
fix: update indexer world-of-tomorrow schema after update of indexer search results

### DIFF
--- a/src/Jackett.Common/Definitions/world-of-tomorrow.yml
+++ b/src/Jackett.Common/Definitions/world-of-tomorrow.yml
@@ -94,7 +94,7 @@ settings:
   - name: info_free
     type: info
     label: About Freeleech and OnlyUpload at World-of-Tomorrow
-    default: "<ul><li>FreeLeech are torrents where neither the download or upload is counted.</li><li>OnlyUpload are torrents where download is not counted but upload is. Good for building your Ratio up.</li></ul>"
+    default: "<ul><li>FreeLeech are torrents where neither the download or upload is counted. (On the Jackett dashboard search results these are tagged as NoUpload).</li><li>OnlyUpload are torrents where download is not counted but upload is. Good for building your Ratio up. (On the Jackett dashboard search results these are tagged as Freeleech).</li></ul>"
   - name: sortby
     type: select
     label: Sort requested from site

--- a/src/Jackett.Common/Definitions/world-of-tomorrow.yml
+++ b/src/Jackett.Common/Definitions/world-of-tomorrow.yml
@@ -176,9 +176,8 @@ search:
       selector: div.sr-cover img
       attribute: src
     imdbid:
-      selector: a.sr-link-badge[href*="imdb.com"], a.sr-link-badge[href*="imdb.com/title/"], a[href*="imdb.com/title/"]
+      selector: a.sr-link-badge[href*="imdb.com"]
       attribute: href
-      optional: true
     size:
       selector: span.sr-detail-size, div.sr-dup-meta span:nth-child(1)
     grabs:

--- a/src/Jackett.Common/Definitions/world-of-tomorrow.yml
+++ b/src/Jackett.Common/Definitions/world-of-tomorrow.yml
@@ -94,7 +94,7 @@ settings:
   - name: info_free
     type: info
     label: About Freeleech and OnlyUpload at World-of-Tomorrow
-    default: "<ul><li>FreeLeech are torrents where neither the download or upload is counted. (On the Jackett dashboard search results these are tagged as NoUpload).</li><li>OnlyUpload are torrents where download is not counted but upload is. Good for building your Ratio up. (On the Jackett dashboard search results these are tagged as Freeleech).</li></ul>"
+    default: "<ul><li>FreeLeech are torrents where neither the download or upload is counted.</li><li>OnlyUpload are torrents where download is not counted but upload is. Good for building your Ratio up.</li></ul>"
   - name: sortby
     type: select
     label: Sort requested from site
@@ -152,16 +152,22 @@ search:
     limit: 100
 
   rows:
-    selector: div.sr-card
+    selector: div.sr-card, div.sr-dup-item
 
   fields:
     categorydesc:
-      selector: div.sr-badge-cat
+      selector: div.sr-badge-cat, div.sr-dup-meta span:nth-child(5)
       remove: span.sr-badge-lang
+      filters:
+        - name: re_replace
+          args: ["(?i)^(Filme|Serien|Musik|Audio|Spiele|Games|Apps|Software|Sonstiges)\\s+", ""]
+        - name: re_replace
+          args: ["\\s*\\[[^\\]]+\\]\\s*$", ""]
+        - name: trim
     title:
-      selector: div.sr-title-row a[href^="torrent.php"]
+      selector: a[href^="torrent.php"]:has(span)
     details:
-      selector: div.sr-title-row a[href^="torrent.php"]
+      selector: a[href^="torrent.php"]:has(span)
       attribute: href
     download:
       selector: a[href^="download.php?torrent="]
@@ -170,24 +176,41 @@ search:
       selector: div.sr-cover img
       attribute: src
     imdbid:
-      selector: a.sr-link-badge[href*="imdb.com"]
+      selector: a.sr-link-badge[href*="imdb.com"], a.sr-link-badge[href*="imdb.com/title/"], a[href*="imdb.com/title/"]
       attribute: href
+      optional: true
     size:
-      selector: span.sr-detail-size
+      selector: span.sr-detail-size, div.sr-dup-meta span:nth-child(1)
     grabs:
       selector: span.sr-detail-dl
+      optional: true
     seeders:
-      selector: span.sr-detail-seed
+      selector: span.sr-detail-seed, div.sr-dup-meta span:nth-child(2)
     leechers:
-      selector: span.sr-detail-leech
+      selector: span.sr-detail-leech, div.sr-dup-meta span:nth-child(3)
     date:
-      selector: span.sr-detail-time i
-      attribute: title
+      selector: span.sr-detail-time, div.sr-dup-meta span:nth-child(4)
       filters:
-        - name: append
-          args: " +01:00"
-        - name: dateparse
-          args: "yyyy-MM-dd HH:mm:ss zzz"
+        - name: re_replace
+          args: ["(?i)^\\s*vor\\s+(.+)$", "$1 ago"]
+        - name: re_replace
+          args: ["(?i)\\bund\\b", ""]
+        - name: re_replace
+          args: ["(?i)\\bSekunde(n)?\\b", "seconds"]
+        - name: re_replace
+          args: ["(?i)\\bMinute(n)?\\b", "minutes"]
+        - name: re_replace
+          args: ["(?i)\\bStunde(n)?\\b", "hours"]
+        - name: re_replace
+          args: ["(?i)\\bTag(e|en)?\\b", "days"]
+        - name: re_replace
+          args: ["(?i)\\bWoche(n)?\\b", "weeks"]
+        - name: re_replace
+          args: ["(?i)\\bMonat(e|en)?\\b", "months"]
+        - name: re_replace
+          args: ["(?i)\\bJahr(e|en)?\\b", "years"]
+        - name: trim
+        - name: timeago
     downloadvolumefactor:
       case:
         span.sr-status-onlyupload: 0 # only upload is counted


### PR DESCRIPTION
#### Description
The tracker recently changed its search results layout to summarize related releases under a single main result. As a result, only the main release was returned by the indexer. This update parses the additional grouped releases as separate results again.

https://github.com/Prowlarr/Indexers/pull/891
