### PR TITLE
simurg: fix false positive for API failures

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/Abstract/GazelleTracker.cs
+++ b/src/Jackett.Common/Indexers/Definitions/Abstract/GazelleTracker.cs
@@ -264,8 +264,11 @@ namespace Jackett.Common.Indexers.Definitions.Abstract
             {
                 // reason for failure should be explained.
                 var jsonError = JObject.Parse(response.ContentString);
-                var errorReason = (string)jsonError["error"];
-                throw new Exception(errorReason);
+
+                if (jsonError.TryGetValue("error", out var errorReason) && errorReason.Value<string>().IsNotNullOrWhiteSpace())
+                {
+                    throw new Exception($"Unexpected response from indexer request: \"{errorReason.Value<string>()}\"");
+                }
             }
 
             if ((int)response.Status >= 400)

--- a/src/Jackett.Common/Indexers/Definitions/GazelleGamesAPI.cs
+++ b/src/Jackett.Common/Indexers/Definitions/GazelleGamesAPI.cs
@@ -267,8 +267,11 @@ namespace Jackett.Common.Indexers.Definitions
             {
                 // reason for failure should be explained.
                 var jsonError = JObject.Parse(response.ContentString);
-                var errorReason = (string)jsonError["error"];
-                throw new Exception(errorReason);
+
+                if (jsonError.TryGetValue("error", out var errorReason) && errorReason.Value<string>().IsNotNullOrWhiteSpace())
+                {
+                    throw new Exception($"Unexpected response from indexer request: \"{errorReason.Value<string>()}\"");
+                }
             }
 
             try

--- a/src/Jackett.Test/Common/Indexers/SimurgTests.cs
+++ b/src/Jackett.Test/Common/Indexers/SimurgTests.cs
@@ -1,0 +1,47 @@
+using System.Linq;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Jackett.Common.Indexers.Definitions;
+using Jackett.Common.Models;
+using Jackett.Test.TestHelpers;
+using NLog;
+using NUnit.Framework;
+
+namespace Jackett.Test.Common.Indexers
+{
+    [TestFixture]
+    public class SimurgTests
+    {
+        private readonly TestWebClient _webClient = new TestWebClient();
+        private readonly Logger _logger = LogManager.GetCurrentClassLogger();
+        private readonly TestCacheService _cacheService = new TestCacheService();
+
+        [Test]
+        public async Task TestRecentFeedAsync()
+        {
+            _webClient.RegisterRequestCallback("https://simurg.world/ajax.php?action=browse&order_by=time&order_way=desc", "Simurg/recent-feed.json");
+
+            var indexer = new Simurg(null, _webClient, _logger, null, _cacheService);
+
+            var query = new TorznabQuery { QueryType = "search" };
+
+            var result = await indexer.ResultsForQuery(query, false);
+            result.IsFromCache.Should().BeFalse();
+
+            var releases = result.Releases.ToList();
+            releases.Should().HaveCount(2);
+
+            var firstRelease = releases.First();
+            firstRelease.Category.Should().HaveCount(2);
+            firstRelease.Category.Should().BeEquivalentTo(new[] { 7020, 100003 });
+            firstRelease.Title.Should().Be("A Spot of Tea and Sorcery: Volume 1");
+            firstRelease.Link.Should().Be("https://simurg.world/torrents.php?action=download&id=10");
+            firstRelease.Guid.Should().Be("https://simurg.world/torrents.php?torrentid=10");
+            firstRelease.Size.Should().Be(3059860L);
+            firstRelease.Seeders.Should().Be(1);
+            firstRelease.Peers.Should().Be(1);
+            firstRelease.DownloadVolumeFactor.Should().Be(1);
+            firstRelease.UploadVolumeFactor.Should().Be(1);
+        }
+    }
+}

--- a/src/Jackett.Test/Jackett.Test.csproj
+++ b/src/Jackett.Test/Jackett.Test.csproj
@@ -52,7 +52,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <Content Include="Resources\*">
+    <Content Include="Resources\**">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </Content>
   </ItemGroup>

--- a/src/Jackett.Test/Resources/Simurg/recent-feed.json
+++ b/src/Jackett.Test/Resources/Simurg/recent-feed.json
@@ -1,0 +1,54 @@
+{
+    "status": "success",
+    "response": {
+        "currentPage": 1,
+        "pages": 20,
+        "results": [
+            {
+                "groupId": "1",
+                "groupName": "A Spot of Tea and Sorcery: Volume 1",
+                "torrentId": 10,
+                "tags": [
+                    "romance"
+                ],
+                "category": "E-Books",
+                "fileCount": 1,
+                "groupTime": "2026-08-08 08:18:49",
+                "size": 3059860,
+                "snatches": 0,
+                "seeders": 1,
+                "leechers": 0,
+                "isFreeleech": false,
+                "isNeutralLeech": false,
+                "isPersonalFreeleech": false,
+                "canUseToken": true,
+                "hasSnatched": false
+            },
+            {
+                "groupId": "2",
+                "groupName": "The Gate of the Feral Gods",
+                "torrentId": 11,
+                "tags": [
+                    "science.fiction",
+                    "utter.failure"
+                ],
+                "category": "Audiobooks",
+                "fileCount": 1,
+                "groupTime": "2026-08-07 19:41:22",
+                "size": 1031604777,
+                "snatches": 0,
+                "seeders": 1,
+                "leechers": 0,
+                "isFreeleech": false,
+                "isNeutralLeech": false,
+                "isPersonalFreeleech": false,
+                "canUseToken": true,
+                "hasSnatched": false
+            }
+        ]
+    },
+    "info": {
+        "source": "Simurg",
+        "version": 2
+    }
+}


### PR DESCRIPTION
#### Description
Fixing a false positive in GazelleTracker when the response contains the word `failure` but not an `error` field.

Adding tests for Simurg for parsing recent feed.

#### Issues Fixed or Closed by this PR

* Fixes #16985