### PR TITLE
hdzero: fix update to v9.2.0

### DIFF
--- a/src/Jackett.Common/Definitions/hdzero.yml
+++ b/src/Jackett.Common/Definitions/hdzero.yml
@@ -119,8 +119,6 @@ search:
       selector: details_link
     download:
       selector: download_link
-    infohash:
-      selector: info_hash
     poster:
       selector: meta.poster
       filters:
@@ -190,4 +188,4 @@ search:
     minimumseedtime:
       # 5 days (as seconds = 5 x 24 x 60 x 60)
       text: 432000
-# json UNIT3D 9.1.5 (custom)
+# json UNIT3D 9.2.0 (custom)


### PR DESCRIPTION
## Description

After updating HDZero to 9.2.0 api has broken with the removal of info_hash parameter from response payload.

### Logs

```bash
2026-05-24 18:03:45.3|Debug|Cardigann|Downloading Feed https://hdzero.org/api/torrents/filter?sortField=created_at&sortDirection=desc&perPage=100
2026-05-24 18:03:45.7|Warn|Cardigann|Unable to connect to indexer

[v2.3.5.5327] NzbDrone.Core.Indexers.Definitions.Cardigann.Exceptions.CardigannException: Error while parsing field=infohash, selector=info_hash, value=<null>: Selector "info_hash" didn't match JSON content
 ---> System.Exception: Selector "info_hash" didn't match JSON content
```