### PR TITLE
pornolab: add .cc domain

### DIFF
--- a/src/Jackett.Common/Definitions/pornolab.yml
+++ b/src/Jackett.Common/Definitions/pornolab.yml
@@ -7,6 +7,7 @@ type: semi-private
 encoding: windows-1251
 links:
   - https://pornolab.net/
+  - https://pornolab.cc/
 
 caps:
   categorymappings:


### PR DESCRIPTION
#### Description
Pornolab is also available on the `.cc` TLD
