### PR TITLE
[fix] p2pbg: add download link

### DIFF
--- a/src/Jackett.Common/Definitions/p2pbg.yml
+++ b/src/Jackett.Common/Definitions/p2pbg.yml
@@ -150,16 +150,20 @@ search:
           args: category
     title:
       selector: td:nth-child(2) a
-    _hash:
+    title_download:
+      text: "{{ .Result.title }}"
+      filters:
+        - name: urlencode
+    infohash:
       selector: td:nth-child(2) a
       attribute: onclick
       filters:
         - name: regexp
           args: ([A-F|a-f|0-9]{40})
     details:
-      text: "torrents/{{ .Result._hash }}"
+      text: "torrents/{{ .Result.infohash }}"
     download:
-      text: "download.php?id={{ .Result._hash }}&f={{ .Result.title }}.torrent"
+      text: "download.php?id={{ .Result.infohash }}&f={{ .Result.title_download }}.torrent"
     magnet:
       selector: a[href^="magnet:?xt="]
       attribute: href

--- a/src/Jackett.Common/Definitions/p2pbg.yml
+++ b/src/Jackett.Common/Definitions/p2pbg.yml
@@ -158,6 +158,8 @@ search:
           args: ([A-F|a-f|0-9]{40})
     details:
       text: "torrents/{{ .Result._hash }}"
+    download:
+      text: "download.php?id={{ .Result._hash }}&f={{ .Result.title }}.torrent"
     magnet:
       selector: a[href^="magnet:?xt="]
       attribute: href


### PR DESCRIPTION
#### Description
P2PBG has torrent download button directly from the search results, but it is available for VIP users only.

Torrent download link can be calculated using the infohash and the title, which is used to for the .torrent file

#### Screenshot (if UI related)

#### Issues Fixed or Closed by this PR

* Fixes #XXXX
