### PR TITLE
cardigann: fix false-positive "redirected to another domain" when redirect includes explicit port

### DIFF
--- a/src/Jackett.Common/Indexers/Definitions/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/Definitions/CardigannIndexer.cs
@@ -852,13 +852,20 @@ namespace Jackett.Common.Indexers.Definitions
 
         protected string GetRedirectDomainHint(string requestUrl, string redirectUrl)
         {
-            if (redirectUrl.IsNullOrWhiteSpace() || !requestUrl.StartsWith(SiteLink) || redirectUrl.StartsWith(SiteLink))
+            if (redirectUrl.IsNullOrWhiteSpace() || !requestUrl.StartsWith(SiteLink))
+            {
+                return null;
+            }
+            
+            var redirectUri = new Uri(redirectUrl);
+            var siteUri = new Uri(SiteLink);
+
+            if (string.Equals(siteUri.Host, redirectUri.Host, StringComparison.OrdinalIgnoreCase))
             {
                 return null;
             }
 
-            var uri = new Uri(redirectUrl);
-            return uri.Scheme + "://" + uri.Host + "/";
+            return redirectUri.Scheme + "://" + redirectUri.Host + "/";
         }
 
         protected string GetRedirectDomainHint(WebResult result) => GetRedirectDomainHint(result.Request.Url, result.RedirectingTo);

--- a/src/Jackett.Common/Indexers/Definitions/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/Definitions/CardigannIndexer.cs
@@ -856,7 +856,7 @@ namespace Jackett.Common.Indexers.Definitions
             {
                 return null;
             }
-            
+
             var redirectUri = new Uri(redirectUrl);
             var siteUri = new Uri(SiteLink);
 

--- a/src/Jackett.Common/Indexers/Definitions/CardigannIndexer.cs
+++ b/src/Jackett.Common/Indexers/Definitions/CardigannIndexer.cs
@@ -860,12 +860,12 @@ namespace Jackett.Common.Indexers.Definitions
             var redirectUri = new Uri(redirectUrl);
             var siteUri = new Uri(SiteLink);
 
-            if (string.Equals(siteUri.Host, redirectUri.Host, StringComparison.OrdinalIgnoreCase))
+            if (!string.Equals(redirectUri.Host, siteUri.Host, StringComparison.Ordinal))
             {
-                return null;
+                return redirectUri.Scheme + "://" + redirectUri.Authority + "/";
             }
 
-            return redirectUri.Scheme + "://" + redirectUri.Host + "/";
+            return null;
         }
 
         protected string GetRedirectDomainHint(WebResult result) => GetRedirectDomainHint(result.Request.Url, result.RedirectingTo);


### PR DESCRIPTION
**Problem:** `GetRedirectDomainHint()` compares the redirect target against `SiteLink` using a raw string `StartsWith()` check instead of comparing hosts. If a tracker's redirect `Location` header explicitly includes the (even default) port — e.g. `https://mazepa.to:443/login.php` — the string comparison against the configured `SiteLink` (`https://mazepa.to/`) fails, even though the host is identical. This makes Jackett throw `"Got redirected to another domain"` instead of correctly falling through to the existing auto-relogin flow (`CheckIfLoginIsNeeded` → `DoLogin()`).

**Evidence:** log from a real failure on the `mazepa` indexer (v0.24.2558.0):
WebClient(HttpWebClient2): Returning Found => [https://mazepa.to:443/login.php?redirect=/tracker.php](https://mazepa.to/login.php?redirect=/tracker.php)
Jackett.Common.ExceptionWithConfigData: Got redirected to another domain. Try changing the indexer URL to https://mazepa.to/.

Same host, just an explicit default port in the Location header — not a real domain change. This is a session/cookie expiry being misclassified as a domain change.

This same root cause likely explains many older reports with identical symptoms across unrelated indexers (#15906, #16130, #15737, #12601, #11518, #7021, #6986, #6715, #2824, #6905, #7215) — any tracker whose redirect responses vary port/scheme/www representation would trip the same false positive.

**Fix:** compare `Uri.Host` instead of a raw string prefix, so scheme/port/www variations of the *same* host no longer trigger a false "domain changed" error, while genuine cross-domain redirects are still caught correctly. Minimal, single-purpose change — behavior for real domain changes is unaffected.

- Fixes #17062