### PR TITLE
ui: fix alert overflow

### DIFF
--- a/src/Jackett.Common/Content/custom.css
+++ b/src/Jackett.Common/Content/custom.css
@@ -181,7 +181,7 @@ hr {
     width: 25px;
 }
 
-.alert-danger {
+[data-notify="container"].alert-danger {
     overflow: auto;
     max-height: 250px;
 }

--- a/src/Jackett.Common/Content/custom.css
+++ b/src/Jackett.Common/Content/custom.css
@@ -181,9 +181,9 @@ hr {
     width: 25px;
 }
 
-.alert {
-    overflow: scroll;
-    max-height: 150px;
+.alert-danger {
+    overflow: auto;
+    max-height: 250px;
 }
 
 .modal-fillwidth {

--- a/src/Jackett.Common/Content/index.html
+++ b/src/Jackett.Common/Content/index.html
@@ -29,7 +29,7 @@
     <link rel="stylesheet" type="text/css" href="../bootstrap/bootstrap.min.css?changed=2017083001">
     <link rel="stylesheet" type="text/css" href="../animate.css?changed=2017083001">
     <link rel="stylesheet" type="text/css" href="../css/tagify.css?changed=11662">
-    <link rel="stylesheet" type="text/css" href="../custom.css?changed=20260904001" media="only screen and (min-device-width: 480px)">
+    <link rel="stylesheet" type="text/css" href="../custom.css?changed=20260908001" media="only screen and (min-device-width: 480px)">
     <link rel="stylesheet" type="text/css" href="../custom_mobile.css?changed=20240225001" media="only screen and (max-device-width: 480px)">
     <link rel="stylesheet" type="text/css" href="../css/jquery.dataTables.min.css?changed=2017083001">
     <link rel="stylesheet" type="text/css" href="../css/bootstrap-multiselect.css?changed=20230107001" />


### PR DESCRIPTION
#### Description
An unintended consequence of the previous PR was that scroll bars were now added to info boxes as well (see screenshot below).

Changing to `.alert-danger` so that it will only apply to error boxes.

Changing from `scroll` to `auto` so that scroll bars are only visible when they're needed.

Bumped the `max-height` so that more text is visible and scroll bars are needed less often. May need fine-tuning, or maybe a percentage used instead; all we need to make sure is that the whole alert box is visible on screen.

#### Screenshot (if UI related)
Before:

<img width="958" height="953" alt="Screenshot 2026-09-08 at 22-51-32 Jackett" src="https://github.com/user-attachments/assets/a28f9eb5-036b-421b-8bf8-6a0898c329d2" />

<img width="939" height="926" alt="screenshot-1788909616313" src="https://github.com/user-attachments/assets/ad2626ca-c106-420d-b8ba-2fc197d09fd4" />

<img width="1902" height="927" alt="screenshot-1788909637770" src="https://github.com/user-attachments/assets/9272be0d-109a-4acb-bc80-e272556a993e" />

After:

<img width="935" height="892" alt="screenshot-1788908250636" src="https://github.com/user-attachments/assets/930bdd4d-692d-4c40-91bf-ec9669dd2437" />

<img width="932" height="884" alt="screenshot-1788909388683" src="https://github.com/user-attachments/assets/1b66d798-8a70-4327-87d4-b8b540b615de" />

<img width="1894" height="893" alt="screenshot-1788909293356" src="https://github.com/user-attachments/assets/edd0742e-799d-44ca-b878-648cbaea1318" />

#### Issues Fixed or Closed by this PR

* Related #17050

##### [!IMPORTANT]
This project does **not** accept pull requests that are fully or predominantly AI-generated.
AI tools may be utilized solely in an assistive capacity.
Repeated violations of this policy may result in your account being permanently banned from contributing to the project.
