### PR TITLE
torrenting: change to categorydesc

### DIFF
--- a/src/Jackett.Common/Definitions/torrenting.yml
+++ b/src/Jackett.Common/Definitions/torrenting.yml
@@ -106,12 +106,8 @@ search:
     selector: table.t1 > tbody > tr
 
   fields:
-    category:
-      selector: a[href^="?"]
-      attribute: href
-      filters:
-        - name: replace
-          args: ["?", ""]
+    categorydesc:
+      selector: td.i.p
     title:
       selector: a[href^="/t/"]
     details:

--- a/src/Jackett.Common/Definitions/torrenting.yml
+++ b/src/Jackett.Common/Definitions/torrenting.yml
@@ -106,8 +106,17 @@ search:
     selector: table.t1 > tbody > tr
 
   fields:
+    # category layout may differ per user
+    category:
+      selector: a[href^="?"]
+      attribute: href
+      optional: true
+      filters:
+        - name: replace
+          args: ["?", ""]
     categorydesc:
       selector: td.i.p
+      optional: true
     title:
       selector: a[href^="/t/"]
     details:

--- a/src/Jackett.Common/Definitions/torrenting.yml
+++ b/src/Jackett.Common/Definitions/torrenting.yml
@@ -107,16 +107,14 @@ search:
 
   fields:
     # category layout may differ per user
-    category:
-      selector: a[href^="?"]
-      attribute: href
+    categorydesc_alt:
+      selector: a[href^="?"] img
+      attribute: alt
       optional: true
-      filters:
-        - name: replace
-          args: ["?", ""]
     categorydesc:
       selector: td.i.p
       optional: true
+      default: "{{ .Result.categorydesc_alt }}"
     title:
       selector: a[href^="/t/"]
     details:


### PR DESCRIPTION
The site changed category display from numeric ID links (eg `<a href="?25">`) to plain text in a table. Switch from category ID lookup to description-based matching against the categorydesc values.

#### Description

The goal is to resolve the category matching issue for the site since their recent redesign, which resulted in categories no longer being detected. (The recent change to the file 247f71ccb31517ab61514e580ed1ba6ce81ee975 didn't seem to capture categories.)

#### Issues Fixed or Closed by this PR

I guess this is still related to #16884.

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.

