### PR TITLE
[Feature] Add TV IMDb search support to NorBits

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/NorBits.cs
+++ b/src/Jackett.Common/Indexers/Definitions/NorBits.cs
@@ -56,7 +56,7 @@ namespace Jackett.Common.Indexers.Definitions
             {
                 TvSearchParams = new List<TvSearchParam>
                 {
-                    TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep
+                    TvSearchParam.Q, TvSearchParam.Season, TvSearchParam.Ep, TvSearchParam.ImdbId
                 },
                 MovieSearchParams = new List<MovieSearchParam>
                 {
@@ -69,7 +69,8 @@ namespace Jackett.Common.Indexers.Definitions
                 BookSearchParams = new List<BookSearchParam>
                 {
                     BookSearchParam.Q
-                }
+                },
+                TvSearchImdbAvailable = true
             };
 
             caps.Categories.AddCategoryMapping("main_cat[]=1", TorznabCatType.Movies, "Filmer");
@@ -208,6 +209,7 @@ namespace Jackett.Common.Indexers.Definitions
             var releases = new List<ReleaseInfo>();
             var exactSearchTerm = query.GetQueryString();
             var searchUrl = SearchUrl;
+            var requestedImdbId = ParseUtil.GetLongFromString(query.ImdbID);
 
             var searchTerms = new List<string> { exactSearchTerm };
 
@@ -261,6 +263,13 @@ namespace Jackett.Common.Indexers.Definitions
                         var title = qDetails?.GetAttribute("title").Trim();
                         var details = new Uri(SiteLink + qDetails?.GetAttribute("href").TrimStart('/'));
 
+                        var imdbLink = row.QuerySelector("a[href*=\"imdb.com/title/tt\"]")?.GetAttribute("href");
+                        var imdbId = ParseUtil.GetLongFromString(imdbLink);
+                        if (query.IsTVSearch && query.IsImdbQuery && (!imdbId.HasValue || imdbId != requestedImdbId))
+                        {
+                            continue;
+                        }
+
                         var mainCategory = row.QuerySelector("td:nth-of-type(1) a[href*=\"main_cat[]\"]")?.GetAttribute("href")?.Split('?').Last();
                         var secondCategory = row.QuerySelector("td:nth-of-type(1) a[href*=\"sub2_cat[]\"]")?.GetAttribute("href")?.Split('?').Last();
 
@@ -298,9 +307,7 @@ namespace Jackett.Common.Indexers.Definitions
                             release.Genres = release.Genres.Union(genres.Split(',')).ToList();
                         }
 
-                        // IMDB
-                        var imdbLink = row.QuerySelector("a[href*=\"imdb.com/title/tt\"]")?.GetAttribute("href");
-                        release.Imdb = ParseUtil.GetLongFromString(imdbLink);
+                        release.Imdb = imdbId;
 
                         if (row.QuerySelector("img[title=\"100% freeleech\"]") != null)
                         {
@@ -374,6 +381,12 @@ namespace Jackett.Common.Indexers.Definitions
             if (!string.IsNullOrWhiteSpace(query.ImdbID))
             {
                 searchterm = "imdbsearch=" + query.ImdbID;
+
+                var episodeSearchTerm = query.GetEpisodeSearchString();
+                if (!string.IsNullOrWhiteSpace(episodeSearchTerm))
+                {
+                    searchterm += "&search=" + WebUtilityHelpers.UrlEncode(episodeSearchTerm, Encoding.GetEncoding(28591));
+                }
             }
             else if (!string.IsNullOrWhiteSpace(term))
             {

--- a/src/Jackett.Common/Indexers/Definitions/NorBits.cs
+++ b/src/Jackett.Common/Indexers/Definitions/NorBits.cs
@@ -215,7 +215,7 @@ namespace Jackett.Common.Indexers.Definitions
 
             // duplicate search without diacritics
             var baseSearchTerm = StringUtil.RemoveDiacritics(exactSearchTerm);
-            if (baseSearchTerm != exactSearchTerm)
+            if (!query.IsImdbQuery && baseSearchTerm != exactSearchTerm)
             {
                 searchTerms.Add(baseSearchTerm);
             }

--- a/src/Jackett.Test/Common/Definitions/NorBitsTests.cs
+++ b/src/Jackett.Test/Common/Definitions/NorBitsTests.cs
@@ -1,0 +1,138 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Jackett.Common.Indexers.Definitions;
+using Jackett.Common.Models;
+using Jackett.Common.Utils.Clients;
+using Jackett.Test.TestHelpers;
+using NLog;
+using NUnit.Framework;
+using WebClient = Jackett.Common.Utils.Clients.WebClient;
+using WebRequest = Jackett.Common.Utils.Clients.WebRequest;
+
+namespace Jackett.Test.Common.Definitions
+{
+    [TestFixture]
+    public class NorBitsTests
+    {
+        [Test]
+        public async Task ImdbTvSearchWithDiacriticsSendsOneTrackerSearchAsync()
+        {
+            var webClient = new ScriptedWebClient();
+            webClient.QueueSearchResponse(AuthenticatedPage(TorrentRow("Requested.Show.S02", "tt1234567", 1)));
+            webClient.QueueSearchResponse(AuthenticatedPage(TorrentRow("Requested.Show.S02", "tt1234567", 1)));
+            var indexer = CreateIndexer(webClient);
+            var query = ImdbQuery();
+            query.SearchTerm = "Éxample Show";
+
+            await indexer.ResultsForQuery(query, false);
+
+            var trackerSearches = webClient.Requests
+                .Where(request => request.Url.Contains("imdbsearch="))
+                .Select(request => request.Url)
+                .ToList();
+
+            Assert.That(trackerSearches, Is.EqualTo(new[]
+            {
+                "https://norbits.net/browse.php?imdbsearch=tt1234567&search=S02&incldead=1&fullsearch=0&scenerelease=0"
+            }));
+        }
+
+        [Test]
+        public async Task ImdbTvSearchReturnsOnlyRowsForRequestedImdbAsync()
+        {
+            var webClient = new ScriptedWebClient();
+            webClient.QueueSearchResponse(AuthenticatedPage(
+                TorrentRow("Requested.Show.S02", "tt1234567", 1),
+                TorrentRow("Different.Show.S02", "tt7654321", 2),
+                TorrentRow("Missing.Imdb.Show.S02", null, 3)));
+            var indexer = CreateIndexer(webClient);
+
+            var result = await indexer.ResultsForQuery(ImdbQuery(), false);
+
+            Assert.That(
+                result.Releases.Select(release => release.Title),
+                Is.EqualTo(new[] { "Requested.Show.S02" }));
+        }
+
+        private static NorBits CreateIndexer(ScriptedWebClient webClient) =>
+            new NorBits(
+                null,
+                webClient,
+                LogManager.GetCurrentClassLogger(),
+                null,
+                new TestCacheService());
+
+        private static TorznabQuery ImdbQuery() => new TorznabQuery
+        {
+            QueryType = "tvsearch",
+            ImdbID = "tt1234567",
+            Season = 2,
+            Cache = false
+        };
+
+        private static string AuthenticatedPage(params string[] rows) =>
+            $@"<html><body><a href=""logout.php"">Logout</a>
+                <table id=""torrentTable""><tbody><tr><th>Header</th></tr>{string.Join(string.Empty, rows)}</tbody></table>
+                </body></html>";
+
+        private static string TorrentRow(string title, string imdbId, int id)
+        {
+            var imdbLink = imdbId == null
+                ? string.Empty
+                : $@"<a href=""https://imdb.com/title/{imdbId}"">IMDb</a>";
+
+            return $@"<tr>
+                <td><a href=""?main_cat[]=2"">TV</a></td>
+                <td><a href=""download.php?id={id}"">Download</a><a href=""details.php?id={id}"" title=""{WebUtility.HtmlEncode(title)}"">Details</a>{imdbLink}</td>
+                <td><a>1</a></td><td></td><td>2026-08-0912:00:00</td><td></td>
+                <td>1 GB</td><td>1</td><td>2</td><td>3</td>
+                </tr>";
+        }
+
+        private sealed class ScriptedWebClient : WebClient
+        {
+            private readonly Queue<WebResult> _searchResponses = new Queue<WebResult>();
+
+            public ScriptedWebClient()
+                : base(null, null, null, new Jackett.Common.Models.Config.ServerConfig(null))
+            {
+            }
+
+            public List<WebRequest> Requests { get; } = new List<WebRequest>();
+
+            public void QueueSearchResponse(string content) =>
+                _searchResponses.Enqueue(new WebResult
+                {
+                    ContentString = content,
+                    Status = HttpStatusCode.OK
+                });
+
+            public override Task<WebResult> GetResultAsync(WebRequest request)
+            {
+                Requests.Add(request);
+
+                if (!request.Url.Contains("imdbsearch="))
+                {
+                    return Task.FromResult(new WebResult
+                    {
+                        ContentString = AuthenticatedPage(),
+                        Request = request,
+                        Status = HttpStatusCode.OK
+                    });
+                }
+
+                if (_searchResponses.Count == 0)
+                {
+                    throw new InvalidOperationException($"No scripted response for {request.Url}");
+                }
+
+                var response = _searchResponses.Dequeue();
+                response.Request = request;
+                return Task.FromResult(response);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What changed

- Advertise IMDb ID support for NorBits TV searches through its Torznab capabilities.
- Combine `imdbsearch=<id>` with Jackett's normalized season, episode, or air-date search term when one is supplied.
- Verify the IMDb ID on every returned TV row and discard missing or mismatched IDs.

## Why

NorBits already supports IMDb searches, but Jackett only advertised that capability for movies. NorBits can combine its IMDb field with `search=S01`, `search=S01E01`, or a date, allowing the tracker to narrow results before pagination.

When no combined match exists, NorBits may ignore the IMDb constraint and return global text-search results. The response check prevents those unrelated releases from reaching the Torznab client. IMDb-only searches remain supported, and ordinary text searches retain their existing behavior.

## Validation

- Release build of `Jackett.Common` on .NET 9: 0 warnings, 0 errors.
- `git diff --check` passes.
- Isolated live validation against NorBits:
  - IMDb-only search returned only matching IMDb releases.
  - IMDb plus season returned only the requested title and season.
  - IMDb plus a nonexistent episode reproduced the tracker's global text fallback, while Jackett returned zero unrelated releases.
  - IMDb plus a nonexistent air date likewise returned zero unrelated releases.

No tracker credentials, private response data, or real search examples are included in the code.