### PR TITLE
ui: cap max-height on alert messages to prevent screen overflow

### DIFF
--- a/src/Jackett.Common/Content/custom.css
+++ b/src/Jackett.Common/Content/custom.css
@@ -181,6 +181,11 @@ hr {
     width: 25px;
 }
 
+.alert {
+    overflow: scroll;
+    max-height: 150px;
+}
+
 .modal-fillwidth {
     width: 1200px;
     min-width:80%;

--- a/src/Jackett.Common/Content/index.html
+++ b/src/Jackett.Common/Content/index.html
@@ -29,7 +29,7 @@
     <link rel="stylesheet" type="text/css" href="../bootstrap/bootstrap.min.css?changed=2017083001">
     <link rel="stylesheet" type="text/css" href="../animate.css?changed=2017083001">
     <link rel="stylesheet" type="text/css" href="../css/tagify.css?changed=11662">
-    <link rel="stylesheet" type="text/css" href="../custom.css?changed=20240225001" media="only screen and (min-device-width: 480px)">
+    <link rel="stylesheet" type="text/css" href="../custom.css?changed=20260904001" media="only screen and (min-device-width: 480px)">
     <link rel="stylesheet" type="text/css" href="../custom_mobile.css?changed=20240225001" media="only screen and (max-device-width: 480px)">
     <link rel="stylesheet" type="text/css" href="../css/jquery.dataTables.min.css?changed=2017083001">
     <link rel="stylesheet" type="text/css" href="../css/bootstrap-multiselect.css?changed=20230107001" />


### PR DESCRIPTION
ui: cap max-height on alert messages to prevent screen overflow

Caps the maximum height of Bootstrap alerts to 150px and enables vertical scrolling. This prevents long error messages and stack traces from taking up the entire viewport and pushing the close button off-screen.

#### Description
This PR fixes a layout issue where long error messages or extensive stack traces in the Web UI expand indefinitely, consuming the entire screen and pushing essential UI elements (like the close "×" button) out of the viewport.

#### The Issue
When Jackett encounters a critical error or a long-winded tracker response, the Web UI displays this data inside a Bootstrap .alert component. Because these alerts currently have no height restrictions:

* Viewport Takeover: A massive stack trace stretches the alert container down the entire page.
* Broken UI Navigation: The close ("×") button is pushed completely off-screen, forcing users to manually scroll all the way down or refresh the page just to dismiss the notification.
* Poor UX: It disrupts the clean dashboard layout and creates an frustrating workflow when troubleshooting.

#### Screenshot
<img width="2297" height="1790" alt="image" src="https://github.com/user-attachments/assets/e1468c27-1f81-4e1b-b5bf-01c60fc73e5d" />

#### The Solution
Custom CSS fix targeting the alert class to keep long errors contained, readable, and easily dismissible.

```css
.alert { 
    overflow-y: auto; 
    max-height: 150px;
}
```

#### What This Change Does

* Limits Vertical Expansion: Restricts the alert box to a maximum height of 150px, preserving the main dashboard layout.
* Enables Scrolling: Adds a vertical scrollbar (overflow-y: auto) inside the alert container so users can still read or copy the full stack trace if needed.
* Keeps Controls Visible: Ensures the close button remains easily accessible within the viewport without breaking the page structure.

#### Screenshot
<img width="2272" height="1180" alt="image" src="https://github.com/user-attachments/assets/284ab9e2-ce41-415a-9949-c0a997ba469e" />
