### PR TITLE
Log non-torrent download response body at Debug level instead of Error

### DIFF
--- a/src/Jackett.Server/Controllers/DownloadController.cs
+++ b/src/Jackett.Server/Controllers/DownloadController.cs
@@ -81,7 +81,7 @@ namespace Jackett.Server.Controllers
                 catch (Exception e)
                 {
                     var content = indexer.Encoding.GetString(downloadBytes);
-                    _logger.Error(content);
+                    _logger.Debug(content);
                     throw new Exception("BencodeParser failed", e);
                 }
 


### PR DESCRIPTION
Fixes #15631

## What's happening

When `DownloadAsync` receives a non-torrent response (typically an HTML error page), the BencodeParser throws, and the catch block decodes the response body and logs it at Error level:

```csharp
var content = indexer.Encoding.GetString(downloadBytes);
_logger.Error(content);   // every line of HTML becomes a separate journal entry
throw new Exception("BencodeParser failed", e);
```

Because systemd/journald logs each newline as a separate record, a 500-line HTML page produces 500 Error-level journal entries per failed download. Users with misconfigured or intermittently failing indexers can hit thousands of log lines per minute with enhanced logging turned off.

## What this changes

`_logger.Error(content)` → `_logger.Debug(content)`

The response body is now only written to the log when enhanced logging is enabled, which is the appropriate place for raw response dumps.

The user-visible error is still fully reported — the outer catch at line 92 logs `"Error downloading. indexer: ... path: ..."` at Error level with the full exception, so failures are not silenced.

## Why only this line

The "BencodeParser failed" message in the re-thrown exception propagates to the outer catch and gets logged at Error with the indexer name and path. That's the right signal. The full HTML body is debugging material, not an operational alert.

No other changes. `dotnet format` does not affect this line.