### PR TITLE
Fix BTSCHOOL result column selectors

### DIFF
--- a/src/Jackett.Common/Definitions/btschool.yml
+++ b/src/Jackett.Common/Definitions/btschool.yml
@@ -107,7 +107,7 @@ search:
       attribute: href
     date_elapsed:
       # time type: time elapsed (default)
-      selector: td:nth-child(4) > span[title]
+      selector: td:nth-child(3) > span[title]
       attribute: title
       optional: true
       filters:
@@ -117,7 +117,7 @@ search:
           args: "yyyy-MM-dd HH:mm:ss zzz"
     date_added:
       # time added
-      selector: td:nth-child(4):not(:has(span))
+      selector: td:nth-child(3):not(:has(span))
       optional: true
       filters:
         - name: append
@@ -127,19 +127,19 @@ search:
     date:
       text: "{{ if or .Result.date_elapsed .Result.date_added }}{{ or .Result.date_elapsed .Result.date_added }}{{ else }}now{{ end }}"
     size:
-      selector: td.rowfollow:nth-child(5)
+      selector: td.rowfollow:nth-child(4)
       optional: true
       default: 512MB
     seeders:
-      selector: td.rowfollow:nth-child(6)
+      selector: td.rowfollow:nth-child(5)
       optional: true
       default: 0
     leechers:
-      selector: td.rowfollow:nth-child(7)
+      selector: td.rowfollow:nth-child(6)
       optional: true
       default: 0
     grabs:
-      selector: td.rowfollow:nth-child(8)
+      selector: td.rowfollow:nth-child(7)
       optional: true
       default: 0
     downloadvolumefactor:


### PR DESCRIPTION
#### Description
BTSCHOOL must have added a new UI element because the column selectors were off and the data returned was bad.

#### Screenshot (if UI related)
Jacket after:
<img width="3260" height="1774" alt="2026-07-28 at 22 10 01" src="https://github.com/user-attachments/assets/32747b21-85fb-43c3-8f58-231365678d4e" />

Prowlarr before:
<img width="1806" height="701" alt="2026-07-28_at_18 12 10" src="https://github.com/user-attachments/assets/99d6e2e9-38b3-42f6-9e87-ce385fbbcc48" />

Prowlarr after:
<img width="3608" height="1398" alt="2026-07-28 at 22 12 33" src="https://github.com/user-attachments/assets/c00b1f45-31b9-495f-ade7-35cf5bb7f020" />


#### Issues Fixed or Closed by this PR
I was going to submit a bug but then I decided to just go the next step and create a PR instead

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
