### PR TITLE
runtheframes-api: add private tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,6 +581,7 @@ Prior versions of Jackett are no longer supported.
  * Romanian Metal Torrents (RMT)
  * RoTorrent (ROT)
  * Rousi.pro
+ * RunTheFrames [![(invite needed)][inviteneeded]](#)
  * SAMARITANO
  * SBPT
  * SceneHD [![(invite needed)][inviteneeded]](#)

--- a/src/Jackett.Common/Definitions/runtheframes-api.yml
+++ b/src/Jackett.Common/Definitions/runtheframes-api.yml
@@ -2,7 +2,7 @@
 id: runtheframes-api
 name: RunTheFrames (API)
 description: "RunTheFrames is a GERMAN Private Torrent Tracker for MOVIES / TV / GENERAL"
-language: en-US
+language: de-DE
 type: private
 encoding: UTF-8
 links:
@@ -15,7 +15,7 @@ caps:
     - {id: 3, cat: TV/Anime, desc: "Anime"}
     - {id: 4, cat: TV/Documentary, desc: "Dokumentationen"}
     - {id: 5, cat: Audio, desc: "Music"}
-    - {id: 6, cat: PC/Games, desc: "Games"}
+    - {id: 6, cat: Console, desc: "Games"}
     - {id: 7, cat: PC, desc: "Software"}
     - {id: 8, cat: Audio/Other, desc: "Podcast"}
 
@@ -32,7 +32,7 @@ settings:
   - name: info_key
     type: info
     label: About your API key
-    default: "Find or Generate a new API Token by accessing your <a href=\"https://runtheframes.xyz/\" target=\"_blank\">RetroMoviesClub</a> account <i>My Settings</i> page and clicking on the <b>API Key</b> tab."
+    default: "Find or Generate a new API Token by accessing your <a href=\"https://runtheframes.xyz/\" target=\"_blank\">RunTheFrames</a> account <i>My Settings</i> page and clicking on the <b>API Key</b> tab."
   - name: freeleech
     type: checkbox
     label: Search freeleech only

--- a/src/Jackett.Common/Definitions/runtheframes-api.yml
+++ b/src/Jackett.Common/Definitions/runtheframes-api.yml
@@ -1,0 +1,193 @@
+---
+id: runtheframes-api
+name: RunTheFrames (API)
+description: "RunTheFrames is a GERMAN Private Torrent Tracker for MOVIES / TV / GENERAL"
+language: en-US
+type: private
+encoding: UTF-8
+links:
+  - https://runtheframes.xyz/
+
+caps:
+  categorymappings:
+    - {id: 1, cat: Movies, desc: "Movies"}
+    - {id: 2, cat: TV, desc: "TV"}
+    - {id: 3, cat: TV/Anime, desc: "Anime"}
+    - {id: 4, cat: TV/Documentary, desc: "Dokumentationen"}
+    - {id: 5, cat: Audio, desc: "Music"}
+    - {id: 6, cat: PC/Games, desc: "Games"}
+    - {id: 7, cat: PC, desc: "Software"}
+    - {id: 8, cat: Audio/Other, desc: "Podcast"}
+
+  modes:
+    search: [q]
+    movie-search: [q, imdbid, tmdbid]
+    tv-search: [q, season, ep, imdbid, tvdbid, tmdbid]
+    music-search: [q]
+
+settings:
+  - name: apikey
+    type: text
+    label: APIKey
+  - name: info_key
+    type: info
+    label: About your API key
+    default: "Find or Generate a new API Token by accessing your <a href=\"https://runtheframes.xyz/\" target=\"_blank\">RetroMoviesClub</a> account <i>My Settings</i> page and clicking on the <b>API Key</b> tab."
+  - name: freeleech
+    type: checkbox
+    label: Search freeleech only
+    default: false
+  - name: single_file_release_use_filename
+    type: checkbox
+    label: Use filename as title for single file releases
+    default: true
+  - name: sort
+    type: select
+    label: Sort requested from site
+    default: created_at
+    options:
+      created_at: created
+      seeders: seeders
+      size: size
+      name: title
+  - name: type
+    type: select
+    label: Order requested from site
+    default: desc
+    options:
+      desc: desc
+      asc: asc
+  - name: info_activity
+    type: info
+    label: Account Inactivity
+    default: "Accounts with no activity (login/traffic) for more than 90 days may be automatically pruned."
+
+login:
+  path: api/torrents
+  method: get
+  error:
+    - selector: a[href*="/login"]
+      message:
+        text: "The API key was not accepted by {{ .Config.sitelink }}."
+    - selector: :root:contains("Account is Banned")
+
+search:
+  paths:
+    # https://hdinnovations.github.io/UNIT3D/torrent_api.html
+    # https://github.com/HDInnovations/UNIT3D/blob/master/app/Http/Controllers/API/TorrentController.php#L657
+    - path: api/torrents/filter
+      response:
+        type: json
+
+  headers:
+    Authorization: ["Bearer {{ .Config.apikey }}"]
+
+  inputs:
+    $raw: "{{ range .Categories }}&categories[]={{.}}{{end}}"
+    name: "{{ .Keywords }}"
+    imdbId: "{{ .Query.IMDBIDShort }}"
+    tmdbId: "{{ .Query.TMDBID }}"
+    "free[]": "{{ if .Config.freeleech }}100{{ else }}{{ end }}"
+    sortField: "{{ .Config.sort }}"
+    sortDirection: "{{ .Config.type }}"
+    perPage: 100
+
+  keywordsfilters:
+    - name: re_replace
+      args: ["\\.", " "]
+
+  rows:
+    selector: data
+    attribute: attributes
+
+  fields:
+    category:
+      selector: category_id
+    title_optional:
+      selector: name
+    title_filename:
+      selector: "files[0].name"
+      optional: true
+    files:
+      selector: num_file
+    title:
+      text: "{{ if and (.Config.single_file_release_use_filename) (eq .Result.files \"1\") (.Result.title_filename) }}{{ .Result.title_filename }}{{ else }}{{ .Result.title_optional }}{{ end }}"
+    details:
+      selector: details_link
+    download:
+      selector: download_link
+    poster:
+      selector: meta.poster
+      filters:
+        - name: replace
+          args: ["https://via.placeholder.com/90x135", ""]
+    imdbid:
+      selector: imdb_id
+    tmdbid:
+      selector: tmdb_id
+    tvdbid:
+      selector: tvdb_id
+    genre:
+      selector: meta.genres
+      filters:
+        - name: re_replace
+          args: ["(?i)(Science Fiction)", "Science_Fiction"]
+        - name: re_replace
+          args: ["(?i)(TV Movie)", "TV_Movie"]
+        - name: replace
+          args: [" & ", "_&_"]
+    _internal:
+      selector: internal
+      case:
+        False: "{{ .False }}"
+        True: "{{ .True }}"
+    description:
+      text: "{{ if .Result._internal }}Internal{{ else }}{{ end }}{{ if and .Result._internal .Result.genre }} | {{ else }}{{ end }}{{ .Result.genre }}"
+    seeders:
+      selector: seeders
+    leechers:
+      selector: leechers
+    grabs:
+      selector: times_completed
+    date:
+      # "created_at": "2021-10-18T00:34:50.000000Z" is returned by Newtonsoft.Json.Linq as 18/10/2021 00:34:50
+      selector: created_at
+      filters:
+        - name: append
+          args: " +00:00" # GMT
+        - name: dateparse
+          args: "MM/dd/yyyy HH:mm:ss zzz"
+    size:
+      selector: size
+    _featured:
+      selector: featured
+      case:
+        False: "{{ .False }}"
+        True: "{{ .True }}"
+    downloadvolumefactor_freeleech:
+      # api returns 0%, 25%, 50%, 75%, 100%
+      selector: freeleech
+      case:
+        0%: 1 # not free
+        25%: 0.75
+        50%: 0.5
+        75%: 0.25
+        100%: 0 # freeleech
+        "*": 0 # catch errors
+    downloadvolumefactor:
+      text: "{{ if .Result._featured }}0{{ else }}{{ .Result.downloadvolumefactor_freeleech }}{{ end }}"
+    uploadvolumefactor_double_upload:
+      # api returns False, True
+      selector: double_upload
+      case:
+        False: 1 # normal
+        True: 2 # double
+    uploadvolumefactor:
+      text: "{{ if .Result._featured }}2{{ else }}{{ .Result.uploadvolumefactor_double_upload }}{{ end }}"
+# global MR is 0.4 but torrents must be seeded for 72 hours
+#    minimumratio:
+#      text: 0.4
+    minimumseedtime:
+      # 72 hours (as seconds = 3 x 24 x 60 x 60)
+      text: 259200
+# json UNIT3D 9.2.0


### PR DESCRIPTION
#### Description
Adds RunTheFrames (API) private tracker.
The tracker is based on UNIT3D v9.2.0.
Global ratio 0.4 and a minimum seed time of 72 hours.

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #16824

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
