### PR TITLE
[bjshare] Filter freeleech-only search results

### DIFF
--- a/src/Jackett.Common/Definitions/bjshare.yml
+++ b/src/Jackett.Common/Definitions/bjshare.yml
@@ -97,7 +97,7 @@ search:
       args: ["(?i)\\b(?:[SE]\\d{1,4}){1,2}\\b\\s?", ""] # remove SXXEXX or SXX from search
 
   rows:
-    selector: "tr.torrent, tr.group_torrent:not(.season_header)"
+    selector: "tr.torrent, tr.group_torrent:not(.season_header){{ if .Config.freeleech }}:has(strong.free){{ else }}{{ end }}"
 
   fields:
     category_raw:


### PR DESCRIPTION
#### Description
Update the BJ-Share Cardigann definition so freeleech-only searches exclude non-freeleech rows after IMDb redirects to group pages.

When the `freeleech` option is enabled, the rows selector now requires `strong.free`. Normal searches retain the existing row selection.

#### Screenshot (if UI related)
Not applicable.

#### Issues Fixed or Closed by this PR
Follow-up to comment in [#16855](https://github.com/Jackett/Jackett/pull/16855#issuecomment-4953033641) (`bjshare: migrate to yml`), applying the requested freeleech filtering adjustment.

Tested and confirmed to work. 

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
