### PR TITLE
pornotorrent: use the site's native torznab api

### DIFF
--- a/src/Jackett.Common/Definitions/pornotorrent.yml
+++ b/src/Jackett.Common/Definitions/pornotorrent.yml
@@ -56,6 +56,8 @@ search:
       # Sat, 01 Aug 2026 01:00:00 GMT
       selector: pubDate
       filters:
+        - name: replace
+          args: ["GMT", "+00:00"]
         - name: dateparse
           args: "ddd, dd MMM yyyy HH:mm:ss zzz"
     seeders:

--- a/src/Jackett.Common/Definitions/pornotorrent.yml
+++ b/src/Jackett.Common/Definitions/pornotorrent.yml
@@ -9,10 +9,12 @@ testlinktorrent: false
 links:
   - https://pornotorrent.com.br/
 legacylinks:
+  - https://www.pornotorrent.eu/
   - https://pornotorrent.net.br/
 
 caps:
   categorymappings:
+    # from https://pornotorrent.com.br/torznab?t=caps
     - {id: 6000, cat: XXX, desc: "XXX"}
     - {id: 6080, cat: XXX/SD, desc: "XXX/SD"}
     - {id: 6090, cat: XXX/WEB-DL, desc: "XXX/WEB-DL"}
@@ -50,8 +52,10 @@ search:
     magnet:
       selector: enclosure
       attribute: url
-    size:
+    size_check:
       selector: size
+    size:
+      text: "{{ if eq .Result.size_check \"0\" }}5GB{{ else }}{{ .Result.size_check }}{{ end }}"
     date:
       # Sat, 01 Aug 2026 01:00:00 GMT
       selector: pubDate
@@ -65,7 +69,9 @@ search:
     leechers:
       text: 0
     downloadvolumefactor:
-      text: 0
+      selector: "[name=downloadvolumefactor]"
+      attribute: value
     uploadvolumefactor:
-      text: 1
+      selector: "[name=uploadvolumefactor]"
+      attribute: value
 # torznab xml

--- a/src/Jackett.Common/Definitions/pornotorrent.yml
+++ b/src/Jackett.Common/Definitions/pornotorrent.yml
@@ -14,8 +14,8 @@ legacylinks:
 caps:
   categorymappings:
     - {id: 6000, cat: XXX, desc: "XXX"}
-    - {id: 6070, cat: XXX/SD, desc: "XXX/SD"}
-    - {id: 6080, cat: XXX/WEB-DL, desc: "XXX/WEB-DL"}
+    - {id: 6080, cat: XXX/SD, desc: "XXX/SD"}
+    - {id: 6090, cat: XXX/WEB-DL, desc: "XXX/WEB-DL"}
 
   modes:
     search: [q]

--- a/src/Jackett.Common/Definitions/pornotorrent.yml
+++ b/src/Jackett.Common/Definitions/pornotorrent.yml
@@ -9,59 +9,61 @@ testlinktorrent: false
 links:
   - https://pornotorrent.com.br/
 legacylinks:
-  - https://www.pornotorrent.eu/
   - https://pornotorrent.net.br/
 
 caps:
   categorymappings:
-    - {id: XXX, cat: XXX, desc: XXX}
+    - {id: 6000, cat: XXX, desc: "XXX"}
+    - {id: 6010, cat: XXX/DVD, desc: "XXX/DVD"}
+    - {id: 6070, cat: XXX/SD, desc: "XXX/SD"}
+    - {id: 6080, cat: XXX/WEB-DL, desc: "XXX/WEB-DL"}
 
   modes:
     search: [q]
+    movie-search: [q]
 
 settings: []
 
-download:
-  selectors:
-    - selector: a[href^="magnet:?xt="]
-      attribute: href
-
 search:
   paths:
-    - path: /
+    - path: torznab/
+      method: get
+      response:
+        type: xml
+
   inputs:
-    s: "{{ .Keywords }}"
-    cat: 0
+    t: search
+    q: "{{ .Keywords }}"
+    limit: 100
 
   rows:
-    selector: article.cp-card
+    selector: channel > item
 
   fields:
     category:
-      text: XXX
+      selector: "[name=category]"
+      attribute: value
     title:
-      selector: h3.cp-card__title
+      selector: title
     details:
-      selector: h3.cp-card__title > a
-      attribute: href
-    download:
-      selector: h3.cp-card__title > a
-      attribute: href
-    poster:
-      selector: img
-      attribute: src
-    date:
-      text: now
+      selector: guid
+    magnet:
+      selector: enclosure
+      attribute: url
     size:
-      text: 5GB
+      selector: size
+    date:
+      # Sat, 01 Aug 2026 01:00:00 GMT
+      selector: pubDate
+      filters:
+        - name: dateparse
+          args: "ddd, dd MMM yyyy HH:mm:ss zzz"
     seeders:
       text: 1
     leechers:
-      text: 1
+      text: 0
     downloadvolumefactor:
       text: 0
     uploadvolumefactor:
       text: 1
-    description:
-      selector: span:has(span.cm-ico-clock)
-# engine n/a
+# torznab xml

--- a/src/Jackett.Common/Definitions/pornotorrent.yml
+++ b/src/Jackett.Common/Definitions/pornotorrent.yml
@@ -14,7 +14,6 @@ legacylinks:
 caps:
   categorymappings:
     - {id: 6000, cat: XXX, desc: "XXX"}
-    - {id: 6010, cat: XXX/DVD, desc: "XXX/DVD"}
     - {id: 6070, cat: XXX/SD, desc: "XXX/SD"}
     - {id: 6080, cat: XXX/WEB-DL, desc: "XXX/WEB-DL"}
 
@@ -41,6 +40,7 @@ search:
 
   fields:
     category:
+      # the feed puts the specific category first, the 6000 parent second
       selector: "[name=category]"
       attribute: value
     title:


### PR DESCRIPTION
#### Description

The current definition scrapes `/?s=` and is dead: the site returns 403 to Prowlarr/Jackett/Cardigann user-agents on that path. It also reported hardcoded `size: 5GB` and `date: now` on every result.

The site now serves a native Torznab endpoint at `/torznab/` (200 for the same user-agents), so this switches to consuming that XML, with real size, date and SD/WEB-DL categories.

I run the site.

#### Issues Fixed or Closed by this PR

* n/a
