### PR TITLE
Fix SKTorrent indexer

### DIFF
--- a/src/Jackett.Common/Definitions/sktorrent-org.yml
+++ b/src/Jackett.Common/Definitions/sktorrent-org.yml
@@ -6,7 +6,7 @@ language: en-US
 type: semi-private
 encoding: UTF-8
 links:
-  - https://sktorrent.org/
+  - https://sktorrent.eu/torrent/
 
 caps:
   categorymappings:
@@ -84,22 +84,22 @@ settings:
       asc: asc
 
 login:
-  path: account-login.php
+  path: login.php
   method: post
   inputs:
-    username: "{{ .Config.username }}"
-    password: "{{ .Config.password }}"
+    uid: "{{ .Config.username }}"
+    pwd: "{{ .Config.password }}"
   error:
     - selector: div.myFrame:contains("Access Denied")
   test:
-    path: index.php
-    selector: a[href="account-logout.php"]
+    path: torrents.php
+    selector: a[href="logout.php"]
 
 search:
   paths:
-    # https://sktorrent.org/torrents-search.php?c48=1&c2=1&c1=1&c42=1&c4=1&search=&cat=0&incldead=1&freeleech=0&inclexternal=0&lang=0
-    # https://sktorrent.org/torrents-search.php?search=&cat=0&incldead=0&freeleech=0&inclexternal=0&lang=0
-    - path: torrents-search.php
+    # https://sktorrent.eu/torrent/torrents.php?c48=1&c2=1&c1=1&c42=1&c4=1&search=&cat=0&incldead=1&freeleech=0&inclexternal=0&lang=0
+    # https://sktorrent.eu/torrent/torrents.php?search=&cat=0&incldead=0&freeleech=0&inclexternal=0&lang=0
+    - path: torrents.php
   inputs:
     $raw: "{{ range .Categories }}c{{.}}=1&{{end}}"
     search: "{{ .Keywords }}"
@@ -119,7 +119,7 @@ search:
       args: ["(\\w+)", "+$1"] # prepend + to each word
 
   rows:
-    selector: tr.t-row:has(a[href^="download.php?id="])
+    selector: tr:has(a[href^="download.php?id="])
     filters:
       - name: andmatch
 


### PR DESCRIPTION
SKTorrent completely changed their domain to .eu, moved to a `/torrent/` subfolder, renamed login endpoints to `login.php`, changed form inputs to `uid`/`pwd`, and removed the `t-row` class from search results. This PR fixes all of these issues to restore functionality.