### PR TITLE
torrentdownload: add missing BooksAudiobooks category mapping

### DIFF
--- a/src/Jackett.Common/Definitions/torrentdownload.yml
+++ b/src/Jackett.Common/Definitions/torrentdownload.yml
@@ -26,6 +26,7 @@ caps:
     - {id: ApplicationsWindows, cat: PC/0day, desc: "Applications Windows"}
     - {id: AudioBooks, cat: Audio/Audiobook, desc: "Books Audiobooks"}
     - {id: AudioAudiobooks, cat: Audio/Audiobook, desc: "Books Audiobooks"}
+    - {id: BooksAudiobooks, cat: Audio/Audiobook, desc: "Books Audiobooks"}
     - {id: AudioLossless, cat: Audio/Lossless, desc: "Audio Lossless"}
     - {id: AudioMusic, cat: Audio/MP3, desc: "Audio Music"}
     - {id: BooksAcademic, cat: Books, desc: "Books Academic"}


### PR DESCRIPTION
#### Indexer/Tracker

TorrentDownload

#### Description

The `category` field strips every non-letter character from the site's category label:

```yaml
category:
  selector: div.tt-name > span.smallish
  filters:
    - name: re_replace
      args: ["[^A-Za-z]+", ""] # strip everything but letters
```

The site's **"Books > Audio books"** label therefore reduces to `BooksAudiobooks`, which has no
entry in `categorymappings`. Releases in that category come back uncategorised and are missed by
category-filtered searches (Audio/Audiobook, newznab 3030).

Worth noting: the two existing entries `AudioBooks` and `AudioAudiobooks` (lines 27-28) both
already carry `desc: "Books Audiobooks"` — i.e. they were both aimed at this same site label, but
neither slug matches what the site actually emits. This adds the value the site really produces
and leaves the existing two untouched.

Confirmed against a live instance, which logs the unmapped value verbatim:

```
Invalid category for value: 'BooksAudiobooks'
```

(112 occurrences in the debug log; by far the most frequent unmapped value for this indexer.)

Observed via Prowlarr, which shares this Cardigann definition — the extraction logic and the
resulting slug are identical either way.

Validated with `scripts/validate.py` against `schema.json`.

#### Issues Fixed or Closed by this PR

None.
