### PR TITLE
arabp2p: add poster field (screenshot thumbnail)

### DIFF
--- a/src/Jackett.Common/Definitions/arabp2p.yml
+++ b/src/Jackett.Common/Definitions/arabp2p.yml
@@ -194,6 +194,10 @@ search:
       selector: a[href^="magnet:?xt="]
       attribute: href
       optional: true
+    poster:
+      selector: a.screenshot
+      attribute: rel
+      optional: true
     date:
       selector: span.upload-date > span
       attribute: title


### PR DESCRIPTION
#### Description

Add a `poster` field for arabp2p. Each torrent row has a screenshot/thumbnail URL exposed via the title anchor's `rel` attribute:

```html
<a href="index.php?page=torrent-details&id=111582"
   class="screenshot"
   rel="https://images2.imgbox.com/b8/9c/ZGhrFmfk_o.jpg">
  <span class="tor_link">Title…</span>
</a>
```

Picking it up surfaces the thumbnail in Prowlarr's UI (and any consumer that reads the Torznab `poster` field). Real example from the 2026-05-24 listing scrape: the row for `id=111582` has `rel="https://images2.imgbox.com/b8/9c/ZGhrFmfk_o.jpg"` — a valid 240×320 cover image.

```yaml
poster:
  selector: a.screenshot
  attribute: rel
  optional: true
```

Marked `optional: true` because uploaders sometimes leave it blank.

#### Issues Fixed or Closed by this PR

(none — additive)
