### PR TITLE
torr9: season and episode api search now working

### DIFF
--- a/src/Jackett.Common/Definitions/torr9.yml
+++ b/src/Jackett.Common/Definitions/torr9.yml
@@ -83,8 +83,8 @@ search:
     t: "{{ if .Query.IMDBID }}movie{{ else }}{{ end }}{{ if .Query.TVDBID }}tvsearch{{ else }}{{ end }}{{ if or .Query.TVDBID .Query.IMDBID }}{{ else }}search{{ end }}"
     q: "{{ .Keywords }}"
     cat: "{{ join .Categories \",\" }}"
-#    season: "{{ .Query.Season }}"
-#    ep: "{{ .Query.Ep }}"
+    season: "{{ .Query.Season }}"
+    ep: "{{ .Query.Ep }}"
     imdbid: "{{ .Query.IMDBID }}"
     tvdbid: "{{ .Query.TVDBID }}"
     limit: 100


### PR DESCRIPTION
#### Description
When searching for a specific episode in Sonarr, all episodes are retrieved, and not just the desired one. As indicated in 7b4829f, searching by season and episode was not working at the time in Torr9. Therefore, season and ep lines were commented out.

I did some tests and can confirm that this is now working.

#### Issues Fixed or Closed by this PR

None
