### PR TITLE
arabp2p: parse English bracket title forms

### DIFF
--- a/src/Jackett.Common/Definitions/arabp2p.yml
+++ b/src/Jackett.Common/Definitions/arabp2p.yml
@@ -161,6 +161,16 @@ search:
           args: ["\\[(\\d+(?:[\\s-]+\\d+)*)\\]\\s*\\[(\\d{4})\\]\\s*\\[م(\\d+)\\]", "S$3E$1 [$2]"]
         - name: re_replace
           args: ["\\[(\\d+(?:[\\s-]+\\d+)*)\\]\\s*\\[م(\\d+)\\]", "S$2E$1"]
+        # English bracket forms used by YANGO / SHAHID / TOD packs:
+        #   [E08 E09] [S01]  -> S01E08-E09  (episode range with explicit season)
+        #   [E81] [S01]      -> S01E81      (episode first, season second)
+        #   [S05] [E02]      -> S05E02      (season first, episode second)
+        - name: re_replace
+          args: ["\\[E(\\d+)\\s+E(\\d+)\\]\\s*\\[S(\\d+)\\]", "S$3E$1-E$2"]
+        - name: re_replace
+          args: ["\\[E(\\d+)\\]\\s*\\[S(\\d+)\\]", "S$2E$1"]
+        - name: re_replace
+          args: ["\\[S(\\d+)\\]\\s*\\[E(\\d+)\\]", "S$1E$2"]
         - name: re_replace
           args: ["^\\[(\\d+(?:[\\s-]+\\d+)*)\\](?!\\s*\\[م)", "S01E$1"]
         - name: re_replace

--- a/src/Jackett.Common/Definitions/arabp2p.yml
+++ b/src/Jackett.Common/Definitions/arabp2p.yml
@@ -162,15 +162,13 @@ search:
         - name: re_replace
           args: ["\\[(\\d+(?:[\\s-]+\\d+)*)\\]\\s*\\[م(\\d+)\\]", "S$2E$1"]
         # English bracket forms used by YANGO / SHAHID / TOD packs:
-        #   [E08 E09] [S01] / [E08-E09] [S01]  -> S01E08-E09  (episode range with explicit season)
-        #   [E81] [S01]                        -> S01E81      (episode first, season second)
-        #   [S05] [E02]                        -> S05E02      (season first, episode second)
+        #   [E08 E09] [S01] / [E08-E09] [S01]  -> S01E08 E09 / S01E08-E09
+        #   [E81] [S01]                        -> S01E81
+        #   [S05] [E02]                        -> S05E02
         - name: re_replace
-          args: ["\\[E(\\d+)[\\s-]+E(\\d+)\\]\\s*\\[S(\\d+)\\]", "S$3E$1-E$2"]
+          args: ["\\[(E\\d+(?:[\\s-]+E\\d+)?)\\]\\s*\\[(S\\d+)\\]", "$2$1"]
         - name: re_replace
-          args: ["\\[E(\\d+)\\]\\s*\\[S(\\d+)\\]", "S$2E$1"]
-        - name: re_replace
-          args: ["\\[S(\\d+)\\]\\s*\\[E(\\d+)\\]", "S$1E$2"]
+          args: ["\\[(S\\d+)\\]\\s*\\[(E\\d+)\\]", "$1$2"]
         - name: re_replace
           args: ["^\\[(\\d+(?:[\\s-]+\\d+)*)\\](?!\\s*\\[م)", "S01E$1"]
         - name: re_replace

--- a/src/Jackett.Common/Definitions/arabp2p.yml
+++ b/src/Jackett.Common/Definitions/arabp2p.yml
@@ -162,11 +162,11 @@ search:
         - name: re_replace
           args: ["\\[(\\d+(?:[\\s-]+\\d+)*)\\]\\s*\\[م(\\d+)\\]", "S$2E$1"]
         # English bracket forms used by YANGO / SHAHID / TOD packs:
-        #   [E08 E09] [S01]  -> S01E08-E09  (episode range with explicit season)
-        #   [E81] [S01]      -> S01E81      (episode first, season second)
-        #   [S05] [E02]      -> S05E02      (season first, episode second)
+        #   [E08 E09] [S01] / [E08-E09] [S01]  -> S01E08-E09  (episode range with explicit season)
+        #   [E81] [S01]                        -> S01E81      (episode first, season second)
+        #   [S05] [E02]                        -> S05E02      (season first, episode second)
         - name: re_replace
-          args: ["\\[E(\\d+)\\s+E(\\d+)\\]\\s*\\[S(\\d+)\\]", "S$3E$1-E$2"]
+          args: ["\\[E(\\d+)[\\s-]+E(\\d+)\\]\\s*\\[S(\\d+)\\]", "S$3E$1-E$2"]
         - name: re_replace
           args: ["\\[E(\\d+)\\]\\s*\\[S(\\d+)\\]", "S$2E$1"]
         - name: re_replace

--- a/src/Jackett.Common/Definitions/arabp2p.yml
+++ b/src/Jackett.Common/Definitions/arabp2p.yml
@@ -162,13 +162,12 @@ search:
         - name: re_replace
           args: ["\\[(\\d+(?:[\\s-]+\\d+)*)\\]\\s*\\[م(\\d+)\\]", "S$2E$1"]
         # English bracket forms used by YANGO / SHAHID / TOD packs:
-        #   [E08 E09] [S01] / [E08-E09] [S01]  -> S01E08 E09 / S01E08-E09
-        #   [E81] [S01]                        -> S01E81
-        #   [S05] [E02]                        -> S05E02
+        #   [E08] [S01] / [E08-E09] [S01]  -> S01E08 / S01E08-E09
+        # [S05] [E02] / [S05] [E02 E03]  -> S05E02 / S05E02 E03
         - name: re_replace
           args: ["\\[(E\\d+(?:[\\s-]+E\\d+)?)\\]\\s*\\[(S\\d+)\\]", "$2$1"]
         - name: re_replace
-          args: ["\\[(S\\d+)\\]\\s*\\[(E\\d+)\\]", "$1$2"]
+          args: ["\\[(S\\d+)\\]\\s*\\[(E\\d+(?:[\\s-]+E\\d+)?)\\]", "$1$2"]
         - name: re_replace
           args: ["^\\[(\\d+(?:[\\s-]+\\d+)*)\\](?!\\s*\\[م)", "S01E$1"]
         - name: re_replace


### PR DESCRIPTION
#### Description

ArabP2P uploaders (YANGO / SHAHID / TOD / shofha packs) sometimes label torrents with an English bracket form for the season + episode markers instead of the Arabic-bracket form the current title regex chain handles. Three real-world shapes are not parsed today:

| arabp2p title (real-world) | Current YAML output | Sonarr can parse it? |
|---|---|---|
| `ليل [E81] [S01] [SHAHID]` | unchanged | No |
| `ليل [S05][E02]` | unchanged | No |
| `Frenchman [E08 E09] [S01]` | unchanged | No |

Sonarr's parser anchors on `SxxEyy`, so without normalization these rows end up as ungrabbable releases in queue triage. This PR adds three `re_replace` rules positioned right after the Arabic-bracket handlers and before the bare `^[NN]` rule:

```yaml
- name: re_replace
  args: ["\\[E(\\d+)\\s+E(\\d+)\\]\\s*\\[S(\\d+)\\]", "S$3E$1-E$2"]
- name: re_replace
  args: ["\\[E(\\d+)\\]\\s*\\[S(\\d+)\\]", "S$2E$1"]
- name: re_replace
  args: ["\\[S(\\d+)\\]\\s*\\[E(\\d+)\\]", "S$1E$2"]
```

After the change (verified by simulating the full filter chain in Python — same three rows + the existing Arabic-bracket regressions all behave correctly):

| Input | Output |
|---|---|
| `ليل [E81] [S01] [SHAHID]` | `ليل S01E81 [SHAHID]` |
| `ليل [S05][E02]` | `ليل S05E02` |
| `Frenchman [E08 E09] [S01]` | `Frenchman S01E08-E09` |
| `الفرنساوي [09] [2026] [م1]` (existing Arabic form) | `الفرنساوي S01E09 [2026]` — unchanged |
| `الفرنساوي [09] [م1]` (existing Arabic form) | `الفرنساوي S01E09` — unchanged |

#### Notes

- Patterns are taken from a deployed adapter that's been running against arabp2p in production since 2026-05-22; the three shapes above are the only English bracket forms observed in the wild that the current YAML misses.
- Out of scope but flagging as a follow-up candidate: the existing `E(\d+)[\s-]+(\d+)` rule (line ~167) has no negative lookahead, so a title like `Show S01E05 1080p` collapses to `S01E05-E1080p`. That latent bug doesn't manifest on typical arabp2p torrent names (which use Arabic brackets, not scene form), but if Cardigann gains other consumers of this filter chain it would matter. Happy to follow up.

#### Issues Fixed or Closed by this PR

(none filed — small focused regex addition)
