### PR TITLE
arabp2p: avoid collapsing 'E05 1080p' into 'E05-E1080p' via lookahead

### DIFF
--- a/src/Jackett.Common/Definitions/arabp2p.yml
+++ b/src/Jackett.Common/Definitions/arabp2p.yml
@@ -163,9 +163,9 @@ search:
           args: ["\\[(\\d+(?:[\\s-]+\\d+)*)\\]\\s*\\[م(\\d+)\\]", "S$2E$1"]
         - name: re_replace
           args: ["^\\[(\\d+(?:[\\s-]+\\d+)*)\\](?!\\s*\\[م)", "S01E$1"]
-        # Negative lookahead avoids "E05 1080p" collapsing to "E05-E1080p"
+        # Negative lookahead avoids "E05 1080p"/"E05 1080P" collapsing to "E05-E1080p"
         - name: re_replace
-          args: ["E(\\d+)[\\s-]+(\\d+)(?![\\dp])", "E$1-E$2"]
+          args: ["E(\\d+)[\\s-]+(\\d+)(?![\\dpP])", "E$1-E$2"]
         - name: re_replace
           args: ["\\[\\s*\\]", ""]
         - name: re_replace

--- a/src/Jackett.Common/Definitions/arabp2p.yml
+++ b/src/Jackett.Common/Definitions/arabp2p.yml
@@ -163,9 +163,8 @@ search:
           args: ["\\[(\\d+(?:[\\s-]+\\d+)*)\\]\\s*\\[م(\\d+)\\]", "S$2E$1"]
         - name: re_replace
           args: ["^\\[(\\d+(?:[\\s-]+\\d+)*)\\](?!\\s*\\[م)", "S01E$1"]
-        # Negative lookahead avoids "E05 1080p"/"E05 1080P" collapsing to "E05-E1080p"
         - name: re_replace
-          args: ["E(\\d+)[\\s-]+(\\d+)(?![\\dpP])", "E$1-E$2"]
+          args: ["E(\\d+)[\\s-]+(\\d+)\\b", "E$1-E$2"]
         - name: re_replace
           args: ["\\[\\s*\\]", ""]
         - name: re_replace

--- a/src/Jackett.Common/Definitions/arabp2p.yml
+++ b/src/Jackett.Common/Definitions/arabp2p.yml
@@ -163,8 +163,9 @@ search:
           args: ["\\[(\\d+(?:[\\s-]+\\d+)*)\\]\\s*\\[م(\\d+)\\]", "S$2E$1"]
         - name: re_replace
           args: ["^\\[(\\d+(?:[\\s-]+\\d+)*)\\](?!\\s*\\[م)", "S01E$1"]
+        # Negative lookahead avoids "E05 1080p" collapsing to "E05-E1080p"
         - name: re_replace
-          args: ["E(\\d+)[\\s-]+(\\d+)", "E$1-E$2"]
+          args: ["E(\\d+)[\\s-]+(\\d+)(?![\\dp])", "E$1-E$2"]
         - name: re_replace
           args: ["\\[\\s*\\]", ""]
         - name: re_replace


### PR DESCRIPTION
#### Description

Latent bug in the title-regex chain: the rule

```yaml
- name: re_replace
  args: ["E(\\d+)[\\s-]+(\\d+)", "E$1-E$2"]
```

has no negative lookahead, so a torrent title like `Show S01E05 1080p` is rewritten to `Show S01E05-E1080p` — the `1080` is parsed as a second episode and the `p` is left dangling. The pattern fires on any `E<n><sep><digits>` with no constraint that the second group be a plausible episode count.

The fix is a one-character addition — a negative lookahead `(?![\dp])` that prevents matching when the second group is followed by another digit (likely a longer number that isn't an episode) or `p` (resolution suffix like `1080p`/`720p`).

```yaml
- name: re_replace
  args: ["E(\\d+)[\\s-]+(\\d+)(?![\\dp])", "E$1-E$2"]
```

#### Verification

Simulated the full filter chain in Python (matching .NET regex semantics) against bug + regression cases:

| Input | Before fix | After fix |
|---|---|---|
| `Show S01E05 1080p` | `Show S01E05-E1080p` (bug) | `Show S01E05 1080p` ✓ |
| `Show S02E10 720p WEB-DL` | `Show S02E10-E720p WEB-DL` (bug) | `Show S02E10 720p WEB-DL` ✓ |
| `Show S02E10-1080p H264` | `Show S02E10-E1080p H264` (bug) | `Show S02E10-1080p H264` ✓ |
| `Show E08 09 WEB-DL` (legit range) | `Show E08-E09 WEB-DL` | `Show E08-E09 WEB-DL` ✓ |
| `Show E08-09 WEB-DL` (legit range) | `Show E08-E09 WEB-DL` | `Show E08-E09 WEB-DL` ✓ |
| `Long Show E099 100 WEB-DL` (3-digit episode) | `Long Show E099-E100 WEB-DL` | `Long Show E099-E100 WEB-DL` ✓ |
| `الفرنساوي [09] [م1]` (Arabic form) | `الفرنساوي S01E09` | `الفرنساوي S01E09` ✓ |

So every legitimate use of the rule is preserved; the resolution false-positive is eliminated.

#### Notes

- Discovered while writing test coverage for #16853 (the sibling PR adding English bracket-form rules to the same chain). Both PRs are independent — landing order doesn't matter.
- Doesn't manifest often on current arabp2p torrent names (which tend to use Arabic-bracket forms, not scene form), but the rule fires on any title shape that mixes `EnnE` + ` 1080p`. A separate PR to keep the surface area tight.

#### Issues Fixed or Closed by this PR

(none filed — small focused regex fix)
