### PR TITLE
nordicbytes: remove 'internal' selector

### DIFF
--- a/src/Jackett.Common/Definitions/nordicbytes.yml
+++ b/src/Jackett.Common/Definitions/nordicbytes.yml
@@ -152,13 +152,8 @@ search:
           args: ["(?i)(TV Movie)", "TV_Movie"]
         - name: replace
           args: [" & ", "_&_"]
-    _internal:
-      selector: internal
-      case:
-        0: "{{ .False }}"
-        1: "{{ .True }}"
     description:
-      text: "{{ if .Result._internal }}Internal{{ else }}{{ end }}{{ if and .Result._internal .Result.genre }} | {{ else }}{{ end }}{{ .Result.genre }}"
+      text: "{{ .Result.genre }}"
     seeders:
       selector: seeders
     leechers:


### PR DESCRIPTION
#### Description
Remove the `internal` selector. API currently always returns false for Jackett/Prowlarr compatibility, they've reportedly done away with internal torrents as a concept. Old definition would mark all releases as internal. 

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* N/A

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
