### PR TITLE
arabp2p: fix date format (yy-MM-dd hh:mm:ss tt)

### DIFF
--- a/src/Jackett.Common/Definitions/arabp2p.yml
+++ b/src/Jackett.Common/Definitions/arabp2p.yml
@@ -200,7 +200,7 @@ search:
       # auto adjusted by site account profile
       filters:
         - name: dateparse
-          args: "MM-yy-dd HH:mm:ss tt"
+          args: "yy-MM-dd hh:mm:ss tt"
     size:
       selector: span.size
     seeders:


### PR DESCRIPTION
#### Description

The `dateparse` format string for arabp2p's `date` field has month/year swapped and uses 24-hour token (`HH`) with an AM/PM token (`tt`). All arabp2p dates therefore fail to parse for every Jackett and Prowlarr (sync) user.

```diff
- args: "MM-yy-dd HH:mm:ss tt"
+ args: "yy-MM-dd hh:mm:ss tt"
```

Empirically verified against 30 consecutive rows on the live site (full sample + git-blame in #16858). The site emits `26-05-24 05:02:45 PM` for "today at 5pm", which only parses correctly with `yy-MM-dd hh:mm:ss tt`. The current `MM-yy-dd` form would interpret month as `26` (invalid).

Regression introduced in [4e9d907d](https://github.com/Jackett/Jackett/commit/4e9d907d2) (2025-03-14 "arabp2p: new selectors") — the redesign added AM/PM but the format string got transcribed wrong.

#### Issues Fixed or Closed by this PR

* Fixes #16858
