### PR TITLE
v3x: add new indexer

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,6 +665,7 @@ Prior versions of Jackett are no longer supported.
  * upload.cx (ULCX)
  * Upscale Vault
  * UTOPIA
+ * V3X
  * Vault network
  * VC-Lib [![(invite needed)][inviteneeded]](#)
  * VietMediaF

--- a/src/Jackett.Common/Definitions/v3x.yml
+++ b/src/Jackett.Common/Definitions/v3x.yml
@@ -5,6 +5,7 @@ description: "V3X is a FRENCH Private Torrent Tracker for MOVIES / TV / GENERAL"
 language: fr-FR
 type: private
 encoding: UTF-8
+requestDelay: 2
 links:
   - https://api.v3x.club/
 

--- a/src/Jackett.Common/Definitions/v3x.yml
+++ b/src/Jackett.Common/Definitions/v3x.yml
@@ -1,0 +1,83 @@
+---
+id: v3x
+name: V3X
+description: "V3X is a FRENCH Private Torrent Tracker for MOVIES / TV / GENERAL"
+language: fr-FR
+type: private
+encoding: UTF-8
+links:
+  - https://api.v3x.club/
+
+caps:
+  categorymappings:
+    - {id: 2000, cat: Movies, desc: "Films"}
+    - {id: 5000, cat: TV, desc: "Séries"}
+    - {id: 3000, cat: Audio, desc: "Audio"}
+    - {id: 7000, cat: Books, desc: "Ebooks"}
+    - {id: 4000, cat: PC, desc: "Applications"}
+    - {id: 1000, cat: Console, desc: "Jeux vidéo"}
+    - {id: 8000, cat: Other, desc: "Divers"}
+
+  modes:
+    search: [q]
+    tv-search: [q, season, ep, tmdbid]
+    movie-search: [q, tmdbid]
+    music-search: [q]
+    book-search: [q]
+  allowrawsearch: true
+
+settings:
+  - name: apikey
+    type: text
+    label: API Key
+  - name: info_key
+    type: info
+    label: About your API key
+    default: "Create your API key on V3X in Réglages -> Intégrations (needs the torznab scope)."
+
+# no login block: the tracker authenticates every request with ?apikey=
+search:
+  paths:
+    - path: indexer/search
+      response:
+        type: json
+  inputs:
+    apikey: "{{ .Config.apikey }}"
+    q: "{{ .Keywords }}"
+    cat: "{{ join .Categories \",\" }}"
+    tmdbid: "{{ .Query.TMDBID }}"
+    season: "{{ .Query.Season }}"
+    ep: "{{ .Query.Ep }}"
+    limit: 100
+
+  rows:
+    selector: results
+
+  fields:
+    title:
+      selector: title
+    details:
+      selector: details
+    download:
+      selector: download
+    size:
+      selector: size
+    seeders:
+      selector: seeders
+    leechers:
+      selector: leechers
+    grabs:
+      selector: grabs
+    infohash:
+      selector: infohash
+    category:
+      selector: category
+    date:
+      selector: pubdate
+    tmdbid:
+      selector: tmdbid
+      optional: true
+    downloadvolumefactor:
+      selector: downloadvolumefactor
+    uploadvolumefactor:
+      selector: uploadvolumefactor

--- a/src/Jackett.Common/Definitions/v3x.yml
+++ b/src/Jackett.Common/Definitions/v3x.yml
@@ -7,7 +7,8 @@ type: private
 encoding: UTF-8
 requestDelay: 2
 links:
-  - https://api.v3x.club/
+  - https://v3x.club/
+  - https://v3x.tw/
 
 caps:
   categorymappings:
@@ -34,12 +35,23 @@ settings:
   - name: info_key
     type: info
     label: About your API key
-    default: "Create your API key on V3X in Réglages -> Intégrations (needs the torznab scope)."
+    default: "Create your API key on V3X in <b>Réglages -> Intégrations</b> (needs the torznab scope)."
+  - name: apiurl
+    label: API URL
+    type: text
+    default: api.v3x.club
 
-# no login block: the tracker authenticates every request with ?apikey=
+login:
+  # returns "401 Unauthorized, check your credentials" if apikey is invalid
+  path: "https://{{ .Config.apiurl }}/indexer/search"
+  method: get
+  inputs:
+    apikey: "{{ .Config.apikey }}"
+    limit: 1
+
 search:
   paths:
-    - path: indexer/search
+    - path: "https://{{ .Config.apiurl }}/indexer/search"
       response:
         type: json
   inputs:

--- a/src/Jackett.Common/Definitions/v3x.yml
+++ b/src/Jackett.Common/Definitions/v3x.yml
@@ -95,7 +95,6 @@ search:
           args: "MM/dd/yyyy HH:mm:ss zzz"
     tmdbid:
       selector: tmdbid
-      optional: true
     downloadvolumefactor:
       selector: downloadvolumefactor
     uploadvolumefactor:

--- a/src/Jackett.Common/Definitions/v3x.yml
+++ b/src/Jackett.Common/Definitions/v3x.yml
@@ -86,6 +86,8 @@ search:
     selector: results
 
   fields:
+    category:
+      selector: category
     title_phase1:
       selector: title
     title_vostfr:
@@ -106,18 +108,10 @@ search:
       selector: details
     download:
       selector: download
-    size:
-      selector: size
-    seeders:
-      selector: seeders
-    leechers:
-      selector: leechers
-    grabs:
-      selector: grabs
     infohash:
       selector: infohash
-    category:
-      selector: category
+    tmdbid:
+      selector: tmdbid
     date:
       # "created_at": "2026-08-21T01:28:14.004Z" is returned by Newtonsoft.Json.Linq as 08/21/2026 01:28:14
       selector: pubdate
@@ -126,9 +120,16 @@ search:
           args: " +00:00" # GMT
         - name: dateparse
           args: "MM/dd/yyyy HH:mm:ss zzz"
-    tmdbid:
-      selector: tmdbid
+    size:
+      selector: size
+    seeders:
+      selector: seeders
+    leechers:
+      selector: leechers
+    grabs:
+      selector: grabs
     downloadvolumefactor:
       selector: downloadvolumefactor
     uploadvolumefactor:
       selector: uploadvolumefactor
+# json v0.18

--- a/src/Jackett.Common/Definitions/v3x.yml
+++ b/src/Jackett.Common/Definitions/v3x.yml
@@ -40,6 +40,25 @@ settings:
     label: API URL
     type: text
     default: api.v3x.club
+  - name: multilang
+    type: checkbox
+    label: Replace MULTi by another language in release name
+    default: false
+  - name: multilanguage
+    type: select
+    label: Replace MULTi by this language
+    default: FRENCH
+    options:
+      FRENCH: FRENCH
+      MULTi.FRENCH: MULTi.FRENCH
+      ENGLISH: ENGLISH
+      MULTi.ENGLISH: MULTi.ENGLISH
+      VOSTFR: VOSTFR
+      MULTi.VOSTFR: MULTi.VOSTFR
+  - name: vostfr
+    type: checkbox
+    label: Replace VOSTFR and SUBFRENCH with ENGLISH
+    default: false
 
 login:
   # returns "401 Unauthorized, check your credentials" if apikey is invalid
@@ -67,8 +86,22 @@ search:
     selector: results
 
   fields:
-    title:
+    title_phase1:
       selector: title
+    title_vostfr:
+      text: "{{ .Result.title_phase1 }}"
+      filters:
+        - name: re_replace
+          args: ["(?i)\\b(vostfr|subfrench)\\b", "ENGLISH"]
+    title_phase2:
+      text: "{{ if .Config.vostfr }}{{ .Result.title_vostfr }}{{ else }}{{ .Result.title_phase1 }}{{ end }}"
+    title_multilang:
+      text: "{{ .Result.title_phase2 }}"
+      filters:
+        - name: re_replace
+          args: ["(?i)\\b(MULTI(?!.*(?:FRENCH|ENGLISH|VOSTFR|VF2|VFF|VFQ|VOQ|VFI|VOF)))\\b", "{{ .Config.multilanguage }}"]
+    title:
+      text: "{{ if .Config.multilang }}{{ .Result.title_multilang }}{{ else }}{{ .Result.title_phase2 }}{{ end }}"
     details:
       selector: details
     download:

--- a/src/Jackett.Common/Definitions/v3x.yml
+++ b/src/Jackett.Common/Definitions/v3x.yml
@@ -86,7 +86,13 @@ search:
     category:
       selector: category
     date:
+      # "created_at": "2026-08-21T01:28:14.004Z" is returned by Newtonsoft.Json.Linq as 08/21/2026 01:28:14
       selector: pubdate
+      filters:
+        - name: append
+          args: " +00:00" # GMT
+        - name: dateparse
+          args: "MM/dd/yyyy HH:mm:ss zzz"
     tmdbid:
       selector: tmdbid
       optional: true


### PR DESCRIPTION
Description:
This adds a definition for V3X, a french private tracker (movies, tv, music, books, games). I'm the admin of the tracker.

The site has a JSON search endpoint made specifically for this definition, auth is done with the user API key so there is no login page scraping. I tested it on a local Jackett: adding the indexer, keyword search, categories, tmdbid search and torrent download, everything works.

Screenshot:
<img width="1920" height="945" alt="image" src="https://github.com/user-attachments/assets/776d286f-2e16-4ef2-8e20-40d3870074da" />
<img width="897" height="186" alt="image" src="https://github.com/user-attachments/assets/88ad385f-6c3a-4bde-92bf-f36f790bd435" />

Issues Fixed or Closed by this PR:
#17021