### PR TITLE
HD-Space: add cookie login variant

### DIFF
--- a/src/Jackett.Common/Definitions/hdspacecookie.yml
+++ b/src/Jackett.Common/Definitions/hdspacecookie.yml
@@ -66,8 +66,6 @@ settings:
     options:
       2: desc
       1: asc
-  - name: info_flaresolverr
-    type: info_flaresolverr
 
 login:
   method: cookie

--- a/src/Jackett.Common/Definitions/hdspacecookie.yml
+++ b/src/Jackett.Common/Definitions/hdspacecookie.yml
@@ -1,0 +1,190 @@
+---
+id: hdspacecookie
+name: HD-SpaceCookie
+description: "HD-Space (HDS) is a Private Torrent Tracker for HD MOVIES / TV. This uses the cookie method for access"
+language: en-US
+type: private
+encoding: UTF-8
+links:
+  - https://hd-space.org/
+
+caps:
+  categorymappings:
+    - {id: 15, cat: Movies/BluRay, desc: "Movie / Blu-ray"}
+    - {id: 40, cat: Movies/HD, desc: "Movie / Remux"}
+    - {id: 18, cat: Movies/HD, desc: "Movie / 720p"}
+    - {id: 19, cat: Movies/HD, desc: "Movie / 1080p"}
+    - {id: 46, cat: Movies/UHD, desc: "Movie / 2160p"}
+    - {id: 21, cat: TV/HD, desc: "TV Show / 720p HDTV"}
+    - {id: 22, cat: TV/HD, desc: "TV Show / 1080p HDTV"}
+    - {id: 45, cat: TV/UHD, desc: "TV Show / 2160p HDTV"}
+    - {id: 24, cat: TV/Documentary, desc: "Documentary / 720p"}
+    - {id: 25, cat: TV/Documentary, desc: "Documentary / 1080p"}
+    - {id: 47, cat: TV/Documentary, desc: "Documentary / 2160p"}
+    - {id: 27, cat: TV/Anime, desc: "Animation / 720p"}
+    - {id: 28, cat: TV/Anime, desc: "Animation / 1080p"}
+    - {id: 48, cat: TV/Anime, desc: "Animation / 2160p"}
+    - {id: 30, cat: Audio/Lossless, desc: "Music / HQ Audio"}
+    - {id: 31, cat: Audio/Video, desc: "Music / Videos"}
+    - {id: 33, cat: XXX, desc: "XXX / 720p"}
+    - {id: 34, cat: XXX, desc: "XXX / 1080p"}
+    - {id: 49, cat: XXX, desc: "XXX / 2160p"}
+    - {id: 36, cat: Movies/Other, desc: "Trailers"}
+    - {id: 37, cat: PC, desc: "Software"}
+    - {id: 38, cat: Other, desc: "Others"}
+    - {id: 41, cat: Movies/UHD, desc: "Movie / 4K UHD"}
+
+  modes:
+    search: [q]
+    tv-search: [q, season, ep, imdbid]
+    movie-search: [q, imdbid]
+    music-search: [q]
+
+settings:
+  - name: cookie
+    type: text
+    label: Cookie
+  - name: info_cookie
+    type: info_cookie
+  - name: freeleech
+    type: checkbox
+    label: Filter freeleech only
+    default: false
+  - name: sort
+    type: select
+    label: Sort requested from site
+    default: 3
+    options:
+      3: created
+      5: seeders
+      4: size
+      2: title
+  - name: type
+    type: select
+    label: Order requested from site
+    default: 2
+    options:
+      2: desc
+      1: asc
+  - name: info_flaresolverr
+    type: info_flaresolverr
+
+login:
+  method: cookie
+  inputs:
+    cookie: "{{ .Config.cookie }}"
+  test:
+    path: index.php
+    selector: a[href="logout.php"]
+
+search:
+  paths:
+    # https://hd-space.org/index.php?page=torrents&search=&active=0&options=0&category=15;18;19
+    - path: index.php
+  inputs:
+    page: torrents
+    search: "{{ if .Query.IMDBID }}{{ .Query.IMDBIDShort }}{{ else }}{{ .Keywords }}{{ end }}"
+    category: "{{ if .Categories }}{{ range .Categories }}{{.}};{{end}}{{ else }}0{{ end }}"
+    # 0 default, 1 genre, 2 imdb, 3 uploader
+    options: "{{ if .Query.IMDBID }}2{{ else }}0{{ end }}"
+    # 0 all, 1 activeonly, 2 deadonly
+    active: 0
+    order: "{{ .Config.sort }}"
+    by: "{{ .Config.type }}"
+
+  rows:
+    selector: "table.lista[width=\"100%\"] > tbody > style ~ tr{{ if .Config.freeleech }}:has(img[src=\"gold/gold.png\"]){{ else }}{{ end }}, table.lista[width=\"100%\"] > tbody > style ~ tr{{ if .Config.freeleech }}:has(img[src=\"images/sf.png\"]){{ else }}{{ end }}"
+
+  fields:
+    category:
+      selector: td a[href^="index.php?page=torrents&category="]
+      attribute: href
+      filters:
+        - name: querystring
+          args: category
+        # change broken/missing cat 0 to Others
+        - name: re_replace
+          args: ["\\b0\\b", "38"]
+    title_default:
+      selector: td a[href^="index.php?page=torrent-details"]
+      filters:
+        - name: htmldecode
+    title:
+      selector: a[href^="download.php?id="]
+      attribute: href
+      filters:
+        - name: querystring
+          args: f
+        - name: htmldecode
+        - name: htmldecode # double usage is intentional
+        - name: replace
+          args: [".torrent", ""]
+        - name: trim
+      optional: true
+      default: "{{ .Result.title_default }}"
+    details:
+      selector: td a[href^="index.php?page=torrent-details"]
+      attribute: href
+    download:
+      selector: a[href^="download.php?id="]
+      attribute: href
+    poster:
+      selector: td a[href^="index.php?page=torrent-details"]
+      attribute: onmouseover
+      filters:
+        - name: regexp
+          args: src=\./(.+?)\s
+    imdbid:
+      selector: td a[href^="index.php?page=torrent-details"]
+      attribute: onmouseover
+      filters:
+        - name: regexp
+          args: /(\d{8}).jpg
+    date_day:
+      # Today at 09:17:08
+      # Yesterday at 17:11:03
+      selector: td:nth-child(5):contains("day")
+      # auto adjusted by site account profile
+      optional: true
+      filters:
+        - name: re_replace
+          args: ["[ ]at|[//\xa0\\s,]+", " "]
+    date_year:
+      # January 30, 2024, 20:23:21
+      selector: td:nth-child(5):not(:contains("day"))
+      # auto adjusted by site account profile
+      optional: true
+      filters:
+        - name: re_replace
+          args: ["[//\xa0\\s,]+", " "]
+        - name: dateparse
+          args: "MMMM dd yyyy HH:mm:ss"
+    date:
+      text: "{{ if or .Result.date_day .Result.date_year }}{{ or .Result.date_day .Result.date_year }}{{ else }}now{{ end }}"
+    size:
+      selector: td:nth-child(6)
+    seeders:
+      selector: td:nth-child(8)
+    leechers:
+      selector: td:nth-child(9)
+    grabs:
+      selector: td:nth-child(10)
+    genre:
+      selector: td:nth-child(2)
+      remove: a
+    description:
+      text: "{{ .Result.genre }}"
+    downloadvolumefactor:
+      case:
+        img[src="images/sf.png"]: 0 # side freeleech
+        img[src="gold/gold.png"]: 0
+        img[src="gold/silver.png"]: 0.5
+        "*": 1
+    uploadvolumefactor:
+      text: 1
+    minimumratio:
+      text: 1.0
+    minimumseedtime:
+      # 1 day (as seconds = 1 x 24 x 60 x 60)
+      text: 86400
+# xbtit


### PR DESCRIPTION
#### Description
Add `hdspacecookie` definition to support cookie-based authentication for HD-Space. I could not get the current implementation (user + password) to work at all, but it works fine with cookies.

#### Screenshot (if UI related)
N/A
#### Issues Fixed or Closed by this PR
N/A

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
