### PR TITLE
ebookbay: lowercase search keywords

### DIFF
--- a/src/Jackett.Common/Definitions/ebookbay.yml
+++ b/src/Jackett.Common/Definitions/ebookbay.yml
@@ -95,6 +95,10 @@ search:
     - path: "page/3/"
     - path: "page/4/"
     - path: "page/5/"
+  keywordsfilters:
+    # the site search is case sensitive and a query containing uppercase
+    # characters is redirected to the site root, returning no results
+    - name: tolower
   inputs:
     s: "{{ .Keywords }}"
 


### PR DESCRIPTION
The site search is case sensitive. A query containing uppercase characters is redirected (301) to the site root, which Cardigann surfaces as "Redirected to https://ebb.la/ from indexer request" and treats as an indexer failure, rather than returning zero results.

#### Description
The bug

https://ebb.la/?s=dune returns 7 results
https://ebb.la/?s=Dune returns 301 Moved Permanently to https://ebb.la/
Same word, only the capital differs

#### Issues Fixed or Closed by this PR
The fix

keywordsfilters: [- name: tolower], matching the pattern already used by 5 other Jackett definitions

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
