### PR TITLE
Migrate legacy DonTorrent .ch domain

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/DonTorrent.cs
+++ b/src/Jackett.Common/Indexers/Definitions/DonTorrent.cs
@@ -38,6 +38,7 @@ namespace Jackett.Common.Indexers.Definitions
         };
         public override string[] LegacySiteLinks => new[]
         {
+            "https://dontorrent.ch/", // parking page with JavaScript redirect
             "https://dontorrent.haus/",
             "https://dontorrent.news/",
             "https://dontorrent.institute/",


### PR DESCRIPTION
## Summary

- classify `https://dontorrent.ch/` as a legacy DonTorrent site link
- migrate existing configurations to the current default site instead of parsing the JavaScript parking page

## Reproduction

Existing installations configured with `https://dontorrent.ch/` receive a small parking response whose only content is a `window.location.replace(...)` JavaScript redirect. DonTorrent then fails its RSS/test request with `Exception (dontorrent): Redirecting`.

The current default `https://todotorrents.org/ultimos` responds normally. Adding the old `.ch` URL to `LegacySiteLinks` uses Jackett's existing migration path in `BaseIndexer.LoadValuesFromJson`.

## Validation

- reproduced the failure with Jackett 0.24.2503
- confirmed the `.ch` response is a JavaScript parking redirect
- confirmed the current default `/ultimos` endpoint returns HTTP 200
- `git diff --check` passes

This is a data-only site-link migration; no parser behavior is changed.