### PR TITLE
nyaasi: replace single quotes with wildcard

### DIFF
--- a/src/Jackett.Common/Definitions/nyaasi.yml
+++ b/src/Jackett.Common/Definitions/nyaasi.yml
@@ -158,6 +158,8 @@ search:
       args: [" *\\b((?:19|20)\\d{2})\\b", "{{ if .Config.radarr_compatibility }}{{ else }} $1{{ end }}"]
     - name: re_replace
       args: ["(?i) *\\b(S(?:0|eason *)?1)\\b", "{{ if .Config.strip_s01 }}{{ else }} $1{{ end }}"]
+    - name: replace
+      args: ["'", "?"]
 
   rows:
     selector: tr.default,tr.danger,tr.success


### PR DESCRIPTION
#### Description
Fix for `Aren't Wicked` to return `Arent Wicked` as well.

I didn't found this behavior documented somewhere, but seems to work fine in this scenario. 