### PR TITLE
fix: turn TR4KER into private

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,6 @@ Prior versions of Jackett are no longer supported.
  * themixingbowl (TMB)
  * Toloka
  * TorrentMasters
- * TR4KER
  * TrahT
  * TribalMixes
  * Union Fansub
@@ -654,6 +653,7 @@ Prior versions of Jackett are no longer supported.
  * Torrenting (TT)
  * TorrentLeech (TL)
  * ToTheGlory (TTG) [![(invite needed)][inviteneeded]](#)
+ * TR4KER
  * TrackerMK
  * TrackerZero [PAY2DL]
  * TranceTraffic

--- a/src/Jackett.Common/Definitions/tr4ker.yml
+++ b/src/Jackett.Common/Definitions/tr4ker.yml
@@ -1,9 +1,9 @@
 ---
 id: tr4ker
 name: TR4KER
-description: "TR4KER is a FRENCH Semi-Private Torrent Tracker for MOVIES / TV / GENERAL"
+description: "TR4KER is a FRENCH Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: fr-FR
-type: semi-private
+type: private
 encoding: UTF-8
 requestDelay: 1 # 60 request per minute
 links:


### PR DESCRIPTION
#### Description

TR4KER is a private tracker. The fact that it is described as semi-private adds the torrents as public which prevent them from getting downloaded.