### PR TITLE
torrentdownload: add 14 missing category mappings

### DIFF
--- a/src/Jackett.Common/Definitions/torrentdownload.yml
+++ b/src/Jackett.Common/Definitions/torrentdownload.yml
@@ -15,12 +15,15 @@ legacylinks:
 caps:
   categorymappings:
     - {id: Adult, cat: XXX, desc: Adult}
+    - {id: AdultPornAnimationHentai, cat: XXX, desc: "Adult Porn Animation/Hentai"}
+    - {id: AdultPornGames, cat: XXX, desc: "Adult Porn Games"}
     - {id: AdultPornHDVideo, cat: XXX, desc: "Adult Porn HD Video"}
     - {id: AdultPornPictures, cat: XXX, desc: "Adult Porn Pictures"}
     - {id: AdultPornVideo, cat: XXX, desc: "Adult Porn Video"}
     - {id: Anime, cat: TV/Anime, desc: Anime}
     - {id: AnimeAnimeOther, cat: TV/Anime, desc: "Anime Other"}
     - {id: AnimeEnglishtranslated, cat: TV/Anime, desc: "Anime English translated"}
+    - {id: AnimeHentai, cat: XXX, desc: "Anime Hentai"}
     - {id: Applications, cat: PC/0day, desc: Applications}
     - {id: ApplicationsAndroid, cat: PC/Mobile-Android, desc: "Applications Android"}
     - {id: ApplicationsWindows, cat: PC/0day, desc: "Applications Windows"}
@@ -39,30 +42,40 @@ caps:
     - {id: BooksTextbooks, cat: Books, desc: "Books Textbooks"}
     - {id: Ebooks, cat: Books/EBook, desc: "Books Ebooks"}
     - {id: Games, cat: Console, desc: Games}
+    - {id: GamesPC, cat: PC/Games, desc: "Games PC"}
     - {id: GamesWindows, cat: PC/Games, desc: "Games Windows"}
     - {id: Movies, cat: Movies, desc: Movies}
     - {id: MoviesAction, cat: Movies, desc: Movies Action}
+    - {id: MoviesBollywood, cat: Movies, desc: "Movies Bollywood"}
+    - {id: MoviesComedy, cat: Movies, desc: "Movies Comedy"}
     - {id: MoviesConcerts, cat: Movies, desc: "Movies Concerts"}
     - {id: MoviesCrime, cat: Movies, desc: "Movies Crime"}
     - {id: MoviesDocumentary, cat: TV/Documentary, desc: "Movies Documentary"}
     - {id: MoviesDubbedMovies, cat: Movies, desc: "Movies Dubbed Movies"}
     - {id: MoviesHighresMovies, cat: Movies, desc: "Movies Highres Movies"}
+    - {id: MoviesHorror, cat: Movies, desc: "Movies Horror"}
     - {id: MoviesMusicvideos, cat: Audio/Video, desc: "Movies Musicvideos"}
     - {id: MoviesThriller, cat: Movies, desc: "Movies Thriller"}
     - {id: Music, cat: Audio, desc: Music}
+    - {id: MusicBollywood, cat: Audio, desc: "Music Bollywood"}
+    - {id: MusicCompilationVariousArtistsVA, cat: Audio, desc: "Music Compilation / Various Artists (VA)"}
     - {id: MusicFLAC, cat: Audio/Lossless, desc: "Music FLAC"}
     - {id: MusicHardrock, cat: Audio, desc: "Music Hardrock"}
+    - {id: MusicHipHop, cat: Audio, desc: "Music Hip Hop"}
     - {id: MusicLossless, cat: Audio/Lossless, desc: "Music Lossless"}
     - {id: MusicMp, cat: Audio/MP3, desc: "Music Mp3"}
     - {id: MusicRB, cat: Audio, desc: "Music R&B"}
+    - {id: MusicRap, cat: Audio, desc: "Music Rap"}
     - {id: MusicTranceHouseDance, cat: Audio, desc: "Music Trance House Dance"}
     - {id: Other, cat: Other, desc: Other}
     - {id: OtherComics, cat: Other, desc: "Other Comics"}
     - {id: OtherEbooks, cat: Books/EBook, desc: "Other Ebooks"}
     - {id: OtherTutorials, cat: Other, desc: "Other Tutorials"}
     - {id: OtherUnsorted, cat: Other, desc: "Other Unsorted"}
+    - {id: OtherXXX, cat: XXX, desc: "Other XXX"}
     - {id: PicturesPicturesOther, cat: Other/Misc, desc: "Pictures Other"}
     - {id: PicturesWallpapers, cat: Other/Misc, desc: "Pictures Wallpapers"}
+    - {id: Series, cat: TV, desc: "Series"}
     - {id: Software, cat: PC/0day, desc: "Software"}
     - {id: TV, cat: TV, desc: TV}
     - {id: TVBBC, cat: TV, desc: "TV BBC"}
@@ -75,6 +88,7 @@ caps:
     - {id: VideoMusic, cat: Audio/Video, desc: "Video Music"}
     - {id: XXX, cat: XXX, desc: XXX}
     - {id: XXXHDVideo, cat: XXX, desc: "XXX HD Video"}
+    - {id: XXXHentai, cat: XXX, desc: "XXX Hentai"}
     - {id: XXXPictures, cat: XXX, desc: "XXX Pictures"}
     - {id: XXXVideo, cat: XXX, desc: "XXX Video"}
 


### PR DESCRIPTION
#### Indexer/Tracker

TorrentDownload

#### Description

Adds 14 category values the site emits that currently have no mapping. All were observed live;
search strings to reproduce each are below. Added in alphabetical order.

| Search this on the site | Site label | Strips to |
|---|---|---|
| `xxx` | `Other XXX` | `OtherXXX` |
| `hip hop album` | `Music > Hip Hop` | `MusicHipHop` |
| `hentai` | `Adult / Porn > Animation/Hentai` | `AdultPornAnimationHentai` |
| `rap` | `Music > Rap` | `MusicRap` |
| `hentai uncensored` | `Anime > Hentai` | `AnimeHentai` |
| `hentai` | `Adult / Porn > Games` | `AdultPornGames` |
| `xxx hentai` | `XXX > Hentai` | `XXXHentai` |
| `hindi movie` | `Movies > Bollywood` | `MoviesBollywood` |
| `bollywood` | `Music > Bollywood` | `MusicBollywood` |
| `pc game` | `Games PC` | `GamesPC` |
| `rap album` | `Music > Compilation / Various Artists (VA)` | `MusicCompilationVariousArtistsVA` |
| `comedy dvdrip` | `Movies > Comedy` | `MoviesComedy` |
| `mystery` | `Movies > Horror` | `MoviesHorror` |
| `horror dvdrip` | `Series` | `Series` |

The first four are the common ones; the rest are long tail (1-3 rows per search).

I left out per-show values like `TV > American Horror Story` — the site has an open-ended number of
those, so they didn't seem worth chasing even though `TVEllenDeGeneres` is already in the file.

#### Issues Fixed or Closed by this PR

None.
