### PR TITLE
animebytes: Update passkey validation to include length 56

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/AnimeBytes.cs
+++ b/src/Jackett.Common/Indexers/Definitions/AnimeBytes.cs
@@ -119,8 +119,8 @@ namespace Jackett.Common.Indexers.Definitions
         {
             LoadValuesFromJson(configJson);
 
-            if (ConfigData.Passkey.Value.Length != 32 && ConfigData.Passkey.Value.Length != 48)
-                throw new Exception("invalid passkey configured: expected length: 32 or 48, got " + ConfigData.Passkey.Value.Length);
+            if (ConfigData.Passkey.Value.Length is not (32 or 48 or 56))
+                throw new Exception("invalid passkey configured: expected length: 32, 48, or 56, got " + ConfigData.Passkey.Value.Length);
 
             var results = await PerformQuery(new TorznabQuery());
             if (!results.Any())

--- a/src/Jackett.Common/Indexers/Definitions/AnimeBytes.cs
+++ b/src/Jackett.Common/Indexers/Definitions/AnimeBytes.cs
@@ -119,7 +119,7 @@ namespace Jackett.Common.Indexers.Definitions
         {
             LoadValuesFromJson(configJson);
 
-            if (ConfigData.Passkey.Value.Length is not (32 or 48 or 56))
+            if (ConfigData.Passkey.Value.Length is not 32 and not 48 and not 56)
                 throw new Exception("invalid passkey configured: expected length: 32, 48, or 56, got " + ConfigData.Passkey.Value.Length);
 
             var results = await PerformQuery(new TorznabQuery());


### PR DESCRIPTION
#### Description
Add 56 to the accepted API key lengths.

#### Issues Fixed or Closed by this PR

* Fixes #16924 