### PR TITLE
pornolab: add .biz TLD

### DIFF
--- a/src/Jackett.Common/Definitions/pornolab.yml
+++ b/src/Jackett.Common/Definitions/pornolab.yml
@@ -8,6 +8,7 @@ encoding: windows-1251
 links:
   - https://pornolab.net/
   - https://pornolab.cc/
+  - https://pornolab.biz/
 
 caps:
   categorymappings:


### PR DESCRIPTION
#### Description
Pornolab is also available on the `.biz` TLD
This is reflected in their SSL cert